### PR TITLE
fix(http): allow MCP-Protocol-Version header and DELETE method in CORS

### DIFF
--- a/openzim_mcp/http_app.py
+++ b/openzim_mcp/http_app.py
@@ -218,11 +218,21 @@ def apply_cors_middleware(app: Starlette, config: object) -> None:
     app.add_middleware(
         CORSMiddleware,
         allow_origins=list(origins),
-        allow_methods=["GET", "POST", "OPTIONS"],
+        # DELETE is the MCP streamable-HTTP method for explicit session
+        # termination (per the spec; see also the SDK handler in
+        # streamable_http.py: "Allow: GET, POST, DELETE"). Without it,
+        # browser preflight blocks clean session shutdown.
+        allow_methods=["GET", "POST", "OPTIONS", "DELETE"],
         # Mcp-Session-Id is sent by streamable-HTTP clients on every request
-        # after initialization to resume a session; without allowing it,
-        # browser CORS preflight rejects all session-resume requests.
-        allow_headers=["Authorization", "Content-Type", "Mcp-Session-Id"],
+        # after initialization to resume a session; MCP-Protocol-Version is
+        # sent on every post-init request per the MCP spec. Without allowing
+        # both, browser CORS preflight rejects all session-resume requests.
+        allow_headers=[
+            "Authorization",
+            "Content-Type",
+            "Mcp-Session-Id",
+            "MCP-Protocol-Version",
+        ],
         expose_headers=["Mcp-Session-Id"],
     )
 

--- a/tests/test_http_cors.py
+++ b/tests/test_http_cors.py
@@ -94,3 +94,45 @@ def test_unauthorized_response_includes_cors_headers():
     assert (
         resp.headers.get("access-control-allow-origin") == "https://allowed.example.com"
     )
+
+
+def test_cors_preflight_allows_mcp_protocol_version_header():
+    """MCP-Protocol-Version is sent on every post-init request per the MCP spec.
+
+    Without this header in allow_headers, browser preflight rejects every
+    request after the initial handshake — making the streamable-HTTP server
+    unreachable from any browser MCP client.
+    """
+    app = _build_app(["http://localhost:5173"])
+    client = TestClient(app)
+    resp = client.options(
+        "/hello",
+        headers={
+            "Origin": "http://localhost:5173",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "mcp-protocol-version",
+        },
+    )
+    assert resp.status_code == 200
+    allowed = resp.headers.get("access-control-allow-headers", "").lower()
+    assert "mcp-protocol-version" in allowed
+
+
+def test_cors_preflight_allows_delete_for_session_termination():
+    """The MCP streamable-HTTP spec defines DELETE for explicit session
+    termination (the SDK's handler advertises ``Allow: GET, POST, DELETE``).
+
+    Without DELETE in allow_methods, browser MCP clients cannot cleanly
+    end a session and must abandon it (the server eventually times it out).
+    """
+    app = _build_app(["http://localhost:5173"])
+    client = TestClient(app)
+    resp = client.options(
+        "/hello",
+        headers={
+            "Origin": "http://localhost:5173",
+            "Access-Control-Request-Method": "DELETE",
+        },
+    )
+    assert resp.status_code == 200
+    assert "DELETE" in resp.headers.get("access-control-allow-methods", "")


### PR DESCRIPTION
## Summary

- Add ``MCP-Protocol-Version`` to the CORS ``allow_headers`` list. Browser MCP clients send this header on every post-init request per the MCP spec. Without it, preflight returns 400 ``Disallowed CORS headers`` and the client connection drops.
- Add ``DELETE`` to ``allow_methods``. The MCP streamable-HTTP SDK advertises ``Allow: GET, POST, DELETE`` and uses DELETE for explicit session termination; without it, browser clients cannot cleanly end a session.

## Discovery

Wiring openzim-mcp into llama.cpp's webui MCP client surfaced both gaps. With CORS configured for the chat origin and the MCP server running locally, the first POST succeeded and the very next preflight failed with:

```
HTTP/1.1 400 Bad Request
content-type: text/plain; charset=utf-8

Disallowed CORS headers
```

Adding ``MCP-Protocol-Version`` to ``allow_headers`` unblocks the connection. The DELETE gap was found while auditing for similar issues — the MCP SDK's session-termination handler (``mcp/server/streamable_http.py:752``) is reachable from non-browser clients today, but blocked at the CORS preflight for browser clients.

## Test plan

- [x] Existing CORS tests still pass.
- [x] New preflight test asserts ``MCP-Protocol-Version`` is allowed.
- [x] New preflight test asserts ``DELETE`` is allowed.
- [x] Manually verified: with the patch applied, llama.cpp webui successfully connects to openzim-mcp over CORS and runs an agentic tool-call loop end-to-end.