### PR TITLE
feat: add HTTP transport support with CLI args and env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ python -m openzim_mcp /path/to/zim/files
 openzim-mcp --mode advanced /path/to/zim/files
 python -m openzim_mcp --mode advanced /path/to/zim/files
 
+# HTTP transport modes (SSE or streamable-http)
+openzim-mcp --transport sse --host 0.0.0.0 --port 9000 /path/to/zim/files
+openzim-mcp --transport streamable-http --host 0.0.0.0 --port 9000 /path/to/zim/files
+
+# Or use environment variables
+export OPENZIM_MCP_TRANSPORT=sse
+export OPENZIM_MCP_HOST=0.0.0.0
+export OPENZIM_MCP_PORT=9000
+openzim-mcp /path/to/zim/files
+
 # For development (from source)
 uv run python -m openzim_mcp /path/to/zim/files
 uv run python -m openzim_mcp --mode advanced /path/to/zim/files
@@ -155,6 +165,28 @@ See [Simple Mode Guide](docs/SIMPLE_MODE_GUIDE.md) for detailed information.
   "openzim-mcp-advanced": {
     "command": "openzim-mcp",
     "args": ["--mode", "advanced", "/path/to/zim/files"]
+  }
+}
+```
+
+**SSE Transport:**
+
+```json
+{
+  "openzim-mcp-sse": {
+    "command": "openzim-mcp",
+    "args": ["--transport", "sse", "--host", "0.0.0.0", "--port", "9000", "/path/to/zim/files"]
+  }
+}
+```
+
+**Streamable HTTP Transport:**
+
+```json
+{
+  "openzim-mcp-http": {
+    "command": "openzim-mcp",
+    "args": ["--transport", "streamable-http", "--host", "0.0.0.0", "--port", "9000", "/path/to/zim/files"]
   }
 }
 ```
@@ -1243,6 +1275,11 @@ export OPENZIM_MCP_LOGGING__FORMAT="%(asctime)s - %(name)s - %(levelname)s - %(m
 
 # Server configuration
 export OPENZIM_MCP_SERVER_NAME=my_openzim_mcp_server
+
+# Transport configuration
+export OPENZIM_MCP_TRANSPORT=sse
+export OPENZIM_MCP_HOST=0.0.0.0
+export OPENZIM_MCP_PORT=9000
 ```
 
 ### Configuration Options
@@ -1258,6 +1295,9 @@ export OPENZIM_MCP_SERVER_NAME=my_openzim_mcp_server
 | `OPENZIM_MCP_LOGGING__LEVEL` | `INFO` | Logging level |
 | `OPENZIM_MCP_LOGGING__FORMAT` | `%(asctime)s - %(name)s - %(levelname)s - %(message)s` | Log message format |
 | `OPENZIM_MCP_SERVER_NAME` | `openzim-mcp` | Server instance name |
+| `OPENZIM_MCP_TRANSPORT` | `stdio` | Transport type (stdio, sse, streamable-http) |
+| `OPENZIM_MCP_HOST` | `127.0.0.1` | Host to bind for HTTP transports |
+| `OPENZIM_MCP_PORT` | `8000` | Port to bind for HTTP transports |
 
 ---
 

--- a/openzim_mcp/main.py
+++ b/openzim_mcp/main.py
@@ -1,8 +1,8 @@
 """Main entry point for OpenZIM MCP server."""
 
 import argparse
-import os
 import atexit
+import os
 import sys
 
 from .config import OpenZimMcpConfig

--- a/openzim_mcp/main.py
+++ b/openzim_mcp/main.py
@@ -1,11 +1,12 @@
 """Main entry point for OpenZIM MCP server."""
 
 import argparse
+import os
 import atexit
 import sys
 
 from .config import OpenZimMcpConfig
-from .constants import TOOL_MODE_SIMPLE, VALID_TOOL_MODES
+from .constants import TOOL_MODE_SIMPLE, VALID_TOOL_MODES, VALID_TRANSPORT_TYPES
 from .exceptions import OpenZimMcpConfigurationError
 from .instance_tracker import InstanceTracker
 from .server import OpenZimMcpServer
@@ -45,6 +46,26 @@ Environment Variables:
             f"(default: {TOOL_MODE_SIMPLE}, or from OPENZIM_MCP_TOOL_MODE env var)"
         ),
     )
+    parser.add_argument(
+        "--transport",
+        choices=sorted(VALID_TRANSPORT_TYPES),
+        default=os.environ.get("OPENZIM_MCP_TRANSPORT", "stdio"),
+        help=(
+            "Transport type: stdio, sse, or streamable-http"
+            " (default: stdio, or from OPENZIM_MCP_TRANSPORT env var)"
+        ),
+    )
+    parser.add_argument(
+        "--host",
+        default=os.environ.get("OPENZIM_MCP_HOST", "127.0.0.1"),
+        help="Host to bind for HTTP transports (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("OPENZIM_MCP_PORT", "8000")),
+        help="Port to bind for HTTP transports (default: 8000)",
+    )
 
     # Handle case where no arguments provided
     if len(sys.argv) == 1:
@@ -79,7 +100,12 @@ Environment Variables:
         atexit.register(cleanup_instance)
 
         # Create and run server
-        server = OpenZimMcpServer(config, instance_tracker)
+        server = OpenZimMcpServer(
+            config,
+            instance_tracker,
+            host=args.host,
+            port=args.port,
+        )
 
         mode_desc = (
             "SIMPLE mode (1 intelligent tool + all underlying tools)"
@@ -95,7 +121,7 @@ Environment Variables:
             file=sys.stderr,
         )
 
-        server.run(transport="stdio")
+        server.run(transport=args.transport)
 
     except OpenZimMcpConfigurationError as e:
         print(f"Configuration error: {e}", file=sys.stderr)

--- a/openzim_mcp/server.py
+++ b/openzim_mcp/server.py
@@ -33,12 +33,16 @@ class OpenZimMcpServer:
         self,
         config: OpenZimMcpConfig,
         instance_tracker: Optional[InstanceTracker] = None,
+        host: str = "127.0.0.1",
+        port: int = 8000,
     ):
         """Initialize OpenZIM MCP server.
 
         Args:
             config: Server configuration
             instance_tracker: Optional instance tracker for multi-server management
+            host: Host to bind to for HTTP transports (SSE, streamable-http)
+            port: Port to bind to for HTTP transports (SSE, streamable-http)
         """
         self.config = config
         self.instance_tracker = instance_tracker
@@ -69,7 +73,7 @@ class OpenZimMcpServer:
             self.simple_tools_handler = SimpleToolsHandler(self.zim_operations)
 
         # Initialize MCP server
-        self.mcp = FastMCP(config.server_name)
+        self.mcp = FastMCP(config.server_name, host=host, port=port)
         self._register_tools()
 
         logger.info(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -33,7 +33,9 @@ class TestMainModule:
 
         # Verify calls
         mock_config_class.assert_called_once_with(allowed_directories=["/test/dir"])
-        mock_server_class.assert_called_once_with(mock_config, mock_tracker)
+        mock_server_class.assert_called_once_with(
+            mock_config, mock_tracker, host="127.0.0.1", port=8000
+        )
         mock_server.run.assert_called_once_with(transport="stdio")
 
     @patch("openzim_mcp.main.InstanceTracker")


### PR DESCRIPTION
This PR adds support for running the OpenZIM MCP server over HTTP transports (SSE and streamable-http) through CLI arguments and environment variables.

**Changes:**
- `server.py`: Added `host`/`port` parameters to `OpenZimMcpServer.__init__`, passed through to `FastMCP`
- `main.py`: Added `--transport`, `--host`, `--port` CLI arguments with env var fallbacks
- `README.md`: Documented HTTP transport modes, MCP config examples, and env var options

**Usage:**
```bash
# CLI
openzim-mcp --transport sse --host 0.0.0.0 --port 9000 /path/to/zim/files

# Env vars
export OPENZIM_MCP_TRANSPORT=sse
export OPENZIM_MCP_HOST=0.0.0.0
export OPENZIM_MCP_PORT=9000
openzim-mcp /path/to/zim/files
```

**Environment Variables:**
| Variable | Default | Description |
|----------|---------|-------------|
| `OPENZIM_MCP_TRANSPORT` | `stdio` | Transport type (stdio, sse, streamable-http) |
| `OPENZIM_MCP_HOST` | `127.0.0.1` | Host to bind for HTTP transports |
| `OPENZIM_MCP_PORT` | `8000` | Port to bind for HTTP transports |