### PR TITLE
chore: prep for v1.1.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Run OpenZIM MCP as a long-running service. Pass `--transport http` (or set `OPEN
 - **Safe-default startup check** — the server *refuses* to bind a non-localhost host without a token. (Bind `127.0.0.1` for local-only access; put a reverse proxy in front for TLS.)
 - **CORS allow-list** — explicit origins via `OPENZIM_MCP_CORS_ORIGINS`; wildcard `*` is rejected at startup.
 - **Health endpoints** — `/healthz` (liveness) and `/readyz` (at least one allowed dir is readable). Both exempt from auth so probes work cleanly.
-- **Multi-arch Docker image** — `ghcr.io/cameronrye/openzim-mcp:1.1.1`, builds for `linux/amd64` and `linux/arm64`, runs as non-root.
+- **Multi-arch Docker image** — `ghcr.io/cameronrye/openzim-mcp:1.1.2`, builds for `linux/amd64` and `linux/arm64`, runs as non-root.
 
 Legacy SSE transport is also available via `--transport sse` (or `OPENZIM_MCP_TRANSPORT=sse`) for clients that haven't migrated to streamable-HTTP. SSE does **not** apply the bearer-token / CORS / health-endpoint middleware, so the server *refuses* to start with `--transport sse` bound to anything other than `127.0.0.1`/`::1`/`localhost`. For exposed deployments use `--transport http`.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -107,7 +107,7 @@ This recipe puts OpenZIM MCP on a single host, reachable from the rest of your L
 ```yaml
 services:
   openzim-mcp:
-    image: ghcr.io/cameronrye/openzim-mcp:1.1.1
+    image: ghcr.io/cameronrye/openzim-mcp:1.1.2
     restart: unless-stopped
     ports:
       - "127.0.0.1:8000:8000"
@@ -119,7 +119,7 @@ services:
 
 What's intentional here:
 
-- **Pinned tag** (`:1.1.1`, not `:latest`). Upgrades are deliberate — `docker compose pull` is a thing you do, not a thing that happens to you.
+- **Pinned tag** (`:1.1.2`, not `:latest`). Upgrades are deliberate — `docker compose pull` is a thing you do, not a thing that happens to you.
 - **Host port bound to `127.0.0.1`**. The container listens on all interfaces (the image's default `OPENZIM_MCP_HOST=0.0.0.0`), but Docker's port publish restricts external exposure to loopback. The Tailscale variant below lifts this restriction by binding to a specific interface.
 - **Read-only ZIM mount** (`:ro`). The server only reads ZIM files; mounting read-only ensures a server compromise can't damage them.
 - **Token via env, not hard-coded.** Put it in a `.env` file next to the compose file (and add `.env` to `.gitignore`). The image's defaults already set `TRANSPORT=http`, `HOST=0.0.0.0`, `PORT=8000`, so they're not repeated here.
@@ -227,7 +227,7 @@ This is the LAN compose file with two changes: a `caddy` service is added, and t
 ```yaml
 services:
   openzim-mcp:
-    image: ghcr.io/cameronrye/openzim-mcp:1.1.1
+    image: ghcr.io/cameronrye/openzim-mcp:1.1.2
     restart: unless-stopped
     expose:
       - "8000"
@@ -313,7 +313,7 @@ docker compose pull
 docker compose up -d
 ```
 
-The image tag in `docker-compose.yml` is pinned (`:1.1.1`) — change it to the new version before pulling. Pinning is deliberate: `:latest` makes upgrades a surprise, and the v1 release notes (or future v1.x release notes) tell you when an upgrade involves a breaking change.
+The image tag in `docker-compose.yml` is pinned (`:1.1.2`) — change it to the new version before pulling. Pinning is deliberate: `:latest` makes upgrades a surprise, and the v1 release notes (or future v1.x release notes) tell you when an upgrade involves a breaking change.
 
 ### Watching logs
 

--- a/openzim_mcp/server.py
+++ b/openzim_mcp/server.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Literal, Optional
+from typing import Any, Dict, Literal, Optional
 
 from mcp.server.fastmcp import FastMCP
 
@@ -238,14 +238,21 @@ class OpenZimMcpServer:
                 - "articles related to Climate_Change"
             """
             try:
-                # Build options dict from parameters
-                options = {}
-                if limit is not None:
-                    options["limit"] = limit
+                # Build options dict from parameters. Simple mode is for
+                # smaller / context-limited LLMs, so we apply tighter
+                # defaults than ContentConfig's (100 000-char articles,
+                # 10-result searches) when the caller doesn't specify them.
+                # An LLM that wants the full article can still pass an
+                # explicit ``max_content_length``; this only affects calls
+                # that omit it.
+                options: Dict[str, Any] = {
+                    "limit": limit if limit is not None else 5,
+                    "max_content_length": (
+                        max_content_length if max_content_length is not None else 8000
+                    ),
+                }
                 if offset != 0:
                     options["offset"] = offset
-                if max_content_length is not None:
-                    options["max_content_length"] = max_content_length
 
                 # Use simple tools handler. handle_zim_query is synchronous and
                 # performs blocking ZIM I/O, so dispatch it to a worker thread

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1494,3 +1494,69 @@ class TestToolModeRegistration:
         assert (
             "zim_query" not in names
         ), "advanced mode should not register the simple-mode wrapper"
+
+
+class TestSimpleModeWrapperDefaults:
+    """The simple-mode ``zim_query`` wrapper applies tighter defaults than
+    advanced-mode ``ContentConfig`` because simple mode targets context-
+    constrained LLMs. A 100 000-char article (the prod default) injected
+    into a small chat context dominates prefill and re-evaluates on every
+    subsequent agentic turn, so the simple wrapper caps both ``limit`` and
+    ``max_content_length`` when the caller doesn't pass them.
+    """
+
+    def test_zim_query_caps_max_content_length_when_unspecified(
+        self, test_config: OpenZimMcpConfig
+    ):
+        """Calling ``zim_query`` without ``max_content_length`` passes 8000 to
+        the handler — not None, and not the 100 000-char ContentConfig default.
+        """
+        simple_config = test_config.model_copy(update={"tool_mode": "simple"})
+        server = OpenZimMcpServer(simple_config)
+        captured: dict = {}
+
+        def fake_handle_zim_query(query, zim_file_path, options):
+            captured["options"] = options
+            return "ok"
+
+        assert server.simple_tools_handler is not None
+        server.simple_tools_handler.handle_zim_query = fake_handle_zim_query
+
+        tool_fn = server.mcp._tool_manager._tools["zim_query"].fn
+        asyncio.run(tool_fn(query="search for evolution"))
+
+        assert captured["options"]["max_content_length"] == 8000
+        assert captured["options"]["limit"] == 5
+        assert "offset" not in captured["options"]  # default 0 is suppressed
+
+    def test_zim_query_caller_overrides_take_precedence(
+        self, test_config: OpenZimMcpConfig
+    ):
+        """An explicit caller-supplied ``max_content_length`` / ``limit``
+        wins over the simple-wrapper defaults. The caps are a floor for
+        small LLMs, not a ceiling on what advanced callers can request.
+        """
+        simple_config = test_config.model_copy(update={"tool_mode": "simple"})
+        server = OpenZimMcpServer(simple_config)
+        captured: dict = {}
+
+        def fake_handle_zim_query(query, zim_file_path, options):
+            captured["options"] = options
+            return "ok"
+
+        assert server.simple_tools_handler is not None
+        server.simple_tools_handler.handle_zim_query = fake_handle_zim_query
+
+        tool_fn = server.mcp._tool_manager._tools["zim_query"].fn
+        asyncio.run(
+            tool_fn(
+                query="get article Evolution",
+                limit=20,
+                max_content_length=50000,
+                offset=10,
+            )
+        )
+
+        assert captured["options"]["max_content_length"] == 50000
+        assert captured["options"]["limit"] == 20
+        assert captured["options"]["offset"] == 10

--- a/website/humans.txt
+++ b/website/humans.txt
@@ -64,4 +64,4 @@
     Language: English
     Doctype: HTML5
     IDE: Various (VS Code, Vim, etc.)
-    Version: 1.1.1
+    Version: 1.1.2

--- a/website/index.html
+++ b/website/index.html
@@ -20,7 +20,7 @@
   <meta property="og:site_name" content="OpenZIM MCP">
   <meta property="og:url" content="https://cameronrye.github.io/openzim-mcp/">
   <meta property="og:title" content="OpenZIM MCP — Knowledge that works offline">
-  <meta property="og:description" content="MCP server for offline ZIM-archive access. Streamable HTTP, batch retrieval, per-entry resources, subscriptions. v1.1.1.">
+  <meta property="og:description" content="MCP server for offline ZIM-archive access. Streamable HTTP, batch retrieval, per-entry resources, subscriptions. v1.1.2.">
   <meta property="og:image" content="https://cameronrye.github.io/openzim-mcp/assets/og-image.svg">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
@@ -35,7 +35,7 @@
   <meta name="twitter:creator" content="@cameronrye">
   <meta name="twitter:url" content="https://cameronrye.github.io/openzim-mcp/">
   <meta name="twitter:title" content="OpenZIM MCP — Knowledge that works offline">
-  <meta name="twitter:description" content="MCP server for offline ZIM-archive access. Streamable HTTP, batch retrieval, per-entry resources, subscriptions. v1.1.1.">
+  <meta name="twitter:description" content="MCP server for offline ZIM-archive access. Streamable HTTP, batch retrieval, per-entry resources, subscriptions. v1.1.2.">
   <meta name="twitter:image" content="https://cameronrye.github.io/openzim-mcp/assets/og-image.svg">
   <meta name="twitter:image:alt" content="OpenZIM MCP 1.0 — Knowledge that works offline">
 
@@ -72,7 +72,7 @@
     "alternateName": "OpenZIM MCP Server",
     "description": "A modern, secure MCP server that enables AI models to access and search ZIM format knowledge bases offline with intelligent, structured access patterns",
     "url": "https://cameronrye.github.io/openzim-mcp/",
-    "softwareVersion": "1.1.1",
+    "softwareVersion": "1.1.2",
     "releaseNotes": "https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md",
     "applicationCategory": "DeveloperApplication",
     "applicationSubCategory": "AI Tools",
@@ -182,7 +182,7 @@
     <section id="hero" class="hero">
       <div class="container hero__inner">
         <div class="hero__content">
-          <span class="eyebrow">MCP&nbsp;SERVER · v1.1.1</span>
+          <span class="eyebrow">MCP&nbsp;SERVER · v1.1.2</span>
           <h1 class="hero__title">Knowledge that works offline.</h1>
           <p class="hero__lead">
             OpenZIM MCP gives any AI model structured, secure access to ZIM archives —
@@ -204,7 +204,7 @@
             </button>
           </div>
           <ul class="hero__stats">
-            <li><span class="hero__stat-num">v1.1.1</span><span class="hero__stat-label">Latest release</span></li>
+            <li><span class="hero__stat-num">v1.1.2</span><span class="hero__stat-label">Latest release</span></li>
             <li><span class="hero__stat-num">1 + 21</span><span class="hero__stat-label">Simple / advanced tools</span></li>
             <li><span class="hero__stat-num">80%+</span><span class="hero__stat-label">Test coverage</span></li>
             <li><span class="hero__stat-num">MIT</span><span class="hero__stat-label">License</span></li>
@@ -333,7 +333,7 @@
             <pre><code>docker run -p 8000:8000 \
   -e OPENZIM_MCP_AUTH_TOKEN="$TOKEN" \
   -v /path/to/zim:/data:ro \
-  ghcr.io/cameronrye/openzim-mcp:1.1.1 \
+  ghcr.io/cameronrye/openzim-mcp:1.1.2 \
   --transport http --host 0.0.0.0 /data</code></pre>
           </li>
 
@@ -447,7 +447,7 @@ zim://gutenberg/entry/I%2Fbook_cover.jpg
                 <pre><code>uv tool install openzim-mcp</code></pre>
               </div>
               <div class="tabs__panel" id="install-docker" role="tabpanel" aria-labelledby="tab-install-docker" hidden>
-                <pre><code>docker pull ghcr.io/cameronrye/openzim-mcp:1.1.1</code></pre>
+                <pre><code>docker pull ghcr.io/cameronrye/openzim-mcp:1.1.2</code></pre>
               </div>
               <div class="tabs__panel" id="install-source" role="tabpanel" aria-labelledby="tab-install-source" hidden>
                 <pre><code>git clone https://github.com/cameronrye/openzim-mcp.git

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -6,7 +6,7 @@
 
 OpenZIM MCP is a Model Context Protocol (MCP) server that enables AI models to access and search ZIM format knowledge bases offline. It provides intelligent, structured access patterns that LLMs need to effectively navigate vast knowledge repositories like Wikipedia, Wiktionary, and other offline content archives.
 
-**Version**: 1.1.1 <!-- x-release-please-version -->
+**Version**: 1.1.2 <!-- x-release-please-version -->
 **License**: MIT
 **Python**: 3.12+
 **Repository**: https://github.com/cameronrye/openzim-mcp


### PR DESCRIPTION
Companion to PR #100 (the actual code fix). Picks up the freeform 1.1.1 → 1.1.2 references that release-please's automated PR doesn't touch, plus a small perf tweak piggybacked on the same release.

## Commits

### ``chore: prep for v1.1.2 release``
- ``README.md`` — "Multi-arch Docker image" Docker tag
- ``docs/deployment.md`` — compose-recipe image tags (Recipe 1 + Recipe 2) and the two prose mentions of the pinned tag
- ``website/index.html`` — hero eyebrow, "Latest release" stat, og/twitter description, JSON-LD ``softwareVersion``, embedded ``docker pull`` snippets
- ``website/humans.txt`` — Version line
- ``website/llms.txt`` — Version (still in ``release-please-config.json`` ``extra-files`` but the ``generic`` updater hasn't actually been bumping it through 1.0.1/1.1.0/1.1.1 — manual nudge here, worth a separate config investigation)

### ``perf(server): cap zim_query content size in simple-mode wrapper``
Simple mode targets context-constrained LLMs (slow prompt eval, small ``--ctx-size``), but the wrapper still forwarded the advanced-mode defaults — ``max_content_length=100000`` and ``limit=10`` from ``ContentConfig`` — when the caller didn't specify them. A single ``get article ...`` round thus injected ~100 KB into the conversation, which is then re-prompt-evaluated on every subsequent agentic turn and dominates per-turn latency.

Tightened wrapper defaults (``max_content_length=8000``, ``limit=5``). Explicit caller-supplied values still win — these are floors for small models, not ceilings on capable callers. Tests in ``TestSimpleModeWrapperDefaults`` cover both paths.

Caught while profiling a real chat-with-tool round on a Vulkan-backend qwen3.5-9b at ~10 tok/s prompt eval — turns 2-N showed prompt eval times of 200+ s, primarily because earlier ``get article`` results stayed in the conversation and re-evaluated each turn.

## Why no "What's new" section

v1.1.2's substantive change is the SDK-transport ``allowed_origins`` fix in PR #100 — a single-bug patch. The README marquee and "What's new in v1.1.0" stay focused on the v1.1.0 feature drop, which is the right framing for a patch release.

## Merge order

This should land **after** PR #100 (which carries the security fix and ``CHANGELOG.md`` will be auto-populated by release-please from the ``fix:`` and ``perf:`` commits). Once both are in, release-please's open PR for v1.1.2 should refresh and be mergeable.

## Verification

- ``grep -rn "1\.1\.1"`` across the touched files returns empty.
- ``python3 website/validate.py`` — all checks pass.
- ``uv run pytest tests/`` — 921 passed, 37 skipped (added 2 new wrapper-default tests).