### PR TITLE
fix(server): make simple mode actually expose only zim_query

### DIFF
--- a/openzim_mcp/config.py
+++ b/openzim_mcp/config.py
@@ -85,7 +85,7 @@ class OpenZimMcpConfig(BaseSettings):
         default="simple",
         description=(
             "Tool mode: 'advanced' for all 21 tools, "
-            "'simple' for 1 intelligent tool plus underlying tools"
+            "'simple' for 1 intelligent natural-language tool (zim_query)"
         ),
     )
     transport: Literal["stdio", "http", "sse"] = Field(

--- a/openzim_mcp/main.py
+++ b/openzim_mcp/main.py
@@ -43,7 +43,7 @@ Environment Variables:
         default=None,
         help=(
             f"Tool mode: 'advanced' for all 21 tools, 'simple' for 1 "
-            f"intelligent NL tool + underlying tools "
+            f"intelligent NL tool "
             f"(default: {TOOL_MODE_SIMPLE}, or from OPENZIM_MCP_TOOL_MODE env var)"
         ),
     )
@@ -123,7 +123,7 @@ def main() -> None:
         server = OpenZimMcpServer(config)
 
         mode_desc = (
-            "SIMPLE mode (1 intelligent tool + all underlying tools)"
+            "SIMPLE mode (1 intelligent tool)"
             if config.tool_mode == TOOL_MODE_SIMPLE
             else "ADVANCED mode (21 specialized tools)"
         )

--- a/openzim_mcp/server.py
+++ b/openzim_mcp/server.py
@@ -121,8 +121,7 @@ class OpenZimMcpServer:
         )
         if config.tool_mode == TOOL_MODE_SIMPLE:
             logger.info(
-                "Running in SIMPLE mode with 1 intelligent tool (zim_query) "
-                "plus all underlying tools"
+                "Running in SIMPLE mode with 1 intelligent tool (zim_query)"
             )
         else:
             logger.debug(
@@ -168,7 +167,14 @@ class OpenZimMcpServer:
         )
 
     def _register_simple_tools(self) -> None:
-        """Register simple mode tools with underlying tools for routing."""
+        """Register the single ``zim_query`` tool used in simple mode.
+
+        Simple mode exposes exactly one MCP tool. ``zim_query`` parses the
+        natural-language query, classifies its intent, and delegates to
+        ``ZimOperations`` directly — the underlying advanced-mode tools are
+        deliberately not registered, so the schema sent to the model stays
+        compact and matches the README's "simple mode = 1 tool" promise.
+        """
 
         # Register the simple wrapper tools that LLMs will primarily use
         @self.mcp.tool()
@@ -252,11 +258,7 @@ class OpenZimMcpServer:
                     context=f"Query: {query}, File: {zim_file_path}",
                 )
 
-        # Also register the advanced tools so they're available for advanced use
-        # This allows the simple mode to still have access to all functionality
-        self._register_advanced_tools()
-
-        logger.info("Simple mode tools registered (zim_query + all underlying tools)")
+        logger.info("Simple mode tools registered (zim_query only)")
 
     def _register_tools(self) -> None:
         """Register MCP tools based on configured mode."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,9 +28,17 @@ def temp_dir() -> Generator[Path, None, None]:
 
 @pytest.fixture
 def test_config(temp_dir: Path) -> OpenZimMcpConfig:
-    """Create a test configuration."""
+    """Create a test configuration with the full advanced tool surface.
+
+    Most tests exercise individual advanced-mode tools (``get_zim_entries``,
+    ``search_zim_file``, the per-entry resource handler, etc.). Pinning the
+    fixture to ``tool_mode='advanced'`` keeps those tests independent of the
+    default mode. The few tests that specifically validate simple-mode
+    behavior construct their own ``OpenZimMcpConfig`` instead.
+    """
     return OpenZimMcpConfig(
         allowed_directories=[str(temp_dir)],
+        tool_mode="advanced",
         cache=CacheConfig(enabled=True, max_size=10, ttl_seconds=60),
         content=ContentConfig(max_content_length=1000, snippet_length=100),
         logging=LoggingConfig(level="DEBUG"),
@@ -226,6 +234,7 @@ def test_config_with_zim_data(
 
     return OpenZimMcpConfig(
         allowed_directories=allowed_dirs,
+        tool_mode="advanced",
         cache=CacheConfig(enabled=True, max_size=10, ttl_seconds=60),
         content=ContentConfig(max_content_length=1000, snippet_length=100),
         logging=LoggingConfig(level="DEBUG"),

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1393,3 +1393,69 @@ class TestOpenZimMcpServerParameterValidation:
         server.zim_operations.browse_namespace.assert_called_once_with(
             "test.zim", "A", 50, 10
         )
+
+
+def _registered_tool_names(server: OpenZimMcpServer) -> set[str]:
+    """Return the set of MCP tools registered on ``server``.
+
+    FastMCP exposes the live registry via ``_tool_manager._tools`` (also used
+    by ``test_batch_get_entries``).
+    """
+    tools = (
+        server.mcp._tool_manager._tools
+        if hasattr(server.mcp, "_tool_manager")
+        else {}
+    )
+    return set(tools.keys())
+
+
+class TestToolModeRegistration:
+    """Registered tool surface must match the configured ``tool_mode``.
+
+    Simple mode advertises a single intelligent tool (``zim_query``); any
+    extra registered tool defeats the entire point of the mode (the model
+    receives every advanced tool's schema as part of the prompt, which is
+    what bloats prefill into the multi-thousand-token range observed in
+    real chat clients).
+    """
+
+    def test_simple_mode_registers_only_zim_query(
+        self, test_config: OpenZimMcpConfig
+    ):
+        """Simple mode must register exactly one tool: ``zim_query``."""
+        simple_config = test_config.model_copy(update={"tool_mode": "simple"})
+        server = OpenZimMcpServer(simple_config)
+
+        names = _registered_tool_names(server)
+        assert names == {"zim_query"}, (
+            "simple mode must expose only zim_query; "
+            f"got {sorted(names)}"
+        )
+
+    def test_advanced_mode_registers_full_tool_surface(
+        self, test_config: OpenZimMcpConfig
+    ):
+        """Advanced mode must register the full advanced tool surface,
+        and it must NOT include the simple-mode wrapper ``zim_query``.
+        """
+        # test_config now defaults to tool_mode='advanced' (see conftest).
+        assert test_config.tool_mode == "advanced"
+        server = OpenZimMcpServer(test_config)
+
+        names = _registered_tool_names(server)
+        # A representative sample of advanced-only tools that should appear.
+        for expected in (
+            "list_zim_files",
+            "search_zim_file",
+            "get_zim_entry",
+            "get_zim_metadata",
+            "browse_namespace",
+            "get_article_structure",
+        ):
+            assert expected in names, (
+                f"advanced mode missing {expected!r}; got {sorted(names)}"
+            )
+        # And the simple-only wrapper must NOT be present in advanced mode.
+        assert "zim_query" not in names, (
+            "advanced mode should not register the simple-mode wrapper"
+        )


### PR DESCRIPTION
## Summary

Simple mode is documented as a one-tool surface (``zim_query``) for LLMs that struggle with the full 21-tool catalog. In practice, ``_register_simple_tools`` *also* called ``_register_advanced_tools``, so the model received every advanced tool's schema in the prompt anyway — defeating the entire purpose of the mode and bloating prefill into the multi-thousand-token range.

This PR:

- Drops the spurious ``self._register_advanced_tools()`` call from the simple-mode path so simple mode actually registers exactly one tool.
- Updates the now-stale strings that still claimed "1 tool plus all underlying tools" in ``server.py`` log output, ``main.py`` CLI ``--mode`` help, ``main.py`` startup banner, and the ``OpenZimMcpConfig.tool_mode`` field description.
- Adds ``TestToolModeRegistration`` in ``tests/test_server.py`` with two assertions: simple mode registers exactly ``{'zim_query'}``, and advanced mode registers a representative cross-section of advanced tools (``list_zim_files``, ``search_zim_file``, ``get_zim_entry``, ``get_zim_metadata``, ``browse_namespace``, ``get_article_structure``) without ``zim_query``.

## Conftest change

The default ``test_config`` fixture now sets ``tool_mode='advanced'``. Previously the fixture defaulted to simple mode and 42 existing tests passed only because of the bug being fixed (they exercise advanced-mode tools but built their server from ``test_config``). Two fixtures (``test_config`` and ``test_config_with_zim_data``) get the explicit ``tool_mode='advanced'`` and ``TestToolModeRegistration`` constructs its own simple-mode config via ``model_copy`` for the simple-mode case.

## Discovery

While integrating openzim-mcp with llama.cpp's webui MCP client, the model's first message took ~10 minutes of prompt-eval time on a Vulkan build. Inspecting the request body showed ~6 KB of tool schemas being sent — far more than ``zim_query`` alone needs (it's ~780 tokens). Tracing the registration path led here.

## Test plan

- [x] ``uv run pytest tests/`` — 875 passed.
- [x] New ``test_simple_mode_registers_only_zim_query`` and ``test_advanced_mode_registers_full_tool_surface`` both pass.
- [x] Manually verified end-to-end against llama.cpp's MCP webui: with the fix applied, the model's prompt size dropped from ~6 200 tokens to ~1 100 tokens for a single-turn ``zim_query`` call.