### PR TITLE
fix(server): mirror cors_origins into SDK transport allowed_origins

### DIFF
--- a/openzim_mcp/server.py
+++ b/openzim_mcp/server.py
@@ -86,6 +86,15 @@ class OpenZimMcpServer:
         # via OPENZIM_MCP_ALLOWED_HOSTS for those deployments. Loopback
         # entries are always preserved so localhost-direct access keeps
         # working alongside the proxied path.
+        #
+        # The MCP SDK's transport security ALSO validates the Origin header
+        # against ``allowed_origins`` (separate from CORS — application-layer
+        # DNS-rebinding defense). Without populating it, every browser
+        # request fails with ``403 Invalid Origin header`` even after CORS
+        # preflight succeeds. We mirror ``OPENZIM_MCP_CORS_ORIGINS`` into the
+        # SDK's ``allowed_origins`` because they encode the same trust
+        # decision: an origin we let into CORS is one we let past the
+        # rebinding check.
         fastmcp_kwargs: dict = {}
         if config.transport == "http" and config.allowed_hosts:
             from mcp.server.transport_security import TransportSecuritySettings
@@ -97,6 +106,7 @@ class OpenZimMcpServer:
                     "[::1]:*",
                     *config.allowed_hosts,
                 ],
+                allowed_origins=list(config.cors_origins),
             )
         self.mcp = FastMCP(config.server_name, **fastmcp_kwargs)
         self.mcp._mcp_server.version = __version__

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -181,6 +181,60 @@ def test_fastmcp_uses_sdk_default_when_hosts_unset(tmp_path):
     assert hosts.isdisjoint({"mcp.example.com"})
 
 
+def test_fastmcp_mirrors_cors_origins_into_transport_allowed_origins(tmp_path):
+    """``cors_origins`` is mirrored into the SDK's ``allowed_origins``.
+
+    The SDK's transport security validates the Origin header (separate from
+    CORS — application-layer DNS-rebinding defense) against
+    ``allowed_origins``. Without populating it, every browser request fails
+    with ``403 Invalid Origin header`` even after CORS preflight succeeds.
+    Reusing ``cors_origins`` is correct because the two encode the same
+    trust decision: an origin we let into CORS is one we let past the
+    rebinding check.
+    """
+    from mcp.server.transport_security import TransportSecuritySettings
+
+    from openzim_mcp.config import OpenZimMcpConfig
+    from openzim_mcp.server import OpenZimMcpServer
+
+    cfg = OpenZimMcpConfig(
+        allowed_directories=[str(tmp_path)],
+        transport="http",
+        allowed_hosts=["mcp.example.com"],
+        cors_origins=["https://app.example.com", "https://chat.example.com"],
+    )
+    server = OpenZimMcpServer(cfg)
+
+    sec: TransportSecuritySettings = server.mcp.settings.transport_security  # type: ignore[union-attr]
+    assert sec is not None
+    origins = set(sec.allowed_origins)
+    assert origins == {"https://app.example.com", "https://chat.example.com"}
+
+
+def test_fastmcp_allowed_origins_empty_when_cors_unset(tmp_path):
+    """No cors_origins ⇒ empty SDK allowed_origins.
+
+    Non-browser MCP clients send no Origin header and bypass the SDK's
+    origin check, so the empty list is the right default for deployments
+    that only serve curl/desktop MCP clients.
+    """
+    from mcp.server.transport_security import TransportSecuritySettings
+
+    from openzim_mcp.config import OpenZimMcpConfig
+    from openzim_mcp.server import OpenZimMcpServer
+
+    cfg = OpenZimMcpConfig(
+        allowed_directories=[str(tmp_path)],
+        transport="http",
+        allowed_hosts=["mcp.example.com"],
+    )
+    server = OpenZimMcpServer(cfg)
+
+    sec: TransportSecuritySettings = server.mcp.settings.transport_security  # type: ignore[union-attr]
+    assert sec is not None
+    assert list(sec.allowed_origins) == []
+
+
 def test_fastmcp_ignores_allowed_hosts_when_transport_stdio(tmp_path):
     """allowed_hosts is HTTP-only; stdio transport doesn't surface a Host header."""
     from openzim_mcp.config import OpenZimMcpConfig


### PR DESCRIPTION
## Summary

Browser MCP clients today get ``403 Invalid Origin header`` from any openzim-mcp deployment that sets ``OPENZIM_MCP_ALLOWED_HOSTS`` (i.e. anything behind Tailscale serve or a reverse proxy) — even when CORS is configured correctly.

The MCP SDK's ``TransportSecurityMiddleware`` is a separate layer from CORS: it validates the Origin header against ``allowed_origins`` as application-layer DNS-rebinding defense. Today only ``allowed_hosts`` is wired up; ``allowed_origins`` defaults to ``[]``, so once host-checking is enabled, the *origin* check rejects every browser request after preflight has already approved it.

Mirror ``config.cors_origins`` into ``TransportSecuritySettings.allowed_origins``. The two settings encode the same trust decision — an origin that's been added to the CORS allowlist is one that should also be allowed past the rebinding check. Non-browser MCP clients send no Origin header and the SDK skips the check, so curl/desktop/agent clients are unaffected.

## Discovery

Hit while wiring ``zim.owl-atlas.ts.net`` to a browser-based MCP client. Local testing missed this because the local config never set ``allowed_hosts`` → SDK falls through to ``enable_dns_rebinding_protection=False`` and skips both host *and* origin checks. The bug only surfaces when ``allowed_hosts`` is set (which is required for Tailscale-serve / reverse-proxy hostnames) and the client is a browser.

## Changes

- ``openzim_mcp/server.py``: pass ``allowed_origins=list(config.cors_origins)`` to ``TransportSecuritySettings`` alongside the existing ``allowed_hosts`` wiring. No change to the activation condition (``allowed_hosts`` still gates whether the middleware is installed at all).
- ``tests/test_http_transport.py``: two new tests asserting the mirror happens (and that the empty-by-default case still works).

## Test plan

- [x] ``uv run pytest tests/`` — 919 passed, 37 skipped (no new failures).
- [x] Manually reproduced the 403 against ``zim.owl-atlas.ts.net`` running v1.1.1, applied the fix in a local image, and verified the full ``initialize`` POST from the chat origin returns 200 with a session ID.