### PR TITLE
ci: dispatch docker-publish from release-please

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,6 +9,12 @@ on:
       - "Dockerfile"
       - ".dockerignore"
       - ".github/workflows/docker-publish.yml"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build and publish (e.g., v1.0.0)"
+        required: true
+        type: string
 
 jobs:
   publish:
@@ -18,6 +24,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -26,7 +34,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -35,13 +43,18 @@ jobs:
 
       - name: Extract version from tag
         id: meta
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         run: |
-          TAG=${GITHUB_REF#refs/tags/v}
-          echo "version=$TAG" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          # Strip leading 'v' so the image tag is X.Y.Z, not vX.Y.Z
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push (on tag)
-        if: github.event_name == 'push'
+      - name: Build and push (on tag or dispatch)
+        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -167,3 +167,39 @@ jobs:
               console.error('❌ Failed to trigger release workflow:', error.message);
               throw error;
             }
+
+  # Trigger the docker-publish workflow when a release is created.
+  # Tag pushes from release-please use GITHUB_TOKEN, which GitHub explicitly
+  # blocks from triggering downstream workflows — so the `push: tags` trigger
+  # on docker-publish.yml never fires for bot-created releases. We dispatch
+  # it explicitly here, mirroring the trigger-release pattern above.
+  trigger-docker-publish:
+    runs-on: ubuntu-latest
+    needs: [release-please, validate-release]
+    if: needs.release-please.outputs.release_created && needs.validate-release.result == 'success'
+    permissions:
+      actions: write
+    steps:
+      - name: Trigger docker-publish workflow
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const tagName = '${{ needs.release-please.outputs.tag_name }}';
+            console.log(`Triggering docker-publish workflow for tag: ${tagName}`);
+
+            try {
+              const result = await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'docker-publish.yml',
+                ref: 'main',
+                inputs: {
+                  tag: tagName
+                }
+              });
+              console.log('✅ docker-publish workflow triggered successfully');
+              console.log(`Workflow dispatch result: ${result.status}`);
+            } catch (error) {
+              console.error('❌ Failed to trigger docker-publish workflow:', error.message);
+              throw error;
+            }


### PR DESCRIPTION
## Summary

- Tag pushes from release-please use `GITHUB_TOKEN`, which GitHub blocks from triggering downstream workflows. The `push: tags` trigger on `docker-publish.yml` therefore never fires for bot-created releases — `v1.0.0` was tagged but no image was published to GHCR.
- Add `workflow_dispatch` (with a `tag` input) to `docker-publish.yml` so it can be invoked for any tag.
- Add a `trigger-docker-publish` job to `release-please.yml` that dispatches `docker-publish.yml` whenever a release is created. Mirrors the existing `trigger-release` job.

After this lands, GHCR images will publish automatically on every release-please-created tag, and any past missed tag (starting with `v1.0.0`) can be backfilled with:

```bash
gh workflow run docker-publish.yml -f tag=v1.0.0
```

## Test plan

- [ ] CI's PR-build-only path (`Publish Docker Image` job, `pull_request` event) still passes — validates the build still works through the broadened `if` conditions.
- [ ] After merge, run `gh workflow run docker-publish.yml -f tag=v1.0.0` and confirm `ghcr.io/cameronrye/openzim-mcp:1.0.0` and `:latest` become pullable.
- [ ] Next release-please-created release publishes its GHCR image automatically without manual dispatch.