### PR TITLE
fix: walk_namespace, related-articles, and confidence beta-refinement fixes

### DIFF
--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -76,13 +76,7 @@ class SimpleToolsHandler:
                 f"confidence: {confidence:.2f}"
             )
 
-            low_confidence_note = ""
-            if confidence < 0.6:
-                low_confidence_note = (
-                    "\n\n*Note: This query interpretation has moderate confidence. "
-                    "If the results aren't what you expected, "
-                    "try rephrasing your query.*\n"
-                )
+            low_confidence_note = self._confidence_note(intent, confidence)
 
             # ``list_files`` is the only intent that doesn't need a ZIM file.
             if intent == "list_files":
@@ -121,6 +115,33 @@ class SimpleToolsHandler:
                 f"3. Try a simpler query\n"
                 f"4. Check server logs for details"
             )
+
+    @staticmethod
+    def _confidence_note(intent: str, confidence: float) -> str:
+        """Render a confidence note tier-appropriate for the parsed intent.
+
+        Tiers:
+          * < 0.55 — "low confidence". Names the interpreted intent so the
+            caller can spot fallbacks (e.g. ``"tell me a joke"`` lands on
+            the search-fallback at confidence 0.5; saying the result is
+            "moderate confidence" understates that nothing matched).
+          * 0.55–0.7 — "moderate confidence" (legacy wording).
+          * >= 0.7 — no note (well-calibrated, don't pester).
+        """
+        if confidence < 0.55:
+            return (
+                "\n\n*Note: Low confidence in query interpretation "
+                f"(interpreted as `{intent}`). "
+                "Try rephrasing your query if the results aren't what "
+                "you expected.*\n"
+            )
+        if confidence < 0.7:
+            return (
+                "\n\n*Note: This query interpretation has moderate confidence. "
+                "If the results aren't what you expected, "
+                "try rephrasing your query.*\n"
+            )
+        return ""
 
     # ---------------------------------------------------------------- handlers
 

--- a/openzim_mcp/tools/navigation_tools.py
+++ b/openzim_mcp/tools/navigation_tools.py
@@ -159,8 +159,15 @@ def _register_walk_namespace(server: "OpenZimMcpServer") -> None:
         Returns:
             Dict with keys: namespace, cursor, limit, returned_count,
             scanned_count, next_cursor, done, scanned_through_id,
-            total_entries, entries. On failure, returns a
-            ``{"error": True, ...}`` envelope (see ``responses.tool_error``).
+            archive_entry_count, total_in_namespace,
+            total_in_namespace_is_lower_bound, total_entries, entries.
+            ``archive_entry_count`` is the file-level entry count;
+            ``total_in_namespace`` is the namespace-specific count (None
+            when not derivable without a full scan, i.e. old-scheme
+            archives). ``total_entries`` is a deprecated alias of
+            ``archive_entry_count`` retained for v1.1.0 callers.
+            On failure, returns a ``{"error": True, ...}`` envelope (see
+            ``responses.tool_error``).
         """
         try:
             try:

--- a/openzim_mcp/tools/structure_tools.py
+++ b/openzim_mcp/tools/structure_tools.py
@@ -424,8 +424,13 @@ def _register_get_related_articles(server: "OpenZimMcpServer") -> None:
 
         Returns:
             Dict with ``entry_path`` and ``outbound_results`` (a list of
-            ``{path, title}`` records). On failure, returns a
-            ``{"error": True, ...}`` envelope (see ``responses.tool_error``).
+            ``{path, title, link_text}`` records). ``title`` is the linked
+            entry's actual archive title (resolved by archive lookup;
+            falls back to ``path`` when the entry is missing). ``link_text``
+            is the original anchor text from the source article — useful
+            when the source article links to the target with a different
+            display string. On failure, returns a ``{"error": True, ...}``
+            envelope (see ``responses.tool_error``).
         """
         try:
             try:

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -1034,12 +1034,17 @@ class _NamespaceMixin:
                 # Namespace count is only authoritative for new-scheme C
                 # (iterator emits exactly C). Old-scheme would need a full
                 # archive scan to derive it; report None rather than mislead.
+                # ``is_lower_bound`` is meaningless when the count is None,
+                # so report None there too — saying ``False`` alongside a
+                # null count would read as "this null is the exact count".
+                total_in_namespace: Optional[int]
+                is_lower_bound: Optional[bool]
                 if has_new_scheme:
-                    total_in_namespace: Optional[int] = archive_entry_count
+                    total_in_namespace = archive_entry_count
                     is_lower_bound = False
                 else:
                     total_in_namespace = None
-                    is_lower_bound = False
+                    is_lower_bound = None
 
                 return self._build_walk_result(
                     namespace=namespace,
@@ -1072,13 +1077,16 @@ class _NamespaceMixin:
         next_cursor: Optional[int],
         archive_entry_count: int,
         total_in_namespace: Optional[int],
-        total_in_namespace_is_lower_bound: bool,
+        total_in_namespace_is_lower_bound: Optional[bool],
     ) -> Dict[str, Any]:
         """Assemble the walk_namespace result dict.
 
         ``archive_entry_count`` is the file-level entry count.
         ``total_in_namespace`` is the namespace-specific count (None when
         not derivable without a full scan, e.g. old-scheme archives).
+        ``total_in_namespace_is_lower_bound`` is False when authoritative,
+        True when sampling-derived, None when ``total_in_namespace`` is
+        also None (no count means no lower-bound semantics).
         ``total_entries`` is kept as a deprecated alias of
         ``archive_entry_count`` for v1.1.0 callers; remove in a future major.
         """

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -974,34 +974,37 @@ class _NamespaceMixin:
             with _zim_ops_mod.zim_archive(validated) as archive:
                 has_new_scheme = getattr(archive, "has_new_namespace_scheme", False)
 
+                archive_entry_count = archive.entry_count
+
                 # New-scheme M is sourced from metadata_keys, not the entry
                 # iterator (which only surfaces C). Hand the request to a
                 # dedicated walker so callers see real metadata entries
                 # instead of zero matches after a full archive scan.
                 if has_new_scheme and namespace == "M":
-                    return self._walk_new_scheme_metadata(archive, cursor, limit)
+                    return self._walk_new_scheme_metadata(
+                        archive, cursor, limit, archive_entry_count
+                    )
                 # Other-than-C namespaces in new-scheme aren't on the
                 # iterable surface; short-circuit so callers don't pay the
                 # full-archive scan to discover that.
                 if has_new_scheme and namespace != "C":
-                    result = {
-                        "namespace": namespace,
-                        "cursor": cursor,
-                        "limit": limit,
-                        "returned_count": 0,
-                        "scanned_count": 0,
-                        "next_cursor": None,
-                        "done": True,
-                        "scanned_through_id": None,
-                        "total_entries": archive.entry_count,
-                        "entries": [],
-                    }
-                    return result
+                    return self._build_walk_result(
+                        namespace=namespace,
+                        cursor=cursor,
+                        limit=limit,
+                        entries=[],
+                        scanned_count=0,
+                        scanned_through_id=None,
+                        done=True,
+                        next_cursor=None,
+                        archive_entry_count=archive_entry_count,
+                        total_in_namespace=0,
+                        total_in_namespace_is_lower_bound=False,
+                    )
 
-                total = archive.entry_count
                 entries: List[Dict[str, Any]] = []
                 entry_id = cursor
-                while entry_id < total and len(entries) < limit:
+                while entry_id < archive_entry_count and len(entries) < limit:
                     try:
                         entry = archive._get_entry_by_id(entry_id)
                         path = entry.path
@@ -1021,33 +1024,87 @@ class _NamespaceMixin:
                         logger.debug(f"walk_namespace: entry {entry_id} skipped: {e}")
                     entry_id += 1
 
-                done = entry_id >= total
+                done = entry_id >= archive_entry_count
                 next_cursor = None if done else entry_id
                 # scanned_through_id reflects the last ID we examined regardless
                 # of whether it matched the filter. None if we never entered the
                 # loop (cursor was already past the end).
                 scanned_through_id = entry_id - 1 if entry_id > cursor else None
-                result = {
-                    "namespace": namespace,
-                    "cursor": cursor,
-                    "limit": limit,
-                    "returned_count": len(entries),
-                    "scanned_count": entry_id - cursor,
-                    "next_cursor": next_cursor,
-                    "done": done,
-                    "scanned_through_id": scanned_through_id,
-                    "total_entries": total,
-                    "entries": entries,
-                }
-                return result
+
+                # Namespace count is only authoritative for new-scheme C
+                # (iterator emits exactly C). Old-scheme would need a full
+                # archive scan to derive it; report None rather than mislead.
+                if has_new_scheme:
+                    total_in_namespace: Optional[int] = archive_entry_count
+                    is_lower_bound = False
+                else:
+                    total_in_namespace = None
+                    is_lower_bound = False
+
+                return self._build_walk_result(
+                    namespace=namespace,
+                    cursor=cursor,
+                    limit=limit,
+                    entries=entries,
+                    scanned_count=entry_id - cursor,
+                    scanned_through_id=scanned_through_id,
+                    done=done,
+                    next_cursor=next_cursor,
+                    archive_entry_count=archive_entry_count,
+                    total_in_namespace=total_in_namespace,
+                    total_in_namespace_is_lower_bound=is_lower_bound,
+                )
         except OpenZimMcpArchiveError:
             raise
         except Exception as e:
             raise OpenZimMcpArchiveError(f"walk_namespace failed: {e}") from e
 
     @staticmethod
+    def _build_walk_result(
+        *,
+        namespace: str,
+        cursor: int,
+        limit: int,
+        entries: List[Dict[str, Any]],
+        scanned_count: int,
+        scanned_through_id: Optional[int],
+        done: bool,
+        next_cursor: Optional[int],
+        archive_entry_count: int,
+        total_in_namespace: Optional[int],
+        total_in_namespace_is_lower_bound: bool,
+    ) -> Dict[str, Any]:
+        """Assemble the walk_namespace result dict.
+
+        ``archive_entry_count`` is the file-level entry count.
+        ``total_in_namespace`` is the namespace-specific count (None when
+        not derivable without a full scan, e.g. old-scheme archives).
+        ``total_entries`` is kept as a deprecated alias of
+        ``archive_entry_count`` for v1.1.0 callers; remove in a future major.
+        """
+        return {
+            "namespace": namespace,
+            "cursor": cursor,
+            "limit": limit,
+            "returned_count": len(entries),
+            "scanned_count": scanned_count,
+            "next_cursor": next_cursor,
+            "done": done,
+            "scanned_through_id": scanned_through_id,
+            "archive_entry_count": archive_entry_count,
+            "total_in_namespace": total_in_namespace,
+            "total_in_namespace_is_lower_bound": total_in_namespace_is_lower_bound,
+            "total_entries": archive_entry_count,  # deprecated alias
+            "entries": entries,
+        }
+
+    @classmethod
     def _walk_new_scheme_metadata(
-        archive: Archive, cursor: int, limit: int
+        cls,
+        archive: Archive,
+        cursor: int,
+        limit: int,
+        archive_entry_count: int,
     ) -> Dict[str, Any]:
         """Walk M (metadata) entries in a new-scheme archive via metadata_keys."""
         try:
@@ -1060,19 +1117,19 @@ class _NamespaceMixin:
         end = min(start + limit, total)
         entries = [{"path": f"M/{k}", "title": k} for k in keys[start:end]]
         done = end >= total
-        result: Dict[str, Any] = {
-            "namespace": "M",
-            "cursor": cursor,
-            "limit": limit,
-            "returned_count": len(entries),
-            "scanned_count": end - start,
-            "next_cursor": None if done else end,
-            "done": done,
-            "scanned_through_id": end - 1 if end > start else None,
-            "total_entries": total,
-            "entries": entries,
-        }
-        return result
+        return cls._build_walk_result(
+            namespace="M",
+            cursor=cursor,
+            limit=limit,
+            entries=entries,
+            scanned_count=end - start,
+            scanned_through_id=end - 1 if end > start else None,
+            done=done,
+            next_cursor=None if done else end,
+            archive_entry_count=archive_entry_count,
+            total_in_namespace=total,
+            total_in_namespace_is_lower_bound=False,
+        )
 
     def walk_namespace(
         self,

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -612,6 +612,14 @@ class _StructureMixin:
 
         Returns the result dict directly (not a JSON string) so MCP tools
         can hand it straight to FastMCP's structured-content path.
+
+        Each outbound result carries:
+
+        - ``path``: the resolved ZIM entry path of the link target.
+        - ``title``: the linked entry's actual archive title (resolved by
+          looking up ``path`` in the archive). Falls back to ``path`` when
+          the entry is missing or the lookup fails.
+        - ``link_text``: the original anchor text from the source article.
         """
         if limit < 1 or limit > 100:
             raise OpenZimMcpValidationError(
@@ -645,10 +653,19 @@ class _StructureMixin:
                 ):
                     continue
                 seen.add(target)
-                title = link.get("text") or link.get("title") or target
-                outbound.append({"path": target, "title": title})
+                outbound.append(
+                    {
+                        "path": target,
+                        # Placeholder; resolved via archive lookup below
+                        # under a single archive open so we don't pay one
+                        # open per result.
+                        "title": target,
+                        "link_text": link.get("text") or link.get("title") or "",
+                    }
+                )
                 if len(outbound) >= limit:
                     break
+            self._resolve_outbound_titles(zim_file_path, outbound)
             result["outbound_results"] = outbound
         except OpenZimMcpArchiveError as e:
             # Partial-success contract: an archive- or extraction-level
@@ -662,6 +679,32 @@ class _StructureMixin:
             result["outbound_error"] = str(e)
 
         return result
+
+    @staticmethod
+    def _resolve_outbound_titles(
+        zim_file_path: str, outbound: List[Dict[str, Any]]
+    ) -> None:
+        """Fill in each outbound entry's ``title`` from its archive title.
+
+        Single archive open shared across all entries (limit ≤ 100). On any
+        per-entry lookup failure the title stays at its placeholder (path)
+        so callers always see a non-empty string. A failure to open the
+        archive at all is also non-fatal — leave placeholders in place.
+        """
+        if not outbound:
+            return
+        try:
+            with _zim_ops_mod.zim_archive(Path(zim_file_path)) as archive:
+                for item in outbound:
+                    try:
+                        entry = archive.get_entry_by_path(item["path"])
+                        title = getattr(entry, "title", None)
+                        if title:
+                            item["title"] = title
+                    except Exception as e:
+                        logger.debug(f"title lookup for {item['path']} failed: {e}")
+        except Exception as e:
+            logger.debug(f"archive open for title resolution failed: {e}")
 
     def get_related_articles(
         self,

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -626,13 +626,23 @@ class _StructureMixin:
                 f"limit must be between 1 and 100 (provided: {limit})"
             )
 
+        # Resolve the path once so both link extraction and the title
+        # resolution archive open use the same canonical absolute path.
+        # Without this, ``~/zims/foo.zim`` opens fine for link extraction
+        # (validated inside extract_article_links_data) but silently fails
+        # in _resolve_outbound_titles, which would otherwise call
+        # ``Path("~/zims/foo.zim")`` directly — Path does not expand ``~``.
+        validated_path = self.path_validator.validate_path(zim_file_path)
+        validated_path = self.path_validator.validate_zim_file(validated_path)
+        validated_str = str(validated_path)
+
         result: Dict[str, Any] = {"entry_path": entry_path}
 
         try:
             # Use the dict-returning extract_article_links_data so we don't
             # round-trip through json.dumps + json.loads just to walk the
             # outbound link graph.
-            links_data = self.extract_article_links_data(zim_file_path, entry_path)
+            links_data = self.extract_article_links_data(validated_str, entry_path)
             # extract_article_links_data resolves redirects internally and
             # stores the post-redirect entry path in ``links_data["path"]``.
             # Resolve relative links against THAT path, not the caller-supplied
@@ -665,7 +675,7 @@ class _StructureMixin:
                 )
                 if len(outbound) >= limit:
                     break
-            self._resolve_outbound_titles(zim_file_path, outbound)
+            self._resolve_outbound_titles(validated_str, outbound)
             result["outbound_results"] = outbound
         except OpenZimMcpArchiveError as e:
             # Partial-success contract: an archive- or extraction-level

--- a/tests/test_get_related_articles.py
+++ b/tests/test_get_related_articles.py
@@ -1,6 +1,7 @@
 """Tests for get_related_articles tool."""
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -159,7 +160,7 @@ class TestGetRelatedArticles:
         assert outbound[0]["link_text"] == "Animalia"
 
     def test_title_resolution_uses_validated_path_not_raw_input(
-        self, server: OpenZimMcpServer, monkeypatch
+        self, server: OpenZimMcpServer, monkeypatch, tmp_path
     ):
         """Title resolution must open the archive with the path validator's output.
 
@@ -170,13 +171,21 @@ class TestGetRelatedArticles:
         link extraction but silently fail to open for title resolution,
         leaving every outbound title at its placeholder.
         """
+        # Use ``tmp_path`` so the "resolved" path is a real absolute path
+        # in this OS's native form. Comparing string equality across
+        # platforms breaks on Windows because ``Path()`` normalises
+        # forward slashes to backslashes — assert via Path equality
+        # instead, which is platform-correct.
         raw_input = "~/zims/wiki.zim"
-        resolved = "/abs/path/to/zims/wiki.zim"
+        resolved = tmp_path / "zims" / "wiki.zim"
+        resolved_str = str(resolved)
 
         # Path validator simulates ``~`` expansion: raw input → resolved abs path.
         server.zim_operations.path_validator = MagicMock()
-        server.zim_operations.path_validator.validate_path.return_value = resolved
-        server.zim_operations.path_validator.validate_zim_file.return_value = resolved
+        server.zim_operations.path_validator.validate_path.return_value = resolved_str
+        server.zim_operations.path_validator.validate_zim_file.return_value = (
+            resolved_str
+        )
 
         server.zim_operations.extract_article_links_data = MagicMock(
             return_value={
@@ -204,7 +213,9 @@ class TestGetRelatedArticles:
                 return False
 
         def _zim_archive_spy(path, *a, **kw):
-            opened_paths.append(str(path))
+            # Normalise to Path so cross-platform comparisons work
+            # (Windows' ``Path('/foo/bar')`` is ``\foo\bar``).
+            opened_paths.append(Path(path))
             return _Ctx()
 
         monkeypatch.setattr(
@@ -221,7 +232,7 @@ class TestGetRelatedArticles:
             f"expected archive open to use validated path {resolved!r}; "
             f"actually opened: {opened_paths!r}"
         )
-        assert raw_input not in opened_paths, (
+        assert Path(raw_input) not in opened_paths, (
             f"archive was opened with the raw, unresolved path {raw_input!r}; "
             f"this bypasses path expansion and silently fails on `~` paths"
         )

--- a/tests/test_get_related_articles.py
+++ b/tests/test_get_related_articles.py
@@ -15,8 +15,18 @@ class TestGetRelatedArticles:
 
     @pytest.fixture
     def server(self, test_config: OpenZimMcpConfig) -> OpenZimMcpServer:
-        """Create a test server instance."""
-        return OpenZimMcpServer(test_config)
+        """Create a test server instance with a stub path validator.
+
+        The stub passes the input through unchanged so unit tests can
+        focus on outbound-link logic without registering paths in
+        ``allowed_directories``. Tests that need to verify the validated
+        path actually flows into the archive open replace this stub.
+        """
+        srv = OpenZimMcpServer(test_config)
+        srv.zim_operations.path_validator = MagicMock()
+        srv.zim_operations.path_validator.validate_path.side_effect = lambda p: p
+        srv.zim_operations.path_validator.validate_zim_file.side_effect = lambda p: p
+        return srv
 
     def test_outbound_uses_extract_article_links(self, server: OpenZimMcpServer):
         """Outbound delegates to extract_article_links_data, resolves URLs, dedupes.
@@ -147,6 +157,74 @@ class TestGetRelatedArticles:
         assert outbound[0]["path"] == "C/Animal"
         assert outbound[0]["title"] == "Animal"
         assert outbound[0]["link_text"] == "Animalia"
+
+    def test_title_resolution_uses_validated_path_not_raw_input(
+        self, server: OpenZimMcpServer, monkeypatch
+    ):
+        """Title resolution must open the archive with the path validator's output.
+
+        ``extract_article_links_data`` runs the input through ``validate_path``
+        (which expands ``~`` and resolves symlinks) before opening libzim;
+        ``_resolve_outbound_titles`` must use the same resolved path.
+        Otherwise inputs like ``~/zims/wiki.zim`` open successfully for
+        link extraction but silently fail to open for title resolution,
+        leaving every outbound title at its placeholder.
+        """
+        raw_input = "~/zims/wiki.zim"
+        resolved = "/abs/path/to/zims/wiki.zim"
+
+        # Path validator simulates ``~`` expansion: raw input → resolved abs path.
+        server.zim_operations.path_validator = MagicMock()
+        server.zim_operations.path_validator.validate_path.return_value = resolved
+        server.zim_operations.path_validator.validate_zim_file.return_value = resolved
+
+        server.zim_operations.extract_article_links_data = MagicMock(
+            return_value={
+                "path": "C/Source",
+                "internal_links": [
+                    {"url": "Animal", "text": "Animalia"},
+                ],
+            }
+        )
+
+        # Track every path we're asked to open so we can assert it's the
+        # validated one, not the raw ``~/...`` input.
+        opened_paths: list = []
+
+        target_entry = MagicMock()
+        target_entry.title = "Animal"
+        mock_archive = MagicMock()
+        mock_archive.get_entry_by_path.return_value = target_entry
+
+        class _Ctx:
+            def __enter__(self):
+                return mock_archive
+
+            def __exit__(self, *a):
+                return False
+
+        def _zim_archive_spy(path, *a, **kw):
+            opened_paths.append(str(path))
+            return _Ctx()
+
+        monkeypatch.setattr(
+            "openzim_mcp.zim_operations.zim_archive",
+            _zim_archive_spy,
+        )
+
+        server.zim_operations.get_related_articles_data(raw_input, "C/Source", limit=10)
+
+        # The archive must be opened with the validator's output, not the raw
+        # ``~/...`` string. Path("~/zims/wiki.zim") does NOT auto-expand on
+        # Python 3, so the raw form would silently fail to find the file.
+        assert resolved in opened_paths, (
+            f"expected archive open to use validated path {resolved!r}; "
+            f"actually opened: {opened_paths!r}"
+        )
+        assert raw_input not in opened_paths, (
+            f"archive was opened with the raw, unresolved path {raw_input!r}; "
+            f"this bypasses path expansion and silently fails on `~` paths"
+        )
 
     def test_title_falls_back_to_path_when_archive_lookup_fails(
         self, server: OpenZimMcpServer, monkeypatch

--- a/tests/test_get_related_articles.py
+++ b/tests/test_get_related_articles.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from typing import Callable, List
 from unittest.mock import MagicMock
 
 import pytest
@@ -9,6 +10,33 @@ import pytest
 from openzim_mcp.config import OpenZimMcpConfig
 from openzim_mcp.exceptions import OpenZimMcpValidationError
 from openzim_mcp.server import OpenZimMcpServer
+
+
+def _patch_zim_archive(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_archive: MagicMock,
+    on_open: Callable[[object], None] | None = None,
+) -> None:
+    """Patch ``openzim_mcp.zim_operations.zim_archive`` to return ``mock_archive``.
+
+    The hook ``on_open`` (when provided) is called with each path the
+    production code asks to open — useful for asserting the archive is
+    opened with the expected (validated) path, not the raw caller input.
+    """
+
+    class _Ctx:
+        def __enter__(self) -> MagicMock:
+            return mock_archive
+
+        def __exit__(self, *a: object) -> bool:
+            return False
+
+    def _factory(path: object, *_a: object, **_kw: object) -> _Ctx:
+        if on_open is not None:
+            on_open(path)
+        return _Ctx()
+
+    monkeypatch.setattr("openzim_mcp.zim_operations.zim_archive", _factory)
 
 
 class TestGetRelatedArticles:
@@ -130,25 +158,7 @@ class TestGetRelatedArticles:
         target_entry.path = "C/Animal"
         mock_archive = MagicMock()
         mock_archive.get_entry_by_path.return_value = target_entry
-
-        class _Ctx:
-            def __enter__(self):
-                return mock_archive
-
-            def __exit__(self, *a):
-                return False
-
-        monkeypatch.setattr(
-            "openzim_mcp.zim_operations.zim_archive",
-            lambda *a, **kw: _Ctx(),
-        )
-        server.zim_operations.path_validator = MagicMock()
-        server.zim_operations.path_validator.validate_path.return_value = (
-            "/zim/test.zim"
-        )
-        server.zim_operations.path_validator.validate_zim_file.return_value = (
-            "/zim/test.zim"
-        )
+        _patch_zim_archive(monkeypatch, mock_archive)
 
         result = server.zim_operations.get_related_articles_data(
             "/zim/test.zim", "C/Source", limit=10
@@ -197,30 +207,19 @@ class TestGetRelatedArticles:
         )
 
         # Track every path we're asked to open so we can assert it's the
-        # validated one, not the raw ``~/...`` input.
-        opened_paths: list = []
+        # validated one, not the raw ``~/...`` input. Normalise via Path so
+        # cross-platform comparisons work (Windows' ``Path('/foo/bar')`` is
+        # ``\foo\bar``).
+        opened_paths: List[Path] = []
 
         target_entry = MagicMock()
         target_entry.title = "Animal"
         mock_archive = MagicMock()
         mock_archive.get_entry_by_path.return_value = target_entry
-
-        class _Ctx:
-            def __enter__(self):
-                return mock_archive
-
-            def __exit__(self, *a):
-                return False
-
-        def _zim_archive_spy(path, *a, **kw):
-            # Normalise to Path so cross-platform comparisons work
-            # (Windows' ``Path('/foo/bar')`` is ``\foo\bar``).
-            opened_paths.append(Path(path))
-            return _Ctx()
-
-        monkeypatch.setattr(
-            "openzim_mcp.zim_operations.zim_archive",
-            _zim_archive_spy,
+        _patch_zim_archive(
+            monkeypatch,
+            mock_archive,
+            on_open=lambda path: opened_paths.append(Path(path)),
         )
 
         server.zim_operations.get_related_articles_data(raw_input, "C/Source", limit=10)
@@ -257,25 +256,7 @@ class TestGetRelatedArticles:
 
         mock_archive = MagicMock()
         mock_archive.get_entry_by_path.side_effect = Exception("not found")
-
-        class _Ctx:
-            def __enter__(self):
-                return mock_archive
-
-            def __exit__(self, *a):
-                return False
-
-        monkeypatch.setattr(
-            "openzim_mcp.zim_operations.zim_archive",
-            lambda *a, **kw: _Ctx(),
-        )
-        server.zim_operations.path_validator = MagicMock()
-        server.zim_operations.path_validator.validate_path.return_value = (
-            "/zim/test.zim"
-        )
-        server.zim_operations.path_validator.validate_zim_file.return_value = (
-            "/zim/test.zim"
-        )
+        _patch_zim_archive(monkeypatch, mock_archive)
 
         result = server.zim_operations.get_related_articles_data(
             "/zim/test.zim", "C/Source", limit=10

--- a/tests/test_get_related_articles.py
+++ b/tests/test_get_related_articles.py
@@ -94,6 +94,110 @@ class TestGetRelatedArticles:
                 "/zim/test.zim", "C/Source", limit=10
             )
 
+    def test_title_is_target_entry_title_not_anchor_text(
+        self, server: OpenZimMcpServer, monkeypatch
+    ):
+        """Outbound ``title`` is the linked entry's title; ``link_text`` is the anchor.
+
+        Beta-test feedback: prior shape conflated the two — the result said
+        ``{path: "Animal", title: "Animalia"}`` (where "Animalia" is the
+        inline anchor text in the source article, not the article title).
+        """
+        server.zim_operations.extract_article_links_data = MagicMock(
+            return_value={
+                "path": "C/Source",
+                "internal_links": [
+                    # Anchor text differs from the target's actual title.
+                    {"url": "Animal", "text": "Animalia"},
+                ],
+            }
+        )
+
+        # Stub archive lookup so the target's "real" title is resolved.
+        target_entry = MagicMock()
+        target_entry.title = "Animal"
+        target_entry.path = "C/Animal"
+        mock_archive = MagicMock()
+        mock_archive.get_entry_by_path.return_value = target_entry
+
+        class _Ctx:
+            def __enter__(self):
+                return mock_archive
+
+            def __exit__(self, *a):
+                return False
+
+        monkeypatch.setattr(
+            "openzim_mcp.zim_operations.zim_archive",
+            lambda *a, **kw: _Ctx(),
+        )
+        server.zim_operations.path_validator = MagicMock()
+        server.zim_operations.path_validator.validate_path.return_value = (
+            "/zim/test.zim"
+        )
+        server.zim_operations.path_validator.validate_zim_file.return_value = (
+            "/zim/test.zim"
+        )
+
+        result = server.zim_operations.get_related_articles_data(
+            "/zim/test.zim", "C/Source", limit=10
+        )
+        outbound = result["outbound_results"]
+        assert len(outbound) == 1
+        assert outbound[0]["path"] == "C/Animal"
+        assert outbound[0]["title"] == "Animal"
+        assert outbound[0]["link_text"] == "Animalia"
+
+    def test_title_falls_back_to_path_when_archive_lookup_fails(
+        self, server: OpenZimMcpServer, monkeypatch
+    ):
+        """When archive lookup fails, ``title`` falls back to the path.
+
+        Possible failure modes: target lives in a different namespace,
+        the entry is missing, or libzim raises. ``link_text`` still
+        carries the original anchor text either way.
+        """
+        server.zim_operations.extract_article_links_data = MagicMock(
+            return_value={
+                "path": "C/Source",
+                "internal_links": [
+                    {"url": "Missing_Article", "text": "see Missing"},
+                ],
+            }
+        )
+
+        mock_archive = MagicMock()
+        mock_archive.get_entry_by_path.side_effect = Exception("not found")
+
+        class _Ctx:
+            def __enter__(self):
+                return mock_archive
+
+            def __exit__(self, *a):
+                return False
+
+        monkeypatch.setattr(
+            "openzim_mcp.zim_operations.zim_archive",
+            lambda *a, **kw: _Ctx(),
+        )
+        server.zim_operations.path_validator = MagicMock()
+        server.zim_operations.path_validator.validate_path.return_value = (
+            "/zim/test.zim"
+        )
+        server.zim_operations.path_validator.validate_zim_file.return_value = (
+            "/zim/test.zim"
+        )
+
+        result = server.zim_operations.get_related_articles_data(
+            "/zim/test.zim", "C/Source", limit=10
+        )
+        outbound = result["outbound_results"]
+        assert len(outbound) == 1
+        assert outbound[0]["path"] == "C/Missing_Article"
+        # No title resolvable -> falls back to the target path
+        assert outbound[0]["title"] == "C/Missing_Article"
+        assert outbound[0]["link_text"] == "see Missing"
+
 
 class TestResolveLinkToEntryPath:
     """Test ``_resolve_link_to_entry_path`` static helper.

--- a/tests/test_namespace_scheme_aware.py
+++ b/tests/test_namespace_scheme_aware.py
@@ -218,6 +218,85 @@ class TestWalkNamespaceNewScheme:
         assert result["done"] is True
 
 
+class TestWalkNamespaceTotalInNamespace:
+    """walk_namespace must report a namespace-specific count, not the file total.
+
+    Beta-test feedback: walking an empty namespace returned ``total_entries``
+    equal to the whole archive's entry count, which is misleading. The fix
+    introduces ``total_in_namespace`` (matching browse_namespace) and renames
+    the file-total field to the unambiguous ``archive_entry_count``. The old
+    ``total_entries`` is kept as a deprecated alias of ``archive_entry_count``.
+    """
+
+    def test_new_scheme_C_total_matches_entry_count(
+        self,
+        ops_for_zim_data: ZimOperations,
+        basic_test_zim_files: Dict[str, Optional[Path]],
+    ):
+        """New-scheme C: iterator emits only C, so total_in_namespace == entry_count.
+
+        The count is authoritative because libzim tells us exactly.
+        """
+        zim = _require(basic_test_zim_files["nons"])
+        result = ops_for_zim_data.walk_namespace_data(str(zim), "C", limit=500)
+        # nons/small.zim has entry_count=2 (favicon.png, main.html)
+        assert result["archive_entry_count"] == 2
+        assert result["total_in_namespace"] == 2
+        assert result["total_in_namespace_is_lower_bound"] is False
+        # Deprecated alias kept for backward compatibility
+        assert result["total_entries"] == 2
+
+    def test_new_scheme_M_total_matches_metadata_keys(
+        self,
+        ops_for_zim_data: ZimOperations,
+        basic_test_zim_files: Dict[str, Optional[Path]],
+    ):
+        """New-scheme M count is len(metadata_keys), not archive.entry_count."""
+        zim = _require(basic_test_zim_files["nons"])
+        result = ops_for_zim_data.walk_namespace_data(str(zim), "M", limit=500)
+        # nons/small.zim has 10 metadata_keys, entry_count=2
+        assert result["archive_entry_count"] == 2
+        assert result["total_in_namespace"] == 10
+        assert result["total_in_namespace_is_lower_bound"] is False
+        # Deprecated alias mirrors archive_entry_count, NOT the namespace count
+        assert result["total_entries"] == 2
+
+    def test_new_scheme_empty_namespace_reports_zero(
+        self,
+        ops_for_zim_data: ZimOperations,
+        basic_test_zim_files: Dict[str, Optional[Path]],
+    ):
+        """An empty namespace must report 0, not the file total.
+
+        This was the headline beta-test issue: walking namespace ``Z``
+        returned ``total_entries: 5175`` (the whole archive size).
+        """
+        zim = _require(basic_test_zim_files["nons"])
+        result = ops_for_zim_data.walk_namespace_data(str(zim), "Z", limit=500)
+        assert result["entries"] == []
+        assert result["total_in_namespace"] == 0
+        assert result["total_in_namespace_is_lower_bound"] is False
+        # archive_entry_count is still the file total — make this explicit
+        assert result["archive_entry_count"] == 2
+
+    def test_old_scheme_total_in_namespace_is_unknown(
+        self,
+        ops_for_zim_data: ZimOperations,
+        basic_test_zim_files: Dict[str, Optional[Path]],
+    ):
+        """Old-scheme: count is None because deriving it needs a full scan.
+
+        Reporting an inaccurate number would be misleading; None signals
+        "not derivable" so callers know to fall back to browse_namespace.
+        """
+        zim = _require(basic_test_zim_files["withns"])
+        result = ops_for_zim_data.walk_namespace_data(str(zim), "M", limit=10)
+        # archive_entry_count is always populated
+        assert result["archive_entry_count"] >= 1
+        # Old-scheme: count not derivable without full scan
+        assert result["total_in_namespace"] is None
+
+
 class TestSearchWithFiltersNewScheme:
     """search_with_filters namespace must be scheme-aware."""
 

--- a/tests/test_namespace_scheme_aware.py
+++ b/tests/test_namespace_scheme_aware.py
@@ -288,6 +288,9 @@ class TestWalkNamespaceTotalInNamespace:
 
         Reporting an inaccurate number would be misleading; None signals
         "not derivable" so callers know to fall back to browse_namespace.
+        ``is_lower_bound`` must also be None — saying ``False`` next to a
+        null count would read as "this null is the exact count", which is
+        nonsense.
         """
         zim = _require(basic_test_zim_files["withns"])
         result = ops_for_zim_data.walk_namespace_data(str(zim), "M", limit=10)
@@ -295,6 +298,8 @@ class TestWalkNamespaceTotalInNamespace:
         assert result["archive_entry_count"] >= 1
         # Old-scheme: count not derivable without full scan
         assert result["total_in_namespace"] is None
+        # When the count is unknown, the lower-bound flag is also unknown
+        assert result["total_in_namespace_is_lower_bound"] is None
 
 
 class TestSearchWithFiltersNewScheme:

--- a/tests/test_simple_tools.py
+++ b/tests/test_simple_tools.py
@@ -820,10 +820,10 @@ class TestLowConfidenceNoteAppendedConsistently:
     def test_low_confidence_note_appended_for_all_intents(
         self, handler, intent, params
     ):
-        """Force confidence below 0.6 and assert every branch appends the note."""
+        """Confidence < 0.55 appends the low-confidence note in every branch."""
         explicit = "/zims/test.zim"
 
-        # Pin intent + params and force confidence below the 0.6 threshold so
+        # Pin intent + params and force confidence below the 0.55 threshold so
         # the low-confidence branch fires deterministically.
         with patch.object(
             IntentParser,
@@ -832,7 +832,55 @@ class TestLowConfidenceNoteAppendedConsistently:
         ):
             result = handler.handle_zim_query("anything", zim_file_path=explicit)
 
-        assert "moderate confidence" in result, (
+        assert "low confidence" in result.lower(), (
             f"intent {intent!r}: low-confidence note missing from response: "
             f"{result!r}"
         )
+
+    def test_low_confidence_note_includes_interpreted_intent(
+        self, handler, mock_zim_operations
+    ):
+        """Low-confidence note surfaces the interpreted intent.
+
+        Callers must be able to see what happened on a fallback — e.g.
+        ``"tell me a joke"`` falls through to the search-fallback at
+        confidence 0.5, and the note should say so.
+        """
+        mock_zim_operations.search_zim_file.return_value = "no results"
+        explicit = "/zims/test.zim"
+        with patch.object(
+            IntentParser,
+            "parse_intent",
+            return_value=("search", {"query": "tell me a joke"}, 0.5),
+        ):
+            result = handler.handle_zim_query("tell me a joke", zim_file_path=explicit)
+
+        # The interpreted intent must be visible to the caller.
+        assert "`search`" in result
+        assert "low confidence" in result.lower()
+
+    def test_moderate_confidence_tier_uses_existing_wording(self, handler):
+        """Confidence in the 0.55-0.7 band keeps the legacy 'moderate' wording.
+
+        Avoid churning well-calibrated mid-tier matches; only the tier-1
+        (default-fallback) wording needed to change.
+        """
+        explicit = "/zims/test.zim"
+        with patch.object(
+            IntentParser,
+            "parse_intent",
+            return_value=("walk_namespace", {"namespace": "C"}, 0.6),
+        ):
+            result = handler.handle_zim_query("anything", zim_file_path=explicit)
+        assert "moderate confidence" in result
+
+    def test_high_confidence_appends_no_note(self, handler):
+        """Confidence ≥ 0.7 should not append any note."""
+        explicit = "/zims/test.zim"
+        with patch.object(
+            IntentParser,
+            "parse_intent",
+            return_value=("walk_namespace", {"namespace": "C"}, 0.95),
+        ):
+            result = handler.handle_zim_query("anything", zim_file_path=explicit)
+        assert "confidence" not in result.lower()


### PR DESCRIPTION
## Summary

Beta-testing v1.1.0 against `wikipedia_en_100_nopic_2026-04.zim` surfaced three rough edges in the v1.1.0 surface (one per "new" feature: `walk_namespace`, `get_related_articles`, and the simple-tools confidence note). This PR fixes all three plus two follow-ups from a self-review pass.

5 commits, conventionally tagged so release-please picks them up on the next release cut.

## The fixes

### 1. `walk_namespace`: report namespace count, not file total

Walking an empty namespace returned `total_entries: 5175` (the whole archive) with `returned_count: 0` — visually dishonest. The field was also inconsistent across branches: M-walker reported `len(metadata_keys)` but C/old-scheme reported `archive.entry_count`.

- **Add** `total_in_namespace` (matching the existing `browse_namespace` field) and `total_in_namespace_is_lower_bound`. Per-branch values:
  - new-scheme M: `len(metadata_keys)`
  - new-scheme empty namespace (`Z`, etc.): `0`
  - new-scheme C: `archive.entry_count` (iterator emits exactly C)
  - old-scheme any: `null` (would need a full scan)
- **Add** `archive_entry_count` as the unambiguous file-total field.
- **Keep** `total_entries` as a deprecated alias of `archive_entry_count` for v1.1.0 callers.
- **Refactor** three near-identical result-dict literals into a `_build_walk_result(...)` helper.

Commit: `52d12a1`

### 2. `get_related_articles`: resolve target title, expose anchor as `link_text`

Each outbound result's `title` carried the inline anchor text from the source article rather than the linked entry's actual title. So `Bird` → `{path: "Animal", title: "Animalia"}` — `"Animalia"` is the link text in the source, not the article title.

New shape: `{path, title, link_text}`. `title` is resolved by archive lookup against the linked path (single archive open shared across all outbound results, bounded by `limit ≤ 100`); falls back to `path` when the entry is missing. `link_text` carries the original anchor text from the source.

Commit: `0a37219`

### 3. `simple_tools`: tier the confidence note, name the interpreted intent

`"tell me a joke"` falls through to the search-fallback at confidence `0.5` because no pattern matches. Calling that result `"moderate confidence"` is too gentle — callers can't tell whether the system understood them or just guessed.

- `< 0.55` → `"Low confidence in query interpretation (interpreted as `<intent>`)"` — names the routed intent so callers see the fallback explicitly
- `0.55–0.7` → existing `"moderate confidence"` wording (kept verbatim for well-calibrated mid-tier matches)
- `>= 0.7` → no note

Commit: `29328cf`

## Self-review fixups

A code-review pass after the three primary fixes turned up two more issues, both fixed in the same branch:

### 4. Threading the validated path into title resolution

Code review caught that `_resolve_outbound_titles` (introduced in fix 2) opened the archive with the raw `zim_file_path` string, while `extract_article_links_data` opened it with the path validator's output. For inputs that need normalisation (`~/zims/wiki.zim`, relative paths, symlinks), the title-resolution open silently fails — `Path("~/foo.zim")` doesn't expand `~`, libzim can't find the file, the `except Exception` block swallows the open failure, and every outbound title falls back to its path placeholder with no error to the caller.

Validate once at the top of `get_related_articles_data` and thread the validated string into both calls. Regression test simulates `~` expansion via a stub validator and asserts the archive is opened with the resolved path, not the raw input.

Commit: `913668f`

### 5. Null `is_lower_bound` when `total_in_namespace` is null

The old-scheme branch returned `{total_in_namespace: null, total_in_namespace_is_lower_bound: false}`, which is internally inconsistent: `is_lower_bound` is a property of the count, and saying `false` next to a null count reads as "this null is the exact count" — nonsense. Set both to `null` together.

Commit: `9d1917d`

## Test plan

- `uv run pytest` — **956 passed**, 27 deselected (live/docker markers); was 955 before, so net +9 new tests across the three fixes (4 walk_namespace, 3 related-articles, 4 confidence tiers, minus 1 reworked existing parameterised test).
- Pre-commit hooks (black, isort, flake8 + pydocstyle, mypy, bandit) green on every commit.
- Backward-compat: `total_entries` alias verified by `test_new_scheme_C_total_matches_entry_count`, `test_new_scheme_M_total_matches_metadata_keys`, `test_new_scheme_empty_namespace_reports_zero` — all pin both the new and legacy fields.
- TDD throughout: each fix has a RED commit (failing test) verified before the GREEN implementation.

## Out of scope

- The `uv.lock` working-tree drift (release-please's v1.1.0 commit didn't run `uv sync`, so the lockfile still pins v1.0.1). Unrelated to these fixes; worth a separate trivial chore PR or it'll get rewritten on the next release-please bump anyway.
- Migrating tool returns to TypedDicts (PR #96 follow-up). The `_build_walk_result` helper is dict-shaped to match the existing surface.
