### PR TITLE
feat(http): operator-acknowledged auth bypass + rate-limit env-var docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,11 @@ repos:
           - flake8-bugbear
           - flake8-comprehensions
           - flake8-simplify
-        args: ["--max-line-length=88", "--extend-ignore=E203,W503,D202"]
+        # Read the same .flake8 that ``make lint`` (and CI) use, so the
+        # local hook can't drift away from CI. The previous inline args
+        # set max-line-length=88 while .flake8 says 128, which silently
+        # blocked commits on lines CI was happy with.
+        args: ["--config=.flake8"]
 
   # Type checking
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/README.md
+++ b/README.md
@@ -1412,9 +1412,10 @@ export OPENZIM_MCP_SERVER_NAME=my_openzim_mcp_server
 |---------|---------|-------------|
 | `OPENZIM_MCP_TOOL_MODE` | `simple` | Tool surface: `simple` (one `zim_query` tool) or `advanced` (21 specialized tools). Controlled by `--tool-mode` on the CLI as well. |
 | `OPENZIM_MCP_TRANSPORT` | `stdio` | Transport protocol: `stdio`, `http`, or `sse`. |
-| `OPENZIM_MCP_HOST` | `127.0.0.1` | HTTP/SSE bind host. Non-loopback hosts require `OPENZIM_MCP_AUTH_TOKEN`. |
+| `OPENZIM_MCP_HOST` | `127.0.0.1` | HTTP/SSE bind host. Non-loopback hosts require `OPENZIM_MCP_AUTH_TOKEN` (or `OPENZIM_MCP_INSECURE_DISABLE_AUTH=1` for HTTP on a closed network). |
 | `OPENZIM_MCP_PORT` | `8000` | HTTP/SSE bind port. |
 | `OPENZIM_MCP_AUTH_TOKEN` | *(unset)* | Bearer token required when binding HTTP/SSE to a non-loopback interface. |
+| `OPENZIM_MCP_INSECURE_DISABLE_AUTH` | `false` | Operator-acknowledged opt-out of the auth requirement on non-loopback HTTP binds. Logs a `WARNING` naming the bound host on every startup. Use only when the surrounding network is your trust boundary (Docker bridge, Tailscale-only, isolated LAN). Does **not** apply to `--transport sse`. |
 | `OPENZIM_MCP_CORS_ORIGINS` | *(empty)* | JSON array of allowed CORS origins for the HTTP transport. Wildcard `*` is rejected. |
 | `OPENZIM_MCP_ALLOWED_HOSTS` | *(empty)* | JSON array of public-facing hostnames the HTTP transport accepts in the `Host` header (e.g. `["mcp.example.com"]`). Loopback is always allowed; this extends it for reverse-proxy and Tailscale-serve deployments. Wildcard `*` is rejected. |
 | `OPENZIM_MCP_SUBSCRIPTIONS_ENABLED` | `true` | Enable MCP resource subscriptions (HTTP transport only). When `false`, `subscribe` calls succeed but no updates fire. |
@@ -1428,6 +1429,23 @@ export OPENZIM_MCP_SERVER_NAME=my_openzim_mcp_server
 | `OPENZIM_MCP_LOGGING__LEVEL` | `INFO` | Logging level |
 | `OPENZIM_MCP_LOGGING__FORMAT` | `%(asctime)s - %(name)s - %(levelname)s - %(message)s` | Log message format |
 | `OPENZIM_MCP_SERVER_NAME` | `openzim-mcp` | Server instance name |
+| `OPENZIM_MCP_RATE_LIMIT__ENABLED` | `true` | Master switch for the global + per-client token-bucket limiter. |
+| `OPENZIM_MCP_RATE_LIMIT__REQUESTS_PER_SECOND` | `10` | Steady-state token refill rate. |
+| `OPENZIM_MCP_RATE_LIMIT__BURST_SIZE` | `20` | Bucket capacity (must be ≤ 1000). |
+| `OPENZIM_MCP_RATE_LIMIT__PER_OPERATION_LIMITS` | `{}` | JSON map of operation name → nested rate-limit config; see snippet below. |
+
+**Per-operation rate-limit overrides** — `OPENZIM_MCP_RATE_LIMIT__PER_OPERATION_LIMITS` accepts a JSON object keyed by operation name. Each value is a full nested `RateLimitConfig`, so an operation can have its own bucket parameters (and its own `enabled` flag). Operations not listed fall through to the global `OPENZIM_MCP_RATE_LIMIT__*` settings.
+
+```bash
+export OPENZIM_MCP_RATE_LIMIT__PER_OPERATION_LIMITS='{
+  "search_zim_file": {"enabled": true, "requests_per_second": 5,  "burst_size": 10},
+  "get_zim_entry":   {"enabled": true, "requests_per_second": 50, "burst_size": 100}
+}'
+```
+
+Operation names match the tool names registered on the server (e.g. `search_zim_file`, `get_zim_entry`, `list_zim_files`, `get_zim_metadata`, `find_entry_by_title`).
+
+> **Disabling rate limiting.** The secure default is on. For closed deployments with a small group of trusted users, `OPENZIM_MCP_RATE_LIMIT__ENABLED=false` turns it off entirely.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Run OpenZIM MCP as a long-running service. Pass `--transport http` (or set `OPEN
 - **Safe-default startup check** — the server *refuses* to bind a non-localhost host without a token. (Bind `127.0.0.1` for local-only access; put a reverse proxy in front for TLS.)
 - **CORS allow-list** — explicit origins via `OPENZIM_MCP_CORS_ORIGINS`; wildcard `*` is rejected at startup.
 - **Health endpoints** — `/healthz` (liveness) and `/readyz` (at least one allowed dir is readable). Both exempt from auth so probes work cleanly.
-- **Multi-arch Docker image** — `ghcr.io/cameronrye/openzim-mcp:1.1.2`, builds for `linux/amd64` and `linux/arm64`, runs as non-root.
+- **Multi-arch Docker image** — `ghcr.io/cameronrye/openzim-mcp:1.2.0`, builds for `linux/amd64` and `linux/arm64`, runs as non-root.
 
 Legacy SSE transport is also available via `--transport sse` (or `OPENZIM_MCP_TRANSPORT=sse`) for clients that haven't migrated to streamable-HTTP. SSE does **not** apply the bearer-token / CORS / health-endpoint middleware, so the server *refuses* to start with `--transport sse` bound to anything other than `127.0.0.1`/`::1`/`localhost`. For exposed deployments use `--transport http`.
 

--- a/README.md
+++ b/README.md
@@ -1412,10 +1412,10 @@ export OPENZIM_MCP_SERVER_NAME=my_openzim_mcp_server
 |---------|---------|-------------|
 | `OPENZIM_MCP_TOOL_MODE` | `simple` | Tool surface: `simple` (one `zim_query` tool) or `advanced` (21 specialized tools). Controlled by `--tool-mode` on the CLI as well. |
 | `OPENZIM_MCP_TRANSPORT` | `stdio` | Transport protocol: `stdio`, `http`, or `sse`. |
-| `OPENZIM_MCP_HOST` | `127.0.0.1` | HTTP/SSE bind host. Non-loopback hosts require `OPENZIM_MCP_AUTH_TOKEN` (or `OPENZIM_MCP_INSECURE_DISABLE_AUTH=1` for HTTP on a closed network). |
+| `OPENZIM_MCP_HOST` | `127.0.0.1` | HTTP/SSE bind host. For `--transport http`, non-loopback hosts require `OPENZIM_MCP_AUTH_TOKEN` (or `OPENZIM_MCP_INSECURE_DISABLE_AUTH=1` on a closed network). For `--transport sse`, non-loopback is refused outright — SSE has no auth middleware and is localhost-only. |
 | `OPENZIM_MCP_PORT` | `8000` | HTTP/SSE bind port. |
-| `OPENZIM_MCP_AUTH_TOKEN` | *(unset)* | Bearer token required when binding HTTP/SSE to a non-loopback interface. |
-| `OPENZIM_MCP_INSECURE_DISABLE_AUTH` | `false` | Operator-acknowledged opt-out of the auth requirement on non-loopback HTTP binds. Logs a `WARNING` naming the bound host on every startup. Use only when the surrounding network is your trust boundary (Docker bridge, Tailscale-only, isolated LAN). Does **not** apply to `--transport sse`. |
+| `OPENZIM_MCP_AUTH_TOKEN` | *(unset)* | Bearer token enforced by the streamable-HTTP transport (`--transport http`). Required when binding HTTP to a non-loopback interface. SSE has no auth middleware; setting a token does **not** allow non-loopback SSE binds. |
+| `OPENZIM_MCP_INSECURE_DISABLE_AUTH` | `false` | Operator-acknowledged opt-out of the auth requirement on non-loopback HTTP binds. Logs a `WARNING` naming the bound host on every startup. Use only when the surrounding network is your trust boundary (Docker bridge, Tailscale-only, isolated LAN). Does **not** apply to `--transport sse` (SSE remains localhost-only). |
 | `OPENZIM_MCP_CORS_ORIGINS` | *(empty)* | JSON array of allowed CORS origins for the HTTP transport. Wildcard `*` is rejected. |
 | `OPENZIM_MCP_ALLOWED_HOSTS` | *(empty)* | JSON array of public-facing hostnames the HTTP transport accepts in the `Host` header (e.g. `["mcp.example.com"]`). Loopback is always allowed; this extends it for reverse-proxy and Tailscale-serve deployments. Wildcard `*` is rejected. |
 | `OPENZIM_MCP_SUBSCRIPTIONS_ENABLED` | `true` | Enable MCP resource subscriptions (HTTP transport only). When `false`, `subscribe` calls succeed but no updates fire. |
@@ -1438,12 +1438,12 @@ export OPENZIM_MCP_SERVER_NAME=my_openzim_mcp_server
 
 ```bash
 export OPENZIM_MCP_RATE_LIMIT__PER_OPERATION_LIMITS='{
-  "search_zim_file": {"enabled": true, "requests_per_second": 5,  "burst_size": 10},
-  "get_zim_entry":   {"enabled": true, "requests_per_second": 50, "burst_size": 100}
+  "search":     {"enabled": true, "requests_per_second": 5,  "burst_size": 10},
+  "get_entry":  {"enabled": true, "requests_per_second": 50, "burst_size": 100}
 }'
 ```
 
-Operation names match the tool names registered on the server (e.g. `search_zim_file`, `get_zim_entry`, `list_zim_files`, `get_zim_metadata`, `find_entry_by_title`).
+Operation names are the internal categories the rate-limiter classifies each call under (not MCP tool names). The recognised set lives in [`openzim_mcp/defaults.py`](openzim_mcp/defaults.py) under `RATE_LIMIT_COSTS`: `search`, `search_with_filters`, `find_entry_by_title`, `get_entry`, `get_zim_entries`, `get_binary_entry`, `browse_namespace`, `get_metadata`, `get_structure`, `get_related_articles`, `suggestions`, and `default` (the fallback bucket for anything uncategorised, e.g. `list_zim_files`).
 
 > **Disabling rate limiting.** The secure default is on. For closed deployments with a small group of trusted users, `OPENZIM_MCP_RATE_LIMIT__ENABLED=false` turns it off entirely.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -107,7 +107,7 @@ This recipe puts OpenZIM MCP on a single host, reachable from the rest of your L
 ```yaml
 services:
   openzim-mcp:
-    image: ghcr.io/cameronrye/openzim-mcp:1.1.2
+    image: ghcr.io/cameronrye/openzim-mcp:1.2.0
     restart: unless-stopped
     ports:
       - "127.0.0.1:8000:8000"
@@ -119,7 +119,7 @@ services:
 
 What's intentional here:
 
-- **Pinned tag** (`:1.1.2`, not `:latest`). Upgrades are deliberate — `docker compose pull` is a thing you do, not a thing that happens to you.
+- **Pinned tag** (`:1.2.0`, not `:latest`). Upgrades are deliberate — `docker compose pull` is a thing you do, not a thing that happens to you.
 - **Host port bound to `127.0.0.1`**. The container listens on all interfaces (the image's default `OPENZIM_MCP_HOST=0.0.0.0`), but Docker's port publish restricts external exposure to loopback. The Tailscale variant below lifts this restriction by binding to a specific interface.
 - **Read-only ZIM mount** (`:ro`). The server only reads ZIM files; mounting read-only ensures a server compromise can't damage them.
 - **Token via env, not hard-coded.** Put it in a `.env` file next to the compose file (and add `.env` to `.gitignore`). The image's defaults already set `TRANSPORT=http`, `HOST=0.0.0.0`, `PORT=8000`, so they're not repeated here.
@@ -227,7 +227,7 @@ This is the LAN compose file with two changes: a `caddy` service is added, and t
 ```yaml
 services:
   openzim-mcp:
-    image: ghcr.io/cameronrye/openzim-mcp:1.1.2
+    image: ghcr.io/cameronrye/openzim-mcp:1.2.0
     restart: unless-stopped
     expose:
       - "8000"
@@ -313,7 +313,7 @@ docker compose pull
 docker compose up -d
 ```
 
-The image tag in `docker-compose.yml` is pinned (`:1.1.2`) — change it to the new version before pulling. Pinning is deliberate: `:latest` makes upgrades a surprise, and the v1 release notes (or future v1.x release notes) tell you when an upgrade involves a breaking change.
+The image tag in `docker-compose.yml` is pinned (`:1.2.0`) — change it to the new version before pulling. Pinning is deliberate: `:latest` makes upgrades a surprise, and the v1 release notes (or future v1.x release notes) tell you when an upgrade involves a breaking change.
 
 ### Watching logs
 

--- a/openzim_mcp/config.py
+++ b/openzim_mcp/config.py
@@ -112,6 +112,18 @@ class OpenZimMcpConfig(BaseSettings):
             "OPENZIM_MCP_AUTH_TOKEN. Never set this in a config file."
         ),
     )
+    insecure_disable_auth: bool = Field(
+        default=False,
+        description=(
+            "Operator-acknowledged escape hatch: allow --transport http to "
+            "bind a non-loopback host without OPENZIM_MCP_AUTH_TOKEN. "
+            "Intended for closed networks (Docker bridge, Tailscale-only, "
+            "isolated LAN) where the network itself is the trust boundary. "
+            "Logs a WARNING naming the bound host on every startup. "
+            "Does not apply to --transport sse — SSE has no auth middleware "
+            "to reason about and remains localhost-only."
+        ),
+    )
     cors_origins: List[str] = Field(
         default_factory=list,
         description=(

--- a/openzim_mcp/http_app.py
+++ b/openzim_mcp/http_app.py
@@ -111,15 +111,28 @@ def check_safe_startup(config: object) -> None:
                 f"SSE transport bound to {host} is not allowed. SSE has no "
                 "auth middleware in this server, so it must bind 127.0.0.1. "
                 "For exposed deployments use --transport http (streamable "
-                "HTTP) with OPENZIM_MCP_AUTH_TOKEN."
+                "HTTP) with OPENZIM_MCP_AUTH_TOKEN. "
+                "OPENZIM_MCP_INSECURE_DISABLE_AUTH does not apply to SSE."
             )
         return
     has_token = getattr(config, "auth_token", None) is not None
     if not is_localhost and not has_token:
+        if getattr(config, "insecure_disable_auth", False):
+            logger.warning(
+                "INSECURE: HTTP transport bound to %s with no auth token "
+                "(OPENZIM_MCP_INSECURE_DISABLE_AUTH=1). The server is "
+                "trusting the surrounding network as the trust boundary. "
+                "Anyone who can reach this address can call every tool.",
+                host,
+            )
+            return
         raise OpenZimMcpConfigurationError(
             f"HTTP transport bound to {host} requires authentication. "
             "Set OPENZIM_MCP_AUTH_TOKEN, or bind to 127.0.0.1 for "
-            "localhost-only access. (Use a reverse proxy for TLS termination.)"
+            "localhost-only access. (Use a reverse proxy for TLS termination.) "
+            "If the surrounding network is your trust boundary (Docker bridge, "
+            "Tailscale-only, isolated LAN) and you accept the risk, set "
+            "OPENZIM_MCP_INSECURE_DISABLE_AUTH=1."
         )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -243,6 +243,23 @@ def test_config_auth_token_is_secret():
     assert cfg.auth_token.get_secret_value() == "abc123"
 
 
+def test_config_default_insecure_disable_auth_is_false():
+    """Default insecure_disable_auth is False (safe default)."""
+    from openzim_mcp.config import OpenZimMcpConfig
+
+    cfg = OpenZimMcpConfig(allowed_directories=[TMP_DIR])
+    assert cfg.insecure_disable_auth is False
+
+
+def test_config_insecure_disable_auth_from_env(monkeypatch):
+    """OPENZIM_MCP_INSECURE_DISABLE_AUTH=1 flips the field to True."""
+    from openzim_mcp.config import OpenZimMcpConfig
+
+    monkeypatch.setenv("OPENZIM_MCP_INSECURE_DISABLE_AUTH", "1")
+    cfg = OpenZimMcpConfig(allowed_directories=[TMP_DIR])
+    assert cfg.insecure_disable_auth is True
+
+
 def test_config_default_cors_origins_empty():
     """Default cors_origins is an empty list."""
     from openzim_mcp.config import OpenZimMcpConfig

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -134,6 +134,7 @@ def test_safe_default_startup_check(host, token, should_start):
     config.transport = "http"
     config.host = host
     config.auth_token = SecretStr(token) if token else None
+    config.insecure_disable_auth = False
 
     if should_start:
         check_safe_startup(config)  # should not raise
@@ -151,6 +152,7 @@ def test_safe_default_check_skipped_for_stdio():
     config.transport = "stdio"
     config.host = "0.0.0.0"  # would refuse for HTTP
     config.auth_token = None
+    config.insecure_disable_auth = False
     check_safe_startup(config)  # no raise
 
 
@@ -175,6 +177,7 @@ def test_safe_default_startup_check_sse(host, should_start):
     # Token presence should not change the SSE outcome — there is no middleware
     # to enforce it on the SSE path.
     config.auth_token = SecretStr("any-token")
+    config.insecure_disable_auth = False
 
     if should_start:
         check_safe_startup(config)
@@ -183,3 +186,56 @@ def test_safe_default_startup_check_sse(host, should_start):
             check_safe_startup(config)
         assert "SSE transport" in str(exc.value)
         assert "127.0.0.1" in str(exc.value)
+
+
+def test_insecure_disable_auth_allows_public_http_no_token(caplog):
+    """With the bypass set, public HTTP bind without token is allowed and warns."""
+    from openzim_mcp.http_app import check_safe_startup
+
+    config = MagicMock()
+    config.transport = "http"
+    config.host = "0.0.0.0"
+    config.auth_token = None
+    config.insecure_disable_auth = True
+
+    with caplog.at_level("WARNING", logger="openzim_mcp.http_app"):
+        check_safe_startup(config)  # must not raise
+
+    assert any(
+        "INSECURE" in rec.getMessage() and "0.0.0.0" in rec.getMessage()
+        for rec in caplog.records
+    ), "expected loud WARNING naming the bound host"
+
+
+def test_insecure_disable_auth_does_not_apply_to_sse():
+    """Bypass is HTTP-only — SSE still refuses non-loopback even when set."""
+    from openzim_mcp.exceptions import OpenZimMcpConfigurationError
+    from openzim_mcp.http_app import check_safe_startup
+
+    config = MagicMock()
+    config.transport = "sse"
+    config.host = "0.0.0.0"
+    config.auth_token = None
+    config.insecure_disable_auth = True
+
+    with pytest.raises(OpenZimMcpConfigurationError) as exc:
+        check_safe_startup(config)
+    assert "SSE transport" in str(exc.value)
+
+
+def test_insecure_disable_auth_redundant_when_token_already_set(caplog):
+    """If a token is set, the bypass is unused (token path takes priority)."""
+    from openzim_mcp.http_app import check_safe_startup
+
+    config = MagicMock()
+    config.transport = "http"
+    config.host = "0.0.0.0"
+    config.auth_token = SecretStr("abc")
+    config.insecure_disable_auth = True
+
+    with caplog.at_level("WARNING", logger="openzim_mcp.http_app"):
+        check_safe_startup(config)
+
+    assert not any(
+        "INSECURE" in rec.getMessage() for rec in caplog.records
+    ), "no INSECURE warning expected when a real token is configured"

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -101,6 +101,7 @@ def test_check_safe_startup_warns_when_localhost_resolves_to_public(monkeypatch)
     config.transport = "http"
     config.host = "localhost"
     config.auth_token = None  # no token → must REFUSE because not loopback
+    config.insecure_disable_auth = False
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")

--- a/uv.lock
+++ b/uv.lock
@@ -890,7 +890,7 @@ wheels = [
 
 [[package]]
 name = "openzim-mcp"
-version = "1.1.1"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },

--- a/website/humans.txt
+++ b/website/humans.txt
@@ -64,4 +64,4 @@
     Language: English
     Doctype: HTML5
     IDE: Various (VS Code, Vim, etc.)
-    Version: 1.1.2
+    Version: 1.2.0

--- a/website/index.html
+++ b/website/index.html
@@ -20,7 +20,7 @@
   <meta property="og:site_name" content="OpenZIM MCP">
   <meta property="og:url" content="https://cameronrye.github.io/openzim-mcp/">
   <meta property="og:title" content="OpenZIM MCP — Knowledge that works offline">
-  <meta property="og:description" content="MCP server for offline ZIM-archive access. Streamable HTTP, batch retrieval, per-entry resources, subscriptions. v1.1.2.">
+  <meta property="og:description" content="MCP server for offline ZIM-archive access. Streamable HTTP, batch retrieval, per-entry resources, subscriptions. v1.2.0.">
   <meta property="og:image" content="https://cameronrye.github.io/openzim-mcp/assets/og-image.svg">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
@@ -35,7 +35,7 @@
   <meta name="twitter:creator" content="@cameronrye">
   <meta name="twitter:url" content="https://cameronrye.github.io/openzim-mcp/">
   <meta name="twitter:title" content="OpenZIM MCP — Knowledge that works offline">
-  <meta name="twitter:description" content="MCP server for offline ZIM-archive access. Streamable HTTP, batch retrieval, per-entry resources, subscriptions. v1.1.2.">
+  <meta name="twitter:description" content="MCP server for offline ZIM-archive access. Streamable HTTP, batch retrieval, per-entry resources, subscriptions. v1.2.0.">
   <meta name="twitter:image" content="https://cameronrye.github.io/openzim-mcp/assets/og-image.svg">
   <meta name="twitter:image:alt" content="OpenZIM MCP 1.0 — Knowledge that works offline">
 
@@ -72,7 +72,7 @@
     "alternateName": "OpenZIM MCP Server",
     "description": "A modern, secure MCP server that enables AI models to access and search ZIM format knowledge bases offline with intelligent, structured access patterns",
     "url": "https://cameronrye.github.io/openzim-mcp/",
-    "softwareVersion": "1.1.2",
+    "softwareVersion": "1.2.0",
     "releaseNotes": "https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md",
     "applicationCategory": "DeveloperApplication",
     "applicationSubCategory": "AI Tools",
@@ -182,7 +182,7 @@
     <section id="hero" class="hero">
       <div class="container hero__inner">
         <div class="hero__content">
-          <span class="eyebrow">MCP&nbsp;SERVER · v1.1.2</span>
+          <span class="eyebrow">MCP&nbsp;SERVER · v1.2.0</span>
           <h1 class="hero__title">Knowledge that works offline.</h1>
           <p class="hero__lead">
             OpenZIM MCP gives any AI model structured, secure access to ZIM archives —
@@ -204,7 +204,7 @@
             </button>
           </div>
           <ul class="hero__stats">
-            <li><span class="hero__stat-num">v1.1.2</span><span class="hero__stat-label">Latest release</span></li>
+            <li><span class="hero__stat-num">v1.2.0</span><span class="hero__stat-label">Latest release</span></li>
             <li><span class="hero__stat-num">1 + 21</span><span class="hero__stat-label">Simple / advanced tools</span></li>
             <li><span class="hero__stat-num">80%+</span><span class="hero__stat-label">Test coverage</span></li>
             <li><span class="hero__stat-num">MIT</span><span class="hero__stat-label">License</span></li>
@@ -333,7 +333,7 @@
             <pre><code>docker run -p 8000:8000 \
   -e OPENZIM_MCP_AUTH_TOKEN="$TOKEN" \
   -v /path/to/zim:/data:ro \
-  ghcr.io/cameronrye/openzim-mcp:1.1.2 \
+  ghcr.io/cameronrye/openzim-mcp:1.2.0 \
   --transport http --host 0.0.0.0 /data</code></pre>
           </li>
 
@@ -447,7 +447,7 @@ zim://gutenberg/entry/I%2Fbook_cover.jpg
                 <pre><code>uv tool install openzim-mcp</code></pre>
               </div>
               <div class="tabs__panel" id="install-docker" role="tabpanel" aria-labelledby="tab-install-docker" hidden>
-                <pre><code>docker pull ghcr.io/cameronrye/openzim-mcp:1.1.2</code></pre>
+                <pre><code>docker pull ghcr.io/cameronrye/openzim-mcp:1.2.0</code></pre>
               </div>
               <div class="tabs__panel" id="install-source" role="tabpanel" aria-labelledby="tab-install-source" hidden>
                 <pre><code>git clone https://github.com/cameronrye/openzim-mcp.git

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -6,7 +6,7 @@
 
 OpenZIM MCP is a Model Context Protocol (MCP) server that enables AI models to access and search ZIM format knowledge bases offline. It provides intelligent, structured access patterns that LLMs need to effectively navigate vast knowledge repositories like Wikipedia, Wiktionary, and other offline content archives.
 
-**Version**: 1.1.2 <!-- x-release-please-version -->
+**Version**: 1.2.0 <!-- x-release-please-version -->
 **License**: MIT
 **Python**: 3.12+
 **Repository**: https://github.com/cameronrye/openzim-mcp


### PR DESCRIPTION
Two related v1.2.0 additions, both prompted by the post-merge feedback thread on #78:

## Why

@flueckiger flagged two sharp edges in the v1.0.0 HTTP-transport rollout:

1. The hard guard refusing to bind a non-loopback host without `OPENZIM_MCP_AUTH_TOKEN` is overkill for closed-network deployments where the network *is* the trust boundary (Docker bridge, Tailscale-only, isolated LAN). Operators were forced to either invent an unused token or invent extra plumbing to keep the server on `127.0.0.1`.
2. The `OPENZIM_MCP_RATE_LIMIT__*` env vars have always worked via pydantic-settings nested syntax but were missing from the README env-var table — including `PER_OPERATION_LIMITS`, where the JSON shape was undiscoverable.

## What

### `OPENZIM_MCP_INSECURE_DISABLE_AUTH=1` (the bypass)

New top-level config field on `OpenZimMcpConfig`. When `--transport http` is bound to a non-loopback host with no auth token, the bypass converts the startup refusal into a `WARNING` log line naming the bound host.

Behaviour matrix (HTTP only — SSE ignores the bypass):

| host | token | bypass | result |
|---|---|---|---|
| 127.0.0.1 | * | * | OK |
| non-loopback | set | * | OK |
| non-loopback | unset | unset | **refuse** |
| non-loopback | unset | set | OK + `WARNING` log every startup |

SSE remains localhost-only regardless of the bypass — there is no auth middleware in the SSE path, so there is nothing for the bypass to switch off. The SSE refuse-message now states this explicitly so operators who try the env var with `--transport sse` get a useful error.

The HTTP refuse-message also points operators at the bypass for the closed-network case.

### Rate-limit env-var docs

Added four rows to the env-var table plus a JSON-shape snippet showing how to set per-operation overrides. The example uses the real operation keys from `defaults.RATE_LIMIT_COSTS` (`search`, `get_entry`, etc.) and points at the source-of-truth file, since those keys are internal categories rather than tool names.

### Side fixes
- The `AUTH_TOKEN` row in the README previously implied a token unlocked non-loopback SSE — false; SSE is localhost-only outright. Reworded the HTTP-vs-SSE split.
- The pre-commit `flake8` hook had drifted from `.flake8` (line-length 88 vs the project's 128), silently blocking commits CI was happy with. Hook now reads `.flake8` directly.

## v1.2.0 prep

Bumps the freeform `1.1.2` → `1.2.0` Docker tags / version stats across [README.md](README.md), [docs/deployment.md](docs/deployment.md), [website/index.html](website/index.html), [website/humans.txt](website/humans.txt), and [website/llms.txt](website/llms.txt). release-please owns `pyproject.toml` / the manifest / `CHANGELOG.md` and will bump those when its auto-PR opens — the prep matches the pattern from #101.

## Tests

- 5 new unit tests for the bypass: allow-with-warning, redundant-with-token (no warning), does-not-apply-to-SSE, plus default + env-var-from-1 on the config.
- Existing `MagicMock`-based safe-startup tests updated to set `insecure_disable_auth = False` explicitly so the new branch can't be silently bypassed by truthy attribute access.
- End-to-end smoke verified locally with a real `OpenZimMcpConfig` (not just mocks):
  - HTTP + 0.0.0.0 + no token + bypass → `WARNING` log + allow
  - HTTP + 0.0.0.0 + no token + no bypass → refuse with the new error pointing at the bypass
  - SSE + 0.0.0.0 + bypass → refuse with the explicit "does not apply to SSE" message

965 tests pass, mypy clean, `make lint` clean, all pre-commit hooks pass.

Closes the gap raised in #78.