### PR TITLE
fix: correct CodeQL badge URL to match workflow name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- Build and Quality Badges -->
 [![CI](https://github.com/cameronrye/openzim-mcp/workflows/CI/badge.svg)](https://github.com/cameronrye/openzim-mcp/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/cameronrye/openzim-mcp/branch/main/graph/badge.svg)](https://codecov.io/gh/cameronrye/openzim-mcp)
-[![CodeQL](https://github.com/cameronrye/openzim-mcp/workflows/CodeQL/badge.svg)](https://github.com/cameronrye/openzim-mcp/actions/workflows/codeql.yml)
+[![CodeQL](https://github.com/cameronrye/openzim-mcp/workflows/CodeQL%20Security%20Analysis/badge.svg)](https://github.com/cameronrye/openzim-mcp/actions/workflows/codeql.yml)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=cameronrye_openzim-mcp&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=cameronrye_openzim-mcp)
 
 <!-- Package and Version Badges -->


### PR DESCRIPTION
## Problem

The CodeQL badge in the README was broken because it referenced a workflow named "CodeQL" but the actual workflow is named "CodeQL Security Analysis".

## Solution

Updated the badge URL to use the correct workflow name with proper URL encoding:
- **Before**: `https://github.com/cameronrye/openzim-mcp/workflows/CodeQL/badge.svg`
- **After**: `https://github.com/cameronrye/openzim-mcp/workflows/CodeQL%20Security%20Analysis/badge.svg`

## Changes

- Fixed the CodeQL badge URL in README.md to match the actual workflow name
- Used proper URL encoding (`%20`) for spaces in the workflow name

## Testing

The badge should now display correctly and show the actual status of the CodeQL Security Analysis workflow.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author