### PR TITLE
fix(http): allow operator-configured Host allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1367,6 +1367,7 @@ export OPENZIM_MCP_SERVER_NAME=my_openzim_mcp_server
 | `OPENZIM_MCP_PORT` | `8000` | HTTP/SSE bind port. |
 | `OPENZIM_MCP_AUTH_TOKEN` | *(unset)* | Bearer token required when binding HTTP/SSE to a non-loopback interface. |
 | `OPENZIM_MCP_CORS_ORIGINS` | *(empty)* | JSON array of allowed CORS origins for the HTTP transport. Wildcard `*` is rejected. |
+| `OPENZIM_MCP_ALLOWED_HOSTS` | *(empty)* | JSON array of public-facing hostnames the HTTP transport accepts in the `Host` header (e.g. `["mcp.example.com"]`). Loopback is always allowed; this extends it for reverse-proxy and Tailscale-serve deployments. Wildcard `*` is rejected. |
 | `OPENZIM_MCP_SUBSCRIPTIONS_ENABLED` | `true` | Enable MCP resource subscriptions (HTTP transport only). When `false`, `subscribe` calls succeed but no updates fire. |
 | `OPENZIM_MCP_WATCH_INTERVAL_SECONDS` | `5` | Polling interval (1–60s) for the subscription mtime watcher. |
 | `OPENZIM_MCP_CACHE__ENABLED` | `true` | Enable/disable caching |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -61,6 +61,18 @@ The wildcard `*` is rejected at startup. Listing exact origins is a deliberate c
 
 If no browser client connects (you're hitting the endpoint from another server, a CLI client, or a desktop MCP client), leave this unset.
 
+### Public hostname allow-list (`OPENZIM_MCP_ALLOWED_HOSTS`)
+
+Required when openzim-mcp sits behind a reverse proxy (Caddy, nginx) or Tailscale serve and the public hostname differs from the bind interface. The MCP SDK applies DNS rebinding protection by validating the `Host` header against an allow-list — loopback values (`127.0.0.1`, `localhost`, `[::1]`) are always permitted, but anything else needs to be listed explicitly:
+
+```bash
+OPENZIM_MCP_ALLOWED_HOSTS='["mcp.example.com"]'
+```
+
+Symptom of a missing entry: requests proxied to openzim-mcp return `421 Misdirected Request` with body `Invalid Host header`, and the server log shows `Invalid Host header: <hostname>`. Recipe 1's loopback variant doesn't need this set; the Tailscale variant and Recipe 2 do.
+
+Entries can include the `:*` wildcard-port suffix (`mcp.example.com:*`) when the proxy preserves a non-default port in the `Host` header. The wildcard `*` alone is rejected at startup — the whole point of the allow-list is DNS rebinding protection.
+
 ### Health probes: `/healthz` and `/readyz`
 
 | Endpoint | Returns 200 when | Use for |
@@ -183,14 +195,19 @@ The `Authorization:Bearer` form (no space after the colon) matches `mcp-remote`'
 
 ### Tailscale variant
 
-To reach the server from your tailnet instead of the LAN, change exactly one line in `docker-compose.yml`:
+To reach the server from your tailnet instead of the LAN, change two lines in `docker-compose.yml`:
 
 ```yaml
     ports:
       - "100.x.y.z:8000:8000"  # your Tailscale IPv4, from `tailscale ip -4`
+    environment:
+      OPENZIM_MCP_AUTH_TOKEN: "${OPENZIM_MCP_AUTH_TOKEN}"
+      OPENZIM_MCP_ALLOWED_HOSTS: '["<device>.<tailnet>.ts.net"]'
 ```
 
 Then make sure the host firewall blocks port 8000 on the public interface (it should already, since you're not publishing on `0.0.0.0`). The bearer token plus tailnet ACLs are your trust boundary; you don't need TLS because the tailnet itself is encrypted.
+
+`OPENZIM_MCP_ALLOWED_HOSTS` is required because Tailscale serve and similar reverse proxies preserve the original `Host` header (the MagicDNS name), which the SDK's default DNS-rebinding allow-list rejects. List the MagicDNS hostname your clients connect to. If you connect by raw Tailscale IP rather than MagicDNS, add `100.x.y.z` to the list instead.
 
 ## Recipe 2: VPS with Caddy and automatic TLS
 
@@ -218,6 +235,7 @@ services:
       - /srv/zim:/data:ro
     environment:
       OPENZIM_MCP_AUTH_TOKEN: "${OPENZIM_MCP_AUTH_TOKEN}"
+      OPENZIM_MCP_ALLOWED_HOSTS: '["zim.example.com"]'
 
   caddy:
     image: caddy:2
@@ -307,7 +325,8 @@ A clean startup logs the bind host/port and the configured allowed directory. An
 
 ### Common failure modes
 
-- **Container exits immediately on start.** Almost always one of two startup checks: HTTP transport bound to a non-loopback host without `OPENZIM_MCP_AUTH_TOKEN`, or `OPENZIM_MCP_CORS_ORIGINS` set to a value containing `*`. The startup error message identifies which.
+- **Container exits immediately on start.** Almost always one of three startup checks: HTTP transport bound to a non-loopback host without `OPENZIM_MCP_AUTH_TOKEN`, or `OPENZIM_MCP_CORS_ORIGINS` / `OPENZIM_MCP_ALLOWED_HOSTS` set to a value containing `*`. The startup error message identifies which.
+- **Clients get 421 Misdirected Request / `Invalid Host header`.** The proxied `Host` header (e.g. `zim.example.com`) isn't in `OPENZIM_MCP_ALLOWED_HOSTS`. Add it. Loopback (`127.0.0.1`, `localhost`, `[::1]`) is always allowed without configuration; everything else needs an explicit entry.
 - **Clients get 401 Unauthorized.** Token mismatch. Verify with `curl -H "Authorization: Bearer $TOKEN" http://host/mcp/...`. Don't paste the token into chat or tickets.
 - **Browser clients get 403 / CORS errors.** Either `OPENZIM_MCP_CORS_ORIGINS` is unset (and a browser is calling) or the client's origin isn't in the allow-list. The browser console shows the offending origin; add it.
 - **`/readyz` returns 503.** None of the configured ZIM directories are readable from inside the container. (With multiple allowed directories, one bad mount is fine — readiness flips only when *all* of them fail.) Check the volume mount path (host side and `/data` side) and that the mount isn't empty. Permissions: the in-container user is UID 10001; the host directory needs to be world-readable or owned by UID 10001.

--- a/openzim_mcp/config.py
+++ b/openzim_mcp/config.py
@@ -119,6 +119,19 @@ class OpenZimMcpConfig(BaseSettings):
             "(no CORS headers emitted)."
         ),
     )
+    allowed_hosts: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Public-facing hostnames the HTTP transport accepts in the "
+            "Host header (e.g. ['mcp.example.com']). Loopback values "
+            "('127.0.0.1', 'localhost', '[::1]') are always allowed; this "
+            "setting extends them when openzim-mcp sits behind a reverse "
+            "proxy or Tailscale serve, which preserve the original Host. "
+            "Entries may be exact ('mcp.example.com') or include the "
+            "':*' wildcard-port suffix ('mcp.example.com:*'). Wildcard "
+            "'*' alone is rejected. Honored only when transport='http'."
+        ),
+    )
     watch_interval_seconds: int = Field(
         default=5,
         ge=1,
@@ -185,6 +198,22 @@ class OpenZimMcpConfig(BaseSettings):
             )
         return v
 
+    @field_validator("allowed_hosts")
+    @classmethod
+    def reject_allowed_hosts_wildcard(cls, v: List[str]) -> List[str]:
+        """Reject wildcard '*' in allowed_hosts (footgun prevention).
+
+        DNS rebinding protection is the whole point of the allow-list;
+        accepting '*' would defeat it. Whitespace-padded variants are
+        normalized before comparison.
+        """
+        if any(host.strip() == "*" for host in v):
+            raise OpenZimMcpConfigurationError(
+                "allowed_hosts wildcard '*' is not allowed. List hostnames "
+                "explicitly (e.g. ['mcp.example.com'])."
+            )
+        return v
+
     def setup_logging(self) -> None:
         """Configure logging based on settings."""
         logging.basicConfig(
@@ -221,6 +250,7 @@ class OpenZimMcpConfig(BaseSettings):
             "host": self.host,
             "port": self.port,
             "cors_origins": sorted(self.cors_origins),
+            "allowed_hosts": sorted(self.allowed_hosts),
             "watch_interval_seconds": self.watch_interval_seconds,
             "subscriptions_enabled": self.subscriptions_enabled,
             "rate_limit_enabled": self.rate_limit.enabled,

--- a/openzim_mcp/server.py
+++ b/openzim_mcp/server.py
@@ -68,7 +68,27 @@ class OpenZimMcpServer:
         # kwarg, but the underlying lowlevel Server does — set it after
         # construction so MCP `serverInfo.version` advertises openzim-mcp's
         # version rather than the SDK's default.
-        self.mcp = FastMCP(config.server_name)
+        #
+        # When sitting behind a reverse proxy or Tailscale serve, the
+        # public hostname differs from the bind interface and the SDK's
+        # default Host allowlist (loopback only) rejects every request
+        # with 421 Misdirected Request. Operators extend the allowlist
+        # via OPENZIM_MCP_ALLOWED_HOSTS for those deployments. Loopback
+        # entries are always preserved so localhost-direct access keeps
+        # working alongside the proxied path.
+        fastmcp_kwargs: dict = {}
+        if config.transport == "http" and config.allowed_hosts:
+            from mcp.server.transport_security import TransportSecuritySettings
+
+            fastmcp_kwargs["transport_security"] = TransportSecuritySettings(
+                allowed_hosts=[
+                    "127.0.0.1:*",
+                    "localhost:*",
+                    "[::1]:*",
+                    *config.allowed_hosts,
+                ],
+            )
+        self.mcp = FastMCP(config.server_name, **fastmcp_kwargs)
         self.mcp._mcp_server.version = __version__
         self._register_tools()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -259,6 +259,46 @@ def test_config_rejects_wildcard_cors():
         OpenZimMcpConfig(allowed_directories=[TMP_DIR], cors_origins=["*"])
 
 
+def test_config_default_allowed_hosts_empty():
+    """Default allowed_hosts is an empty list."""
+    from openzim_mcp.config import OpenZimMcpConfig
+
+    cfg = OpenZimMcpConfig(allowed_directories=[TMP_DIR])
+    assert cfg.allowed_hosts == []
+
+
+def test_config_rejects_wildcard_allowed_hosts():
+    """Wildcard '*' rejected at startup as a footgun.
+
+    The point of an allow-list is DNS rebinding protection; accepting
+    '*' would defeat it.
+    """
+    from openzim_mcp.config import OpenZimMcpConfig
+
+    with pytest.raises(OpenZimMcpConfigurationError):
+        OpenZimMcpConfig(allowed_directories=[TMP_DIR], allowed_hosts=["*"])
+
+
+def test_config_rejects_wildcard_allowed_hosts_with_padding():
+    """Whitespace-padded ' * ' is also rejected (mirrors cors_origins)."""
+    from openzim_mcp.config import OpenZimMcpConfig
+
+    with pytest.raises(OpenZimMcpConfigurationError):
+        OpenZimMcpConfig(allowed_directories=[TMP_DIR], allowed_hosts=[" * "])
+
+
+def test_config_hash_includes_allowed_hosts():
+    """allowed_hosts changes alter the config hash (used for conflict detection)."""
+    from openzim_mcp.config import OpenZimMcpConfig
+
+    base = OpenZimMcpConfig(allowed_directories=[TMP_DIR])
+    extended = OpenZimMcpConfig(
+        allowed_directories=[TMP_DIR],
+        allowed_hosts=["mcp.example.com"],
+    )
+    assert base.get_config_hash() != extended.get_config_hash()
+
+
 def test_config_default_watch_interval():
     """Default watch_interval_seconds is 5."""
     from openzim_mcp.config import OpenZimMcpConfig

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -128,6 +128,9 @@ def test_check_safe_startup_localhost_resolving_to_loopback_is_safe(monkeypatch)
     check_safe_startup(config)
 
 
+_LOOPBACK_HOSTS = {"127.0.0.1:*", "localhost:*", "[::1]:*"}
+
+
 def test_fastmcp_receives_transport_security_when_hosts_configured(tmp_path):
     """allowed_hosts plumbs through to FastMCP as TransportSecuritySettings.
 
@@ -146,17 +149,15 @@ def test_fastmcp_receives_transport_security_when_hosts_configured(tmp_path):
     )
     server = OpenZimMcpServer(cfg)
 
-    # FastMCP doesn't surface the settings publicly; reach in via the
-    # transport-security attribute on the lowlevel server. Either way,
-    # what we care about is "the allow-list contains our hosts".
+    # FastMCP stores transport_security on its settings object. We assert
+    # via set-superset rather than per-element ``in`` so neither (a) future
+    # SDK additions to the loopback defaults nor (b) order changes break
+    # the test, and so static analyzers don't mistake list-membership for
+    # URL substring matching.
     sec: TransportSecuritySettings = server.mcp.settings.transport_security  # type: ignore[union-attr]
     assert sec is not None
-    assert "mcp.example.com" in sec.allowed_hosts
-    assert "alt.example.com:*" in sec.allowed_hosts
-    # Loopback retained
-    assert "127.0.0.1:*" in sec.allowed_hosts
-    assert "localhost:*" in sec.allowed_hosts
-    assert "[::1]:*" in sec.allowed_hosts
+    hosts = set(sec.allowed_hosts)
+    assert hosts >= _LOOPBACK_HOSTS | {"mcp.example.com", "alt.example.com:*"}
 
 
 def test_fastmcp_uses_sdk_default_when_hosts_unset(tmp_path):
@@ -173,11 +174,11 @@ def test_fastmcp_uses_sdk_default_when_hosts_unset(tmp_path):
         transport="http",
     )
     server = OpenZimMcpServer(cfg)
-    # FastMCP's default sets loopback only; non-loopback hostnames absent.
     sec = server.mcp.settings.transport_security  # type: ignore[union-attr]
     assert sec is not None
-    assert "mcp.example.com" not in sec.allowed_hosts
-    assert "127.0.0.1:*" in sec.allowed_hosts
+    hosts = set(sec.allowed_hosts)
+    assert hosts >= _LOOPBACK_HOSTS
+    assert hosts.isdisjoint({"mcp.example.com"})
 
 
 def test_fastmcp_ignores_allowed_hosts_when_transport_stdio(tmp_path):
@@ -192,9 +193,9 @@ def test_fastmcp_ignores_allowed_hosts_when_transport_stdio(tmp_path):
     )
     server = OpenZimMcpServer(cfg)
     sec = server.mcp.settings.transport_security  # type: ignore[union-attr]
-    # Custom host NOT applied — SDK default in effect.
+    # Custom host NOT applied — SDK default in effect (loopback-only).
     if sec is not None:
-        assert "mcp.example.com" not in sec.allowed_hosts
+        assert set(sec.allowed_hosts).isdisjoint({"mcp.example.com"})
 
 
 def test_serve_streamable_http_runs_safe_check_and_serves(monkeypatch, tmp_path):

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -128,6 +128,75 @@ def test_check_safe_startup_localhost_resolving_to_loopback_is_safe(monkeypatch)
     check_safe_startup(config)
 
 
+def test_fastmcp_receives_transport_security_when_hosts_configured(tmp_path):
+    """allowed_hosts plumbs through to FastMCP as TransportSecuritySettings.
+
+    Loopback values are always present in the resulting allow-list so that
+    direct localhost access keeps working alongside the proxied hostname.
+    """
+    from mcp.server.transport_security import TransportSecuritySettings
+
+    from openzim_mcp.config import OpenZimMcpConfig
+    from openzim_mcp.server import OpenZimMcpServer
+
+    cfg = OpenZimMcpConfig(
+        allowed_directories=[str(tmp_path)],
+        transport="http",
+        allowed_hosts=["mcp.example.com", "alt.example.com:*"],
+    )
+    server = OpenZimMcpServer(cfg)
+
+    # FastMCP doesn't surface the settings publicly; reach in via the
+    # transport-security attribute on the lowlevel server. Either way,
+    # what we care about is "the allow-list contains our hosts".
+    sec: TransportSecuritySettings = server.mcp.settings.transport_security  # type: ignore[union-attr]
+    assert sec is not None
+    assert "mcp.example.com" in sec.allowed_hosts
+    assert "alt.example.com:*" in sec.allowed_hosts
+    # Loopback retained
+    assert "127.0.0.1:*" in sec.allowed_hosts
+    assert "localhost:*" in sec.allowed_hosts
+    assert "[::1]:*" in sec.allowed_hosts
+
+
+def test_fastmcp_uses_sdk_default_when_hosts_unset(tmp_path):
+    """Empty allowed_hosts ⇒ no transport_security passed; SDK default applies.
+
+    The SDK default is loopback-only, which is the right behavior for
+    purely local deployments.
+    """
+    from openzim_mcp.config import OpenZimMcpConfig
+    from openzim_mcp.server import OpenZimMcpServer
+
+    cfg = OpenZimMcpConfig(
+        allowed_directories=[str(tmp_path)],
+        transport="http",
+    )
+    server = OpenZimMcpServer(cfg)
+    # FastMCP's default sets loopback only; non-loopback hostnames absent.
+    sec = server.mcp.settings.transport_security  # type: ignore[union-attr]
+    assert sec is not None
+    assert "mcp.example.com" not in sec.allowed_hosts
+    assert "127.0.0.1:*" in sec.allowed_hosts
+
+
+def test_fastmcp_ignores_allowed_hosts_when_transport_stdio(tmp_path):
+    """allowed_hosts is HTTP-only; stdio transport doesn't surface a Host header."""
+    from openzim_mcp.config import OpenZimMcpConfig
+    from openzim_mcp.server import OpenZimMcpServer
+
+    cfg = OpenZimMcpConfig(
+        allowed_directories=[str(tmp_path)],
+        transport="stdio",
+        allowed_hosts=["mcp.example.com"],
+    )
+    server = OpenZimMcpServer(cfg)
+    sec = server.mcp.settings.transport_security  # type: ignore[union-attr]
+    # Custom host NOT applied — SDK default in effect.
+    if sec is not None:
+        assert "mcp.example.com" not in sec.allowed_hosts
+
+
 def test_serve_streamable_http_runs_safe_check_and_serves(monkeypatch, tmp_path):
     """serve_streamable_http calls check_safe_startup, builds app, runs uvicorn."""
     from openzim_mcp.http_app import serve_streamable_http


### PR DESCRIPTION
## Summary

The streamable-HTTP transport currently rejects every request with `421 Misdirected Request` (`Invalid Host header`) when openzim-mcp sits behind a reverse proxy or Tailscale serve — i.e. the deployment patterns the v1.0.0 README advertises.

**Root cause:** The MCP SDK's `TransportSecurityMiddleware` does DNS-rebinding protection by validating the `Host` header against an allowlist. FastMCP auto-defaults that allowlist to loopback only — `["127.0.0.1:*", "localhost:*", "[::1]:*"]` — and openzim-mcp instantiated `FastMCP(config.server_name)` with no `transport_security` override, leaving operators no way to add their public hostname.

**Fix:** Add `OPENZIM_MCP_ALLOWED_HOSTS: List[str]`. When the transport is HTTP and the list is non-empty, build a `TransportSecuritySettings` that retains loopback defaults *and* appends the operator's entries, then pass it to `FastMCP(...)`.

```bash
# Before — fails with 421 behind any proxy
OPENZIM_MCP_TRANSPORT=http
OPENZIM_MCP_HOST=0.0.0.0
OPENZIM_MCP_AUTH_TOKEN=...

# After — works
OPENZIM_MCP_TRANSPORT=http
OPENZIM_MCP_HOST=0.0.0.0
OPENZIM_MCP_AUTH_TOKEN=...
OPENZIM_MCP_ALLOWED_HOSTS='["zim.example.com"]'
```

Wildcard `*` rejected at startup (mirrors the `cors_origins` footgun guard). Loopback always retained so localhost-direct access keeps working alongside the proxied path. Setting is ignored when transport is stdio.

## Changes

- `openzim_mcp/config.py` — new `allowed_hosts` field with wildcard rejection + `get_config_hash()` participation
- `openzim_mcp/server.py` — passes `transport_security=TransportSecuritySettings(...)` to FastMCP when HTTP transport has hosts configured
- `tests/test_config.py` — defaults / wildcard rejection / hash sensitivity
- `tests/test_http_transport.py` — three FastMCP-introspection tests covering all three branches (hosts set, hosts unset, stdio ignores hosts)
- `docs/deployment.md` — new reference section, Tailscale + Recipe-2 examples updated, `421` failure mode added to troubleshooting
- `README.md` — config table entry

## Test plan

- [ ] CI green across all matrix entries
- [ ] After merge → release-please cuts `v1.0.1` PR → docker-publish auto-triggers (via the chain shipped in #89) → `ghcr.io/cameronrye/openzim-mcp:1.0.1` published
- [ ] Pull v1.0.1, redeploy with `OPENZIM_MCP_ALLOWED_HOSTS='["zim.owl-atlas.ts.net"]'`, confirm authed `tools/list` succeeds over Tailscale TLS

## Closes / supersedes

None — discovered while deploying v1.0.0 behind Tailscale serve.