### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Whether you're building a research assistant, knowledge chatbot, or content anal
 - **Configurable**: Flexible configuration with validation
 - **Observable**: Structured logging and health monitoring
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/cameronrye-openzim-mcp).
+
 ## Quick Start
 
 ### Installation


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/cameronrye-openzim-mcp).