### PR TITLE
chore: prep for v1.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@
 
 ---
 
-> 🆕 **NEW in v1.0.0: Streamable HTTP Transport!** Run OpenZIM MCP as a long-running service over HTTP — perfect for homelab, Tailscale, or VPS deployments. Includes bearer-token auth, multi-arch Docker images, resource subscriptions, and a [Deployment Guide](docs/deployment.md). Also new: batch entry retrieval (`get_zim_entries`), per-entry MCP resources for direct browser rendering, and an end-to-end review pass covering archive handling, content extraction, and server hygiene. [Learn more →](#whats-new-in-v100)
+> 🆕 **NEW in v1.1.0: Structured tool output!** All 17 JSON-returning tools now emit MCP `structuredContent` alongside the legacy text envelope — no more double-stringified JSON, no more escape soup. Plus a major namespace-handling fix for new-scheme archives (`list_namespaces` / `browse_namespace` / `walk_namespace` were silently broken on Wikipedia-style ZIMs), pagination for `extract_article_links`, case-insensitive `find_entry_by_title` with proper scoring, and CORS support for browser MCP clients. [Learn more →](#whats-new-in-v110)
+>
+> Still on the v1.0.0 highlights? Streamable HTTP transport, batch entry retrieval, and per-entry resources are documented in the [v1.0.0 section](#whats-new-in-v100).
 
 > **Dual Mode Support:** Choose between Simple mode (1 intelligent natural language tool, default) or Advanced mode (21 specialized tools, plus 3 MCP prompts and 3 MCP resources) to match your LLM's capabilities.
 
@@ -80,6 +82,53 @@ Whether you're building a research assistant, knowledge chatbot, or content anal
 - **Configurable**: Flexible configuration with validation
 - **Observable**: Structured logging and health monitoring
 
+## What's new in v1.1.0
+
+### Structured tool output
+
+The 17 JSON-returning tools now emit MCP `structuredContent` alongside the legacy `content[].text` envelope. Old clients keep parsing the text JSON; new clients read the dict directly. The biggest beneficiary is `search_all`, whose `per_file[].result` field used to be a pre-rendered markdown blob escaped twice through `json.dumps` — it's now a real nested dict.
+
+The four prose/markdown tools (`search_zim_file`, `search_with_filters`, `get_zim_entry`, `get_main_page`) and the simple-mode `zim_query` stay on `-> str` by design.
+
+### Namespace handling, fixed
+
+In new-scheme ZIM archives (the modern format used by current Kiwix Wikipedia builds), libzim's iterable surface only exposes the C namespace and reaches metadata through `archive.metadata_keys`. The previous code parsed the first character of each entry path *as* the namespace, so `Evolution` looked like namespace `'E'`, `Bob_Dylan` like `'B'`, `favicon.png` like `'F'` — including emoji buckets like `'🐜'`. `search_with_filters(namespace='C')` was silently dropping ~95% of legitimate hits.
+
+`list_namespaces`, `browse_namespace`, `walk_namespace`, and the `namespace=` filter now branch on `archive.has_new_namespace_scheme`: new-scheme C uses `entry_count` as an authoritative total, M is enumerated from `metadata_keys`, W is surfaced via `has_main_entry` / `has_illustration`. Old-scheme archives are unaffected.
+
+### Pagination for `extract_article_links`
+
+`extract_article_links` previously dumped every internal/external/media link in one call. On a heavily-linked Wikipedia article (~6k links) that was ~400 KB and overflowed the response token budget. The tool now accepts `limit` / `offset` / `kind` parameters; full counts ship in `total_internal_links` / `total_external_links` / `total_media_links` so callers can size the next page. Parsed extraction is cached once per entry and sliced in-memory (~40× speedup on cached pages).
+
+### Smarter `find_entry_by_title`
+
+The fast path was case-sensitive, so `"evolution"` against an archive titled `"Evolution"` missed and fell through to suggestion fallback with a hardcoded `score: 0.8`. Now the fast path tries five case variants × C/A namespaces; suggestion results get rank-derived scores in (0, 0.95] so an exact case-insensitive match (promoted to 1.0) always outranks partials.
+
+### Per-entry resource size caps
+
+`zim://{name}/entry/{path}` now caps text bodies at 256 KB UTF-8 with a notice pointing at `get_zim_entry` for paged reads. Oversize binary bodies are *refused* (not silently clipped, since a sliced PDF/PNG won't open) — callers should use `get_binary_entry`, which has explicit `max_size_bytes` and a `truncated` flag.
+
+### Simple mode actually works
+
+`_register_simple_tools` was also calling `_register_advanced_tools`, so simple-mode clients received every advanced tool's schema in the prompt anyway — defeating the entire point of the mode and inflating prefill into the multi-thousand-token range. Fixed: simple mode now registers exactly one tool (`zim_query`). Confirmed against llama.cpp's MCP webui — single-turn prompt size dropped from ~6,200 tokens to ~1,100.
+
+### CORS for browser MCP clients
+
+Two additions to the HTTP transport's CORS layer:
+
+- `MCP-Protocol-Version` is now in `allow_headers`. Browser MCP clients send this on every post-init request per the MCP spec; without it, the second preflight returned `400 Disallowed CORS headers` and the connection dropped.
+- `DELETE` is now in `allow_methods`. The MCP streamable-HTTP SDK uses DELETE for explicit session termination.
+
+### Polish
+
+- `get_server_health` now reports a real `started_at` and `uptime_seconds` instead of `"unknown"`.
+- Configuration redaction format changed from the misleading `...data` to unambiguous `<redacted>/data`.
+- Server-tools timestamps go through a single `_utc_now_iso()` helper so a response no longer mixes timezone-aware UTC with naive local.
+- `zim_query("")` rejects empty input upfront with example queries instead of falling through to a no-op search.
+- `get_search_suggestions` schema now documents the 2-character minimum.
+- The "cache hit rate is low" warning waits until ≥50 accesses before commenting (previously fired at 22% during normal session warm-up).
+- `get_zim_entry`'s truncation tail now reads "of body content" so callers can tell the limit applies to the body, not the wrapper headers.
+
 ## What's new in v1.0.0
 
 ### Streamable HTTP transport
@@ -90,7 +139,7 @@ Run OpenZIM MCP as a long-running service. Pass `--transport http` (or set `OPEN
 - **Safe-default startup check** — the server *refuses* to bind a non-localhost host without a token. (Bind `127.0.0.1` for local-only access; put a reverse proxy in front for TLS.)
 - **CORS allow-list** — explicit origins via `OPENZIM_MCP_CORS_ORIGINS`; wildcard `*` is rejected at startup.
 - **Health endpoints** — `/healthz` (liveness) and `/readyz` (at least one allowed dir is readable). Both exempt from auth so probes work cleanly.
-- **Multi-arch Docker image** — `ghcr.io/cameronrye/openzim-mcp:1.0.0`, builds for `linux/amd64` and `linux/arm64`, runs as non-root.
+- **Multi-arch Docker image** — `ghcr.io/cameronrye/openzim-mcp:1.1.0`, builds for `linux/amd64` and `linux/arm64`, runs as non-root.
 
 Legacy SSE transport is also available via `--transport sse` (or `OPENZIM_MCP_TRANSPORT=sse`) for clients that haven't migrated to streamable-HTTP. SSE does **not** apply the bearer-token / CORS / health-endpoint middleware, so the server *refuses* to start with `--transport sse` bound to anything other than `127.0.0.1`/`::1`/`localhost`. For exposed deployments use `--transport http`.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ We actively support the following versions of OpenZIM MCP with security updates:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.0.x   | Yes                |
-| < 1.0   | No                 |
+| 1.1.x   | Yes                |
+| < 1.1   | No                 |
 
 ## Reporting a Vulnerability
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -107,7 +107,7 @@ This recipe puts OpenZIM MCP on a single host, reachable from the rest of your L
 ```yaml
 services:
   openzim-mcp:
-    image: ghcr.io/cameronrye/openzim-mcp:1.0.0
+    image: ghcr.io/cameronrye/openzim-mcp:1.1.0
     restart: unless-stopped
     ports:
       - "127.0.0.1:8000:8000"
@@ -119,7 +119,7 @@ services:
 
 What's intentional here:
 
-- **Pinned tag** (`:1.0.0`, not `:latest`). Upgrades are deliberate — `docker compose pull` is a thing you do, not a thing that happens to you.
+- **Pinned tag** (`:1.1.0`, not `:latest`). Upgrades are deliberate — `docker compose pull` is a thing you do, not a thing that happens to you.
 - **Host port bound to `127.0.0.1`**. The container listens on all interfaces (the image's default `OPENZIM_MCP_HOST=0.0.0.0`), but Docker's port publish restricts external exposure to loopback. The Tailscale variant below lifts this restriction by binding to a specific interface.
 - **Read-only ZIM mount** (`:ro`). The server only reads ZIM files; mounting read-only ensures a server compromise can't damage them.
 - **Token via env, not hard-coded.** Put it in a `.env` file next to the compose file (and add `.env` to `.gitignore`). The image's defaults already set `TRANSPORT=http`, `HOST=0.0.0.0`, `PORT=8000`, so they're not repeated here.
@@ -227,7 +227,7 @@ This is the LAN compose file with two changes: a `caddy` service is added, and t
 ```yaml
 services:
   openzim-mcp:
-    image: ghcr.io/cameronrye/openzim-mcp:1.0.0
+    image: ghcr.io/cameronrye/openzim-mcp:1.1.0
     restart: unless-stopped
     expose:
       - "8000"
@@ -313,7 +313,7 @@ docker compose pull
 docker compose up -d
 ```
 
-The image tag in `docker-compose.yml` is pinned (`:1.0.0`) — change it to the new version before pulling. Pinning is deliberate: `:latest` makes upgrades a surprise, and the v1 release notes (or future v1.x release notes) tell you when an upgrade involves a breaking change.
+The image tag in `docker-compose.yml` is pinned (`:1.1.0`) — change it to the new version before pulling. Pinning is deliberate: `:latest` makes upgrades a surprise, and the v1 release notes (or future v1.x release notes) tell you when an upgrade involves a breaking change.
 
 ### Watching logs
 

--- a/openzim_mcp/tools/resource_tools.py
+++ b/openzim_mcp/tools/resource_tools.py
@@ -175,14 +175,20 @@ class ZimEntryResource(Resource):
             # Cap text bodies so an 800 KB Wikipedia article doesn't overrun
             # the response token budget. The notice points callers at the
             # paged get_zim_entry tool for the rest.
-            decoded = raw.decode("utf-8", errors="replace")
-            if len(decoded.encode("utf-8")) > DEFAULT_RESOURCE_MAX_BYTES:
+            # Cap-cross check uses raw byte length so the decoded string
+            # isn't re-encoded twice on the hot path (once here, again in
+            # _truncate_text_body). For valid UTF-8 the counts match
+            # exactly; for invalid input the diagnostic log might miss
+            # bodies that only cross the cap after errors="replace"
+            # expansion — _truncate_text_body still truncates correctly.
+            if len(raw) > DEFAULT_RESOURCE_MAX_BYTES:
                 logger.info(
                     "Resource %s truncated: %d bytes -> %d byte cap",
                     self.entry_path,
                     len(raw),
                     DEFAULT_RESOURCE_MAX_BYTES,
                 )
+            decoded = raw.decode("utf-8", errors="replace")
             return _truncate_text_body(decoded, DEFAULT_RESOURCE_MAX_BYTES)
         # Binary — FastMCP base64-wraps when content is bytes. Truncating a
         # binary body silently corrupts it (a clipped PDF / PNG won't open),

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -650,7 +650,13 @@ class _StructureMixin:
                 if len(outbound) >= limit:
                     break
             result["outbound_results"] = outbound
-        except Exception as e:
+        except OpenZimMcpArchiveError as e:
+            # Partial-success contract: an archive- or extraction-level
+            # failure surfaces as an empty result with an error string,
+            # not a hard tool error. Programming errors (TypeError,
+            # AttributeError, etc.) are intentionally NOT caught here
+            # so they propagate up to the tool layer and become real
+            # tool_error envelopes instead of fake successes.
             logger.debug(f"get_related_articles outbound failed: {e}")
             result["outbound_results"] = []
             result["outbound_error"] = str(e)

--- a/tests/test_get_related_articles.py
+++ b/tests/test_get_related_articles.py
@@ -56,6 +56,44 @@ class TestGetRelatedArticles:
                 "/zim/test.zim", "C/Source", limit=0
             )
 
+    def test_archive_error_swallowed_into_outbound_error(
+        self, server: OpenZimMcpServer
+    ):
+        """Archive-level failures surface as outbound_error, not as a raise.
+
+        Partial-success contract: callers get an empty outbound_results
+        list plus an outbound_error string, so a successful entry header
+        still ships even when link extraction fails.
+        """
+        from openzim_mcp.exceptions import OpenZimMcpArchiveError
+
+        server.zim_operations.extract_article_links_data = MagicMock(
+            side_effect=OpenZimMcpArchiveError("entry not found")
+        )
+
+        result = server.zim_operations.get_related_articles_data(
+            "/zim/test.zim", "C/Missing", limit=10
+        )
+        assert result["outbound_results"] == []
+        assert "entry not found" in result["outbound_error"]
+
+    def test_unexpected_exception_propagates(self, server: OpenZimMcpServer):
+        """Programming errors (e.g. TypeError) must NOT be swallowed.
+
+        Previously this method caught bare ``Exception``, so a real bug
+        in the link-extraction path would surface as a successful-looking
+        response with the bug message embedded as a string. Narrowed to
+        ``OpenZimMcpArchiveError`` so genuine programming errors bubble
+        up to the tool layer's ``tool_error`` envelope instead.
+        """
+        server.zim_operations.extract_article_links_data = MagicMock(
+            side_effect=TypeError("boom")
+        )
+        with pytest.raises(TypeError, match="boom"):
+            server.zim_operations.get_related_articles_data(
+                "/zim/test.zim", "C/Source", limit=10
+            )
+
 
 class TestResolveLinkToEntryPath:
     """Test ``_resolve_link_to_entry_path`` static helper.

--- a/website/assets/og-image.svg
+++ b/website/assets/og-image.svg
@@ -30,6 +30,6 @@
   </g>
 
   <text x="600" y="500" font-family="Geist, Inter, system-ui, sans-serif" font-size="68" font-weight="600" fill="#F5F1E8" text-anchor="middle" letter-spacing="-1">OpenZIM MCP</text>
-  <text x="600" y="552" font-family="JetBrains Mono, ui-monospace, monospace" font-size="22" fill="#FFD24A" text-anchor="middle" letter-spacing="2">MCP SERVER · v1.0.0</text>
+  <text x="600" y="552" font-family="JetBrains Mono, ui-monospace, monospace" font-size="22" fill="#FFD24A" text-anchor="middle" letter-spacing="2">MCP SERVER · v1.1.0</text>
   <text x="600" y="590" font-family="Geist, Inter, system-ui, sans-serif" font-size="20" fill="#7A8499" text-anchor="middle">Knowledge that works offline.</text>
 </svg>

--- a/website/humans.txt
+++ b/website/humans.txt
@@ -64,4 +64,4 @@
     Language: English
     Doctype: HTML5
     IDE: Various (VS Code, Vim, etc.)
-    Version: 1.0.0
+    Version: 1.1.0

--- a/website/index.html
+++ b/website/index.html
@@ -20,14 +20,14 @@
   <meta property="og:site_name" content="OpenZIM MCP">
   <meta property="og:url" content="https://cameronrye.github.io/openzim-mcp/">
   <meta property="og:title" content="OpenZIM MCP — Knowledge that works offline">
-  <meta property="og:description" content="MCP server for offline ZIM-archive access. Streamable HTTP, batch retrieval, per-entry resources, subscriptions. v1.0.0.">
+  <meta property="og:description" content="MCP server for offline ZIM-archive access. Streamable HTTP, batch retrieval, per-entry resources, subscriptions. v1.1.0.">
   <meta property="og:image" content="https://cameronrye.github.io/openzim-mcp/assets/og-image.svg">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:alt" content="OpenZIM MCP 1.0 — Knowledge that works offline">
   <meta property="og:locale" content="en_US">
   <meta property="article:author" content="Cameron Rye">
-  <meta property="article:modified_time" content="2026-05-03T00:00:00Z">
+  <meta property="article:modified_time" content="2026-05-05T00:00:00Z">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -35,7 +35,7 @@
   <meta name="twitter:creator" content="@cameronrye">
   <meta name="twitter:url" content="https://cameronrye.github.io/openzim-mcp/">
   <meta name="twitter:title" content="OpenZIM MCP — Knowledge that works offline">
-  <meta name="twitter:description" content="MCP server for offline ZIM-archive access. Streamable HTTP, batch retrieval, per-entry resources, subscriptions. v1.0.0.">
+  <meta name="twitter:description" content="MCP server for offline ZIM-archive access. Streamable HTTP, batch retrieval, per-entry resources, subscriptions. v1.1.0.">
   <meta name="twitter:image" content="https://cameronrye.github.io/openzim-mcp/assets/og-image.svg">
   <meta name="twitter:image:alt" content="OpenZIM MCP 1.0 — Knowledge that works offline">
 
@@ -72,7 +72,7 @@
     "alternateName": "OpenZIM MCP Server",
     "description": "A modern, secure MCP server that enables AI models to access and search ZIM format knowledge bases offline with intelligent, structured access patterns",
     "url": "https://cameronrye.github.io/openzim-mcp/",
-    "softwareVersion": "1.0.0",
+    "softwareVersion": "1.1.0",
     "releaseNotes": "https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md",
     "applicationCategory": "DeveloperApplication",
     "applicationSubCategory": "AI Tools",
@@ -182,7 +182,7 @@
     <section id="hero" class="hero">
       <div class="container hero__inner">
         <div class="hero__content">
-          <span class="eyebrow">MCP&nbsp;SERVER · v1.0.0</span>
+          <span class="eyebrow">MCP&nbsp;SERVER · v1.1.0</span>
           <h1 class="hero__title">Knowledge that works offline.</h1>
           <p class="hero__lead">
             OpenZIM MCP gives any AI model structured, secure access to ZIM archives —
@@ -204,7 +204,7 @@
             </button>
           </div>
           <ul class="hero__stats">
-            <li><span class="hero__stat-num">v1.0.0</span><span class="hero__stat-label">Latest release</span></li>
+            <li><span class="hero__stat-num">v1.1.0</span><span class="hero__stat-label">Latest release</span></li>
             <li><span class="hero__stat-num">1 + 21</span><span class="hero__stat-label">Simple / advanced tools</span></li>
             <li><span class="hero__stat-num">80%+</span><span class="hero__stat-label">Test coverage</span></li>
             <li><span class="hero__stat-num">MIT</span><span class="hero__stat-label">License</span></li>
@@ -333,7 +333,7 @@
             <pre><code>docker run -p 8000:8000 \
   -e OPENZIM_MCP_AUTH_TOKEN="$TOKEN" \
   -v /path/to/zim:/data:ro \
-  ghcr.io/cameronrye/openzim-mcp:1.0.0 \
+  ghcr.io/cameronrye/openzim-mcp:1.1.0 \
   --transport http --host 0.0.0.0 /data</code></pre>
           </li>
 
@@ -447,7 +447,7 @@ zim://gutenberg/entry/I%2Fbook_cover.jpg
                 <pre><code>uv tool install openzim-mcp</code></pre>
               </div>
               <div class="tabs__panel" id="install-docker" role="tabpanel" aria-labelledby="tab-install-docker" hidden>
-                <pre><code>docker pull ghcr.io/cameronrye/openzim-mcp:1.0.0</code></pre>
+                <pre><code>docker pull ghcr.io/cameronrye/openzim-mcp:1.1.0</code></pre>
               </div>
               <div class="tabs__panel" id="install-source" role="tabpanel" aria-labelledby="tab-install-source" hidden>
                 <pre><code>git clone https://github.com/cameronrye/openzim-mcp.git

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -6,7 +6,7 @@
 
 OpenZIM MCP is a Model Context Protocol (MCP) server that enables AI models to access and search ZIM format knowledge bases offline. It provides intelligent, structured access patterns that LLMs need to effectively navigate vast knowledge repositories like Wikipedia, Wiktionary, and other offline content archives.
 
-**Version**: 1.0.0 <!-- x-release-please-version -->
+**Version**: 1.1.0 <!-- x-release-please-version -->
 **License**: MIT
 **Python**: 3.12+
 **Repository**: https://github.com/cameronrye/openzim-mcp


### PR DESCRIPTION
Companion to release-please PR #95 (`chore(main): release 1.1.0`). Picks up the loose ends release-please can't handle on its own — version stamps in docs/website, supported-versions table, marquee README copy — plus two small follow-ups from a bug-hunt review of the v1.0.1 → v1.1.0 diff.

## Commits

### `7ac722e docs: refresh README, deployment, and SECURITY for v1.1.0`
- New "What's new in v1.1.0" section in README (structured tool output, namespace fix, link pagination, find-by-title scoring, resource caps, simple-mode fix, CORS additions); v1.0.0 section preserved below
- Lead callout rewritten for v1.1.0 highlights
- Pinned Docker image tags `:1.0.0` → `:1.1.0` in both deployment compose recipes (LAN + VPS)
- `SECURITY.md` supported-versions table updated to `1.1.x`

### `bfec4c1 perf(resources): avoid redundant UTF-8 re-encode in size check`
Per-entry resource read previously encoded the decoded body twice on every request — once at the call site for the cap check, then again inside `_truncate_text_body` for slicing. Cap check now uses raw byte length, eliminating one full-body allocation per read on the HTTP hot path.

### `a8ab322 fix(structure): narrow get_related_articles error catch from bare Exception`
`get_related_articles_data` previously caught bare `Exception`, so a programming bug (TypeError, AttributeError) surfaced as a successful-looking response with the bug message embedded as `outbound_error` instead of a real `tool_error` envelope. Narrowed to `OpenZimMcpArchiveError` — the partial-success contract for archive/extraction failures stays intact, but real bugs propagate. Two new tests pin both behaviors.

### `dacdcf1 docs(website): bump version refs from 1.0.0 to 1.1.0`
Marketing site updates: hero eyebrow + "Latest release" stat, og/twitter meta, JSON-LD `softwareVersion`, `article:modified_time`, embedded Docker pull commands, og-image SVG, `humans.txt`, `llms.txt`. The "1.0 release" editorial section is intentionally kept — it celebrates the v1 milestone, not the latest patch.

## Known follow-up (not addressed in this PR)

`website/llms.txt` has an `<!-- x-release-please-version -->` marker and is listed under `extra-files` in `release-please-config.json`, but release-please isn't applying the bump (the file stayed at 1.0.0 through the v1.0.1 release too). Likely a `generic` updater drift issue. Bumped manually here; worth a separate config investigation.

## Verification

- `make lint` — clean (96 files)
- `make type-check` — clean (mypy, 38 source files)
- `make security` — bandit 0 findings, pip-audit no known vulnerabilities
- `uv run pytest` — 946 passed, 27 deselected (live/docker markers)
- `website/validate.py` — all checks pass

## Merge order

This should land **before** PR #95. Once merged to main, release-please will refresh PR #95 to include the `perf:` and `fix:` commits in the v1.1.0 CHANGELOG automatically.