### PR TITLE
chore(v2): mark Phase A shipped at v2.0.0a1

### DIFF
--- a/docs/v2/README.md
+++ b/docs/v2/README.md
@@ -27,7 +27,7 @@ These apply across all phases; per-phase specs do not re-litigate them.
 
 | Phase | Theme | Items | Status | Spec |
 |-------|-------|-------|--------|------|
-| **A** | Quality wins, non-breaking | #1, #2, #4, #5, #14 | In Design (approved) | [2026-05-08-v2-phase-a-quality-wins-design.md](../superpowers/specs/2026-05-08-v2-phase-a-quality-wins-design.md) |
+| **A** | Quality wins, non-breaking | #1, #2, #4, #5, #14 | **Shipped (v2.0.0a1)** | [2026-05-08-v2-phase-a-quality-wins-design.md](../superpowers/specs/2026-05-08-v2-phase-a-quality-wins-design.md) |
 | **B** | Response contract | #3, #13 | Planned | _TBD_ |
 | **C** | New retrieval primitives | #7, #10, #11 | Planned | _TBD_ |
 | **D** | Optional ML accelerators | #6, #8, #12, #15 | Planned | _TBD_ |


### PR DESCRIPTION
Tracking-doc update only. Marks the Phase A row in `docs/v2/README.md`
as **Shipped (v2.0.0a1)** now that #108 is merged and the tag is on
[`669c0a9`](https://github.com/cameronrye/openzim-mcp/commit/669c0a9).