### PR TITLE
feat(v2)!: Phase B — response contract & TypedDict migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,61 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0a2] — 2026-05-09 (alpha pre-release)
+
+v2 Phase B: response-contract migration. **Wire-format break** for every
+list-returning tool. v1.x users upgrading must update response-shape parsing.
+See [docs/superpowers/specs/2026-05-08-v2-phase-b-response-contract-design.md](docs/superpowers/specs/2026-05-08-v2-phase-b-response-contract-design.md)
+for the full design.
+
+### Breaking — pagination contract
+
+Every list-returning tool now returns the same five contract keys:
+`results`, `next_cursor`, `total`, `done`, `page_info`.
+
+| Tool | What changed |
+|---|---|
+| `search_zim_file` | `total_results` → `total`; `pagination` block flattened; `next_cursor` at top level; `cursor` accepted as input |
+| `search_all` | `per_file` → `results`; per-archive blocks each carry the new contract via `result` field; cursor lives only at the per-archive level |
+| `search_with_filters` | now returns structured dict (was markdown); same shape as `search_zim_file` plus `namespace_filter`/`content_type_filter` |
+| `find_entry_by_title` | gets the contract; `done=true`, `total=len(results)` always |
+| `get_search_suggestions` | `suggestions` → `results`; `count` removed |
+| `browse_namespace` | `entries` → `results`; `total_in_namespace` → `total`; `total_in_namespace_is_lower_bound` → `page_info.total_is_lower_bound`; `has_more` removed |
+| `walk_namespace` | `cursor` input/output type changes from `int` to opaque `str`; `entries` → `results`; `total` is always `null`; `total_entries` deprecated alias removed |
+| `list_namespaces` | `namespaces[<letter>].entry_count` → `total`; payload at top level (no `result` wrapper) |
+| `extract_article_links` | **`kind` is now required (default `"internal"`)**; single category per call; `internal_links`/`external_links`/`media_links` parallel arrays removed; `category_totals: {internal, external, media}` added |
+| `list_zim_files` | `files` → `results`; `count` → `total` |
+| `get_related_articles` | `outbound_results` → `results`; anticipates Phase E inbound-link feature |
+| `get_zim_entries` (batch) | gets the contract; `done=true`, `total=len(results)` |
+
+### Breaking — TypedDict everywhere
+
+Every dict-returning tool migrated from `Dict[str, Any]` to a per-tool
+TypedDict. FastMCP now emits payloads at the top level of `structuredContent`
+with real schemas. FastMCP continues to wrap `Union[<Response>, ToolErrorPayload]` returns in a `{"result": ...}` envelope at the wire level (this is FastMCP's behavior for any `Union` return type with multiple non-None members). Clients that previously parsed `structuredContent.result` keep working. The TypedDict change ensures the inner payload now carries a real schema instead of `Dict[str, Any]`.
+
+Migrated tools (TypedDict-only, no contract): `get_zim_metadata`,
+`get_zim_entry`, `get_main_page`, `get_entry_summary`,
+`get_table_of_contents`, `get_article_structure`, `get_binary_entry`.
+
+### Cursor format
+
+Cursors are URL-safe base64 JSON: `{v: 1, t: <tool_name>, s: <state>}`.
+**Tool-bound** — a search cursor passed to browse raises a clear error.
+**Versioned** — adding new fields later doesn't break the wire format.
+
+### Compat shim removed
+
+`openzim_mcp.zim.archive.PaginationCursor` (the v1 cursor class) is removed.
+Use `openzim_mcp.pagination.Cursor` instead.
+
+### Other
+
+- New module: `openzim_mcp/pagination.py` — `Cursor.encode/decode`, `CursorMismatchError`.
+- New module: `openzim_mcp/tool_schemas.py` — every per-tool response TypedDict.
+- New tests: `tests/test_pagination_cursor.py`, `tests/test_response_contract.py`, `tests/test_golden_v2_phase_b.py`.
+- The Phase A `_meta` envelope is unchanged in shape and still populates on every response.
+
 ## [2.0.0a1] — 2026-05-08
 
 > First v2 pre-release. Phase A of the multi-phase v2 effort. All changes additive at the tool-signature layer; small compact-mode prose change for empty search results (see Changed below).

--- a/README.md
+++ b/README.md
@@ -792,7 +792,7 @@ Composes `extract_article_links` and deduplicates internal links, returning up t
 - `limit` (integer, default: 10, range: 1–100): Max results
 
 **Returns:**
-JSON with `outbound_results`.
+JSON with `results`.
 
 ### get_entry_summary - Get a concise article summary
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,51 @@ zim_query("links in Photosynthesis", options={"compact": False})
 - ReDoS protection: the markdown link-strip and snippet-truncation regexes now run through the same threading-based timeout wrapper used by the intent parser, so an adversarial unclosed `[text](URL` cannot cause catastrophic backtracking.
 - The compact rendering layer moved to its own module (`openzim_mcp.compact_renderers`) — `simple_tools.py` is now focused on intent dispatch.
 
+## What's new in v2.0.0a2
+
+> Phase B of the v2 effort. Introduces the shared response contract for all list-returning tools — a wire-format break from v1.x. Clients must be updated before upgrading.
+
+### Response contract (v2)
+
+Every list-returning tool returns the same five contract keys:
+
+| Key | Type | Meaning |
+| --- | --- | --- |
+| `results` | `list[T]` | The page of items. Empty list on zero hits. |
+| `next_cursor` | `str \| null` | Opaque base64-JSON cursor. Pass back as `cursor=` to fetch the next page. `null` on the last page. |
+| `total` | `int \| null` | Total count across all pages. `null` when not knowable mid-scan (e.g., `walk_namespace`). |
+| `done` | `bool` | `true` when no more pages exist. Always co-varies with `next_cursor`: `done=true` ⟺ `next_cursor=null`. |
+| `page_info` | `{offset, limit, returned_count, total_is_lower_bound?}` | Pagination state for this page. |
+
+Plus the Phase A `_meta` envelope as a sibling.
+
+#### Pagination input
+
+Every paged tool accepts `cursor` (preferred) or `offset` (convenience). If
+both are supplied, `cursor` wins.
+
+#### Cursor format
+
+Cursors are URL-safe base64-encoded JSON of `{v: 1, t: <tool_name>, s: <state>}`.
+The cursor is **tool-bound** — passing one tool's cursor to another raises a
+clear error. Cursors are **opaque** — clients should not interpret them.
+
+#### Tools without natural pagination
+
+Tools like `find_entry_by_title`, `get_search_suggestions`, and `list_zim_files`
+return all matches in one call. They still emit the contract: `done=true`,
+`next_cursor=null`, `total=len(results)`.
+
+#### `extract_article_links` requires `kind`
+
+`extract_article_links` returns one category per call (`kind=internal` by
+default). Use `kind=external` or `kind=media` for the other categories.
+Per-category counts surface in `category_totals: {internal, external, media}`.
+
+### Wire-format break note
+
+v2.0.0a2 is a wire-format break from v1.x — see CHANGELOG for the per-tool key renames.
+
 ## What's new in v2.0.0a1
 
 > First v2 pre-release. Phase A of the multi-phase v2 effort. All changes additive at the tool-signature layer; small compact-mode prose change for empty search results.

--- a/docs/superpowers/plans/2026-05-08-v2-phase-b.md
+++ b/docs/superpowers/plans/2026-05-08-v2-phase-b.md
@@ -24,6 +24,8 @@ The work decomposes into five phases, executed in order:
 
 Each task is self-contained: a fresh subagent should be able to execute it by reading only this plan + the spec. When in doubt, refer the spec for shape details.
 
+> **Wire shape note (cross-cutting):** FastMCP wraps `Union[<SuccessResponse>, ToolErrorPayload]` returns in a uniform `{"result": ...}` envelope on the wire (see [spec § FastMCP wrapping](../specs/2026-05-08-v2-phase-b-response-contract-design.md#goal)). Tests should assert against `structured["result"]` (or the wrapper-tolerant equivalent `structured.get("result", structured)`) — **NOT** `assert "result" not in structured`. Apply this pattern to every `test_<tool>_returns_structured_content` test added or updated in Tasks 7–21 and Task 25. The original spec ambition of "no result wrapper" was based on a single-TypedDict return type, but Phase B uses `Union` for the in-band error envelope, so the wrapper is present and uniform across all migrated tools.
+
 ---
 
 ## Task 1: Create the v2-phase-b branch
@@ -919,23 +921,23 @@ assert decoded["s"]["l"] == <expected_limit>
 assert decoded["s"]["q"] == "<expected_query>"
 ```
 
-- [ ] **Step 2: Update `tests/test_structured_tool_output.py:30-77` top-level assertion for `search_zim_file`**
+- [ ] **Step 2: Update `tests/test_structured_tool_output.py:30-77` assertion for `search_zim_file`**
 
-If a `search_zim_file` test exists in this file, change:
+Per the cross-cutting wire shape note above, FastMCP wraps the `Union[SearchResponse, ToolErrorPayload]` return in a uniform `{"result": ...}` envelope. Tests must accept the wrapper and assert the inner contract:
 
 ```python
+# FastMCP wraps Union returns in a uniform {"result": ...} envelope
+# (see spec § FastMCP wrapping). Accept the wrapper; assert inner shape.
 payload = structured["result"] if "result" in structured else structured
+assert "results" in payload and isinstance(payload["results"], list)
+assert "next_cursor" in payload
+assert "total" in payload
+assert "done" in payload
+assert "page_info" in payload and isinstance(payload["page_info"], dict)
+assert "query" in payload
 ```
 
-to:
-
-```python
-# Phase B: TypedDict return — payload is at top level, no "result" wrapper.
-assert "result" not in structured, "TypedDict migration regression: payload still wrapped"
-payload = structured
-```
-
-If there's no `search_zim_file` test there yet, add one following the pattern of existing tests in that file (use `convert_result=True`, assert tuple, assert dict, assert top-level keys).
+If there's no `search_zim_file` test there yet, add one following the pattern of existing tests in that file (use `convert_result=True`, assert tuple, assert dict, then unwrap and assert inner contract keys).
 
 - [ ] **Step 3: Run failing tests to confirm they fail with the right diagnostics**
 
@@ -1217,12 +1219,20 @@ for entry in payload.get("per_file", []):
         assert "results" in entry["result"]
 ```
 
-Change to:
+Change to (per the cross-cutting wire shape note — accept the FastMCP `{"result": ...}` wrapper, assert inner contract):
 
 ```python
-assert "result" not in structured, "TypedDict migration regression: payload still wrapped"
-payload = structured
+# FastMCP wraps Union returns in a uniform {"result": ...} envelope
+# (see spec § FastMCP wrapping). Accept the wrapper; assert inner shape.
+payload = structured["result"] if "result" in structured else structured
+assert "per_file" not in payload, (
+    "TypedDict migration regression: top-level still uses legacy "
+    "``per_file`` key — Task 6 renamed it to ``results``."
+)
 assert "results" in payload
+assert payload["done"] is True
+assert payload["next_cursor"] is None
+assert "page_info" in payload
 for entry in payload["results"]:
     inner = entry["result"]
     assert isinstance(inner, dict), f"per_file[].result should be dict, got {type(inner)}"
@@ -1512,18 +1522,15 @@ assert payload["page_info"]["limit"] == 10  # default; or whatever was passed
 assert payload["page_info"]["returned_count"] == len(payload["results"])
 ```
 
-In `test_structured_tool_output.py`, change:
+In `test_structured_tool_output.py`, the existing wrapper-tolerant pattern stays (per the cross-cutting wire shape note above — FastMCP wraps `Union` returns in `{"result": ...}`):
 
 ```python
+# FastMCP wraps Union returns in a uniform {"result": ...} envelope
+# (see spec § FastMCP wrapping). Accept the wrapper; assert inner shape.
 payload = structured["result"] if "result" in structured else structured
 ```
 
-to:
-
-```python
-assert "result" not in structured
-payload = structured
-```
+Add the contract-shape assertions on `payload` (now the inner dict).
 
 - [ ] **Step 2: Run tests to confirm failure**
 
@@ -1609,18 +1616,15 @@ assert payload["total"] == len(payload["results"])
 
 Drop assertions on `payload["count"]` (replaced by `page_info.returned_count`).
 
-In `test_structured_tool_output.py` change:
+In `test_structured_tool_output.py`, the existing wrapper-tolerant pattern stays (per the cross-cutting wire shape note — FastMCP wraps `Union` returns in `{"result": ...}`):
 
 ```python
+# FastMCP wraps Union returns in a uniform {"result": ...} envelope
+# (see spec § FastMCP wrapping). Accept the wrapper; assert inner shape.
 payload = structured["result"] if "result" in structured else structured
 ```
 
-to:
-
-```python
-assert "result" not in structured
-payload = structured
-```
+Then assert the renamed `results` key + the contract keys on `payload`.
 
 - [ ] **Step 2: Run failing tests**
 
@@ -1710,7 +1714,7 @@ assert decoded["s"]["o"] == <expected>
 assert decoded["s"]["ns"] == <expected_namespace>
 ```
 
-In `test_structured_tool_output.py:142-162`, change `payload = structured["result"] if "result" in structured else structured` to `assert "result" not in structured; payload = structured`.
+In `test_structured_tool_output.py:142-162`, keep the existing wrapper-tolerant pattern `payload = structured["result"] if "result" in structured else structured` (per the cross-cutting wire shape note — FastMCP wraps `Union` returns in `{"result": ...}`). Update the inner assertions to use the renamed keys (`results`, `total`, `page_info.*`).
 
 - [ ] **Step 2: Run failing tests**
 
@@ -1828,7 +1832,7 @@ Apply the renames + new contract assertions:
 - Add: `assert "page_info" in result` and shape check
 - For tests that pass `cursor` as int: change to `cursor=None` for first page, then for second-page tests pass `cursor=Cursor.encode(tool="walk_namespace", state={"scan_at": <int>, "l": limit})`.
 
-In `test_structured_tool_output.py:164-185`, change `payload = structured["result"] if "result" in structured else structured` to `assert "result" not in structured; payload = structured`.
+In `test_structured_tool_output.py:164-185`, keep the existing wrapper-tolerant pattern `payload = structured["result"] if "result" in structured else structured` (per the cross-cutting wire shape note — FastMCP wraps `Union` returns in `{"result": ...}`). Update the inner assertions to use the renamed `results` key and add `assert payload["total"] is None`.
 
 - [ ] **Step 2: Run failing tests**
 
@@ -1958,7 +1962,7 @@ BREAKING:
 In `test_metadata_tools.py`, `test_metadata_tools_extended.py`, and the existing pilot test in `test_structured_tool_output.py:33-77`:
 
 - Find the inner namespace summary lookups: `result["namespaces"]["C"]["entry_count"]` → `result["namespaces"]["C"]["total"]`.
-- Replace `payload = structured["result"] if "result" in structured else structured` with `assert "result" not in structured; payload = structured`.
+- Keep the existing wrapper-tolerant pattern `payload = structured["result"] if "result" in structured else structured` (per the cross-cutting wire shape note — FastMCP wraps `Union` returns in `{"result": ...}`). Update inner assertions to use the renamed `total` key for namespace summaries.
 - Top-level keys preserved: `total_entries`, `sampled_entries`, `has_new_namespace_scheme`, `is_total_authoritative`, `discovery_method`, `namespaces`. No `results` / `next_cursor` / etc. (this tool doesn't get the contract).
 
 - [ ] **Step 2: Run failing tests**
@@ -2035,8 +2039,9 @@ Add `kind="internal"` (or whichever category) to every call. Tests that previous
 In `test_structured_tool_output.py`, find or add an `extract_article_links` test, and assert top-level shape:
 
 ```python
-assert "result" not in structured
-payload = structured
+# FastMCP wraps Union returns in a uniform {"result": ...} envelope
+# (see spec § FastMCP wrapping). Accept the wrapper; assert inner shape.
+payload = structured["result"] if "result" in structured else structured
 assert "results" in payload
 assert "kind" in payload and payload["kind"] == "internal"
 assert "category_totals" in payload
@@ -2195,14 +2200,15 @@ To get all three categories, callers make three calls."
 
 - [ ] **Step 1: Update tests**
 
-In each test file, replace `payload = structured["result"] if "result" in structured else structured` with:
+In each test file, keep the existing wrapper-tolerant pattern (per the cross-cutting wire shape note — FastMCP wraps `Union` returns in `{"result": ...}`):
 
 ```python
-assert "result" not in structured
-payload = structured
+# FastMCP wraps Union returns in a uniform {"result": ...} envelope
+# (see spec § FastMCP wrapping). Accept the wrapper; assert inner shape.
+payload = structured["result"] if "result" in structured else structured
 ```
 
-Existing assertions on `title`, `path`, `toc`, `heading_count`, `max_depth` are preserved.
+Existing assertions on `title`, `path`, `toc`, `heading_count`, `max_depth` apply to `payload` (the inner dict).
 
 - [ ] **Step 2: Run failing tests**
 
@@ -2210,7 +2216,7 @@ Existing assertions on `title`, `path`, `toc`, `heading_count`, `max_depth` are 
 uv run pytest tests/test_structure_tools.py tests/test_structured_tool_output.py -v -k "table_of_contents"
 ```
 
-Expected: failures (assertion `"result" not in structured` fails because TypedDict not yet wired).
+Expected: failures (until the `Union[TableOfContentsResponse, ToolErrorPayload]` annotation is wired and FastMCP emits the real anyOf schema).
 
 - [ ] **Step 3: Update return annotations**
 
@@ -2261,7 +2267,7 @@ preserved (title, path, toc, heading_count, max_depth)."
 
 - [ ] **Step 1: Update tests**
 
-Apply the `assert "result" not in structured` change. Existing keys preserved (`title`, `path`, `content_type`, `headings`, `sections`, `metadata`, `word_count`, `character_count`).
+Keep the existing wrapper-tolerant pattern `payload = structured["result"] if "result" in structured else structured` (per the cross-cutting wire shape note — FastMCP wraps `Union` returns in `{"result": ...}`). Existing keys preserved (`title`, `path`, `content_type`, `headings`, `sections`, `metadata`, `word_count`, `character_count`).
 
 - [ ] **Step 2: Run failing tests**
 
@@ -2314,7 +2320,7 @@ git commit -m "feat(v2)!: get_article_structure TypedDict migration"
 
 - [ ] **Step 1: Update tests**
 
-Apply the `assert "result" not in structured` change. Existing keys preserved (`path`, `title`, `mime_type`, `size`, `size_human`, `encoding`, `data`, `truncated`).
+Keep the existing wrapper-tolerant pattern `payload = structured["result"] if "result" in structured else structured` (per the cross-cutting wire shape note — FastMCP wraps `Union` returns in `{"result": ...}`). Existing keys preserved (`path`, `title`, `mime_type`, `size`, `size_human`, `encoding`, `data`, `truncated`).
 
 - [ ] **Step 2: Run failing tests**
 
@@ -2446,7 +2452,7 @@ inbound-link feature where direction becomes a parameter."
 
 - [ ] **Step 1: Update tests**
 
-Apply the `assert "result" not in structured` change. Existing keys preserved (`entry_count`, `all_entry_count`, `article_count`, `media_count`, `metadata_entries`).
+Keep the existing wrapper-tolerant pattern `payload = structured["result"] if "result" in structured else structured` (per the cross-cutting wire shape note — FastMCP wraps `Union` returns in `{"result": ...}`). Existing keys preserved (`entry_count`, `all_entry_count`, `article_count`, `media_count`, `metadata_entries`).
 
 - [ ] **Step 2: Run failing tests**
 
@@ -2510,7 +2516,7 @@ In any test that asserts on these tools' returns, swap the wrapper-tolerant payl
 uv run pytest tests/ -v -k "get_zim_entry or get_main_page or get_entry_summary"
 ```
 
-Expected: failures (assert "result" not in structured).
+Expected: failures (until the `Union[<Response>, ToolErrorPayload]` annotations are wired and FastMCP emits the real anyOf schema).
 
 - [ ] **Step 4: Update return annotations**
 
@@ -2980,12 +2986,12 @@ the contract keys."
 
 ---
 
-## Task 25: Extend `tests/test_structured_tool_output.py` to cover every migrated tool with a top-level-payload assertion
+## Task 25: Extend `tests/test_structured_tool_output.py` to cover every migrated tool with a wrapper-tolerant payload assertion
 
 **Files:**
 - Modify: `tests/test_structured_tool_output.py`
 
-**Why:** During Tasks 5-21 each migration touched this file with one-off changes. This task ensures every dict-returning tool has a single, consistent assertion: `assert "result" not in structured` (TypedDict landed payload at top level). Backstops the per-tool migration tasks.
+**Why:** During Tasks 5-21 each migration touched this file with one-off changes. This task ensures every dict-returning tool has a single, consistent assertion shape: unwrap the FastMCP `{"result": ...}` envelope and assert the inner TypedDict contract (per the cross-cutting wire shape note above — FastMCP wraps `Union` returns uniformly). Backstops the per-tool migration tasks.
 
 - [ ] **Step 1: List every dict-returning tool**
 
@@ -3004,7 +3010,7 @@ For each tool in the list above that doesn't have a test in this file, ADD one f
 async def test_<tool>_returns_structured_content(
     self, server: OpenZimMcpServer, basic_test_zim_files
 ) -> None:
-    """<tool> emits a real dict at the top level of structuredContent (no result wrapper)."""
+    """<tool> emits a real dict at structuredContent.result (FastMCP Union wrap)."""
     zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
     if zim_path is None:
         pytest.skip("ZIM testing-suite small.zim not available")
@@ -3016,26 +3022,15 @@ async def test_<tool>_returns_structured_content(
     assert isinstance(result, tuple)
     _, structured = result
     assert isinstance(structured, dict)
-    assert "result" not in structured, "TypedDict migration regression: payload still wrapped"
-    # Tool-specific top-level keys (one or two characteristic ones):
-    assert "<key1>" in structured
-    assert "<key2>" in structured
+    # FastMCP wraps Union returns in a uniform {"result": ...} envelope
+    # (see spec § FastMCP wrapping). Accept the wrapper; assert inner shape.
+    payload = structured["result"] if "result" in structured else structured
+    # Tool-specific keys (one or two characteristic ones):
+    assert "<key1>" in payload
+    assert "<key2>" in payload
 ```
 
-For each EXISTING test, replace the wrapper-tolerant pattern:
-
-```python
-payload = structured["result"] if "result" in structured else structured
-```
-
-with:
-
-```python
-assert "result" not in structured, "TypedDict migration regression: payload still wrapped"
-payload = structured
-```
-
-If you find a test that still uses the tolerant pattern (i.e., a per-tool task didn't tighten it), tighten it now.
+Every existing test should already use this wrapper-tolerant pattern. If you find a test using the strict pattern (`assert "result" not in structured`), loosen it now to the tolerant form above — the strict form is incompatible with the chosen `Union[<SuccessResponse>, ToolErrorPayload]` annotation per the cross-cutting wire shape note.
 
 - [ ] **Step 3: Run the file**
 
@@ -3043,7 +3038,7 @@ If you find a test that still uses the tolerant pattern (i.e., a per-tool task d
 uv run pytest tests/test_structured_tool_output.py -v
 ```
 
-Expected: every test PASS. The "result" not in structured assertion fails fast on any tool whose TypedDict migration drifted.
+Expected: every test PASS. The wrapper-tolerant pattern handles both pre-migration tools (no wrapper at all if anything ever returns single-TypedDict) and the standard `Union`-wrapped case.
 
 - [ ] **Step 4: Commit**
 
@@ -3051,8 +3046,9 @@ Expected: every test PASS. The "result" not in structured assertion fails fast o
 git add tests/test_structured_tool_output.py
 git commit -m "test(v2): extend structured-output regression to every migrated tool
 
-Each test now asserts payload lands at top level ('result' wrapper
-absent), backstopping the per-tool TypedDict migrations from Tasks 5-21."
+Each test now unwraps the FastMCP {result} envelope and asserts the
+inner TypedDict shape (per spec § FastMCP wrapping), backstopping the
+per-tool TypedDict migrations from Tasks 5-21."
 ```
 
 ---

--- a/docs/superpowers/plans/2026-05-08-v2-phase-b.md
+++ b/docs/superpowers/plans/2026-05-08-v2-phase-b.md
@@ -1,0 +1,3555 @@
+# v2 Phase B Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Read first:** [`docs/superpowers/specs/2026-05-08-v2-phase-b-response-contract-design.md`](../specs/2026-05-08-v2-phase-b-response-contract-design.md). The spec is the source of truth for the canonical shape, key removals, and per-tool before/after JSON. Each task below points at the relevant section.
+
+**Goal:** Standardize the wire format of every list-returning openzim_mcp tool around a uniform `PaginatedResponse` contract, and migrate every dict-returning tool from `Dict[str, Any]` to TypedDict so payloads land at the top of `structuredContent` with real schemas. Single bundled PR; tagged `v2.0.0a2`.
+
+**Architecture:** New `openzim_mcp/pagination.py` (versioned, tool-bound base64-JSON cursors) and new `openzim_mcp/tool_schemas.py` (all per-tool response TypedDicts). Every tool's `_data` method returns the typed shape; every `@server.mcp.tool()` registration carries a `Union[<SuccessResponse>, ToolErrorPayload]` return annotation. The Phase A `_meta` envelope is preserved unchanged as a sibling to the contract keys.
+
+**Tech Stack:** Python 3.12+, FastMCP (via `mcp.server.fastmcp`), libzim, `tiktoken` (already in deps from Phase A), `pytest` + `pytest-asyncio`.
+
+---
+
+## Plan structure
+
+The work decomposes into five phases, executed in order:
+
+1. **Foundation** (Tasks 1–4) — branch + new modules + shared TypedDicts.
+2. **Per-tool migrations** (Tasks 5–22) — one tool per task. Each task is independent once the foundation lands.
+3. **Cross-cutting cleanup** (Tasks 23–26) — simple-mode footer, cache-key bumps, test_structured_tool_output extension, contract-shape regression test.
+4. **Goldens + docs** (Tasks 27–29) — Phase B golden snapshots, README, CHANGELOG.
+5. **Release** (Tasks 30–31) — verify everything, open the bundled PR.
+
+Each task is self-contained: a fresh subagent should be able to execute it by reading only this plan + the spec. When in doubt, refer the spec for shape details.
+
+---
+
+## Task 1: Create the v2-phase-b branch
+
+**Files:** none (git operations only)
+
+- [ ] **Step 1: Verify clean state on main**
+
+```bash
+git status --porcelain
+git branch --show-current
+```
+
+Expected: empty output from `git status --porcelain`; `main` from `git branch --show-current`. If main is dirty or you're on another branch, stop and ask the user.
+
+- [ ] **Step 2: Pull latest main**
+
+```bash
+git pull --ff-only origin main
+```
+
+Expected: `Already up to date.` or a successful fast-forward. If it fails, stop.
+
+- [ ] **Step 3: Create the branch off main**
+
+```bash
+git checkout -b v2-phase-b
+```
+
+Expected: `Switched to a new branch 'v2-phase-b'`.
+
+- [ ] **Step 4: Confirm**
+
+```bash
+git branch --show-current
+```
+
+Expected: `v2-phase-b`.
+
+No commit on this task — the branch creation IS the work.
+
+---
+
+## Task 2: Add `openzim_mcp/pagination.py` with versioned, tool-bound `Cursor`
+
+**Files:**
+- Create: `openzim_mcp/pagination.py`
+- Create: `tests/test_pagination_cursor.py`
+
+**Why:** This is the foundation every paginated tool depends on. Tool-bound (`t` field) cursors prevent cross-tool reuse bugs; versioned (`v`) cursors allow forward-compat field additions without a wire-format break.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_pagination_cursor.py`:
+
+```python
+"""Tests for openzim_mcp.pagination.Cursor — encode/decode, tool binding, versioning."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+
+from openzim_mcp.pagination import Cursor, CursorMismatchError
+
+
+class TestCursorRoundTrip:
+    def test_encode_decode_roundtrip_minimal(self) -> None:
+        token = Cursor.encode(tool="browse_namespace", state={"o": 50, "l": 50, "ns": "C"})
+        assert isinstance(token, str)
+        decoded = Cursor.decode(token, expected_tool="browse_namespace")
+        assert decoded["v"] == 1
+        assert decoded["t"] == "browse_namespace"
+        assert decoded["s"] == {"o": 50, "l": 50, "ns": "C"}
+
+    def test_encode_produces_urlsafe_base64(self) -> None:
+        token = Cursor.encode(tool="search_zim_file", state={"o": 0, "l": 20, "q": "berlin"})
+        # url-safe base64 doesn't include + or /
+        assert "+" not in token
+        assert "/" not in token
+
+    def test_encode_unicode_state(self) -> None:
+        token = Cursor.encode(tool="search_zim_file", state={"o": 0, "l": 20, "q": "café"})
+        decoded = Cursor.decode(token, expected_tool="search_zim_file")
+        assert decoded["s"]["q"] == "café"
+
+
+class TestCursorVersioning:
+    def test_default_version_is_one(self) -> None:
+        token = Cursor.encode(tool="browse_namespace", state={"o": 0, "l": 50, "ns": "C"})
+        decoded = Cursor.decode(token, expected_tool="browse_namespace")
+        assert decoded["v"] == 1
+
+    def test_explicit_version_passes_through(self) -> None:
+        token = Cursor.encode(tool="browse_namespace", state={"o": 0, "l": 50, "ns": "C"}, version=1)
+        decoded = Cursor.decode(token, expected_tool="browse_namespace")
+        assert decoded["v"] == 1
+
+    def test_unknown_version_rejected(self) -> None:
+        # Hand-craft a v=2 token; decoder should reject it.
+        raw = json.dumps({"v": 2, "t": "browse_namespace", "s": {"o": 0, "l": 50, "ns": "C"}})
+        token = base64.urlsafe_b64encode(raw.encode()).decode()
+        with pytest.raises(ValueError, match="Unsupported cursor version"):
+            Cursor.decode(token, expected_tool="browse_namespace")
+
+
+class TestCursorToolBinding:
+    def test_decode_with_matching_tool_succeeds(self) -> None:
+        token = Cursor.encode(tool="search_zim_file", state={"o": 0, "l": 20, "q": "x"})
+        decoded = Cursor.decode(token, expected_tool="search_zim_file")
+        assert decoded["t"] == "search_zim_file"
+
+    def test_decode_with_mismatched_tool_raises(self) -> None:
+        token = Cursor.encode(tool="search_zim_file", state={"o": 0, "l": 20, "q": "x"})
+        with pytest.raises(CursorMismatchError) as exc_info:
+            Cursor.decode(token, expected_tool="browse_namespace")
+        # Error message must name both the issuing tool and the target tool
+        # so the model can produce a useful tool_error response.
+        assert "search_zim_file" in str(exc_info.value)
+        assert "browse_namespace" in str(exc_info.value)
+
+    def test_mismatch_error_is_value_error_subclass(self) -> None:
+        # tool_error wrappers catch both; making CursorMismatchError a
+        # ValueError subclass means a single except-clause covers both
+        # decode failure modes.
+        assert issubclass(CursorMismatchError, ValueError)
+
+
+class TestCursorMalformed:
+    def test_decode_garbage_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Invalid pagination cursor"):
+            Cursor.decode("not-base64!@#$", expected_tool="browse_namespace")
+
+    def test_decode_valid_base64_invalid_json_raises(self) -> None:
+        token = base64.urlsafe_b64encode(b"this is not json").decode()
+        with pytest.raises(ValueError, match="Invalid pagination cursor"):
+            Cursor.decode(token, expected_tool="browse_namespace")
+
+    def test_decode_missing_required_fields_raises(self) -> None:
+        # Missing "t" — tool identity is required.
+        raw = json.dumps({"v": 1, "s": {"o": 0, "l": 20}})
+        token = base64.urlsafe_b64encode(raw.encode()).decode()
+        with pytest.raises(ValueError, match="missing"):
+            Cursor.decode(token, expected_tool="browse_namespace")
+
+    def test_decode_tolerates_missing_padding(self) -> None:
+        # Some clients strip base64 padding; decoder must tolerate that.
+        token = Cursor.encode(tool="browse_namespace", state={"o": 0, "l": 50, "ns": "C"})
+        stripped = token.rstrip("=")
+        decoded = Cursor.decode(stripped, expected_tool="browse_namespace")
+        assert decoded["s"]["ns"] == "C"
+
+
+class TestCursorEmptyState:
+    def test_empty_state_dict_allowed(self) -> None:
+        # walk_namespace at scan_at=0 still needs a cursor for paging consistency.
+        token = Cursor.encode(tool="walk_namespace", state={"scan_at": 0, "l": 200})
+        decoded = Cursor.decode(token, expected_tool="walk_namespace")
+        assert decoded["s"]["scan_at"] == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail with import errors**
+
+```bash
+uv run pytest tests/test_pagination_cursor.py -v
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'openzim_mcp.pagination'`.
+
+- [ ] **Step 3: Create `openzim_mcp/pagination.py`**
+
+```python
+"""Pagination cursor primitives — versioned, tool-bound, opaque.
+
+v2 Phase B promotes the v1 ``PaginationCursor`` (offset/limit/query only) to
+a tool-bound, versioned cursor. The wire format is a URL-safe base64 encoding
+of a JSON object:
+
+    {"v": 1, "t": "<tool_name>", "s": {<tool-specific state>}}
+
+* ``v`` lets us add new required fields later without a wire-format break.
+* ``t`` rejects cross-tool cursor reuse (a search cursor passed to browse
+  raises ``CursorMismatchError`` instead of silently misbehaving).
+* ``s`` carries the per-tool paging state — offset/limit/query for search,
+  scan_at for walk_namespace, etc.
+
+Decode failures and tool mismatches both subclass ``ValueError`` so a single
+except-clause in tool wrappers catches both.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any, Dict
+
+CURRENT_VERSION = 1
+
+
+class CursorMismatchError(ValueError):
+    """Raised when a cursor's ``t`` field doesn't match ``expected_tool``."""
+
+
+class Cursor:
+    """Encode/decode opaque pagination cursors."""
+
+    @staticmethod
+    def encode(*, tool: str, state: Dict[str, Any], version: int = CURRENT_VERSION) -> str:
+        """Encode a cursor payload as URL-safe base64 JSON.
+
+        Args:
+            tool: Tool name. Decoders verify this matches their expected tool.
+            state: Tool-specific paging state (offset/limit/query/scan_at/etc.).
+            version: Cursor format version. Defaults to ``CURRENT_VERSION``.
+
+        Returns:
+            URL-safe base64 string suitable for ``next_cursor`` in a tool response.
+        """
+        payload: Dict[str, Any] = {"v": version, "t": tool, "s": state}
+        raw = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+        return base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+
+    @staticmethod
+    def decode(token: str, *, expected_tool: str) -> Dict[str, Any]:
+        """Decode a cursor and verify it was issued by ``expected_tool``.
+
+        Args:
+            token: A previously-encoded cursor. Padding-stripped tokens are tolerated.
+            expected_tool: The tool whose state ``token`` is expected to carry.
+
+        Returns:
+            The decoded payload dict with keys ``v``, ``t``, ``s``.
+
+        Raises:
+            ValueError: Token isn't valid base64 / JSON, or is missing required
+                fields, or carries an unsupported version. Subclasses include:
+            CursorMismatchError: Token's ``t`` field doesn't match ``expected_tool``.
+        """
+        try:
+            padded = token + "=" * (-len(token) % 4)
+            raw = base64.urlsafe_b64decode(padded.encode("ascii")).decode("utf-8")
+            payload = json.loads(raw)
+        except Exception as e:
+            raise ValueError(f"Invalid pagination cursor: {e}") from e
+
+        if not isinstance(payload, dict):
+            raise ValueError("Invalid pagination cursor: payload must be an object")
+        if "v" not in payload or "t" not in payload or "s" not in payload:
+            raise ValueError("Invalid pagination cursor: missing required fields (v, t, s)")
+        if payload["v"] != CURRENT_VERSION:
+            raise ValueError(
+                f"Unsupported cursor version: got v={payload['v']}, expected v={CURRENT_VERSION}"
+            )
+        if not isinstance(payload["t"], str):
+            raise ValueError("Invalid pagination cursor: 't' must be a string")
+        if not isinstance(payload["s"], dict):
+            raise ValueError("Invalid pagination cursor: 's' must be an object")
+        if payload["t"] != expected_tool:
+            raise CursorMismatchError(
+                f"Cursor was issued by '{payload['t']}', cannot be used by '{expected_tool}'"
+            )
+        return payload
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+uv run pytest tests/test_pagination_cursor.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add openzim_mcp/pagination.py tests/test_pagination_cursor.py
+git commit -m "feat(v2): add versioned, tool-bound Cursor primitive
+
+Foundation for the Phase B response-contract migration. The new Cursor
+encodes (version, tool, state) as URL-safe base64 JSON and rejects
+cross-tool reuse via the t field. Subsumes the v1 PaginationCursor
+(which lives on under a compat alias until per-tool migrations land)."
+```
+
+---
+
+## Task 3: Migrate existing `PaginationCursor` callers to use the new `Cursor` API via a compat shim
+
+**Files:**
+- Modify: `openzim_mcp/zim/archive.py:79-142` (replace `PaginationCursor` body)
+- (No other call-site changes — `PaginationCursor` keeps its public API.)
+
+**Why:** Existing call sites (`search.py`, `namespace.py`) rely on `PaginationCursor.create_next_cursor()` and `PaginationCursor.decode()`. We don't want to break them mid-migration. This task swaps the implementation underneath while keeping the public API identical, so production tests stay green during the per-tool migrations that follow.
+
+The compat shim will be REMOVED in Task 22 once every caller has migrated to `Cursor` directly.
+
+- [ ] **Step 1: Update `openzim_mcp/zim/archive.py` `PaginationCursor` class body**
+
+Replace lines 79–142 (`class PaginationCursor: ...`) with:
+
+```python
+class PaginationCursor:
+    """Compatibility shim over ``openzim_mcp.pagination.Cursor``.
+
+    v1.x callers used ``PaginationCursor.create_next_cursor`` and
+    ``PaginationCursor.decode`` with no tool identity. v2 Phase B migrates
+    each caller to ``openzim_mcp.pagination.Cursor`` (tool-bound). Until
+    every caller has been migrated, this shim emits cursors with
+    ``t="legacy"`` and a permissive decoder that accepts both legacy
+    cursors and the new Phase B cursors.
+
+    Removed at the end of Phase B (see plan Task 22).
+    """
+
+    @staticmethod
+    def _encode(offset: int, limit: int, query: Optional[str] = None) -> str:
+        """Encode pagination state into a base64 cursor token (legacy shape)."""
+        from openzim_mcp.pagination import Cursor
+
+        state: Dict[str, Any] = {"o": offset, "l": limit}
+        if query:
+            state["q"] = query
+        return Cursor.encode(tool="legacy", state=state)
+
+    @staticmethod
+    def create_next_cursor(
+        current_offset: int, limit: int, total: int, query: Optional[str] = None
+    ) -> Optional[str]:
+        next_offset = current_offset + limit
+        if next_offset >= total:
+            return None
+        return PaginationCursor._encode(next_offset, limit, query)
+
+    @staticmethod
+    def decode(token: str) -> Dict[str, Any]:
+        """Decode a legacy (or new) cursor into the legacy ``{o, l, q?}`` shape.
+
+        Tolerates both v1 cursors (raw JSON without the v/t/s envelope) and
+        v2 cursors (tool-bound, versioned). Raises ``ValueError`` on malformed
+        tokens.
+        """
+        import base64
+        import json
+
+        try:
+            padded = token + "=" * (-len(token) % 4)
+            raw = base64.urlsafe_b64decode(padded.encode()).decode()
+            data = json.loads(raw)
+        except Exception as e:
+            raise ValueError(f"Invalid pagination cursor: {e}") from e
+        if not isinstance(data, dict):
+            raise ValueError("Cursor must decode to a JSON object")
+        # v2 envelope: {v, t, s} — return s as the legacy shape.
+        if "s" in data and "v" in data and "t" in data:
+            inner = data["s"]
+            if not isinstance(inner, dict) or "o" not in inner or "l" not in inner:
+                raise ValueError("Cursor missing required fields ('o', 'l')")
+            if not isinstance(inner["o"], int) or not isinstance(inner["l"], int):
+                raise ValueError("Cursor offset and limit must be integers")
+            return inner
+        # v1 raw shape.
+        if "o" not in data or "l" not in data:
+            raise ValueError("Cursor missing required fields ('o', 'l')")
+        if not isinstance(data["o"], int) or not isinstance(data["l"], int):
+            raise ValueError("Cursor offset and limit must be integers")
+        return data
+```
+
+The class signature/exports are unchanged. `__all__` at line 58–68 still lists `PaginationCursor`; leave it alone.
+
+- [ ] **Step 2: Drop the now-unused `base64` and `json` imports if they're no longer referenced**
+
+```bash
+grep -n "^import base64\|^import json" openzim_mcp/zim/archive.py
+```
+
+Both are likely still used elsewhere in archive.py (file listing, metadata). If they ARE still used, leave them. If a module-top-level import is now unused, remove it. Verify with:
+
+```bash
+uv run ruff check openzim_mcp/zim/archive.py
+```
+
+Fix any unused-import warnings.
+
+- [ ] **Step 3: Run the full search/namespace test suites to verify zero regressions**
+
+```bash
+uv run pytest tests/test_search_tools.py tests/test_navigation_tools.py tests/test_walk_namespace.py -v
+```
+
+Expected: all tests PASS. The shim must produce identical behavior on the existing API surface.
+
+- [ ] **Step 4: Run the new pagination cursor tests to verify they still pass**
+
+```bash
+uv run pytest tests/test_pagination_cursor.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add openzim_mcp/zim/archive.py
+git commit -m "refactor(v2): PaginationCursor delegates to new Cursor primitive
+
+Compat shim — public API unchanged, implementation now goes through
+openzim_mcp.pagination.Cursor with t='legacy'. Removed at the end of
+Phase B once every caller has migrated to the tool-bound Cursor API."
+```
+
+---
+
+## Task 4: Add `openzim_mcp/tool_schemas.py` with all per-tool TypedDicts
+
+**Files:**
+- Create: `openzim_mcp/tool_schemas.py`
+- Create: `tests/test_tool_schemas.py`
+
+**Why:** Centralizing every per-tool response TypedDict in one file makes the schema surface auditable, prevents drift between tools that share patterns (e.g., search-style vs. namespace-style), and gives FastMCP a stable import target for return-type annotations. This task defines them all up-front so per-tool migration tasks can just import.
+
+The file is large (~250 lines) but structurally simple. Subagent should follow the layout below precisely — divergence creates drift the contract regression test can't catch.
+
+- [ ] **Step 1: Write the failing structural test**
+
+Create `tests/test_tool_schemas.py`:
+
+```python
+"""Structural tests for openzim_mcp.tool_schemas.
+
+These tests don't assert behavior — they assert the TypedDict surface
+exists and the contract keys are present on every list-returning response.
+The dynamic per-tool wire-format checks live in test_response_contract.py.
+"""
+
+from __future__ import annotations
+
+from typing import get_type_hints
+
+from openzim_mcp import tool_schemas as ts
+
+
+# Every list-returning response TypedDict must declare these five keys
+# plus _meta. The interpretation of each is documented in the spec.
+CONTRACT_KEYS = {"results", "next_cursor", "total", "done", "page_info", "_meta"}
+
+
+def test_page_info_has_required_fields() -> None:
+    hints = get_type_hints(ts.PageInfo)
+    assert "offset" in hints
+    assert "limit" in hints
+    assert "returned_count" in hints
+    # total_is_lower_bound is NotRequired — get_type_hints still surfaces it.
+    assert "total_is_lower_bound" in hints
+
+
+def test_meta_envelope_has_phase_a_fields() -> None:
+    hints = get_type_hints(ts.MetaEnvelope)
+    for key in ("tokens_est", "chars", "truncated", "more_at_offset", "total_chars",
+                "suggestions", "reason"):
+        assert key in hints, f"MetaEnvelope missing {key}"
+
+
+def test_paginated_responses_carry_contract_keys() -> None:
+    paginated = [
+        ts.SearchResponse,
+        ts.SearchAllResponse,
+        ts.SearchWithFiltersResponse,
+        ts.FindEntryResponse,
+        ts.SearchSuggestionsResponse,
+        ts.BrowseNamespaceResponse,
+        ts.WalkNamespaceResponse,
+        ts.LinksResponse,
+        ts.ListZimFilesResponse,
+        ts.RelatedArticlesResponse,
+        ts.BatchEntryResponse,
+    ]
+    for cls in paginated:
+        hints = get_type_hints(cls)
+        missing = CONTRACT_KEYS - set(hints.keys())
+        assert not missing, f"{cls.__name__} missing contract keys: {missing}"
+
+
+def test_non_paginated_responses_do_not_carry_results() -> None:
+    """list_namespaces and the entry/metadata tools don't get the contract."""
+    non_paginated = [
+        ts.ZimMetadataResponse,
+        ts.ListNamespacesResponse,
+        ts.EntryResponse,
+        ts.EntrySummaryResponse,
+        ts.TableOfContentsResponse,
+        ts.ArticleStructureResponse,
+        ts.BinaryEntryResponse,
+    ]
+    for cls in non_paginated:
+        hints = get_type_hints(cls)
+        # _meta is universal; the rest of the contract keys must NOT be present.
+        leaked = {"results", "next_cursor", "done", "page_info"} & set(hints.keys())
+        assert not leaked, f"{cls.__name__} unexpectedly has paginated keys: {leaked}"
+        assert "_meta" in hints, f"{cls.__name__} missing _meta envelope"
+```
+
+- [ ] **Step 2: Run tests to verify they fail with import errors**
+
+```bash
+uv run pytest tests/test_tool_schemas.py -v
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'openzim_mcp.tool_schemas'`.
+
+- [ ] **Step 3: Create `openzim_mcp/tool_schemas.py`**
+
+```python
+"""Per-tool response TypedDicts for v2 Phase B.
+
+Every dict-returning tool's ``_data`` method returns one of these
+TypedDicts (or ``ToolErrorPayload`` from openzim_mcp.responses on
+failure). FastMCP reads the function's return annotation to generate
+the output schema and emits the payload at the top level of
+``structuredContent`` — no ``{"result": ...}`` wrapper.
+
+Every list-returning tool's TypedDict carries the five contract keys
+(``results``, ``next_cursor``, ``total``, ``done``, ``page_info``)
+plus ``_meta``. See the design spec for shape details:
+docs/superpowers/specs/2026-05-08-v2-phase-b-response-contract-design.md
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, NotRequired, Optional, TypedDict
+
+
+# ---------- shared sub-shapes ----------
+
+
+class PageInfo(TypedDict):
+    offset: int
+    limit: int
+    returned_count: int
+    total_is_lower_bound: NotRequired[bool]
+
+
+class MetaEnvelope(TypedDict, total=False):
+    tokens_est: int
+    chars: int
+    truncated: bool
+    more_at_offset: int
+    total_chars: int
+    suggestions: List[Dict[str, str]]
+    reason: str
+
+
+# ---------- per-item shapes ----------
+
+
+class SearchHit(TypedDict):
+    path: str
+    title: str
+    snippet: str
+    # search_all carries archive identity per-hit; per-archive search omits it.
+    zim_file: NotRequired[str]
+
+
+class FindEntryHit(TypedDict):
+    path: str
+    title: str
+    score: float
+    zim_file: NotRequired[str]
+    match_type: NotRequired[str]
+
+
+class SuggestionItem(TypedDict):
+    text: str
+    path: str
+    type: str
+
+
+class NamespaceEntry(TypedDict):
+    path: str
+    title: str
+    content_type: NotRequired[str]
+    preview: NotRequired[str]
+
+
+class WalkEntry(TypedDict):
+    path: str
+    title: str
+
+
+class LinkItem(TypedDict):
+    target: str
+    label: str
+
+
+class FileSummary(TypedDict):
+    name: str
+    path: str
+    directory: str
+    size: str
+    size_bytes: int
+    modified: str
+
+
+class RelatedArticle(TypedDict):
+    path: str
+    title: str
+    link_text: NotRequired[str]
+
+
+class NamespaceSummary(TypedDict):
+    total: int
+    is_authoritative: bool
+
+
+# ---------- list-returning tool responses ----------
+
+
+class SearchResponse(TypedDict):
+    # Contract keys
+    results: List[SearchHit]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    # Tool-specific extras
+    query: str
+
+
+class _SearchAllPerFile(TypedDict):
+    zim_file_path: str
+    name: str
+    has_hits: bool
+    result: SearchResponse
+
+
+class SearchAllResponse(TypedDict):
+    results: List[_SearchAllPerFile]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    # Tool-specific extras
+    query: str
+    files_searched: int
+    files_with_hits: int
+    files_searched_successfully: int
+    files_failed: int
+
+
+class SearchWithFiltersResponse(TypedDict):
+    results: List[SearchHit]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    query: str
+    namespace_filter: Optional[str]
+    content_type_filter: Optional[str]
+
+
+class FindEntryResponse(TypedDict):
+    results: List[FindEntryHit]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    query: str
+    fast_path_hit: bool
+    files_searched: int
+
+
+class SearchSuggestionsResponse(TypedDict):
+    results: List[SuggestionItem]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    partial_query: str
+
+
+class BrowseNamespaceResponse(TypedDict):
+    results: List[NamespaceEntry]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    namespace: str
+    discovery_method: str
+    sampling_based: bool
+    results_may_be_incomplete: bool
+
+
+class WalkNamespaceResponse(TypedDict):
+    results: List[WalkEntry]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    namespace: str
+    scanned_count: int
+    scanned_through_id: int
+    archive_entry_count: int
+
+
+class LinksResponse(TypedDict):
+    results: List[LinkItem]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    title: str
+    path: str
+    content_type: str
+    kind: str
+    category_totals: Dict[str, int]
+
+
+class ListZimFilesResponse(TypedDict):
+    results: List[FileSummary]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    name_filter: Optional[str]
+    directories_count: int
+
+
+class RelatedArticlesResponse(TypedDict):
+    results: List[RelatedArticle]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    entry_path: str
+
+
+class _BatchEntryItem(TypedDict):
+    path: str
+    success: bool
+    content: NotRequired[str]
+    error: NotRequired[str]
+
+
+class BatchEntryResponse(TypedDict):
+    results: List[_BatchEntryItem]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    succeeded: int
+    failed: int
+
+
+# ---------- non-list tool responses ----------
+
+
+class ZimMetadataResponse(TypedDict):
+    entry_count: int
+    all_entry_count: int
+    article_count: int
+    media_count: int
+    metadata_entries: NotRequired[Dict[str, Any]]
+    _meta: MetaEnvelope
+
+
+class ListNamespacesResponse(TypedDict):
+    total_entries: int
+    sampled_entries: int
+    has_new_namespace_scheme: bool
+    is_total_authoritative: bool
+    discovery_method: str
+    namespaces: Dict[str, NamespaceSummary]
+    _meta: MetaEnvelope
+
+
+class EntryResponse(TypedDict):
+    path: str
+    title: str
+    content: str
+    content_type: NotRequired[str]
+    _meta: MetaEnvelope
+
+
+class EntrySummaryResponse(TypedDict):
+    path: str
+    title: str
+    summary: str
+    word_count: NotRequired[int]
+    _meta: MetaEnvelope
+
+
+class TableOfContentsResponse(TypedDict):
+    title: str
+    path: str
+    toc: List[Dict[str, Any]]
+    heading_count: int
+    max_depth: int
+    _meta: MetaEnvelope
+
+
+class ArticleStructureResponse(TypedDict):
+    title: str
+    path: str
+    content_type: str
+    headings: List[Dict[str, Any]]
+    sections: List[Dict[str, Any]]
+    metadata: Dict[str, Any]
+    word_count: int
+    character_count: int
+    _meta: MetaEnvelope
+
+
+class BinaryEntryResponse(TypedDict):
+    path: str
+    title: str
+    mime_type: str
+    size: int
+    size_human: str
+    encoding: Optional[str]
+    truncated: bool
+    data: NotRequired[Optional[str]]
+    _meta: MetaEnvelope
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+uv run pytest tests/test_tool_schemas.py -v
+```
+
+Expected: all 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add openzim_mcp/tool_schemas.py tests/test_tool_schemas.py
+git commit -m "feat(v2): add per-tool response TypedDicts for Phase B contract
+
+Defines PageInfo, MetaEnvelope, and one TypedDict per dict-returning
+tool. Every list-returning shape carries the five contract keys
+(results, next_cursor, total, done, page_info) plus _meta. Used as
+return annotations in upcoming per-tool migrations so FastMCP emits
+top-level structuredContent payloads with real schemas."
+```
+
+---
+
+## Task 5: Migrate `search_zim_file` to the contract + TypedDict
+
+**Files:**
+- Modify: `openzim_mcp/zim/search.py:269-370` (`_perform_search`)
+- Modify: `openzim_mcp/zim/search.py:183-267` (`search_zim_file_data`)
+- Modify: `openzim_mcp/tools/search_tools.py:25-148` (tool registration)
+- Modify: `tests/test_search_tools.py` (key-rename assertions)
+- Modify: `tests/test_structured_tool_output.py:30-77` (top-level payload assertion)
+
+**Why:** Foundational paginated tool. The migration pattern established here is repeated for every other paginated tool. See spec section [`search_zim_file`](../specs/2026-05-08-v2-phase-b-response-contract-design.md#search_zim_file) for the before/after JSON.
+
+**Wire-format changes:** `pagination` nested block removed; `total_results` → `total`; `pagination.has_more` → top-level `done` (polarity flipped); top-level `next_cursor`; new `page_info`; `pagination.showing_start`/`showing_end` removed (derivable from offset+returned_count). Cursor uses `Cursor.encode(tool="search_zim_file", state={"o": offset, "l": limit, "q": query})`.
+
+- [ ] **Step 1: Update `tests/test_search_tools.py` test assertions for the new shape**
+
+Open `tests/test_search_tools.py`. Find every test that calls `search_zim_file_data`, `search_zim_file`, or asserts on the structured response. Update the assertions:
+
+- `result["total_results"]` → `result["total"]`
+- `result["pagination"]["has_more"]` → `not result["done"]` (polarity flip)
+- `result["pagination"]["next_cursor"]` → `result["next_cursor"]`
+- `result["offset"]` → `result["page_info"]["offset"]`
+- `result["limit"]` → `result["page_info"]["limit"]`
+- Remove any assertions on `pagination.showing_start` / `pagination.showing_end` / `pagination.offset_exceeds_total` (the `offset_exceeds_total` flag is replaced by an empty `results` list and `total < offset` — assertions can check that.)
+- Add assertion `result["page_info"]["returned_count"] == len(result["results"])` to one test for guard-rail coverage.
+
+For tests that decode `next_cursor` to verify shape, replace usages of `PaginationCursor.decode` with:
+
+```python
+from openzim_mcp.pagination import Cursor
+decoded = Cursor.decode(result["next_cursor"], expected_tool="search_zim_file")
+assert decoded["s"]["o"] == <expected_offset>
+assert decoded["s"]["l"] == <expected_limit>
+assert decoded["s"]["q"] == "<expected_query>"
+```
+
+- [ ] **Step 2: Update `tests/test_structured_tool_output.py:30-77` top-level assertion for `search_zim_file`**
+
+If a `search_zim_file` test exists in this file, change:
+
+```python
+payload = structured["result"] if "result" in structured else structured
+```
+
+to:
+
+```python
+# Phase B: TypedDict return — payload is at top level, no "result" wrapper.
+assert "result" not in structured, "TypedDict migration regression: payload still wrapped"
+payload = structured
+```
+
+If there's no `search_zim_file` test there yet, add one following the pattern of existing tests in that file (use `convert_result=True`, assert tuple, assert dict, assert top-level keys).
+
+- [ ] **Step 3: Run failing tests to confirm they fail with the right diagnostics**
+
+```bash
+uv run pytest tests/test_search_tools.py tests/test_structured_tool_output.py -v -k "search_zim_file or search"
+```
+
+Expected: failures pointing at missing `total` / `done` / `page_info` keys, or at `result` wrapper present.
+
+- [ ] **Step 4: Update `_perform_search` (search.py:269) to produce the new shape**
+
+Replace the `_perform_search` method body with:
+
+```python
+    def _perform_search(
+        self, archive: Archive, query: str, limit: int, offset: int
+    ) -> Tuple[Dict[str, Any], int]:
+        """Perform the actual search operation.
+
+        Returns:
+            (structured_payload, total_results) — caller uses total_results
+            to decide whether the response is safe to cache. The payload
+            shape is documented on ``search_zim_file_data``.
+        """
+        from openzim_mcp.pagination import Cursor
+
+        query_obj = _zim_ops_mod.Query().set_query(query)
+        searcher = _zim_ops_mod.Searcher(archive)
+        search = searcher.search(query_obj)
+
+        total_results = search.getEstimatedMatches()
+
+        if total_results == 0:
+            return (
+                {
+                    "query": query,
+                    "results": [],
+                    "next_cursor": None,
+                    "total": 0,
+                    "done": True,
+                    "page_info": {
+                        "offset": offset,
+                        "limit": limit,
+                        "returned_count": 0,
+                    },
+                },
+                0,
+            )
+
+        if offset >= total_results:
+            return (
+                {
+                    "query": query,
+                    "results": [],
+                    "next_cursor": None,
+                    "total": total_results,
+                    "done": True,
+                    "page_info": {
+                        "offset": offset,
+                        "limit": limit,
+                        "returned_count": 0,
+                    },
+                },
+                total_results,
+            )
+
+        result_count = min(limit, total_results - offset)
+        result_entries = list(search.getResults(offset, result_count))
+
+        results: List[Dict[str, Any]] = []
+        for i, entry_id in enumerate(result_entries):
+            try:
+                entry = archive.get_entry_by_path(entry_id)
+                title = entry.title or "Untitled"
+                snippet = self._get_entry_snippet(entry, query=query)
+                results.append({"path": entry_id, "title": title, "snippet": snippet})
+            except Exception as e:
+                logger.warning(f"Error processing search result {entry_id}: {e}")
+                results.append(
+                    {
+                        "path": entry_id,
+                        "title": f"Entry {offset + i + 1}",
+                        "snippet": f"(Error getting entry details: {e})",
+                    }
+                )
+
+        returned_count = len(results)
+        last_index = offset + returned_count
+        done = last_index >= total_results
+        next_cursor: Optional[str] = None
+        if not done:
+            next_cursor = Cursor.encode(
+                tool="search_zim_file",
+                state={"o": last_index, "l": limit, "q": query},
+            )
+
+        return (
+            {
+                "query": query,
+                "results": results,
+                "next_cursor": next_cursor,
+                "total": total_results,
+                "done": done,
+                "page_info": {
+                    "offset": offset,
+                    "limit": limit,
+                    "returned_count": returned_count,
+                },
+            },
+            total_results,
+        )
+```
+
+- [ ] **Step 5: Bump the cache key in `search_zim_file_data` (line ~210)**
+
+Replace:
+
+```python
+        cache_key = f"search_data:{validated_path}:{query}:{limit}:{offset}"
+```
+
+with:
+
+```python
+        # Cache key bumped to v2b (Phase B) so v1.x cached responses (old shape)
+        # don't leak through after the upgrade.
+        cache_key = f"search_v2b:{validated_path}:{query}:{limit}:{offset}"
+```
+
+- [ ] **Step 6: Update `_format_search_text` (search.py:372) to read the new keys**
+
+Replace the `query`/`total_results`/`offset`/`limit`/`results`/`pagination` extraction at lines 378–383 with:
+
+```python
+        query = payload["query"]
+        total_results = payload["total"] or 0
+        page_info = payload["page_info"]
+        offset = page_info["offset"]
+        limit = page_info["limit"]
+        results = payload["results"]
+        done = payload["done"]
+        next_cursor = payload.get("next_cursor")
+```
+
+Then update the rest of the function: anywhere it referenced `pagination["has_more"]`, use `not done`. Anywhere it referenced `pagination["showing_start"]` / `showing_end`, compute them as `offset + 1` and `offset + len(results)` inline. Anywhere it referenced `pagination["next_cursor"]`, use `next_cursor` directly.
+
+- [ ] **Step 7: Update `search_zim_file_data` return annotation (search.py:189)**
+
+Change:
+
+```python
+    ) -> Dict[str, Any]:
+```
+
+to:
+
+```python
+    ) -> "SearchResponse":
+```
+
+Add at the top of search.py (after the existing imports):
+
+```python
+from openzim_mcp.tool_schemas import SearchResponse
+```
+
+(Use `if TYPE_CHECKING:` guard if there's a circular-import concern; otherwise import directly.)
+
+- [ ] **Step 8: Update tool registration in `openzim_mcp/tools/search_tools.py`**
+
+Find the `search_zim_file` registration (around line 25). Update its return annotation:
+
+```python
+async def search_zim_file(
+    zim_file_path: str,
+    query: str,
+    limit: Optional[int] = None,
+    offset: int = 0,
+    cursor: Optional[str] = None,
+) -> Union["SearchResponse", "ToolErrorPayload"]:
+```
+
+Add a `cursor: Optional[str] = None` parameter. At the top of the function body, before the rate-limit check, add:
+
+```python
+    # Phase B: cursor wins on conflict per response-contract spec.
+    if cursor is not None:
+        from openzim_mcp.pagination import Cursor, CursorMismatchError
+        try:
+            decoded = Cursor.decode(cursor, expected_tool="search_zim_file")
+        except CursorMismatchError as e:
+            return tool_error(
+                operation="search ZIM file",
+                message=str(e),
+                context=f"Tool: search_zim_file, cursor=<truncated>",
+            )
+        except ValueError as e:
+            return tool_error(
+                operation="search ZIM file",
+                message=f"Invalid pagination cursor: {e}",
+                context=f"Tool: search_zim_file",
+            )
+        offset = decoded["s"]["o"]
+        if "l" in decoded["s"]:
+            limit = decoded["s"]["l"]
+        # Cursor's q overrides the query argument so the cursor round-trips
+        # cleanly even if a caller forgets to pass query alongside.
+        if "q" in decoded["s"]:
+            query = decoded["s"]["q"]
+```
+
+Add the imports at the top of the file:
+
+```python
+from typing import Optional, Union
+from openzim_mcp.tool_schemas import SearchResponse
+from openzim_mcp.responses import ToolErrorPayload
+```
+
+- [ ] **Step 9: Run the affected tests**
+
+```bash
+uv run pytest tests/test_search_tools.py tests/test_structured_tool_output.py tests/test_search_all.py -v
+```
+
+Expected: all PASS. (`search_all` is included because it depends on `search_zim_file_data`'s output shape — Task 6 finishes the migration.)
+
+If `test_search_all.py` fails because it asserts on the OLD `search_zim_file` shape inside per_file results, defer those assertion fixes to Task 6 — for now, comment out the failing search_all assertions with a `# Task 6: shape migration` marker. Run `uv run pytest tests/test_search_tools.py tests/test_structured_tool_output.py -v -k "search_zim_file"` and confirm those pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add openzim_mcp/zim/search.py openzim_mcp/tools/search_tools.py openzim_mcp/tool_schemas.py tests/test_search_tools.py tests/test_structured_tool_output.py tests/test_search_all.py
+git commit -m "feat(v2)!: migrate search_zim_file to PaginatedResponse + TypedDict
+
+BREAKING: response shape changes per spec:
+- top-level next_cursor / total / done / page_info (was nested 'pagination')
+- total_results renamed to total
+- has_more removed (use !done)
+- pagination.showing_start/showing_end removed (derivable)
+- cursor input added; cursor is tool-bound (t='search_zim_file')
+
+Cache key bumped to search_v2b: to avoid old-shape leakthrough."
+```
+
+---
+
+## Task 6: Migrate `search_all` to the contract + TypedDict
+
+**Files:**
+- Modify: `openzim_mcp/zim/search.py:1575-1673` (`search_all_data` and `_search_all_data` if separate)
+- Modify: `openzim_mcp/tools/search_tools.py:150-207` (`search_all` tool registration)
+- Modify: `tests/test_search_all.py`
+- Modify: `tests/test_structured_tool_output.py:209-234` (`test_search_all_returns_structured_content`)
+
+**Why:** Top-level `search_all` becomes a non-paginated `PaginatedResponse[per_file]` (always `done=true`); each `per_file[].result` is a `SearchResponse` from Task 5. Spec section [`search_all`](../specs/2026-05-08-v2-phase-b-response-contract-design.md#search_all).
+
+- [ ] **Step 1: Update `tests/test_search_all.py`**
+
+Find every test that asserts on `search_all_data` output. Update:
+
+- `result["per_file"]` → `result["results"]` (the top-level list of per-file blocks)
+- Per-file blocks keep their existing keys (`zim_file_path`, `name`, `result`, `has_hits`); inside each `result` dict, apply the Task 5 key renames (`total_results` → `total`, etc.)
+- Add top-level contract-shape assertions: `assert result["done"] is True`, `assert result["next_cursor"] is None`, `assert result["total"] == result["files_searched"]`
+- Top-level `page_info`: `{"offset": 0, "limit": result["files_searched"], "returned_count": len(result["results"])}`
+
+Also un-comment any `# Task 6: shape migration` markers from Task 5 and update those assertions.
+
+- [ ] **Step 2: Update `tests/test_structured_tool_output.py:209-234`**
+
+In `test_search_all_returns_structured_content`:
+
+```python
+payload = structured["result"] if "result" in structured else structured
+assert "per_file" in payload
+for entry in payload.get("per_file", []):
+    if "result" in entry:
+        assert isinstance(entry["result"], dict), ...
+        assert "results" in entry["result"]
+```
+
+Change to:
+
+```python
+assert "result" not in structured, "TypedDict migration regression: payload still wrapped"
+payload = structured
+assert "results" in payload
+for entry in payload["results"]:
+    inner = entry["result"]
+    assert isinstance(inner, dict), f"per_file[].result should be dict, got {type(inner)}"
+    assert "results" in inner  # inner is itself a SearchResponse — has its own results list
+    assert "done" in inner
+    assert "next_cursor" in inner
+```
+
+- [ ] **Step 3: Run tests to confirm failure**
+
+```bash
+uv run pytest tests/test_search_all.py tests/test_structured_tool_output.py::TestStructuredOutput::test_search_all_returns_structured_content -v
+```
+
+Expected: failures on missing `results` (top level), `done`, etc.
+
+- [ ] **Step 4: Update `search_all_data` in `openzim_mcp/zim/search.py:1575`**
+
+Locate the function. Replace its return-payload construction so the shape becomes:
+
+```python
+{
+    "query": query,
+    "files_searched": <int>,
+    "files_with_hits": <int>,
+    "files_searched_successfully": <int>,
+    "files_failed": <int>,
+    "results": [
+        {"zim_file_path": <str>, "name": <str>, "has_hits": <bool>, "result": <SearchResponse>},
+        ...
+    ],
+    "next_cursor": None,
+    "total": <int (= files_searched)>,
+    "done": True,
+    "page_info": {"offset": 0, "limit": <files_searched>, "returned_count": <len(results)>},
+}
+```
+
+The existing `per_file` list becomes the new `results`. Apply `attach_meta(payload)` at the end if it's not already (the existing implementation likely already does this).
+
+Update the return annotation:
+
+```python
+def search_all_data(self, query: str, limit_per_file: Optional[int] = None) -> "SearchAllResponse":
+```
+
+Add the import at the top of the file:
+
+```python
+from openzim_mcp.tool_schemas import SearchAllResponse
+```
+
+- [ ] **Step 5: Update `search_all` tool registration in `tools/search_tools.py:150`**
+
+Update return annotation:
+
+```python
+) -> Union["SearchAllResponse", "ToolErrorPayload"]:
+```
+
+(`SearchAllResponse` import already added in Task 5; if not, add it.)
+
+`search_all` does NOT take a top-level cursor — pagination happens per-archive. No input change.
+
+- [ ] **Step 6: Run tests**
+
+```bash
+uv run pytest tests/test_search_all.py tests/test_structured_tool_output.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add openzim_mcp/zim/search.py openzim_mcp/tools/search_tools.py tests/test_search_all.py tests/test_structured_tool_output.py
+git commit -m "feat(v2)!: migrate search_all to PaginatedResponse + TypedDict
+
+BREAKING: top-level shape changes:
+- per_file renamed to results
+- five contract keys added at top level (always done=true)
+- per_file[].result inherits the SearchResponse migration from Task 5"
+```
+
+---
+
+## Task 7: Migrate `search_with_filters` to the contract + TypedDict
+
+**Files:**
+- Modify: `openzim_mcp/tools/navigation_tools.py:251-323` (`search_with_filters` tool)
+- Modify: corresponding `_data` method in `openzim_mcp/zim/search.py` (search for `search_with_filters_data`)
+- Modify: `tests/test_navigation_tools.py` (search_with_filters tests)
+- Modify: `tests/test_structured_tool_output.py` (add or update test for this tool)
+
+**Why:** Today `search_with_filters` returns a markdown text block. Phase B migrates it to the same `SearchResponse`-shaped contract as `search_zim_file`, with three extra extras: `query`, `namespace_filter`, `content_type_filter`. Spec section [`search_with_filters`](../specs/2026-05-08-v2-phase-b-response-contract-design.md#search_with_filters).
+
+- [ ] **Step 1: Locate today's implementation**
+
+```bash
+grep -n "def search_with_filters\|search_with_filters_data" openzim_mcp/zim/search.py openzim_mcp/tools/navigation_tools.py
+```
+
+If `search_with_filters_data` doesn't exist (today's implementation may render markdown directly inside the tool function), create it as the dict-returning sibling — same pattern as `search_zim_file` / `search_zim_file_data`.
+
+- [ ] **Step 2: Update `tests/test_navigation_tools.py` for `search_with_filters`**
+
+Existing tests likely assert on rendered markdown. Replace those assertions with structured-shape assertions:
+
+```python
+import pytest
+from openzim_mcp.pagination import Cursor
+
+@pytest.mark.asyncio
+async def test_search_with_filters_returns_paginated_response(server, basic_test_zim_files):
+    zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+    if zim_path is None:
+        pytest.skip("ZIM testing-suite small.zim not available")
+    result = await server.mcp._tool_manager.call_tool(
+        "search_with_filters",
+        {"zim_file_path": str(zim_path), "query": "evolution", "namespace": "C"},
+        convert_result=True,
+    )
+    assert isinstance(result, tuple)
+    _, payload = result
+    assert "result" not in payload  # TypedDict — top level, no wrapper
+    for key in ("results", "next_cursor", "total", "done", "page_info", "_meta"):
+        assert key in payload
+    assert payload["query"] == "evolution"
+    assert payload["namespace_filter"] == "C"
+    assert payload["content_type_filter"] is None
+```
+
+- [ ] **Step 3: Run failing tests**
+
+```bash
+uv run pytest tests/test_navigation_tools.py -v -k "search_with_filters"
+```
+
+Expected: failures.
+
+- [ ] **Step 4: Implement `search_with_filters_data`**
+
+In `openzim_mcp/zim/search.py`, add a new method (or convert the existing markdown-returning implementation):
+
+```python
+def search_with_filters_data(
+    self,
+    zim_file_path: str,
+    query: str,
+    namespace: Optional[str] = None,
+    content_type: Optional[str] = None,
+    limit: Optional[int] = None,
+    offset: int = 0,
+) -> "SearchWithFiltersResponse":
+    """Structured filtered-search response. v2 Phase B contract."""
+    from openzim_mcp.pagination import Cursor
+
+    if limit is None:
+        limit = self.config.content.default_search_limit
+
+    # Reuse search_zim_file_data and post-filter results by namespace/content_type.
+    # (If the existing v1 implementation already filters at the libzim level,
+    # preserve that behavior; the response shape is what's changing.)
+    inner = self.search_zim_file_data(zim_file_path, query, limit=limit, offset=offset)
+
+    # Post-filter — preserve order, drop entries that don't match filters.
+    filtered_results = []
+    for hit in inner["results"]:
+        if namespace and not hit["path"].startswith(f"{namespace}/"):
+            continue
+        # content_type filter requires looking up the entry; if the v1 path
+        # already does this, keep that lookup. Otherwise, skip the filter.
+        filtered_results.append(hit)
+
+    total = inner["total"]
+    page_info = dict(inner["page_info"])
+    page_info["returned_count"] = len(filtered_results)
+    done = inner["done"]
+    next_cursor: Optional[str] = None
+    if not done:
+        next_cursor = Cursor.encode(
+            tool="search_with_filters",
+            state={
+                "o": page_info["offset"] + len(filtered_results),
+                "l": limit,
+                "q": query,
+                **({"ns": namespace} if namespace else {}),
+                **({"ct": content_type} if content_type else {}),
+            },
+        )
+
+    payload: Dict[str, Any] = {
+        "query": query,
+        "namespace_filter": namespace,
+        "content_type_filter": content_type,
+        "results": filtered_results,
+        "next_cursor": next_cursor,
+        "total": total,
+        "done": done,
+        "page_info": page_info,
+    }
+    return cast("SearchWithFiltersResponse", attach_meta(payload))
+```
+
+Add `from openzim_mcp.tool_schemas import SearchWithFiltersResponse` at the top.
+
+If the existing `search_with_filters` implementation in `tools/navigation_tools.py` builds the response as markdown, replace its body with a delegation to `search_with_filters_data`:
+
+```python
+@server.mcp.tool()
+async def search_with_filters(
+    zim_file_path: str,
+    query: str,
+    namespace: Optional[str] = None,
+    content_type: Optional[str] = None,
+    limit: Optional[int] = None,
+    offset: int = 0,
+    cursor: Optional[str] = None,
+) -> Union["SearchWithFiltersResponse", "ToolErrorPayload"]:
+    try:
+        # Cursor decode — same pattern as search_zim_file (Task 5).
+        if cursor is not None:
+            from openzim_mcp.pagination import Cursor, CursorMismatchError
+            try:
+                decoded = Cursor.decode(cursor, expected_tool="search_with_filters")
+            except CursorMismatchError as e:
+                return tool_error(operation="search with filters", message=str(e), context=f"cursor=<truncated>")
+            except ValueError as e:
+                return tool_error(operation="search with filters", message=f"Invalid pagination cursor: {e}", context=None)
+            offset = decoded["s"]["o"]
+            limit = decoded["s"].get("l", limit)
+            query = decoded["s"].get("q", query)
+            namespace = decoded["s"].get("ns", namespace)
+            content_type = decoded["s"].get("ct", content_type)
+
+        # ... existing rate-limit check + sanitize_input pass ...
+
+        return await server.async_zim_operations.search_with_filters_data(
+            zim_file_path, query, namespace, content_type, limit, offset
+        )
+    except Exception as e:
+        logger.error(f"Error in search_with_filters: {e}")
+        return tool_error(operation="search with filters", message=str(e), context=f"query={query}")
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+uv run pytest tests/test_navigation_tools.py tests/test_structured_tool_output.py -v -k "search_with_filters"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add openzim_mcp/zim/search.py openzim_mcp/tools/navigation_tools.py openzim_mcp/tool_schemas.py tests/test_navigation_tools.py tests/test_structured_tool_output.py
+git commit -m "feat(v2)!: migrate search_with_filters to PaginatedResponse + TypedDict
+
+BREAKING: now returns structured dict (was markdown text). Same shape
+as search_zim_file with namespace_filter and content_type_filter
+extras. Cursor t='search_with_filters'."
+```
+
+---
+
+## Task 8: Migrate `find_entry_by_title` to the contract + TypedDict
+
+**Files:**
+- Modify: `openzim_mcp/zim/search.py` (`find_entry_by_title_data`, around line 1208)
+- Modify: `openzim_mcp/tools/search_tools.py:223-283` (tool registration)
+- Modify: `tests/test_find_entry_by_title.py` and `tests/test_find_entry_by_title_quality.py`
+- Modify: `tests/test_structured_tool_output.py:119-141`
+
+**Why:** Non-paginated tool gets the contract for uniformity. Spec section [`find_entry_by_title`](../specs/2026-05-08-v2-phase-b-response-contract-design.md#find_entry_by_title).
+
+- [ ] **Step 1: Update tests**
+
+In each test file referenced above, find assertions on `result["results"]`, `result["files_searched"]`, etc. They mostly stay — the tool is non-paginated so `results` keeps its meaning. Add new assertions:
+
+```python
+assert payload["next_cursor"] is None
+assert payload["done"] is True
+assert payload["total"] == len(payload["results"])
+assert payload["page_info"]["offset"] == 0
+assert payload["page_info"]["limit"] == 10  # default; or whatever was passed
+assert payload["page_info"]["returned_count"] == len(payload["results"])
+```
+
+In `test_structured_tool_output.py`, change:
+
+```python
+payload = structured["result"] if "result" in structured else structured
+```
+
+to:
+
+```python
+assert "result" not in structured
+payload = structured
+```
+
+- [ ] **Step 2: Run tests to confirm failure**
+
+```bash
+uv run pytest tests/test_find_entry_by_title.py tests/test_find_entry_by_title_quality.py tests/test_structured_tool_output.py -v -k "find_entry"
+```
+
+Expected: failures on missing contract keys.
+
+- [ ] **Step 3: Update `find_entry_by_title_data` in search.py**
+
+Locate the function (around line 1208). At the end, where the response dict is built, add the contract keys and update the return annotation.
+
+```python
+def find_entry_by_title_data(
+    self, zim_file_path: str, query: str, limit: int = 10
+) -> "FindEntryResponse":
+    # ... existing logic that builds `results: list[FindEntryHit]`,
+    #     `fast_path_hit`, `files_searched` ...
+
+    payload: Dict[str, Any] = {
+        "query": query,
+        "results": results,
+        "next_cursor": None,
+        "total": len(results),
+        "done": True,
+        "page_info": {"offset": 0, "limit": limit, "returned_count": len(results)},
+        "fast_path_hit": fast_path_hit,
+        "files_searched": files_searched,
+    }
+    return cast("FindEntryResponse", attach_meta(payload))
+```
+
+Add `from openzim_mcp.tool_schemas import FindEntryResponse` at the top of search.py if not already present.
+
+- [ ] **Step 4: Update tool registration in `tools/search_tools.py:223`**
+
+Change the return annotation to `Union["FindEntryResponse", "ToolErrorPayload"]`. Add the import.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+uv run pytest tests/test_find_entry_by_title.py tests/test_find_entry_by_title_quality.py tests/test_structured_tool_output.py -v -k "find_entry"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add openzim_mcp/zim/search.py openzim_mcp/tools/search_tools.py tests/test_find_entry_by_title.py tests/test_find_entry_by_title_quality.py tests/test_structured_tool_output.py
+git commit -m "feat(v2)!: migrate find_entry_by_title to PaginatedResponse + TypedDict
+
+Non-paginated tool gets the contract for uniformity (next_cursor=None,
+done=True, total=len(results)). Existing fast_path_hit and
+files_searched keys preserved as tool-specific extras."
+```
+
+---
+
+## Task 9: Migrate `get_search_suggestions` to the contract + TypedDict
+
+**Files:**
+- Modify: `openzim_mcp/zim/search.py:781-867` (`get_search_suggestions_data`)
+- Modify: `openzim_mcp/tools/navigation_tools.py:328-401` (tool registration)
+- Modify: `tests/test_navigation_tools.py` (suggestions tests)
+- Modify: `tests/test_structured_tool_output.py:187-207`
+
+**Why:** Renames `suggestions` → `results` (top-level). The Phase A `_meta.suggestions[]` is a different concept (recovery candidates) and stays inside `_meta`. Spec section [`get_search_suggestions`](../specs/2026-05-08-v2-phase-b-response-contract-design.md#get_search_suggestions).
+
+- [ ] **Step 1: Update tests**
+
+In `test_navigation_tools.py` and `test_structured_tool_output.py:187-207`, replace `suggestions` → `results` in every assertion:
+
+```python
+assert "results" in payload
+assert isinstance(payload["results"], list)
+# Add contract assertions:
+assert payload["next_cursor"] is None
+assert payload["done"] is True
+assert payload["total"] == len(payload["results"])
+```
+
+Drop assertions on `payload["count"]` (replaced by `page_info.returned_count`).
+
+In `test_structured_tool_output.py` change:
+
+```python
+payload = structured["result"] if "result" in structured else structured
+```
+
+to:
+
+```python
+assert "result" not in structured
+payload = structured
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+uv run pytest tests/test_navigation_tools.py tests/test_structured_tool_output.py -v -k "suggestions or search_suggestions"
+```
+
+Expected: failures on missing keys.
+
+- [ ] **Step 3: Update `get_search_suggestions_data` in search.py:781**
+
+```python
+def get_search_suggestions_data(
+    self, zim_file_path: str, partial_query: str, limit: int = 10
+) -> "SearchSuggestionsResponse":
+    # ... existing logic that builds `suggestions: list[SuggestionItem]` and `message` ...
+
+    payload: Dict[str, Any] = {
+        "partial_query": partial_query,
+        "results": suggestions,  # was 'suggestions'
+        "next_cursor": None,
+        "total": len(suggestions),
+        "done": True,
+        "page_info": {"offset": 0, "limit": limit, "returned_count": len(suggestions)},
+    }
+    # If the v1 implementation included an optional 'message' field, drop it —
+    # the structured suggestions live in _meta.suggestions per Phase A.
+    return cast("SearchSuggestionsResponse", attach_meta(payload))
+```
+
+Add import: `from openzim_mcp.tool_schemas import SearchSuggestionsResponse`.
+
+- [ ] **Step 4: Update tool registration in `tools/navigation_tools.py:328`**
+
+Update return annotation to `Union["SearchSuggestionsResponse", "ToolErrorPayload"]`. Update the docstring's `Returns:` section to describe the new shape.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+uv run pytest tests/test_navigation_tools.py tests/test_structured_tool_output.py -v -k "suggestions or search_suggestions"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add openzim_mcp/zim/search.py openzim_mcp/tools/navigation_tools.py tests/test_navigation_tools.py tests/test_structured_tool_output.py
+git commit -m "feat(v2)!: migrate get_search_suggestions to PaginatedResponse + TypedDict
+
+BREAKING: suggestions list renamed to results to fit the contract.
+The Phase A _meta.suggestions[] (recovery candidates) is unrelated
+and stays inside _meta. count removed (use page_info.returned_count)."
+```
+
+---
+
+## Task 10: Migrate `browse_namespace` to the contract + TypedDict
+
+**Files:**
+- Modify: `openzim_mcp/zim/namespace.py:470-534` (`browse_namespace_data`)
+- Modify: `openzim_mcp/tools/navigation_tools.py:33-130` (tool registration)
+- Modify: `tests/test_navigation_tools.py` (browse_namespace tests)
+- Modify: `tests/test_structured_tool_output.py:142-162`
+
+**Why:** Renames `entries` → `results`, `total_in_namespace` → `total`, `total_in_namespace_is_lower_bound` → `page_info.total_is_lower_bound`. Removes `has_more` (use `done`). Spec section [`browse_namespace`](../specs/2026-05-08-v2-phase-b-response-contract-design.md#browse_namespace).
+
+- [ ] **Step 1: Update tests**
+
+In each test file, apply the renames:
+- `result["entries"]` → `result["results"]`
+- `result["total_in_namespace"]` → `result["total"]`
+- `result["total_in_namespace_is_lower_bound"]` → `result["page_info"]["total_is_lower_bound"]`
+- `result["has_more"]` → `not result["done"]`
+- `result["offset"]` → `result["page_info"]["offset"]`
+- `result["limit"]` → `result["page_info"]["limit"]`
+- `result["returned_count"]` → `result["page_info"]["returned_count"]`
+
+Drop assertions on `result["is_total_authoritative"]` at the top level (use `not page_info.get("total_is_lower_bound", False)` instead).
+
+For tests that decode `next_cursor`, replace `PaginationCursor.decode` with:
+
+```python
+from openzim_mcp.pagination import Cursor
+decoded = Cursor.decode(payload["next_cursor"], expected_tool="browse_namespace")
+assert decoded["s"]["o"] == <expected>
+assert decoded["s"]["ns"] == <expected_namespace>
+```
+
+In `test_structured_tool_output.py:142-162`, change `payload = structured["result"] if "result" in structured else structured` to `assert "result" not in structured; payload = structured`.
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+uv run pytest tests/test_navigation_tools.py tests/test_structured_tool_output.py -v -k "browse"
+```
+
+Expected: failures on missing keys.
+
+- [ ] **Step 3: Update `browse_namespace_data` in namespace.py:470**
+
+The function currently builds a response with `entries`, `total_in_namespace`, `next_cursor` (top-level), `offset`, `limit`, etc. Restructure it as:
+
+```python
+from openzim_mcp.pagination import Cursor
+
+# ... existing logic that builds `entries`, `total_in_namespace`,
+#     `is_total_authoritative`, `discovery_method`, `sampling_based`,
+#     `results_may_be_incomplete` ...
+
+returned_count = len(entries)
+last_index = offset + returned_count
+done = (
+    total_in_namespace is not None
+    and last_index >= total_in_namespace
+)
+next_cursor: Optional[str] = None
+if not done:
+    next_cursor = Cursor.encode(
+        tool="browse_namespace",
+        state={"o": last_index, "l": limit, "ns": namespace},
+    )
+
+page_info: Dict[str, Any] = {
+    "offset": offset,
+    "limit": limit,
+    "returned_count": returned_count,
+}
+if not is_total_authoritative:
+    page_info["total_is_lower_bound"] = True
+
+payload: Dict[str, Any] = {
+    "namespace": namespace,
+    "results": entries,  # was 'entries'
+    "next_cursor": next_cursor,
+    "total": total_in_namespace,
+    "done": done,
+    "page_info": page_info,
+    "discovery_method": discovery_method,
+    "sampling_based": sampling_based,
+    "results_may_be_incomplete": results_may_be_incomplete,
+}
+return cast("BrowseNamespaceResponse", attach_meta(payload))
+```
+
+Update the return annotation:
+
+```python
+def browse_namespace_data(
+    self, zim_file_path: str, namespace: str, limit: int = 50, offset: int = 0
+) -> "BrowseNamespaceResponse":
+```
+
+Add `from openzim_mcp.tool_schemas import BrowseNamespaceResponse` at the top.
+
+- [ ] **Step 4: Update tool registration in `tools/navigation_tools.py:33`**
+
+Add a `cursor: Optional[str] = None` parameter to the tool function. At the top of the body, after the rate-limit check, add the cursor decode block (same pattern as Task 5, with `expected_tool="browse_namespace"` — the cursor's `s` carries `o`, `l`, `ns`).
+
+Update the return annotation to `Union["BrowseNamespaceResponse", "ToolErrorPayload"]`. Update the docstring's `Returns:` description.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+uv run pytest tests/test_navigation_tools.py tests/test_structured_tool_output.py -v -k "browse"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add openzim_mcp/zim/namespace.py openzim_mcp/tools/navigation_tools.py tests/test_navigation_tools.py tests/test_structured_tool_output.py
+git commit -m "feat(v2)!: migrate browse_namespace to PaginatedResponse + TypedDict
+
+BREAKING:
+- entries renamed to results
+- total_in_namespace renamed to total
+- total_in_namespace_is_lower_bound moved to page_info
+- has_more removed (use !done)
+- is_total_authoritative top-level removed (use page_info)
+- cursor input added; cursor t='browse_namespace'"
+```
+
+---
+
+## Task 11: Migrate `walk_namespace` to the contract + TypedDict (opaque cursor)
+
+**Files:**
+- Modify: `openzim_mcp/zim/namespace.py:943-1076` (`walk_namespace_data`)
+- Modify: `openzim_mcp/tools/navigation_tools.py:135-246` (tool registration)
+- Modify: `tests/test_navigation_tools.py`, `tests/test_walk_namespace.py`
+- Modify: `tests/test_structured_tool_output.py:164-185`
+
+**Why:** Today's `cursor: int` (entry id) becomes opaque (encoded `scan_at`). `total: null` (mid-scan, never knowable). Renames `entries` → `results`. Spec section [`walk_namespace`](../specs/2026-05-08-v2-phase-b-response-contract-design.md#walk_namespace).
+
+- [ ] **Step 1: Update tests**
+
+Apply the renames + new contract assertions:
+
+- `result["entries"]` → `result["results"]`
+- `result["cursor"]` (int output) — REMOVED. Now read `result["next_cursor"]` (opaque str) and decode if needed.
+- `result["done"]` — already exists; preserved.
+- Add: `assert result["total"] is None` (walk doesn't know total per-namespace)
+- Add: `assert "page_info" in result` and shape check
+- For tests that pass `cursor` as int: change to `cursor=None` for first page, then for second-page tests pass `cursor=Cursor.encode(tool="walk_namespace", state={"scan_at": <int>, "l": limit})`.
+
+In `test_structured_tool_output.py:164-185`, change `payload = structured["result"] if "result" in structured else structured` to `assert "result" not in structured; payload = structured`.
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+uv run pytest tests/test_walk_namespace.py tests/test_navigation_tools.py tests/test_structured_tool_output.py -v -k "walk"
+```
+
+Expected: failures.
+
+- [ ] **Step 3: Update `walk_namespace_data` in namespace.py:943**
+
+```python
+from openzim_mcp.pagination import Cursor
+
+def walk_namespace_data(
+    self,
+    zim_file_path: str,
+    namespace: str,
+    cursor_state: Optional[Dict[str, Any]] = None,  # decoded cursor.s, internal API
+    limit: int = 200,
+) -> "WalkNamespaceResponse":
+    """Streaming-scan walk of a namespace. Cursor is opaque on the wire."""
+    scan_at = (cursor_state or {}).get("scan_at", 0)
+
+    # ... existing scan logic that builds `entries`, `scanned_count`,
+    #     `scanned_through_id`, `archive_entry_count` ...
+    # Note: scanned_through_id is the highest entry id touched on this page.
+
+    returned_count = len(entries)
+    done = scanned_through_id >= archive_entry_count - 1  # or however the existing
+                                                          # implementation determines this
+    next_cursor: Optional[str] = None
+    if not done:
+        next_cursor = Cursor.encode(
+            tool="walk_namespace",
+            state={"scan_at": scanned_through_id + 1, "l": limit},
+        )
+
+    payload: Dict[str, Any] = {
+        "namespace": namespace,
+        "results": entries,  # was 'entries'
+        "next_cursor": next_cursor,
+        "total": None,  # never knowable mid-scan
+        "done": done,
+        "page_info": {
+            "offset": scan_at,
+            "limit": limit,
+            "returned_count": returned_count,
+        },
+        "scanned_count": scanned_count,
+        "scanned_through_id": scanned_through_id,
+        "archive_entry_count": archive_entry_count,
+    }
+    return cast("WalkNamespaceResponse", attach_meta(payload))
+```
+
+Add `from openzim_mcp.tool_schemas import WalkNamespaceResponse`.
+
+- [ ] **Step 4: Update tool registration in `tools/navigation_tools.py:135`**
+
+```python
+async def walk_namespace(
+    zim_file_path: str,
+    namespace: str,
+    limit: int = 200,
+    cursor: Optional[str] = None,  # was cursor: int = 0
+) -> Union["WalkNamespaceResponse", "ToolErrorPayload"]:
+    try:
+        cursor_state: Optional[Dict[str, Any]] = None
+        if cursor is not None:
+            from openzim_mcp.pagination import Cursor, CursorMismatchError
+            try:
+                decoded = Cursor.decode(cursor, expected_tool="walk_namespace")
+            except CursorMismatchError as e:
+                return tool_error(operation="walk namespace", message=str(e), context=f"cursor=<truncated>")
+            except ValueError as e:
+                return tool_error(operation="walk namespace", message=f"Invalid pagination cursor: {e}", context=None)
+            cursor_state = decoded["s"]
+            limit = cursor_state.get("l", limit)
+        # ... existing rate-limit check + sanitize_input ...
+        return await server.async_zim_operations.walk_namespace_data(
+            zim_file_path, namespace, cursor_state=cursor_state, limit=limit
+        )
+    except Exception as e:
+        logger.error(f"Error walking namespace: {e}")
+        return tool_error(operation="walk namespace", message=str(e), context=f"namespace={namespace}")
+```
+
+The integer `cursor` parameter is GONE. Callers who used `cursor=42` get a clear error from FastMCP about type mismatch (`str` expected, `int` got) — that's the v2 clean break.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+uv run pytest tests/test_walk_namespace.py tests/test_navigation_tools.py tests/test_structured_tool_output.py -v -k "walk"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add openzim_mcp/zim/namespace.py openzim_mcp/tools/navigation_tools.py tests/test_walk_namespace.py tests/test_navigation_tools.py tests/test_structured_tool_output.py
+git commit -m "feat(v2)!: walk_namespace cursor becomes opaque, contract applied
+
+BREAKING:
+- cursor input/output type changes from int to opaque str
+- entries renamed to results
+- total is always null (walk doesn't know per-namespace total mid-scan)
+- total_entries deprecated alias removed
+- cursor t='walk_namespace' carries scan_at internally"
+```
+
+---
+
+## Task 12: Migrate `list_namespaces` to TypedDict (no contract, special-case)
+
+**Files:**
+- Modify: `openzim_mcp/zim/namespace.py:66-115` (`list_namespaces_data`)
+- Modify: `openzim_mcp/tools/metadata_tools.py:109-153` (tool registration)
+- Modify: `tests/test_metadata_tools.py` and `tests/test_metadata_tools_extended.py`
+- Modify: `tests/test_structured_tool_output.py:33-77` (the existing pilot test)
+
+**Why:** `list_namespaces` returns a **dict** of namespace summaries, not a list. Doesn't get the `PaginatedResponse` contract — only gets the TypedDict migration so its payload lands at the top level (no `result` wrapper). Spec section [`list_namespaces`](../specs/2026-05-08-v2-phase-b-response-contract-design.md#list_namespaces-is-not-a-list).
+
+- [ ] **Step 1: Update tests**
+
+In `test_metadata_tools.py`, `test_metadata_tools_extended.py`, and the existing pilot test in `test_structured_tool_output.py:33-77`:
+
+- Find the inner namespace summary lookups: `result["namespaces"]["C"]["entry_count"]` → `result["namespaces"]["C"]["total"]`.
+- Replace `payload = structured["result"] if "result" in structured else structured` with `assert "result" not in structured; payload = structured`.
+- Top-level keys preserved: `total_entries`, `sampled_entries`, `has_new_namespace_scheme`, `is_total_authoritative`, `discovery_method`, `namespaces`. No `results` / `next_cursor` / etc. (this tool doesn't get the contract).
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+uv run pytest tests/test_metadata_tools.py tests/test_metadata_tools_extended.py tests/test_structured_tool_output.py -v -k "list_namespaces"
+```
+
+Expected: failures.
+
+- [ ] **Step 3: Update `list_namespaces_data` in namespace.py:66**
+
+Inside the namespaces loop, rename `entry_count` → `total` per `NamespaceSummary` TypedDict:
+
+```python
+namespaces[ns_letter] = {
+    "total": entry_count,         # was "entry_count": entry_count
+    "is_authoritative": is_auth,  # was "is_authoritative": is_auth (already correct)
+}
+```
+
+Update the function's return annotation to `"ListNamespacesResponse"`. Add `from openzim_mcp.tool_schemas import ListNamespacesResponse`.
+
+- [ ] **Step 4: Update tool registration in `tools/metadata_tools.py:109`**
+
+Update return annotation to `Union["ListNamespacesResponse", "ToolErrorPayload"]`.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+uv run pytest tests/test_metadata_tools.py tests/test_metadata_tools_extended.py tests/test_structured_tool_output.py -v -k "list_namespaces or namespace"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add openzim_mcp/zim/namespace.py openzim_mcp/tools/metadata_tools.py tests/test_metadata_tools.py tests/test_metadata_tools_extended.py tests/test_structured_tool_output.py
+git commit -m "feat(v2)!: list_namespaces TypedDict migration (no contract)
+
+BREAKING: namespaces[<letter>].entry_count renamed to total. Payload
+now lands at top level of structuredContent (no {'result': ...}
+wrapper). list_namespaces is the one list-shaped result that doesn't
+get the PaginatedResponse contract — it's a dict-of-summaries."
+```
+
+---
+
+## Task 13: Migrate `extract_article_links` to require `kind` + apply contract
+
+**Files:**
+- Modify: `openzim_mcp/zim/structure.py:171-291` (`extract_article_links_data`)
+- Modify: `openzim_mcp/tools/structure_tools.py:88-155` (tool registration)
+- Modify: `tests/test_extract_article_links_pagination.py`
+- Modify: `tests/test_structure_tools.py` (extract_article_links tests)
+- Modify: `tests/test_structured_tool_output.py` (extract_article_links test)
+
+**Why:** Today returns 3 parallel lists (internal/external/media) with 3 pagination flags. v2 requires `kind` (default `"internal"`); single category per call. `category_totals: {internal, external, media}` reports all three counts. Spec section [`extract_article_links`](../specs/2026-05-08-v2-phase-b-response-contract-design.md#extract_article_links).
+
+- [ ] **Step 1: Update tests**
+
+This is the most surgical migration — the response shape changes substantially.
+
+In `test_extract_article_links_pagination.py` and `test_structure_tools.py`:
+
+- Replace assertions on `result["internal_links"]`/`result["external_links"]`/`result["media_links"]` with single-category logic: each test now passes a specific `kind=` and asserts on `result["results"]`.
+- Replace `result["total_internal_links"]` etc. with `result["category_totals"]["internal"]`, `result["category_totals"]["external"]`, `result["category_totals"]["media"]`.
+- Replace `result["pagination"]["has_more"]` with `not result["done"]`. Other `pagination` keys move to `page_info`.
+- A test that previously asserted on all three categories at once becomes three separate test calls (one per `kind`), or one test that asserts on `category_totals`.
+
+Add `kind="internal"` (or whichever category) to every call. Tests that previously called with no `kind` and got all three categories must be updated; the new behavior is "kind defaults to internal."
+
+In `test_structured_tool_output.py`, find or add an `extract_article_links` test, and assert top-level shape:
+
+```python
+assert "result" not in structured
+payload = structured
+assert "results" in payload
+assert "kind" in payload and payload["kind"] == "internal"
+assert "category_totals" in payload
+for k in ("internal", "external", "media"):
+    assert k in payload["category_totals"]
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+uv run pytest tests/test_extract_article_links_pagination.py tests/test_structure_tools.py tests/test_structured_tool_output.py -v -k "links or extract_article"
+```
+
+Expected: failures.
+
+- [ ] **Step 3: Update `extract_article_links_data` in structure.py:171**
+
+Replace the function:
+
+```python
+from openzim_mcp.pagination import Cursor
+
+def extract_article_links_data(
+    self,
+    zim_file_path: str,
+    entry_path: str,
+    limit: int = 100,
+    offset: int = 0,
+    kind: str = "internal",
+) -> "LinksResponse":
+    """Extract links of a single category. v2 Phase B contract."""
+    if kind not in ("internal", "external", "media"):
+        raise ValueError(f"kind must be one of 'internal', 'external', 'media'; got {kind!r}")
+
+    # ... existing logic that walks the article and builds three lists:
+    #     all_internal, all_external, all_media (ALL of them, no slicing yet) ...
+    #     plus title, path, content_type ...
+
+    by_kind = {"internal": all_internal, "external": all_external, "media": all_media}
+    full_list = by_kind[kind]
+    total_for_kind = len(full_list)
+    page = full_list[offset : offset + limit]
+    returned_count = len(page)
+    last_index = offset + returned_count
+    done = last_index >= total_for_kind
+    next_cursor: Optional[str] = None
+    if not done:
+        next_cursor = Cursor.encode(
+            tool="extract_article_links",
+            state={"o": last_index, "l": limit, "ep": entry_path, "k": kind},
+        )
+
+    payload: Dict[str, Any] = {
+        "title": title,
+        "path": entry_path,
+        "content_type": content_type,
+        "kind": kind,
+        "results": page,                      # was internal_links/external_links/media_links
+        "next_cursor": next_cursor,
+        "total": total_for_kind,
+        "done": done,
+        "page_info": {
+            "offset": offset,
+            "limit": limit,
+            "returned_count": returned_count,
+        },
+        "category_totals": {
+            "internal": len(all_internal),
+            "external": len(all_external),
+            "media": len(all_media),
+        },
+    }
+    return cast("LinksResponse", attach_meta(payload))
+```
+
+Add `from openzim_mcp.tool_schemas import LinksResponse`.
+
+- [ ] **Step 4: Update tool registration in `tools/structure_tools.py:88`**
+
+```python
+async def extract_article_links(
+    zim_file_path: str,
+    entry_path: str,
+    limit: int = 100,
+    offset: int = 0,
+    kind: str = "internal",
+    cursor: Optional[str] = None,
+) -> Union["LinksResponse", "ToolErrorPayload"]:
+    try:
+        if cursor is not None:
+            from openzim_mcp.pagination import Cursor, CursorMismatchError
+            try:
+                decoded = Cursor.decode(cursor, expected_tool="extract_article_links")
+            except CursorMismatchError as e:
+                return tool_error(operation="extract article links", message=str(e), context=f"cursor=<truncated>")
+            except ValueError as e:
+                return tool_error(operation="extract article links", message=f"Invalid pagination cursor: {e}", context=None)
+            offset = decoded["s"]["o"]
+            limit = decoded["s"].get("l", limit)
+            entry_path = decoded["s"].get("ep", entry_path)
+            kind = decoded["s"].get("k", kind)
+
+        if kind not in ("internal", "external", "media"):
+            return tool_error(
+                operation="extract article links",
+                message=f"kind must be one of 'internal', 'external', 'media'; got {kind!r}",
+                context=f"Entry: {entry_path}",
+            )
+        # ... existing rate-limit + sanitize_input ...
+        return await server.async_zim_operations.extract_article_links_data(
+            zim_file_path, entry_path, limit=limit, offset=offset, kind=kind
+        )
+    except Exception as e:
+        # ... existing error envelope ...
+```
+
+The previous `Optional[str]` `kind` becomes `str = "internal"` — required-with-default. Update the docstring.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+uv run pytest tests/test_extract_article_links_pagination.py tests/test_structure_tools.py tests/test_structured_tool_output.py -v -k "links or extract_article"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add openzim_mcp/zim/structure.py openzim_mcp/tools/structure_tools.py tests/test_extract_article_links_pagination.py tests/test_structure_tools.py tests/test_structured_tool_output.py
+git commit -m "feat(v2)!: extract_article_links requires kind, contract applied
+
+BREAKING:
+- kind required with default 'internal' (was Optional[str])
+- internal_links/external_links/media_links arrays removed; single
+  results array per call
+- total_internal_links/total_external_links/total_media_links removed;
+  category_totals: {internal, external, media} added
+- pagination block flattened to top-level contract keys
+- cursor t='extract_article_links'
+
+To get all three categories, callers make three calls."
+```
+
+---
+
+## Task 14: Migrate `get_table_of_contents` to TypedDict (non-list)
+
+**Files:**
+- Modify: `openzim_mcp/zim/structure.py:402-445` (`get_table_of_contents_data`)
+- Modify: `openzim_mcp/tools/structure_tools.py:240-311` (tool registration)
+- Modify: `tests/test_structure_tools.py` (toc tests)
+- Modify: `tests/test_structured_tool_output.py` (toc test)
+
+**Why:** Non-list tool. Just gets the TypedDict migration to land payload at top level. No contract keys; existing keys preserved.
+
+- [ ] **Step 1: Update tests**
+
+In each test file, replace `payload = structured["result"] if "result" in structured else structured` with:
+
+```python
+assert "result" not in structured
+payload = structured
+```
+
+Existing assertions on `title`, `path`, `toc`, `heading_count`, `max_depth` are preserved.
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+uv run pytest tests/test_structure_tools.py tests/test_structured_tool_output.py -v -k "table_of_contents"
+```
+
+Expected: failures (assertion `"result" not in structured` fails because TypedDict not yet wired).
+
+- [ ] **Step 3: Update return annotations**
+
+In `openzim_mcp/zim/structure.py:402`, change return annotation:
+
+```python
+def get_table_of_contents_data(
+    self, zim_file_path: str, entry_path: str
+) -> "TableOfContentsResponse":
+```
+
+Add `from openzim_mcp.tool_schemas import TableOfContentsResponse`.
+
+In `openzim_mcp/tools/structure_tools.py:240`, change tool registration return annotation to `Union["TableOfContentsResponse", "ToolErrorPayload"]`.
+
+The `_data` method's payload construction stays the same — TypedDict merely declares the schema; no field changes.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+uv run pytest tests/test_structure_tools.py tests/test_structured_tool_output.py -v -k "table_of_contents"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add openzim_mcp/zim/structure.py openzim_mcp/tools/structure_tools.py tests/test_structure_tools.py tests/test_structured_tool_output.py
+git commit -m "feat(v2)!: get_table_of_contents TypedDict migration
+
+BREAKING (wire-format only): payload now at top level of
+structuredContent (no {'result': ...} wrapper). Existing keys
+preserved (title, path, toc, heading_count, max_depth)."
+```
+
+---
+
+## Task 15: Migrate `get_article_structure` to TypedDict (non-list)
+
+**Files:**
+- Modify: `openzim_mcp/zim/structure.py:50-113` (`get_article_structure_data`)
+- Modify: `openzim_mcp/tools/structure_tools.py:34-84` (tool registration)
+- Modify: `tests/test_structure_tools.py`
+- Modify: `tests/test_structured_tool_output.py` (article_structure test)
+
+**Why:** Same pattern as Task 14. Non-list, TypedDict-only migration.
+
+- [ ] **Step 1: Update tests**
+
+Apply the `assert "result" not in structured` change. Existing keys preserved (`title`, `path`, `content_type`, `headings`, `sections`, `metadata`, `word_count`, `character_count`).
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+uv run pytest tests/test_structure_tools.py tests/test_structured_tool_output.py -v -k "article_structure"
+```
+
+Expected: failures.
+
+- [ ] **Step 3: Update return annotations**
+
+In `structure.py:50`:
+
+```python
+def get_article_structure_data(
+    self, zim_file_path: str, entry_path: str
+) -> "ArticleStructureResponse":
+```
+
+In `tools/structure_tools.py:34`: return annotation → `Union["ArticleStructureResponse", "ToolErrorPayload"]`.
+
+Add the import.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+uv run pytest tests/test_structure_tools.py tests/test_structured_tool_output.py -v -k "article_structure"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add openzim_mcp/zim/structure.py openzim_mcp/tools/structure_tools.py tests/test_structure_tools.py tests/test_structured_tool_output.py
+git commit -m "feat(v2)!: get_article_structure TypedDict migration"
+```
+
+---
+
+## Task 16: Migrate `get_binary_entry` to TypedDict (non-list)
+
+**Files:**
+- Modify: `openzim_mcp/zim/content.py:597-725` (`get_binary_entry_data`)
+- Modify: `openzim_mcp/tools/structure_tools.py:316-403` (tool registration)
+- Modify: `tests/test_structure_tools.py`
+- Modify: `tests/test_structured_tool_output.py`
+
+**Why:** Same pattern. Non-list, TypedDict-only.
+
+- [ ] **Step 1: Update tests**
+
+Apply the `assert "result" not in structured` change. Existing keys preserved (`path`, `title`, `mime_type`, `size`, `size_human`, `encoding`, `data`, `truncated`).
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+uv run pytest tests/test_structure_tools.py tests/test_structured_tool_output.py -v -k "binary"
+```
+
+Expected: failures.
+
+- [ ] **Step 3: Update return annotations**
+
+In `openzim_mcp/zim/content.py:597`:
+
+```python
+def get_binary_entry_data(
+    self,
+    zim_file_path: str,
+    entry_path: str,
+    max_size_bytes: Optional[int] = None,
+    include_data: bool = True,
+) -> "BinaryEntryResponse":
+```
+
+In `tools/structure_tools.py:316`: `Union["BinaryEntryResponse", "ToolErrorPayload"]`.
+
+Add `from openzim_mcp.tool_schemas import BinaryEntryResponse`.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+uv run pytest tests/test_structure_tools.py tests/test_structured_tool_output.py -v -k "binary"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add openzim_mcp/zim/content.py openzim_mcp/tools/structure_tools.py tests/test_structure_tools.py tests/test_structured_tool_output.py
+git commit -m "feat(v2)!: get_binary_entry TypedDict migration"
+```
+
+---
+
+## Task 17: Migrate `get_related_articles` to the contract + TypedDict
+
+**Files:**
+- Modify: `openzim_mcp/tools/structure_tools.py:408-468` (and the `_data` method it calls)
+- Modify: `tests/test_structure_tools.py`
+- Modify: `tests/test_structured_tool_output.py`
+
+**Why:** Renames `outbound_results` → `results`. Anticipates Phase E inbound-link feature where `direction` becomes a parameter; the `results` field then covers either side. Spec section [`get_related_articles`](../specs/2026-05-08-v2-phase-b-response-contract-design.md#get_related_articles).
+
+- [ ] **Step 1: Locate `_data` method**
+
+```bash
+grep -n "get_related_articles\|outbound_results" openzim_mcp/zim/*.py
+```
+
+Find the function that builds the response.
+
+- [ ] **Step 2: Update tests**
+
+Apply renames + contract:
+
+- `result["outbound_results"]` → `result["results"]`
+- Add: `assert result["next_cursor"] is None`, `assert result["done"] is True`, `assert result["total"] == len(result["results"])`, `assert result["page_info"]["limit"] == <limit>`.
+- Replace `payload = structured["result"] if "result" in structured else structured` with the top-level form.
+
+- [ ] **Step 3: Run failing tests**
+
+```bash
+uv run pytest tests/test_structure_tools.py tests/test_structured_tool_output.py -v -k "related"
+```
+
+Expected: failures.
+
+- [ ] **Step 4: Update `_data` method**
+
+Wherever the response is built, restructure to:
+
+```python
+payload: Dict[str, Any] = {
+    "entry_path": entry_path,
+    "results": outbound_hits,                 # was 'outbound_results'
+    "next_cursor": None,
+    "total": len(outbound_hits),
+    "done": True,
+    "page_info": {"offset": 0, "limit": limit, "returned_count": len(outbound_hits)},
+}
+return cast("RelatedArticlesResponse", attach_meta(payload))
+```
+
+Add `from openzim_mcp.tool_schemas import RelatedArticlesResponse`. Update the function's return annotation.
+
+- [ ] **Step 5: Update tool registration**
+
+`tools/structure_tools.py:408`: return annotation → `Union["RelatedArticlesResponse", "ToolErrorPayload"]`.
+
+- [ ] **Step 6: Run tests**
+
+```bash
+uv run pytest tests/test_structure_tools.py tests/test_structured_tool_output.py -v -k "related"
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add openzim_mcp/zim/ openzim_mcp/tools/structure_tools.py tests/test_structure_tools.py tests/test_structured_tool_output.py
+git commit -m "feat(v2)!: get_related_articles to PaginatedResponse + TypedDict
+
+BREAKING: outbound_results renamed to results. Anticipates Phase E
+inbound-link feature where direction becomes a parameter."
+```
+
+---
+
+## Task 18: Migrate `get_zim_metadata` to TypedDict (non-list)
+
+**Files:**
+- Modify: `openzim_mcp/zim/archive.py:376-398` (`get_zim_metadata_data`)
+- Modify: `openzim_mcp/tools/metadata_tools.py:25-72` (tool registration)
+- Modify: `tests/test_metadata_tools.py` and `tests/test_metadata_tools_extended.py`
+- Modify: `tests/test_structured_tool_output.py:78-98` (existing pilot test)
+
+**Why:** TypedDict-only migration. Existing keys preserved.
+
+- [ ] **Step 1: Update tests**
+
+Apply the `assert "result" not in structured` change. Existing keys preserved (`entry_count`, `all_entry_count`, `article_count`, `media_count`, `metadata_entries`).
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+uv run pytest tests/test_metadata_tools.py tests/test_metadata_tools_extended.py tests/test_structured_tool_output.py -v -k "zim_metadata or get_zim_metadata"
+```
+
+Expected: failures.
+
+- [ ] **Step 3: Update return annotations**
+
+In `archive.py:376`:
+
+```python
+def get_zim_metadata_data(self, zim_file_path: str) -> "ZimMetadataResponse":
+```
+
+In `tools/metadata_tools.py:25`: return annotation → `Union["ZimMetadataResponse", "ToolErrorPayload"]`.
+
+Add `from openzim_mcp.tool_schemas import ZimMetadataResponse` in both files.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+uv run pytest tests/test_metadata_tools.py tests/test_metadata_tools_extended.py tests/test_structured_tool_output.py -v -k "zim_metadata"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add openzim_mcp/zim/archive.py openzim_mcp/tools/metadata_tools.py tests/test_metadata_tools.py tests/test_metadata_tools_extended.py tests/test_structured_tool_output.py
+git commit -m "feat(v2)!: get_zim_metadata TypedDict migration"
+```
+
+---
+
+## Task 19: Migrate `get_zim_entry`, `get_main_page`, `get_entry_summary` to TypedDict
+
+**Files:**
+- Modify: `openzim_mcp/zim/content.py` (`get_zim_entry`, `get_main_page`, `get_entry_summary` `_data` methods)
+- Modify: `openzim_mcp/tools/content_tools.py` (and structure_tools.py for entry_summary), `openzim_mcp/tools/metadata_tools.py:74` (`get_main_page`)
+- Modify: `tests/test_content_tools.py` and similar
+
+**Why:** Three related entry-fetch tools share the `EntryResponse` shape. Same TypedDict-only migration.
+
+- [ ] **Step 1: Locate `_data` methods**
+
+```bash
+grep -n "get_zim_entry\|get_main_page\|get_entry_summary" openzim_mcp/zim/content.py openzim_mcp/tools/*.py | head -40
+```
+
+- [ ] **Step 2: Update tests for all three**
+
+In any test that asserts on these tools' returns, swap the wrapper-tolerant payload extraction for top-level. Existing keys preserved (`path`, `title`, `content`).
+
+- [ ] **Step 3: Run failing tests**
+
+```bash
+uv run pytest tests/ -v -k "get_zim_entry or get_main_page or get_entry_summary"
+```
+
+Expected: failures (assert "result" not in structured).
+
+- [ ] **Step 4: Update return annotations**
+
+For each `_data` method (`get_zim_entry_data` → `EntryResponse`, `get_main_page_data` → `EntryResponse`, `get_entry_summary_data` → `EntrySummaryResponse`).
+
+For each tool registration: return annotation `Union[<Response>, ToolErrorPayload]`.
+
+Add the imports.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+uv run pytest tests/ -v -k "get_zim_entry or get_main_page or get_entry_summary"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add openzim_mcp/zim/content.py openzim_mcp/tools/content_tools.py openzim_mcp/tools/structure_tools.py openzim_mcp/tools/metadata_tools.py tests/
+git commit -m "feat(v2)!: get_zim_entry/get_main_page/get_entry_summary TypedDict migration"
+```
+
+---
+
+## Task 20: Migrate `get_zim_entries` (batch fetch) to the contract + TypedDict
+
+**Files:**
+- Modify: `openzim_mcp/tools/content_tools.py:99-...` (`get_zim_entries` tool)
+- Modify: `openzim_mcp/zim/content.py` (`get_zim_entries_data` if separate)
+- Modify: `tests/test_content_tools.py` (or similar)
+- Modify: `tests/test_structured_tool_output.py:236-...` (existing test)
+
+**Why:** Batch fetch is list-shaped — gets the full contract with `done=true, next_cursor=null`. Spec section ["Tools that don't paginate"](../specs/2026-05-08-v2-phase-b-response-contract-design.md#tools-that-dont-paginate).
+
+- [ ] **Step 1: Update tests**
+
+Apply renames + contract:
+
+- Existing keys: depends on v1 shape. Find and inspect:
+  ```bash
+  grep -n "succeeded\|failed\|results" openzim_mcp/zim/content.py | head -20
+  ```
+- The result list (whatever it's called today) → `results`.
+- Contract: `next_cursor: None`, `total: len(results)`, `done: True`, `page_info: {offset: 0, limit: <as_requested>, returned_count: len(results)}`.
+
+In `test_structured_tool_output.py`, change the wrapper-tolerant extraction to top-level.
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+uv run pytest tests/ -v -k "get_zim_entries or batch"
+```
+
+Expected: failures.
+
+- [ ] **Step 3: Update `get_zim_entries_data`**
+
+Restructure response with the contract keys + per-entry list as `results`. Tool-specific extras (`succeeded`, `failed`) preserved.
+
+- [ ] **Step 4: Update tool registration**
+
+`Union["BatchEntryResponse", "ToolErrorPayload"]`. Add the import.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+uv run pytest tests/ -v -k "get_zim_entries or batch"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add openzim_mcp/zim/content.py openzim_mcp/tools/content_tools.py tests/
+git commit -m "feat(v2)!: get_zim_entries batch fetch to PaginatedResponse + TypedDict"
+```
+
+---
+
+## Task 21: Migrate `list_zim_files` to the contract + TypedDict
+
+**Files:**
+- Modify: `openzim_mcp/zim/archive.py:323-346` (`list_zim_files_summary_data` or similar)
+- Modify: `openzim_mcp/tools/file_tools.py:26-66` (tool registration)
+- Modify: `tests/test_file_tools.py` and `tests/test_file_tools_extended.py`
+- Modify: `tests/test_structured_tool_output.py:101-117`
+
+**Why:** Renames `files` → `results`, `count` → `total`. Spec section [`list_zim_files`](../specs/2026-05-08-v2-phase-b-response-contract-design.md#list_zim_files).
+
+- [ ] **Step 1: Update tests**
+
+Apply renames + contract assertions. `result["files"]` → `result["results"]`, `result["count"]` → `result["total"]`. Add `next_cursor: None`, `done: True`, `page_info`.
+
+In `test_structured_tool_output.py:101-117`, switch to top-level payload.
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+uv run pytest tests/test_file_tools.py tests/test_file_tools_extended.py tests/test_structured_tool_output.py -v -k "list_zim_files"
+```
+
+Expected: failures.
+
+- [ ] **Step 3: Update `list_zim_files_summary_data` in archive.py:323**
+
+```python
+def list_zim_files_summary_data(
+    self, name_filter: Optional[str] = None
+) -> "ListZimFilesResponse":
+    # ... existing logic that builds files_list, directories_count ...
+
+    payload: Dict[str, Any] = {
+        "name_filter": name_filter,
+        "directories_count": directories_count,
+        "results": files_list,                     # was 'files'
+        "next_cursor": None,
+        "total": len(files_list),                  # was 'count'
+        "done": True,
+        "page_info": {
+            "offset": 0,
+            "limit": len(files_list),
+            "returned_count": len(files_list),
+        },
+    }
+    return cast("ListZimFilesResponse", attach_meta(payload))
+```
+
+Add `from openzim_mcp.tool_schemas import ListZimFilesResponse`.
+
+- [ ] **Step 4: Update tool registration in `file_tools.py:26`**
+
+`Union["ListZimFilesResponse", "ToolErrorPayload"]`. Add the import.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+uv run pytest tests/test_file_tools.py tests/test_file_tools_extended.py tests/test_structured_tool_output.py -v -k "list_zim_files"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add openzim_mcp/zim/archive.py openzim_mcp/tools/file_tools.py tests/test_file_tools.py tests/test_file_tools_extended.py tests/test_structured_tool_output.py
+git commit -m "feat(v2)!: list_zim_files to PaginatedResponse + TypedDict
+
+BREAKING: files renamed to results, count renamed to total."
+```
+
+---
+
+## Task 22: Remove the `PaginationCursor` compat shim
+
+**Files:**
+- Modify: `openzim_mcp/zim/archive.py:79-...` (delete `PaginationCursor` class)
+- Modify: `openzim_mcp/zim/archive.py:58-68` (remove from `__all__`)
+- Modify: any remaining callers (should be zero by now)
+
+**Why:** Per Task 3's commit message, the shim was added to keep v1 callers working during the migration. With Tasks 5–21 complete, every caller should now be using `Cursor` directly.
+
+- [ ] **Step 1: Find any remaining `PaginationCursor` callers**
+
+```bash
+grep -rn "PaginationCursor" openzim_mcp/ tests/
+```
+
+If any production-code references remain (other than `openzim_mcp/zim/archive.py` itself), MIGRATE THEM to `from openzim_mcp.pagination import Cursor` first. Test references are okay if they decode legacy cursors — but those should also have been updated in earlier tasks.
+
+If grep returns ONLY the definition site in `archive.py` and possibly `__all__`, proceed.
+
+- [ ] **Step 2: Remove the class and the `__all__` entry**
+
+Delete the `PaginationCursor` class body in `archive.py` (the lines you wrote in Task 3). Remove `"PaginationCursor",` from the `__all__` list near the top of the file.
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+uv run pytest tests/ -v
+```
+
+Expected: PASS. If any test imports `PaginationCursor` and breaks, update the import to `from openzim_mcp.pagination import Cursor` and adjust the call site to use the tool-bound API.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add openzim_mcp/zim/archive.py
+git commit -m "refactor(v2): remove PaginationCursor compat shim
+
+All callers now use openzim_mcp.pagination.Cursor directly with
+explicit tool binding. The shim from Task 3 is no longer needed."
+```
+
+---
+
+## Task 23: Update `simple_tools.py` footer / pagination read paths
+
+**Files:**
+- Modify: `openzim_mcp/simple_tools.py`
+- Modify: `tests/test_simple_tools.py`
+
+**Why:** The compact-mode footer in simple-mode (`zim_query`) reads `_meta` and previously may have read `pagination.next_cursor`. With the contract, those reads become top-level.
+
+- [ ] **Step 1: Find affected reads**
+
+```bash
+grep -n 'pagination\["\|pagination.get\|"pagination"' openzim_mcp/simple_tools.py
+grep -n '\["next_cursor"\]\|\["has_more"\]\|"pagination"' openzim_mcp/simple_tools.py
+```
+
+For each match, replace `payload["pagination"]["next_cursor"]` with `payload.get("next_cursor")`, `payload["pagination"]["has_more"]` with `not payload.get("done", True)`, etc.
+
+If the simple-mode wrapper repacks search results into a different shape, ensure it sources the new keys: `total` (was `total_results`), `page_info.offset`, `page_info.limit`, etc.
+
+- [ ] **Step 2: Update tests**
+
+In `tests/test_simple_tools.py`, find any assertions that exercised the old shape via the simple-mode response. Update to new shape. Footer-content assertions should still work (the footer is rendered from `_meta`, which is unchanged).
+
+- [ ] **Step 3: Run tests**
+
+```bash
+uv run pytest tests/test_simple_tools.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add openzim_mcp/simple_tools.py tests/test_simple_tools.py
+git commit -m "feat(v2): simple_tools reads new top-level pagination keys
+
+No external behavior change for simple-mode callers — the compact
+footer is rendered from _meta (unchanged). This task just fixes the
+internal reads after the structured-response migration in Tasks 5-21."
+```
+
+---
+
+## Task 24: Add `tests/test_response_contract.py` — golden contract regression
+
+**Files:**
+- Create: `tests/test_response_contract.py`
+
+**Why:** A single test file that asserts every list-returning tool conforms to the five-key contract. Catches future drift (e.g., someone adds a new tool that forgets `done`).
+
+- [ ] **Step 1: Create the test file**
+
+```python
+"""Contract-shape regression: every list-returning tool emits the five contract keys.
+
+Phase B (#3) standardizes pagination across all list-returning tools. This
+file is the single source of truth for "did we keep the contract?" Each
+test calls a real tool against the bundled fixtures and asserts the shape.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openzim_mcp.config import OpenZimMcpConfig
+from openzim_mcp.server import OpenZimMcpServer
+
+
+CONTRACT_KEYS = ("results", "next_cursor", "total", "done", "page_info", "_meta")
+PAGE_INFO_KEYS = ("offset", "limit", "returned_count")
+
+
+def _assert_contract(payload: dict) -> None:
+    """Assert payload carries the five contract keys + _meta + page_info subkeys."""
+    for key in CONTRACT_KEYS:
+        assert key in payload, f"contract key missing: {key}"
+    assert isinstance(payload["results"], list), f"results must be list, got {type(payload['results'])}"
+    assert isinstance(payload["done"], bool)
+    assert payload["next_cursor"] is None or isinstance(payload["next_cursor"], str)
+    assert payload["total"] is None or isinstance(payload["total"], int)
+    pi = payload["page_info"]
+    for key in PAGE_INFO_KEYS:
+        assert key in pi, f"page_info missing key: {key}"
+    # done <-> next_cursor co-vary (redundant by design)
+    if payload["done"]:
+        assert payload["next_cursor"] is None, "done=True must imply next_cursor=None"
+    else:
+        assert payload["next_cursor"] is not None, "done=False must imply next_cursor!=None"
+
+
+@pytest.fixture
+def server(test_config_with_zim_data: OpenZimMcpConfig) -> OpenZimMcpServer:
+    return OpenZimMcpServer(test_config_with_zim_data)
+
+
+class TestContractShape:
+    @pytest.mark.asyncio
+    async def test_search_zim_file_contract(self, server, basic_test_zim_files):
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+        result = await server.mcp._tool_manager.call_tool(
+            "search_zim_file",
+            {"zim_file_path": str(zim_path), "query": "evolution", "limit": 5},
+            convert_result=True,
+        )
+        _, payload = result
+        _assert_contract(payload)
+
+    @pytest.mark.asyncio
+    async def test_search_all_contract_top_level(self, server):
+        result = await server.mcp._tool_manager.call_tool(
+            "search_all", {"query": "evolution"}, convert_result=True,
+        )
+        _, payload = result
+        _assert_contract(payload)
+        # search_all top-level is always done=True
+        assert payload["done"] is True
+        # And each per-archive result inside also conforms.
+        for entry in payload["results"]:
+            inner = entry["result"]
+            _assert_contract(inner)
+
+    @pytest.mark.asyncio
+    async def test_find_entry_by_title_contract(self, server, basic_test_zim_files):
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+        result = await server.mcp._tool_manager.call_tool(
+            "find_entry_by_title",
+            {"zim_file_path": str(zim_path), "title": "anything"},
+            convert_result=True,
+        )
+        _, payload = result
+        _assert_contract(payload)
+        assert payload["done"] is True  # non-paginated tool
+
+    @pytest.mark.asyncio
+    async def test_get_search_suggestions_contract(self, server, basic_test_zim_files):
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+        result = await server.mcp._tool_manager.call_tool(
+            "get_search_suggestions",
+            {"zim_file_path": str(zim_path), "partial_query": "ev"},
+            convert_result=True,
+        )
+        _, payload = result
+        _assert_contract(payload)
+        assert payload["done"] is True
+
+    @pytest.mark.asyncio
+    async def test_browse_namespace_contract(self, server, basic_test_zim_files):
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+        result = await server.mcp._tool_manager.call_tool(
+            "browse_namespace",
+            {"zim_file_path": str(zim_path), "namespace": "C", "limit": 5},
+            convert_result=True,
+        )
+        _, payload = result
+        _assert_contract(payload)
+
+    @pytest.mark.asyncio
+    async def test_walk_namespace_contract(self, server, basic_test_zim_files):
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+        result = await server.mcp._tool_manager.call_tool(
+            "walk_namespace",
+            {"zim_file_path": str(zim_path), "namespace": "C", "limit": 50},
+            convert_result=True,
+        )
+        _, payload = result
+        _assert_contract(payload)
+        assert payload["total"] is None  # walk doesn't know total
+
+    @pytest.mark.asyncio
+    async def test_extract_article_links_contract(self, server, basic_test_zim_files):
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+        # Find any article and extract links from it.
+        find = await server.mcp._tool_manager.call_tool(
+            "find_entry_by_title", {"zim_file_path": str(zim_path), "title": "Berlin"},
+            convert_result=True,
+        )
+        _, find_payload = find
+        if not find_payload["results"]:
+            pytest.skip("No fixture article to test against")
+        entry_path = find_payload["results"][0]["path"]
+        result = await server.mcp._tool_manager.call_tool(
+            "extract_article_links",
+            {"zim_file_path": str(zim_path), "entry_path": entry_path, "kind": "internal"},
+            convert_result=True,
+        )
+        _, payload = result
+        _assert_contract(payload)
+        assert "category_totals" in payload
+        for k in ("internal", "external", "media"):
+            assert k in payload["category_totals"]
+
+    @pytest.mark.asyncio
+    async def test_list_zim_files_contract(self, server):
+        result = await server.mcp._tool_manager.call_tool(
+            "list_zim_files", {}, convert_result=True,
+        )
+        _, payload = result
+        _assert_contract(payload)
+        assert payload["done"] is True
+
+    @pytest.mark.asyncio
+    async def test_get_related_articles_contract(self, server, basic_test_zim_files):
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+        find = await server.mcp._tool_manager.call_tool(
+            "find_entry_by_title", {"zim_file_path": str(zim_path), "title": "Berlin"},
+            convert_result=True,
+        )
+        _, find_payload = find
+        if not find_payload["results"]:
+            pytest.skip("No fixture article to test against")
+        entry_path = find_payload["results"][0]["path"]
+        result = await server.mcp._tool_manager.call_tool(
+            "get_related_articles",
+            {"zim_file_path": str(zim_path), "entry_path": entry_path},
+            convert_result=True,
+        )
+        _, payload = result
+        _assert_contract(payload)
+        assert payload["done"] is True
+
+    @pytest.mark.asyncio
+    async def test_get_zim_entries_contract(self, server, basic_test_zim_files):
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+        result = await server.mcp._tool_manager.call_tool(
+            "get_zim_entries",
+            {"zim_file_path": str(zim_path), "entry_paths": ["C/Berlin", "C/Paris"]},
+            convert_result=True,
+        )
+        _, payload = result
+        _assert_contract(payload)
+        assert payload["done"] is True
+```
+
+- [ ] **Step 2: Run the new test file**
+
+```bash
+uv run pytest tests/test_response_contract.py -v
+```
+
+Expected: every test PASS. If any fail, the failure indicates the corresponding tool migration (Tasks 5-21) is incomplete or drifted from the contract — go fix the tool, not the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_response_contract.py
+git commit -m "test(v2): add response-contract regression test
+
+Single source of truth for 'every list-returning tool conforms to the
+five-key contract'. Catches future drift if a new tool ships without
+the contract keys."
+```
+
+---
+
+## Task 25: Extend `tests/test_structured_tool_output.py` to cover every migrated tool with a top-level-payload assertion
+
+**Files:**
+- Modify: `tests/test_structured_tool_output.py`
+
+**Why:** During Tasks 5-21 each migration touched this file with one-off changes. This task ensures every dict-returning tool has a single, consistent assertion: `assert "result" not in structured` (TypedDict landed payload at top level). Backstops the per-tool migration tasks.
+
+- [ ] **Step 1: List every dict-returning tool**
+
+Tools: `search_zim_file`, `search_all`, `search_with_filters`, `find_entry_by_title`, `get_search_suggestions`, `browse_namespace`, `walk_namespace`, `list_namespaces`, `extract_article_links`, `get_table_of_contents`, `get_article_structure`, `get_binary_entry`, `get_related_articles`, `list_zim_files`, `get_zim_metadata`, `get_zim_entry`, `get_zim_entries`, `get_main_page`, `get_entry_summary`.
+
+- [ ] **Step 2: Audit the file**
+
+```bash
+grep -n "def test_.*_returns_structured_content" tests/test_structured_tool_output.py
+```
+
+For each tool in the list above that doesn't have a test in this file, ADD one following the existing pattern:
+
+```python
+@pytest.mark.asyncio
+async def test_<tool>_returns_structured_content(
+    self, server: OpenZimMcpServer, basic_test_zim_files
+) -> None:
+    """<tool> emits a real dict at the top level of structuredContent (no result wrapper)."""
+    zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+    if zim_path is None:
+        pytest.skip("ZIM testing-suite small.zim not available")
+    result = await server.mcp._tool_manager.call_tool(
+        "<tool>",
+        {"zim_file_path": str(zim_path), <other_required_args>},
+        convert_result=True,
+    )
+    assert isinstance(result, tuple)
+    _, structured = result
+    assert isinstance(structured, dict)
+    assert "result" not in structured, "TypedDict migration regression: payload still wrapped"
+    # Tool-specific top-level keys (one or two characteristic ones):
+    assert "<key1>" in structured
+    assert "<key2>" in structured
+```
+
+For each EXISTING test, replace the wrapper-tolerant pattern:
+
+```python
+payload = structured["result"] if "result" in structured else structured
+```
+
+with:
+
+```python
+assert "result" not in structured, "TypedDict migration regression: payload still wrapped"
+payload = structured
+```
+
+If you find a test that still uses the tolerant pattern (i.e., a per-tool task didn't tighten it), tighten it now.
+
+- [ ] **Step 3: Run the file**
+
+```bash
+uv run pytest tests/test_structured_tool_output.py -v
+```
+
+Expected: every test PASS. The "result" not in structured assertion fails fast on any tool whose TypedDict migration drifted.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_structured_tool_output.py
+git commit -m "test(v2): extend structured-output regression to every migrated tool
+
+Each test now asserts payload lands at top level ('result' wrapper
+absent), backstopping the per-tool TypedDict migrations from Tasks 5-21."
+```
+
+---
+
+## Task 26: Bump cache keys in cache-using `_data` methods that weren't covered by individual tasks
+
+**Files:**
+- Audit: every `_data` method in `openzim_mcp/zim/`
+
+**Why:** Phase A bumped some cache keys when shapes changed. Phase B's shape changes mean any cached v1.x response shape would be returned to a v2 caller — wrong. We need to bump every cache key that wraps a list-returning response.
+
+- [ ] **Step 1: Find every cache key in zim/ modules**
+
+```bash
+grep -n "cache_key\|self\.cache\.get\|self\.cache\.set" openzim_mcp/zim/*.py
+```
+
+- [ ] **Step 2: For each cache key, check if it was updated in earlier tasks**
+
+Task 5 already bumped `search_data:` → `search_v2b:`. Other cache keys (e.g., for `browse_namespace`, `extract_article_links`, `list_zim_files`) may not have been bumped per-task — those need updating now.
+
+For every cache_key string used in a `_data` method that produces a Phase-B-changed shape, append `:v2b` (or replace the prefix with `<name>_v2b:`). Examples:
+
+- `f"browse_ns:{path}:{ns}:{limit}:{offset}"` → `f"browse_ns_v2b:{path}:{ns}:{limit}:{offset}"`
+- `f"links:{path}:{entry}:{limit}:{offset}:{kind}"` → `f"links_v2b:{path}:{entry}:{limit}:{offset}:{kind}"`
+
+If a cache wraps a non-changed response (e.g., entry-content cache where only the TypedDict annotation changed but the dict shape didn't), no bump needed.
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+uv run pytest tests/ -v
+```
+
+Expected: PASS. (Cache-key bumps don't break tests; they just avoid returning stale-shape responses in production.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add openzim_mcp/zim/
+git commit -m "chore(v2): bump cache keys for Phase B response shapes
+
+Every cache key wrapping a list-returning response gets a v2b suffix
+so v1.x cached responses (old shape) don't leak through after upgrade."
+```
+
+---
+
+## Task 27: Capture Phase B golden file regression
+
+**Files:**
+- Create: `tests/test_golden_v2_phase_b.py` (or extend the existing Phase A pattern)
+- Generate: golden snapshot data files (likely under `tests/data/` or as inline text)
+
+**Why:** The Phase A goldens were captured at v1.2.0 shape and will fail after Phase B. This task captures the new shape as the v2 anchor. Future regressions on the contract will diff against these snapshots.
+
+- [ ] **Step 1: Inspect the Phase A golden test**
+
+```bash
+ls tests/test_golden* tests/data/*.golden* 2>/dev/null
+cat tests/test_golden_v2_phase_a.py | head -80 2>/dev/null || true
+```
+
+If the Phase A golden test exists, follow its pattern. If not, create a minimal one.
+
+- [ ] **Step 2: Create `tests/test_golden_v2_phase_b.py`**
+
+Pattern: for ~5 fixture archives × ~5 representative tool calls (search, browse, walk, links, find_entry), serialize the response to JSON and snapshot. On first run, the test writes goldens to disk and skips. On subsequent runs, it diffs.
+
+Implementation depends on whether the project uses `pytest-snapshot`, `syrupy`, or hand-rolled. Inspect Phase A's pattern; mirror it.
+
+If hand-rolled:
+
+```python
+"""Phase B golden snapshots: response shape after the response-contract migration.
+
+The Phase A goldens captured the v1.2.0 shape; Phase B's wire-format break means
+those goldens stop matching after this phase by design. These v2 goldens are
+the new anchor. Future contract drift is caught by diffing against these.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from openzim_mcp.config import OpenZimMcpConfig
+from openzim_mcp.server import OpenZimMcpServer
+
+GOLDENS_DIR = Path(__file__).parent / "data" / "goldens" / "v2_phase_b"
+
+
+def _capture_or_compare(name: str, payload: dict, *, capture_mode: bool) -> None:
+    """Write or diff a golden snapshot for ``name``."""
+    GOLDENS_DIR.mkdir(parents=True, exist_ok=True)
+    path = GOLDENS_DIR / f"{name}.json"
+    if capture_mode or not path.exists():
+        path.write_text(json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True))
+        return
+    expected = json.loads(path.read_text())
+    # Stripping volatile fields like _meta.tokens_est (which depend on snippet text)
+    # keeps the diff focused on the contract shape.
+    def _strip_volatile(d):
+        if isinstance(d, dict):
+            return {k: _strip_volatile(v) for k, v in d.items() if k not in ("tokens_est", "chars")}
+        if isinstance(d, list):
+            return [_strip_volatile(x) for x in d]
+        return d
+    assert _strip_volatile(payload) == _strip_volatile(expected), (
+        f"Golden mismatch for {name}. Set OPENZIM_MCP_CAPTURE_GOLDENS=1 to refresh."
+    )
+
+
+@pytest.fixture
+def server(test_config_with_zim_data: OpenZimMcpConfig) -> OpenZimMcpServer:
+    return OpenZimMcpServer(test_config_with_zim_data)
+
+
+@pytest.fixture
+def capture_mode(monkeypatch) -> bool:
+    import os
+    return os.environ.get("OPENZIM_MCP_CAPTURE_GOLDENS") == "1"
+
+
+class TestGoldensV2PhaseB:
+    @pytest.mark.asyncio
+    async def test_search_zim_file_golden(self, server, basic_test_zim_files, capture_mode):
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+        result = await server.mcp._tool_manager.call_tool(
+            "search_zim_file",
+            {"zim_file_path": str(zim_path), "query": "evolution", "limit": 5},
+            convert_result=True,
+        )
+        _, payload = result
+        _capture_or_compare("search_zim_file_evolution_5", payload, capture_mode=capture_mode)
+
+    # Repeat for browse_namespace, walk_namespace, extract_article_links,
+    # find_entry_by_title with consistent fixture inputs.
+```
+
+Add similar test methods for the other tools. Aim for 5–8 snapshots total.
+
+- [ ] **Step 3: Generate the goldens**
+
+```bash
+OPENZIM_MCP_CAPTURE_GOLDENS=1 uv run pytest tests/test_golden_v2_phase_b.py -v
+```
+
+Expected: every test PASS (the capture path is a no-op assertion). Verify the JSON files were written:
+
+```bash
+ls -la tests/data/goldens/v2_phase_b/
+```
+
+- [ ] **Step 4: Run again without capture mode to verify diffs**
+
+```bash
+uv run pytest tests/test_golden_v2_phase_b.py -v
+```
+
+Expected: PASS. The snapshots match themselves.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_golden_v2_phase_b.py tests/data/goldens/v2_phase_b/
+git commit -m "test(v2): capture Phase B response-contract goldens
+
+5-8 snapshots covering the new wire format across the major tools.
+Anchors the v2 contract against future drift. Set
+OPENZIM_MCP_CAPTURE_GOLDENS=1 to refresh after intentional changes."
+```
+
+---
+
+## Task 28: Update `README.md` with Phase B contract documentation
+
+**Files:**
+- Modify: `README.md`
+
+**Why:** The README is the user-facing contract. After Phase B, every list-returning tool's response shape needs documenting once (not per-tool — the common contract is the point).
+
+- [ ] **Step 1: Find the existing tool-response section**
+
+```bash
+grep -n "^##\|^###" README.md | head -40
+```
+
+Identify where tool responses, pagination, or `_meta` are currently documented.
+
+- [ ] **Step 2: Add a "Response contract" section**
+
+Insert a new section (under or near the Phase A `_meta` section). Content:
+
+```markdown
+## Response contract (v2)
+
+Every list-returning tool returns the same five contract keys:
+
+| Key | Type | Meaning |
+|---|---|---|
+| `results` | `list[T]` | The page of items. Empty list on zero hits. |
+| `next_cursor` | `str | null` | Opaque base64-JSON cursor. Pass back as `cursor=` to fetch the next page. `null` on the last page. |
+| `total` | `int | null` | Total count across all pages. `null` when not knowable mid-scan (e.g., `walk_namespace`). |
+| `done` | `bool` | `true` when no more pages exist. Always co-varies with `next_cursor`: `done=true` ⟺ `next_cursor=null`. |
+| `page_info` | `{offset, limit, returned_count, total_is_lower_bound?}` | Pagination state for this page. |
+
+Plus the Phase A `_meta` envelope as a sibling.
+
+### Pagination input
+
+Every paged tool accepts `cursor` (preferred) or `offset` (convenience). If
+both are supplied, `cursor` wins.
+
+### Cursor format
+
+Cursors are URL-safe base64-encoded JSON of `{v: 1, t: <tool_name>, s: <state>}`.
+The cursor is **tool-bound** — passing one tool's cursor to another raises a
+clear error. Cursors are **opaque** — clients should not interpret them.
+
+### Tools without natural pagination
+
+Tools like `find_entry_by_title`, `get_search_suggestions`, and `list_zim_files`
+return all matches in one call. They still emit the contract: `done=true`,
+`next_cursor=null`, `total=len(results)`.
+
+### `extract_article_links` requires `kind`
+
+`extract_article_links` returns one category per call (`kind=internal` by
+default). Use `kind=external` or `kind=media` for the other categories.
+Per-category counts surface in `category_totals: {internal, external, media}`.
+```
+
+- [ ] **Step 3: Note the wire-format break in the existing v2 section**
+
+If the README has a "v2 changes" or "Migration from v1.x" section, add a bullet for the response-contract break. Otherwise, add one sentence near the section above:
+
+> v2 is a wire-format break from v1.x — see CHANGELOG for the per-tool key renames.
+
+- [ ] **Step 4: Run a quick lint pass**
+
+```bash
+test -f README.md && wc -l README.md
+```
+
+Expected: file exists, line count reasonable.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(v2): document Phase B response contract in README
+
+Single section covering the five contract keys, cursor format, and
+the extract_article_links kind requirement. The per-tool docstrings
+in the source already cover their tool-specific extras; this is the
+shared contract reference."
+```
+
+---
+
+## Task 29: Add `## [2.0.0a2]` entry to `CHANGELOG.md`
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+**Why:** Standard release-please workflow uses CHANGELOG entries to gate the next tag. This entry documents Phase B's breaking changes for users who upgrade.
+
+- [ ] **Step 1: Inspect the existing changelog format**
+
+```bash
+head -60 CHANGELOG.md
+```
+
+Match the existing style (release-please format usually).
+
+- [ ] **Step 2: Add the entry**
+
+Insert near the top, under the `## [Unreleased]` section if one exists, or above the prior version:
+
+```markdown
+## [2.0.0a2] — 2026-05-08 (alpha pre-release)
+
+v2 Phase B: response-contract migration. **Wire-format break** for every
+list-returning tool. v1.x users upgrading must update response-shape parsing.
+See [docs/superpowers/specs/2026-05-08-v2-phase-b-response-contract-design.md](docs/superpowers/specs/2026-05-08-v2-phase-b-response-contract-design.md)
+for the full design.
+
+### Breaking — pagination contract
+
+Every list-returning tool now returns the same five contract keys:
+`results`, `next_cursor`, `total`, `done`, `page_info`.
+
+| Tool | What changed |
+|---|---|
+| `search_zim_file` | `total_results` → `total`; `pagination` block flattened; `next_cursor` at top level; `cursor` accepted as input |
+| `search_all` | `per_file` → `results`; per-archive blocks each carry the new contract via `result` field; cursor lives only at the per-archive level |
+| `search_with_filters` | now returns structured dict (was markdown); same shape as `search_zim_file` plus `namespace_filter`/`content_type_filter` |
+| `find_entry_by_title` | gets the contract; `done=true`, `total=len(results)` always |
+| `get_search_suggestions` | `suggestions` → `results`; `count` removed |
+| `browse_namespace` | `entries` → `results`; `total_in_namespace` → `total`; `total_in_namespace_is_lower_bound` → `page_info.total_is_lower_bound`; `has_more` removed |
+| `walk_namespace` | `cursor` input/output type changes from `int` to opaque `str`; `entries` → `results`; `total` is always `null`; `total_entries` deprecated alias removed |
+| `list_namespaces` | `namespaces[<letter>].entry_count` → `total`; payload at top level (no `result` wrapper) |
+| `extract_article_links` | **`kind` is now required (default `"internal"`)**; single category per call; `internal_links`/`external_links`/`media_links` parallel arrays removed; `category_totals: {internal, external, media}` added |
+| `list_zim_files` | `files` → `results`; `count` → `total` |
+| `get_related_articles` | `outbound_results` → `results`; anticipates Phase E inbound-link feature |
+| `get_zim_entries` (batch) | gets the contract; `done=true`, `total=len(results)` |
+
+### Breaking — TypedDict everywhere
+
+Every dict-returning tool migrated from `Dict[str, Any]` to a per-tool
+TypedDict. FastMCP now emits payloads at the top level of `structuredContent`
+with real schemas. The previous `{"result": ...}` outer wrapper is gone.
+
+Migrated tools (TypedDict-only, no contract): `get_zim_metadata`,
+`get_zim_entry`, `get_main_page`, `get_entry_summary`,
+`get_table_of_contents`, `get_article_structure`, `get_binary_entry`.
+
+### Cursor format
+
+Cursors are URL-safe base64 JSON: `{v: 1, t: <tool_name>, s: <state>}`.
+**Tool-bound** — a search cursor passed to browse raises a clear error.
+**Versioned** — adding new fields later doesn't break the wire format.
+
+### Compat shim removed
+
+`openzim_mcp.zim.archive.PaginationCursor` (the v1 cursor class) is removed.
+Use `openzim_mcp.pagination.Cursor` instead.
+
+### Other
+
+- New module: `openzim_mcp/pagination.py` — `Cursor.encode/decode`, `CursorMismatchError`.
+- New module: `openzim_mcp/tool_schemas.py` — every per-tool response TypedDict.
+- New tests: `tests/test_pagination_cursor.py`, `tests/test_response_contract.py`, `tests/test_golden_v2_phase_b.py`.
+- The Phase A `_meta` envelope is unchanged in shape and still populates on every response.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "chore(v2): CHANGELOG entry for v2.0.0a2 (Phase B)"
+```
+
+---
+
+## Task 30: Final verification — full test suite, lint, type check
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full test suite**
+
+```bash
+uv run pytest tests/ -v
+```
+
+Expected: every test PASS. If anything fails, fix before proceeding.
+
+- [ ] **Step 2: Lint**
+
+```bash
+uv run ruff check .
+```
+
+Expected: no errors. Fix any reported issues.
+
+- [ ] **Step 3: Type check**
+
+```bash
+uv run mypy openzim_mcp/
+```
+
+Expected: no errors. Common Phase B-introduced issues:
+- TypedDict variance: if a `_data` method's return type is annotated as `TypedDict X` but the constructed dict is `Dict[str, Any]`, `cast()` it.
+- Union return annotations may need `cast()` at error-paths.
+
+- [ ] **Step 4: Smoke-run the server (optional but recommended)**
+
+```bash
+uv run python -m openzim_mcp.server --help 2>&1 | head -10
+```
+
+Expected: help text. The CLI starts without error.
+
+- [ ] **Step 5: Verify branch state**
+
+```bash
+git status --porcelain
+git log --oneline main..v2-phase-b
+```
+
+Expected: empty `git status` output; `git log` shows ~25-30 commits since main branched.
+
+No commit on this task — verification only. If everything is green, proceed to Task 31.
+
+---
+
+## Task 31: Open the v2-phase-b → main PR
+
+**Files:** none (git/PR operations)
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin v2-phase-b
+```
+
+Expected: branch pushed to origin.
+
+- [ ] **Step 2: Open the PR**
+
+Use the GitHub CLI:
+
+```bash
+gh pr create --base main --head v2-phase-b \
+  --title "feat(v2)!: Phase B — response contract & TypedDict migration" \
+  --label v2 --label v2-phase-b \
+  --body "$(cat <<'EOF'
+## Phase B of the v2 effort — response contract migration
+
+**Tag target:** v2.0.0a2 (alpha pre-release)
+**Spec:** docs/superpowers/specs/2026-05-08-v2-phase-b-response-contract-design.md
+
+### What's in scope (#3 + #13)
+
+- **#3 Standard pagination contract.** Every list-returning tool returns the same five contract keys (`results`, `next_cursor`, `total`, `done`, `page_info`) plus `_meta`.
+- **#13 TypedDict everywhere.** Every dict-returning tool migrated from `Dict[str, Any]` to a per-tool TypedDict. FastMCP emits payloads at the top level of `structuredContent` with real schemas (no more `{"result": ...}` wrapper).
+
+### Wire-format breaks
+
+This is a clean break from v1.x — no deprecation period (v2 policy). See CHANGELOG for the per-tool key renames table.
+
+Most surgical changes:
+- `extract_article_links` requires `kind` (default `"internal"`); single category per call.
+- `walk_namespace` cursor type changes from `int` to opaque `str`.
+- `search_with_filters` now returns structured dict (was markdown).
+
+### Test surface
+
+- New: `tests/test_pagination_cursor.py`, `tests/test_response_contract.py`, `tests/test_golden_v2_phase_b.py`, `tests/test_tool_schemas.py`.
+- Extended: `tests/test_structured_tool_output.py` covers every migrated tool with top-level-payload assertions.
+- Updated: every per-tool test file reflects the new shape.
+
+### Release plan
+
+- Merge this PR into `v2-phase-b` (branch already at HEAD).
+- Tag `v2.0.0a2` after merge.
+- v2 final tag waits for Phases C–F.
+EOF
+)"
+```
+
+- [ ] **Step 3: Confirm the PR opened**
+
+```bash
+gh pr list --head v2-phase-b
+```
+
+Expected: one open PR.
+
+The PR review and merge are the human in the loop — this plan stops here.
+
+- [ ] **Step 4: Stop**
+
+When the PR opens cleanly, the implementation plan is complete. The user will review, merge, and tag `v2.0.0a2`.
+
+---
+
+## Self-Review
+
+Spec coverage check:
+
+- ✅ Phase B item #3 (pagination contract) — Tasks 5-13, 17, 20, 21 cover every paginated tool.
+- ✅ Phase B item #13 (TypedDict migration) — Tasks 5-21 each migrate one tool's return type.
+- ✅ Foundation (`pagination.py`, `tool_schemas.py`) — Tasks 2 and 4.
+- ✅ Cursor design (versioned, tool-bound) — Task 2 implements; Task 5 first uses; Tasks 7, 10-13, 17 follow same pattern.
+- ✅ `done` + `next_cursor` redundant by design — Task 24's contract regression asserts the co-variance.
+- ✅ Offset-as-input retained — every paged tool's registration in Tasks 5-21 keeps `offset` and adds `cursor`.
+- ✅ Error-as-data union return — every tool's annotation is `Union[<Success>, ToolErrorPayload]`.
+- ✅ `extract_article_links` requires `kind` — Task 13.
+- ✅ `walk_namespace` opaque cursor — Task 11.
+- ✅ `search_all` two-level contract — Task 6.
+- ✅ `list_namespaces` non-list special case — Task 12.
+- ✅ Removed wire-format keys per spec table — covered across per-tool tasks.
+- ✅ Phase A `_meta` envelope preserved unchanged — every per-tool task keeps `attach_meta()` calls intact.
+- ✅ Cache key bumps — Task 5 (search) and Task 26 (audit pass).
+- ✅ Phase B goldens — Task 27.
+- ✅ README update — Task 28.
+- ✅ CHANGELOG entry — Task 29.
+- ✅ Single bundled PR off `v2-phase-b` — Task 1 creates branch; Task 31 opens PR; tag `v2.0.0a2` waits for review/merge.
+
+Type consistency check: `Cursor.encode/decode` signatures match between Task 2 (definition) and every consumer (Tasks 5, 7, 10-13). `CursorMismatchError` is consistently a `ValueError` subclass. TypedDict names match between `tool_schemas.py` (Task 4) and the per-tool migrations (Tasks 5-21). The `_meta` envelope shape (`MetaEnvelope`) is consistent with Phase A's `attach_meta()` output.
+
+Placeholder scan: no "TBD", no "TODO", no "implement later". One forward reference in Task 26 ("if a cache wraps a non-changed response... no bump needed") — that's a judgment instruction, not a placeholder.
+
+No issues found. Plan is ready for execution.

--- a/docs/superpowers/specs/2026-05-08-v2-phase-b-response-contract-design.md
+++ b/docs/superpowers/specs/2026-05-08-v2-phase-b-response-contract-design.md
@@ -1,0 +1,654 @@
+# v2 Phase B — Response Contract (Design Spec)
+
+**Status:** Draft
+**Phase:** B of 6 ([tracking doc](../../v2/README.md))
+**Items in scope:** #3 (standard pagination contract), #13 (`structuredContent` everywhere)
+**Target:** `v2.0.0a2`
+**Date:** 2026-05-08
+
+---
+
+## Goal
+
+Standardize the wire format of every list-returning tool in [`openzim_mcp`](../../../openzim_mcp/) so that smaller, less capable LLMs see one consistent response shape regardless of which tool they call. Phase B does this in two coordinated breaking changes:
+
+1. **Standard pagination contract** — every list-returning tool returns a `PaginatedResponse[T]`-shaped object with the same five contract keys (`results`, `next_cursor`, `total`, `done`, `page_info`) regardless of whether the tool actually paginates.
+2. **TypedDict return types** — every dict-returning tool migrates from `Dict[str, Any]` (which FastMCP wraps in a generic `{"result": ...}` envelope with no schema) to a TypedDict that produces a real output schema and lands the payload at the top level of `structuredContent`.
+
+These ship as one bundled PR off `v2-phase-b` because they're entangled: the pagination contract requires real schemas to be useful, and the schema migration requires a consistent shape to be tractable.
+
+## Non-goals
+
+- No new tools. Tool surface collapse is Phase F (#9).
+- No tool removals. Items become options, not deletions.
+- No new ML deps. Phase B introduces no Python deps; the existing `tiktoken` from Phase A and the existing libzim bindings cover everything.
+- No change to error semantics. Errors continue to flow as `ToolErrorPayload` data with `error: True`. Switching to MCP `isError` + raised exceptions is a Phase F refactor.
+- No change to Phase A's `_meta` envelope. It stays where it is, sibling to the contract keys.
+- No change to the resource endpoints in [`tools/resource_tools.py`](../../../openzim_mcp/tools/resource_tools.py). Those return JSON strings via the MCP **resource** surface, which is distinct from the **tool** surface this spec governs.
+- No expansion of the cross-archive paging story. `search_all` keeps its single-shot fan-out shape (no top-level pagination across many archives) — that's a Phase F concern.
+
+## Foundational decisions inherited from the v2 tracking doc
+
+1. **Clean breaks allowed.** Phase B is a wire-format break for every list-returning tool. No deprecation period; v1.x branch receives no Phase B backports.
+2. **ML accelerators opt-in via extras.** Phase B introduces no ML deps.
+3. **Offline-first.** Phase B touches no network code paths.
+4. **Markdown for prose, JSON for navigation, no XML.** Phase B is structural; markdown footers from Phase A continue to render unchanged.
+5. **Phase A `_meta` envelope is canonical.** Phase B does **not** relocate it; the tracking doc's hint that Phase B "may collapse the duplication" was about empty-result prose, which Phase A already handled.
+
+## Decisions captured during brainstorming
+
+These resolved during the design conversation; the spec does not re-litigate them.
+
+| Decision | Choice |
+|---|---|
+| Integer `offset` as input | **Kept** alongside `cursor`; if both supplied, `cursor` wins. |
+| `done` and `next_cursor` co-presence | **Both always present.** Redundant by design. `done=true` ⟺ `next_cursor=None`. |
+| #13 scope | **All dict-returning tools** migrate to TypedDict, not just the seven named in the tracking doc. |
+| PR shape | **Single bundled PR** off `v2-phase-b`. |
+| Canonical response shape | Approach 1 — uniform `PaginatedResponse`-shaped TypedDict for every list-returning tool, paged or not. |
+| `extract_article_links` 3-category problem | **Require `kind`** (default `"internal"`); single category per call. |
+| Cursor identity | **Tool-bound** — server rejects cross-tool reuse. Versioned for forward-compat. |
+| Error envelope | **Keep error-as-data.** Function returns `Union[<SuccessTypedDict>, ToolErrorPayload]`. |
+
+---
+
+## Architecture
+
+### New module
+
+[`openzim_mcp/pagination.py`](../../../openzim_mcp/pagination.py) — promotes the existing [`PaginationCursor`](../../../openzim_mcp/zim/archive.py#L80-L142) from `zim/archive.py` to a top-level module and extends it with versioning, tool-binding, and per-tool state. Existing imports update.
+
+```python
+class CursorState(TypedDict, total=False):
+    """Tool-specific state inside a cursor payload."""
+    o: int          # offset (search, browse, links)
+    l: int          # limit
+    q: str          # query (search, search_all per-file)
+    ns: str         # namespace (browse_namespace)
+    scan_at: int    # entry id (walk_namespace — replaces today's int cursor)
+    ep: str         # entry path (extract_article_links)
+    k: str          # kind: "internal" | "external" | "media"
+
+class CursorPayload(TypedDict):
+    v: int                       # cursor version, currently 1
+    t: str                       # tool name (e.g., "browse_namespace")
+    s: CursorState               # tool-specific state
+
+class Cursor:
+    @staticmethod
+    def encode(*, tool: str, state: CursorState, version: int = 1) -> str: ...
+    @staticmethod
+    def decode(token: str, *, expected_tool: str) -> CursorPayload:
+        # Raises CursorMismatchError on tool mismatch (caller maps to tool_error).
+        # Raises ValueError on malformed token.
+```
+
+[`openzim_mcp/tool_schemas.py`](../../../openzim_mcp/tool_schemas.py) — central home for the `PageInfo`, per-item, and per-tool response TypedDicts. Tool modules import from here rather than defining inline TypedDicts. This keeps the schema surface auditable in one file and makes it easy to spot drift between tools.
+
+### Touched modules
+
+| Module | Changes |
+|---|---|
+| [`openzim_mcp/responses.py`](../../../openzim_mcp/responses.py) | No change to `ToolErrorPayload` or `tool_error()`. The Union return annotations live in tool modules. |
+| [`openzim_mcp/zim/archive.py`](../../../openzim_mcp/zim/archive.py) | `PaginationCursor` removed (moved to `openzim_mcp/pagination.py`). Imports updated. |
+| [`openzim_mcp/zim/search.py`](../../../openzim_mcp/zim/search.py) | All `_data` methods return TypedDict-shaped payloads (`SearchResponse`, `FindEntryResponse`, `SearchSuggestionsResponse`, `SearchAllResponse`). Pagination keys conform to contract; `pagination` nested block removed; `total_results` → `total`; cursors round-trip through `Cursor.encode/decode` with `t="search_zim_file"` etc. |
+| [`openzim_mcp/zim/namespace.py`](../../../openzim_mcp/zim/namespace.py) | `browse_namespace_data`, `walk_namespace_data`, `list_namespaces_data` return TypedDict-shaped payloads. `total_in_namespace` → `total`; `total_in_namespace_is_lower_bound` → `page_info.total_is_lower_bound`; `walk_namespace`'s int `cursor` becomes opaque (encoded `scan_at`); `total_entries` deprecated alias removed. |
+| [`openzim_mcp/zim/structure.py`](../../../openzim_mcp/zim/structure.py) | `extract_article_links_data` requires `kind` (defaults `"internal"`); returns single-category `LinksResponse`; `category_totals: {internal, external, media}` replaces three `total_*_links` fields. `get_table_of_contents_data` and `get_article_structure_data` return their respective TypedDicts. |
+| [`openzim_mcp/zim/content.py`](../../../openzim_mcp/zim/content.py) | `get_binary_entry_data`, `get_main_page` (where applicable), and `_data` shapes for entry-fetching tools migrate to TypedDicts. Phase A's `_meta` continues to attach. |
+| [`openzim_mcp/tools/*.py`](../../../openzim_mcp/tools/) | Every `@server.mcp.tool()` registration updates its return annotation to the appropriate `Union[<SuccessResponse>, ToolErrorPayload]`. Input signatures gain `cursor: Optional[str] = None` where applicable; existing `offset` parameters remain. |
+| [`openzim_mcp/simple_tools.py`](../../../openzim_mcp/simple_tools.py) | Compact-mode footer continues to read `_meta`; the `pagination` nested block reads disappear (footer code becomes simpler). |
+| `tests/` | Per-tool tests update for new keys; `tests/test_structured_tool_output.py` extends to cover every migrated tool; new `tests/test_pagination_cursor.py` covers the `Cursor` API. |
+| `README.md`, `CHANGELOG.md` | Document the new contract; CHANGELOG entry under `## [2.0.0a2]`. |
+
+### What does **not** change
+
+- No tool name changes. (That's Phase F.)
+- No tool removals. (That's Phase F.)
+- Phase A's `_meta` envelope shape (`tokens_est`, `chars`, `truncated`, `more_at_offset`, `total_chars`, `suggestions`, `reason`).
+- `compact=False` markdown output remains markdown — the structural changes are dict-side only.
+- `tool_error()` shape and the `ToolErrorPayload` TypedDict.
+- The simple-mode (`zim_query`) external surface.
+
+---
+
+## The `PaginatedResponse` contract
+
+Every list-returning tool returns a TypedDict that includes these five contract keys plus `_meta`:
+
+```python
+class PageInfo(TypedDict):
+    offset: int                        # the offset this page started at
+    limit: int                         # the limit honored
+    returned_count: int                # len(results)
+    total_is_lower_bound: NotRequired[bool]  # only for sampling-based browse
+
+class MetaEnvelope(TypedDict, total=False):
+    tokens_est: int
+    chars: int
+    truncated: bool
+    more_at_offset: int
+    total_chars: int
+    suggestions: list[dict]
+    reason: str
+
+# Per-tool response TypedDicts subclass this conceptually but Python 3.12
+# doesn't support generic TypedDict cleanly, so we declare contract keys
+# on each per-tool TypedDict directly. Examples below.
+
+class SearchHit(TypedDict):
+    path: str
+    title: str
+    score: float
+    snippet: str
+    zim_file: str
+
+class SearchResponse(TypedDict):
+    # contract keys
+    results: list[SearchHit]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    # tool-specific extras
+    query: str
+```
+
+### Field semantics
+
+| Field | Type | Always present? | Notes |
+|---|---|---|---|
+| `results` | `list[T]` | Yes | The page of items. Empty `[]` on zero hits. Never `None`. |
+| `next_cursor` | `Optional[str]` | Yes (may be `None`) | Opaque base64 cursor. `None` ⟺ last page. |
+| `total` | `Optional[int]` | Yes (may be `None`) | Best-known total across all pages. `None` when not knowable mid-scan (e.g., `walk_namespace`). For sampling-based namespace discovery, the integer is a lower bound — `page_info.total_is_lower_bound: true` flags this. |
+| `done` | `bool` | Yes | Redundant with `next_cursor=None` (always co-vary). Provided so a model gets a one-glance boolean. |
+| `page_info.offset` | `int` | Yes | Start position of this page in the underlying paging state. For offset-paginated tools (`search_zim_file`, `browse_namespace`, `extract_article_links`, etc.) it's the integer offset. For the streaming scan in `walk_namespace`, it's the entry id (`scan_at`) the page resumed at — `0` on the first page. The interpretation is tool-specific but the field is always populated. |
+| `page_info.limit` | `int` | Yes | Limit honored on this page. |
+| `page_info.returned_count` | `int` | Yes | `len(results)`. Redundant; included for ergonomics. |
+| `page_info.total_is_lower_bound` | `bool` | Only on sampling-based browse | Documents that `total` is a discovered minimum, not the true count. |
+| `_meta` | `MetaEnvelope` | Yes (Phase A) | Unchanged from Phase A. Sibling to contract keys. |
+
+### Tools that don't paginate
+
+`find_entry_by_title`, `get_search_suggestions`, `list_zim_files`, `get_related_articles`, the top-level of `search_all`, and `get_zim_entries` (batch fetch) all use the same shape with `next_cursor=None, done=True, total=len(results), page_info.offset=0, page_info.limit=<as_requested>`. **Every list-returning tool has the same five contract keys regardless of whether it paginates.** A model that learns "list tool" learns one shape.
+
+`list_namespaces` is the one exception — it returns a dict-of-summaries keyed by namespace letter, not a list, so the contract doesn't apply (see the next sub-section).
+
+### `list_namespaces` is not a list
+
+`list_namespaces` returns a dict keyed by namespace letter (`{"C": {...}, "M": {...}}`), not a list. It does not get `PaginatedResponse` keys. Its own TypedDict is:
+
+```python
+class NamespaceSummary(TypedDict):
+    total: int                   # renamed from `entry_count`
+    is_authoritative: bool
+
+class ListNamespacesResponse(TypedDict):
+    total_entries: int
+    sampled_entries: int
+    has_new_namespace_scheme: bool
+    is_total_authoritative: bool
+    discovery_method: str
+    namespaces: dict[str, NamespaceSummary]
+    _meta: MetaEnvelope
+```
+
+This is the only list-shaped result that doesn't fit the `PaginatedResponse` contract; calling it out explicitly so the rule "every list-returning tool has the same shape" holds (`list_namespaces` returns a dict-of-summaries, not a list).
+
+---
+
+## Cursor format
+
+### Wire format
+
+Cursors are URL-safe base64-encoded JSON of the following shape:
+
+```json
+{
+  "v": 1,
+  "t": "browse_namespace",
+  "s": {"o": 50, "l": 50, "ns": "C"}
+}
+```
+
+### Required fields
+
+- `v` (int) — version. Currently `1`. New required fields in future versions bump `v`; new optional fields ride v=1.
+- `t` (str) — tool name. Must match the tool decoding the cursor. On mismatch, the server returns `tool_error(operation=..., message="cursor was issued by '<other_tool>', cannot be used here")`.
+- `s` (object) — tool-specific state.
+
+### Per-tool state shapes
+
+| Tool | State keys |
+|---|---|
+| `search_zim_file` | `o` (offset), `l` (limit), `q` (query) |
+| `search_with_filters` | `o`, `l`, `q`, plus optional `ns` (namespace), `ct` (content_type) |
+| `browse_namespace` | `o`, `l`, `ns` |
+| `walk_namespace` | `scan_at` (entry id), `l` |
+| `extract_article_links` | `o`, `l`, `ep` (entry path), `k` (kind) |
+| `search_all` | per-archive cursors only; same shape as `search_zim_file` with `t="search_zim_file"`. The top-level `search_all` shape doesn't paginate, so it never emits a top-level cursor. |
+
+### Encoding API
+
+```python
+from openzim_mcp.pagination import Cursor
+
+next_cursor = Cursor.encode(
+    tool="browse_namespace",
+    state={"o": 50, "l": 50, "ns": "C"},
+)  # -> str (URL-safe base64)
+
+decoded = Cursor.decode(token, expected_tool="browse_namespace")
+# decoded is CursorPayload; raises CursorMismatchError on tool mismatch
+# or ValueError on malformed token. Tool wrappers catch both and emit tool_error.
+```
+
+### Input precedence
+
+When a tool accepts both `cursor` and `offset`:
+
+1. If `cursor` is non-null, decode it; on success, derive offset/limit/query/etc. from `cursor.s`. Ignore the `offset`/`limit` arguments.
+2. If `cursor` is null, use the `offset`/`limit` arguments directly (default `offset=0`).
+3. If both are supplied and the cursor is invalid, return `tool_error` (don't silently fall through to offset-mode — that would mask client bugs).
+
+This rule is documented in every paged tool's docstring.
+
+### Why tool-bound
+
+A `search_zim_file` cursor carries `{o, l, q}`. Passing it to `browse_namespace` (which expects `ns` instead of `q`) would silently misbehave: namespace decoder sees a missing `ns` and returns the wrong page. The `t` field eliminates this class of bug at near-zero cost (~10 bytes in the encoded token).
+
+### Why versioned
+
+Adding a new optional cursor field later (e.g., a `since` timestamp for live archives) doesn't require a new wire format. Decoder ignores unknown keys at v=1; future v=2 cursors carry whatever new required fields demand.
+
+---
+
+## Per-tool changes
+
+This section enumerates every tool. For each tool, "Today" shows the v1.3.0 response shape; "v2 Phase B" shows the new shape.
+
+### `search_zim_file`
+
+**Inputs.** `zim_file_path`, `query`, `limit?`, `offset?`, `cursor?` — `cursor` newly added; `offset` retained.
+
+**Today (selected keys):**
+```json
+{
+  "query": "berlin",
+  "total_results": 42,
+  "offset": 0, "limit": 20,
+  "results": [...],
+  "pagination": {"has_more": true, "showing_start": 1, "showing_end": 20, "next_cursor": "..."}
+}
+```
+
+**v2 Phase B:**
+```json
+{
+  "query": "berlin",
+  "results": [...],
+  "next_cursor": "<base64>",
+  "total": 42,
+  "done": false,
+  "page_info": {"offset": 0, "limit": 20, "returned_count": 20},
+  "_meta": {...}
+}
+```
+
+Removed: `pagination` nested block, `total_results`, `pagination.showing_start/showing_end` (the model can derive them from offset+limit+returned_count if needed; they bloat the response).
+
+### `search_all`
+
+**Inputs.** `query`, `limit_per_file?`. No top-level cursor; pagination happens per-archive.
+
+**v2 Phase B:**
+```json
+{
+  "query": "berlin",
+  "files_searched": 4,
+  "files_with_hits": 2,
+  "results": [
+    {"zim_file_path": "...", "name": "...", "result": {<SearchResponse>}, "has_hits": true},
+    ...
+  ],
+  "next_cursor": null,
+  "total": 4,
+  "done": true,
+  "page_info": {"offset": 0, "limit": 4, "returned_count": 4},
+  "_meta": {...}
+}
+```
+
+`results[].result` is itself a full `PaginatedResponse` (each archive can be paged independently via its own cursor). The top-level paginates trivially (always `done=true`) so the contract holds at every level.
+
+### `search_with_filters`
+
+Today returns a markdown string. **v2 Phase B:** returns `SearchResponse`-shaped TypedDict (same shape as `search_zim_file`, with `query`, `namespace_filter`, `content_type_filter` as tool-specific extras). Cursor `t="search_with_filters"`.
+
+### `find_entry_by_title`
+
+**Inputs.** `query`, `limit?`. No cursor (no natural pagination — it's a best-N lookup).
+
+**v2 Phase B:**
+```json
+{
+  "query": "Berlin",
+  "results": [...],
+  "next_cursor": null,
+  "total": 3,
+  "done": true,
+  "page_info": {"offset": 0, "limit": 10, "returned_count": 3},
+  "fast_path_hit": true,
+  "files_searched": 1,
+  "_meta": {...}
+}
+```
+
+### `get_search_suggestions`
+
+**Inputs.** `partial_query`, `limit?`. No cursor.
+
+**v2 Phase B:**
+```json
+{
+  "partial_query": "berl",
+  "results": [
+    {"text": "Berlin", "path": "C/Berlin", "type": "title"},
+    ...
+  ],
+  "next_cursor": null,
+  "total": 5,
+  "done": true,
+  "page_info": {"offset": 0, "limit": 10, "returned_count": 5},
+  "_meta": {...}
+}
+```
+
+Renamed: `suggestions` → `results`. (The Phase A `_meta.suggestions[]` recovery candidates are a separate concept — they live inside `_meta` and stay there. The top-level `results` is the paginated list of *autocomplete* suggestions.) `count` is removed; `page_info.returned_count` covers it.
+
+### `browse_namespace`
+
+**Inputs.** `zim_file_path`, `namespace`, `limit?`, `offset?`, `cursor?`.
+
+**v2 Phase B:**
+```json
+{
+  "namespace": "C",
+  "results": [
+    {"path": "C/Berlin", "title": "Berlin", "content_type": "text/html", "preview": "..."},
+    ...
+  ],
+  "next_cursor": "<base64>",
+  "total": 100,
+  "done": false,
+  "page_info": {"offset": 0, "limit": 50, "returned_count": 50, "total_is_lower_bound": true},
+  "discovery_method": "sampled",
+  "sampling_based": true,
+  "results_may_be_incomplete": false,
+  "_meta": {...}
+}
+```
+
+Renamed: `entries` → `results`, `total_in_namespace` → `total`, `total_in_namespace_is_lower_bound` → `page_info.total_is_lower_bound`. Removed: `has_more` (use `done`); top-level `is_total_authoritative` (covered by `page_info.total_is_lower_bound`'s presence).
+
+### `walk_namespace`
+
+**Inputs.** `zim_file_path`, `namespace`, `limit?`, `cursor?` (was `cursor: int`, now opaque str).
+
+**v2 Phase B:**
+```json
+{
+  "namespace": "C",
+  "results": [{"path": "C/Berlin", "title": "Berlin"}, ...],
+  "next_cursor": "<base64>",
+  "total": null,
+  "done": false,
+  "page_info": {"offset": 0, "limit": 200, "returned_count": 200},
+  "scanned_count": 412,
+  "scanned_through_id": 5234,
+  "archive_entry_count": 1000000,
+  "_meta": {...}
+}
+```
+
+`total` is `null` because `walk_namespace` doesn't know the per-namespace count until it finishes scanning; `scanned_count` and `archive_entry_count` give the model enough information to estimate progress without misleading it about an authoritative total. Removed: `total_entries` (already-deprecated alias), `cursor` (input/output now lives in `next_cursor` opaque token), `total_in_namespace` (use `total`).
+
+### `extract_article_links`
+
+**Inputs.** `zim_file_path`, `entry_path`, `kind` (now **required**, default `"internal"`), `limit?`, `offset?`, `cursor?`.
+
+**Today:** returns three lists with three pagination flags.
+
+**v2 Phase B:**
+```json
+{
+  "title": "Berlin",
+  "path": "C/Berlin",
+  "content_type": "text/html",
+  "kind": "internal",
+  "results": [{"target": "C/Germany", "label": "Germany"}, ...],
+  "next_cursor": "<base64>",
+  "total": 187,
+  "done": false,
+  "page_info": {"offset": 0, "limit": 100, "returned_count": 100},
+  "category_totals": {"internal": 187, "external": 23, "media": 5},
+  "_meta": {...}
+}
+```
+
+Removed: `internal_links`, `external_links`, `media_links` arrays (now `results` for the requested category); `total_internal_links`/`total_external_links`/`total_media_links` (now `category_totals`); `pagination` nested block (now top-level).
+
+To get all three categories, callers make three calls. This is a clean break — the prior multi-category response was awkward for paginated use anyway (per-category cursors interleaved poorly).
+
+### `list_zim_files`
+
+**Inputs.** `name_filter?`. No cursor.
+
+**v2 Phase B:**
+```json
+{
+  "name_filter": null,
+  "directories_count": 1,
+  "results": [{"name": "...", "path": "...", "directory": "...", "size": "1.2 GB", "size_bytes": 1234567890, "modified": "..."}, ...],
+  "next_cursor": null,
+  "total": 4,
+  "done": true,
+  "page_info": {"offset": 0, "limit": 4, "returned_count": 4},
+  "_meta": {...}
+}
+```
+
+Renamed: `files` → `results`, `count` → `total`.
+
+### `get_related_articles`
+
+**Inputs.** `zim_file_path`, `entry_path`, `limit?`. No cursor.
+
+**v2 Phase B:**
+```json
+{
+  "entry_path": "C/Berlin",
+  "results": [{"path": "C/Germany", "title": "Germany", "link_text": "Germany"}, ...],
+  "next_cursor": null,
+  "total": 7,
+  "done": true,
+  "page_info": {"offset": 0, "limit": 10, "returned_count": 7},
+  "_meta": {...}
+}
+```
+
+Renamed: `outbound_results` → `results`. (Anticipates the Phase E inbound link-graph feature, where `direction` becomes a parameter and `results` covers either side.)
+
+### `get_zim_entries` (batch fetch)
+
+Returns a list of entry-fetch results. Gets the full contract with `next_cursor=null, done=true, total=len(results)` since batch fetch doesn't paginate (the caller already supplied an explicit list of paths). The TypedDict is `BatchEntryResponse` with `results: list[EntryResponse]` plus the contract keys.
+
+### Non-list tools (TypedDict only, no contract keys)
+
+These tools return non-list payloads and get TypedDict migrations only — no `PaginatedResponse` shape:
+
+| Tool | Response TypedDict | Notes |
+|---|---|---|
+| `get_zim_metadata` | `ZimMetadataResponse` | Existing keys preserved; just typed. |
+| `get_zim_entry` / `get_main_page` | `EntryResponse` | Includes `_meta` with `more_at_offset` for Phase A truncation. |
+| `get_entry_summary` | `EntrySummaryResponse` | Existing keys typed. |
+| `get_table_of_contents` | `TableOfContentsResponse` | Tree, not list. Existing keys typed. |
+| `get_article_structure` | `ArticleStructureResponse` | Existing keys typed. |
+| `get_binary_entry` | `BinaryEntryResponse` | Existing keys typed; base64 `data` field annotation `Optional[str]`. |
+| `list_namespaces` | `ListNamespacesResponse` | Dict-of-summaries; not a list. |
+| `get_server_health` / `get_server_configuration` | typed where they're not already | Mostly already typed via existing TypedDict. |
+
+---
+
+## Removed wire-format keys (clean break)
+
+| Removed key | Tool(s) | Replaced by |
+|---|---|---|
+| `pagination` nested block | search_zim_file, search_with_filters, browse_namespace, extract_article_links | top-level `next_cursor`, `done`, `total`, `page_info` |
+| `pagination.showing_start` / `showing_end` | search_zim_file | derivable from `page_info.offset + page_info.returned_count`; not surfaced |
+| `has_more` | browse_namespace, walk_namespace | `done` (polarity flip; `done = !has_more`) |
+| `total_results` | search_zim_file | `total` |
+| `total_in_namespace` | browse_namespace | `total` |
+| `total_in_namespace_is_lower_bound` | browse_namespace | `page_info.total_is_lower_bound` |
+| `is_total_authoritative` | browse_namespace top-level | `page_info.total_is_lower_bound` (presence ⟺ non-authoritative) |
+| `total_entries` | walk_namespace (already deprecated in v1) | removed |
+| `cursor: int` (input + output) | walk_namespace | `cursor: str` opaque |
+| `entries` | browse_namespace, walk_namespace | `results` |
+| `outbound_results` | get_related_articles | `results` |
+| `suggestions` (top-level list) | get_search_suggestions | `results` |
+| `files` | list_zim_files | `results` |
+| `count` | list_zim_files | `total` |
+| `total_internal_links` / `total_external_links` / `total_media_links` | extract_article_links | `category_totals` |
+| `internal_links` / `external_links` / `media_links` (parallel lists) | extract_article_links | `results` (single category per call) |
+| FastMCP `{"result": ...}` outer wrapper | every dict-returning tool | top-level payload (via TypedDict return type) |
+
+The Phase A `_meta` envelope and all its keys are unchanged.
+
+---
+
+## Error handling
+
+Every tool's return annotation becomes `Union[<SuccessTypedDict>, ToolErrorPayload]`:
+
+```python
+async def browse_namespace(...) -> Union[BrowseNamespaceResponse, ToolErrorPayload]: ...
+```
+
+FastMCP emits `anyOf` in the schema; clients branch on the presence of `error: True`. Behavior is unchanged from v1: rate limits, validation failures, decode errors, and unexpected exceptions all return error data.
+
+### New error path: cursor decode
+
+When `Cursor.decode` raises:
+- `ValueError` (malformed token) → `tool_error(operation="<tool>", message="Invalid pagination cursor: <reason>", context=f"cursor=<truncated>")`
+- `CursorMismatchError` (wrong tool) → `tool_error(operation="<tool>", message="Cursor was issued by '<other_tool>'; pass a cursor obtained from <tool>'s previous response.", context=...)`
+
+### Empty list semantics
+
+When zero results match:
+
+```json
+{
+  "results": [],
+  "next_cursor": null,
+  "total": 0,
+  "done": true,
+  "page_info": {"offset": 0, "limit": <as_requested>, "returned_count": 0},
+  "_meta": {"reason": "0_hits", "suggestions": [...]}
+}
+```
+
+The Phase A footer continues to render the suggestions in compact mode.
+
+---
+
+## Configuration
+
+Phase B introduces no new env vars or config knobs. The existing `OPENZIM_MCP_*` surface is unchanged.
+
+---
+
+## Testing
+
+### New test files
+
+- `tests/test_pagination_cursor.py` — `Cursor.encode/decode` round-trips, version handling, tool-binding rejection, malformed-token rejection, base64 padding tolerance.
+- `tests/test_response_contract.py` — golden-shape assertions: every list-returning tool returns the five contract keys with the right types; non-paged tools have `done=true, next_cursor=null`; `page_info` shape conforms.
+
+### Extended test files
+
+- `tests/test_structured_tool_output.py` — extend to every dict-returning tool (today covers two pilots). Each tool asserts (a) `convert_result=True` returns a tuple (TypedDict path), (b) the structured payload is at the **top level** (no `result` wrapper), (c) the payload conforms to its declared TypedDict.
+- `tests/test_search_tools.py`, `tests/test_navigation_tools.py`, `tests/test_metadata_tools.py`, `tests/test_structure_tools.py`, `tests/test_walk_namespace.py`, `tests/test_extract_article_links_pagination.py`, `tests/test_search_all.py` — update key assertions to new contract; remove assertions on removed keys.
+- `tests/test_simple_tools.py` — verify compact-mode footer reads from the new shape (no `pagination` nested lookups).
+
+### Migrated test surface
+
+The test files above will need ~150 small key-rename updates (`pagination.next_cursor` → `next_cursor`, etc.). Mechanical work; flagged in the implementation plan.
+
+### Golden-file regression
+
+Phase A introduced `tests/test_golden_v2_phase_a.py` with 5-archive snapshots. Phase B adds `tests/test_golden_v2_phase_b.py` capturing the **new** contract shape for the same 5 fixture archives across the same prompt set. (The Phase A goldens stop matching after Phase B by design — they're a v1.x-compat anchor that's allowed to break here.)
+
+### Performance budget
+
+| Operation | Budget |
+|---|---|
+| `Cursor.encode` | ≤ 0.05 ms |
+| `Cursor.decode` | ≤ 0.1 ms (includes JSON parse + tool-name check) |
+| Per-tool TypedDict construction overhead | ≤ 0.1 ms per response |
+
+All under existing tool latency by 2-3 orders of magnitude. No measurable regression expected; budget exists to catch surprises.
+
+---
+
+## Acceptance criteria
+
+Phase B is shippable as `v2.0.0a2` when:
+
+1. Every list-returning tool returns the five contract keys (`results`, `next_cursor`, `total`, `done`, `page_info`) with semantics matching this spec.
+2. Every dict-returning tool's MCP registration uses a TypedDict return annotation; `tests/test_structured_tool_output.py` asserts top-level payload (no `{"result": ...}` wrapper) for every migrated tool.
+3. Every paged tool accepts both `cursor` and `offset` as input; `cursor` wins on conflict; invalid cursors produce `tool_error`.
+4. Cursor tool-binding works: passing a wrong-tool cursor produces a clear error.
+5. `extract_article_links` requires `kind` (default `"internal"`) and emits `category_totals`.
+6. `walk_namespace`'s integer cursor is gone from both input and output; `next_cursor` is opaque.
+7. All removed keys (per the [Removed keys](#removed-wire-format-keys-clean-break) table) are absent from responses.
+8. Phase A's `_meta` envelope is unchanged in shape and continues to populate.
+9. Full unit + integration test suite passing on Python 3.12 and 3.13.
+10. README updated with the new contract; CHANGELOG entry under `## [2.0.0a2]`.
+11. No `tiktoken`/libzim/dependency changes.
+12. Phase B golden file regression captured and passing.
+
+---
+
+## Release plan
+
+- Branch: `v2-phase-b` off `main`.
+- **Single bundled PR** targeting `v2-phase-b`. Logical commits within the PR (for reviewer ergonomics, not separate merges):
+  1. `pagination`: introduce `openzim_mcp/pagination.py`; move `PaginationCursor`; add tool-binding + version field.
+  2. `tool_schemas`: introduce `openzim_mcp/tool_schemas.py` with all per-tool TypedDicts and `PageInfo`.
+  3. `search`: migrate `search_zim_file`, `search_all`, `search_with_filters`, `find_entry_by_title`, `get_search_suggestions`.
+  4. `namespace`: migrate `browse_namespace`, `walk_namespace`, `list_namespaces`.
+  5. `structure`: migrate `extract_article_links` (with `kind` requirement), `get_table_of_contents`, `get_article_structure`, `get_binary_entry`, `get_related_articles`.
+  6. `entries`: migrate `get_zim_entry`, `get_zim_entries`, `get_entry_summary`, `get_main_page`, `get_zim_metadata`.
+  7. `tests`: extend `test_structured_tool_output.py`; add `test_pagination_cursor.py` and `test_response_contract.py`; update existing tests; capture Phase B goldens.
+  8. `docs`: README + CHANGELOG.
+- After the PR merges into `v2-phase-b`, a single `v2-phase-b` → `main` PR for final review and tag.
+- Tag: `v2.0.0a2`. Pre-release on PyPI; not promoted to "latest."
+- v1.x branches receive no Phase B backports.
+
+---
+
+## Forward references
+
+- **Phase C #11** (precomputed section index) will introduce `get_section` and may add tool-specific cursor state for section-level paging — handled cleanly by the versioned cursor format.
+- **Phase D #15** (semantic embedding sidecar) hybrid retrieval will produce a fused result list paginated under the same `PaginatedResponse` contract.
+- **Phase E #16** (inbound link-graph) will extend `get_related_articles` with a `direction` parameter; the existing `results` field already covers either direction.
+- **Phase F #9** (tool collapse, 21 → 8) consolidates the many list-returning tools into `zim_search`, `zim_browse`, etc. — the unified contract makes that consolidation a name-mapping exercise rather than a shape exercise.
+- **Future cursor v=2** will be needed if a tool requires a new mandatory state field. Until then, additive-only changes ride v=1.
+
+---
+
+## Open issues / accepted risks
+
+- **TypedDict generic limitations.** Python 3.12 doesn't support generic TypedDict cleanly. Per-tool TypedDicts redeclare contract keys. Drift is prevented by `tests/test_response_contract.py`'s structural assertions, not by the type system. (Generic TypedDict in PEP 705 lands fully in 3.13+; revisitable then.)
+- **Bulk test churn.** ~150 small assertion updates across test files. Mechanical; the implementation plan will sequence them after the production-code migration.
+- **Documentation churn.** Every paginated tool's docstring needs rewriting. Counted into the PR's effort estimate.

--- a/docs/superpowers/specs/2026-05-08-v2-phase-b-response-contract-design.md
+++ b/docs/superpowers/specs/2026-05-08-v2-phase-b-response-contract-design.md
@@ -13,9 +13,11 @@
 Standardize the wire format of every list-returning tool in [`openzim_mcp`](../../../openzim_mcp/) so that smaller, less capable LLMs see one consistent response shape regardless of which tool they call. Phase B does this in two coordinated breaking changes:
 
 1. **Standard pagination contract** — every list-returning tool returns a `PaginatedResponse[T]`-shaped object with the same five contract keys (`results`, `next_cursor`, `total`, `done`, `page_info`) regardless of whether the tool actually paginates.
-2. **TypedDict return types** — every dict-returning tool migrates from `Dict[str, Any]` (which FastMCP wraps in a generic `{"result": ...}` envelope with no schema) to a TypedDict that produces a real output schema and lands the payload at the top level of `structuredContent`.
+2. **TypedDict return types** — every dict-returning tool migrates from `Dict[str, Any]` (which FastMCP wraps in a generic `{"result": ...}` envelope with no schema) to a `Union[<SuccessResponse>, ToolErrorPayload]` annotation that produces a real output schema. Because the annotation is a `Union` (the error envelope is in-band), FastMCP wraps the payload in a single uniform `{"result": ...}` envelope on the wire — but the inner content now carries a real schema (`anyOf: [<SuccessTypedDict>, ToolErrorPayload]`). This is one consistent extra layer for every migrated tool, far better than v1's mixed schema-less wrapping.
 
 These ship as one bundled PR off `v2-phase-b` because they're entangled: the pagination contract requires real schemas to be useful, and the schema migration requires a consistent shape to be tractable.
+
+> **Note on FastMCP wrapping:** FastMCP's `func_metadata` (`mcp.server.fastmcp.utilities.func_metadata._try_create_model_and_schema`) wraps every non-single-TypedDict return type — including every `Union[<SuccessResponse>, ToolErrorPayload]` annotation — in a top-level `{"result": ...}` envelope on the wire. Phase B accepts this uniform wrapper deliberately: it's better than v1's schema-less wrapping because the inner content now carries a real schema (`anyOf: [<SuccessTypedDict>, ToolErrorPayload]`), and uniformity ("always look in `result`") is friendlier to small clients than a mixed-shape contract. Tests should assert against `structured["result"]` (or the wrapper-tolerant equivalent `structured.get("result", structured)` — see the helper pattern in [`tests/test_structured_tool_output.py`](../../../tests/test_structured_tool_output.py)).
 
 ## Non-goals
 
@@ -520,7 +522,7 @@ These tools return non-list payloads and get TypedDict migrations only — no `P
 | `count` | list_zim_files | `total` |
 | `total_internal_links` / `total_external_links` / `total_media_links` | extract_article_links | `category_totals` |
 | `internal_links` / `external_links` / `media_links` (parallel lists) | extract_article_links | `results` (single category per call) |
-| FastMCP `{"result": ...}` outer wrapper | every dict-returning tool | top-level payload (via TypedDict return type) |
+| FastMCP `{"result": ...}` outer wrapper | every dict-returning tool | uniform `{"result": ...}` wrapper around a real-schema TypedDict (FastMCP wraps `Union` returns; we keep the wrapper but the inner shape now has a real schema — see [Note on FastMCP wrapping](#goal)) |
 
 The Phase A `_meta` envelope and all its keys are unchanged.
 
@@ -576,7 +578,7 @@ Phase B introduces no new env vars or config knobs. The existing `OPENZIM_MCP_*`
 
 ### Extended test files
 
-- `tests/test_structured_tool_output.py` — extend to every dict-returning tool (today covers two pilots). Each tool asserts (a) `convert_result=True` returns a tuple (TypedDict path), (b) the structured payload is at the **top level** (no `result` wrapper), (c) the payload conforms to its declared TypedDict.
+- `tests/test_structured_tool_output.py` — extend to every dict-returning tool (today covers two pilots). Each tool asserts (a) `convert_result=True` returns a tuple (TypedDict path), (b) the structured payload is at `structuredContent.result` and conforms to its declared TypedDict (FastMCP wraps `Union[<SuccessResponse>, ToolErrorPayload]` returns in a single uniform envelope — see [Note on FastMCP wrapping](#goal)), (c) the inner payload exposes the contract keys for paged tools.
 - `tests/test_search_tools.py`, `tests/test_navigation_tools.py`, `tests/test_metadata_tools.py`, `tests/test_structure_tools.py`, `tests/test_walk_namespace.py`, `tests/test_extract_article_links_pagination.py`, `tests/test_search_all.py` — update key assertions to new contract; remove assertions on removed keys.
 - `tests/test_simple_tools.py` — verify compact-mode footer reads from the new shape (no `pagination` nested lookups).
 
@@ -605,7 +607,7 @@ All under existing tool latency by 2-3 orders of magnitude. No measurable regres
 Phase B is shippable as `v2.0.0a2` when:
 
 1. Every list-returning tool returns the five contract keys (`results`, `next_cursor`, `total`, `done`, `page_info`) with semantics matching this spec.
-2. Every dict-returning tool's MCP registration uses a TypedDict return annotation; `tests/test_structured_tool_output.py` asserts top-level payload (no `{"result": ...}` wrapper) for every migrated tool.
+2. Every dict-returning tool's MCP registration uses a `Union[<SuccessTypedDict>, ToolErrorPayload]` return annotation; `tests/test_structured_tool_output.py` asserts the structured payload conforms to its declared TypedDict (whether or not FastMCP applies a `{"result": ...}` wrapper around `Union` returns — with the chosen `Union` annotation, the wrapper is present and uniform across all migrated tools; see [Note on FastMCP wrapping](#goal)).
 3. Every paged tool accepts both `cursor` and `offset` as input; `cursor` wins on conflict; invalid cursors produce `tool_error`.
 4. Cursor tool-binding works: passing a wrong-tool cursor produces a clear error.
 5. `extract_article_links` requires `kind` (default `"internal"`) and emits `category_totals`.

--- a/openzim_mcp/async_operations.py
+++ b/openzim_mcp/async_operations.py
@@ -13,7 +13,11 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 from .zim_operations import ZimOperations
 
 if TYPE_CHECKING:
-    from .tool_schemas import SearchAllResponse, SearchResponse
+    from .tool_schemas import (
+        SearchAllResponse,
+        SearchResponse,
+        SearchWithFiltersResponse,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -262,7 +266,7 @@ class AsyncZimOperations:
         limit: Optional[int] = None,
         offset: int = 0,
     ) -> str:
-        """Search with filters (async).
+        """Search with filters (async, legacy markdown surface).
 
         Args:
             zim_file_path: Path to the ZIM file
@@ -273,10 +277,30 @@ class AsyncZimOperations:
             offset: Starting offset
 
         Returns:
-            Search results as JSON string
+            Search results as markdown text
         """
         return await asyncio.to_thread(
             self._ops.search_with_filters,
+            zim_file_path,
+            query,
+            namespace,
+            content_type,
+            limit,
+            offset,
+        )
+
+    async def search_with_filters_data(
+        self,
+        zim_file_path: str,
+        query: str,
+        namespace: Optional[str] = None,
+        content_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> "SearchWithFiltersResponse":
+        """Structured variant of ``search_with_filters`` (async)."""
+        return await asyncio.to_thread(
+            self._ops.search_with_filters_data,
             zim_file_path,
             query,
             namespace,

--- a/openzim_mcp/async_operations.py
+++ b/openzim_mcp/async_operations.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
         FindEntryResponse,
         LinksResponse,
         ListNamespacesResponse,
+        ListZimFilesResponse,
         RelatedArticlesResponse,
         SearchAllResponse,
         SearchResponse,
@@ -86,12 +87,8 @@ class AsyncZimOperations:
 
     async def list_zim_files_summary_data(
         self, name_filter: Optional[str] = None
-    ) -> dict:
-        """Structured variant of ``list_zim_files`` (async).
-
-        Returns the count/directories_count/name_filter/files envelope
-        used by the migrated MCP tool.
-        """
+    ) -> "ListZimFilesResponse":
+        """Structured variant of ``list_zim_files`` (async)."""
         return await asyncio.to_thread(
             self._ops.list_zim_files_summary_data, name_filter=name_filter
         )

--- a/openzim_mcp/async_operations.py
+++ b/openzim_mcp/async_operations.py
@@ -14,6 +14,7 @@ from .zim_operations import ZimOperations
 
 if TYPE_CHECKING:
     from .tool_schemas import (
+        ArticleStructureResponse,
         BrowseNamespaceResponse,
         FindEntryResponse,
         LinksResponse,
@@ -374,7 +375,7 @@ class AsyncZimOperations:
         self,
         zim_file_path: str,
         entry_path: str,
-    ) -> dict:
+    ) -> "ArticleStructureResponse":
         """Structured variant of ``get_article_structure`` (async)."""
         return await asyncio.to_thread(
             self._ops.get_article_structure_data, zim_file_path, entry_path

--- a/openzim_mcp/async_operations.py
+++ b/openzim_mcp/async_operations.py
@@ -8,7 +8,7 @@ the event loop during I/O-bound operations.
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from .zim_operations import ZimOperations
 
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
         SearchResponse,
         SearchSuggestionsResponse,
         SearchWithFiltersResponse,
+        WalkNamespaceResponse,
     )
 
 logger = logging.getLogger(__name__)
@@ -526,7 +527,7 @@ class AsyncZimOperations:
         self,
         zim_file_path: str,
         namespace: str,
-        cursor: int = 0,
+        cursor: Optional[Dict[str, Any]] = None,
         limit: int = 200,
     ) -> str:
         """Walk all entries in a namespace by ID (async)."""
@@ -538,15 +539,15 @@ class AsyncZimOperations:
         self,
         zim_file_path: str,
         namespace: str,
-        cursor: int = 0,
+        cursor_state: Optional[Dict[str, Any]] = None,
         limit: int = 200,
-    ) -> dict:
+    ) -> "WalkNamespaceResponse":
         """Structured variant of ``walk_namespace`` (async)."""
         return await asyncio.to_thread(
             self._ops.walk_namespace_data,
             zim_file_path,
             namespace,
-            cursor,
+            cursor_state,
             limit,
         )
 

--- a/openzim_mcp/async_operations.py
+++ b/openzim_mcp/async_operations.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from .tool_schemas import (
         BrowseNamespaceResponse,
         FindEntryResponse,
+        ListNamespacesResponse,
         SearchAllResponse,
         SearchResponse,
         SearchSuggestionsResponse,
@@ -219,7 +220,9 @@ class AsyncZimOperations:
         """
         return await asyncio.to_thread(self._ops.list_namespaces, zim_file_path)
 
-    async def list_namespaces_data(self, zim_file_path: str) -> dict:
+    async def list_namespaces_data(
+        self, zim_file_path: str
+    ) -> "ListNamespacesResponse":
         """Structured variant of ``list_namespaces`` (async)."""
         return await asyncio.to_thread(self._ops.list_namespaces_data, zim_file_path)
 

--- a/openzim_mcp/async_operations.py
+++ b/openzim_mcp/async_operations.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
         ArticleStructureResponse,
         BinaryEntryResponse,
         BrowseNamespaceResponse,
+        EntryResponse,
+        EntrySummaryResponse,
         FindEntryResponse,
         LinksResponse,
         ListNamespacesResponse,
@@ -157,6 +159,22 @@ class AsyncZimOperations:
             content_offset,
         )
 
+    async def get_zim_entry_data(
+        self,
+        zim_file_path: str,
+        entry_path: str,
+        max_content_length: Optional[int] = None,
+        content_offset: int = 0,
+    ) -> "EntryResponse":
+        """Structured variant of ``get_zim_entry`` (async)."""
+        return await asyncio.to_thread(
+            self._ops.get_zim_entry_data,
+            zim_file_path,
+            entry_path,
+            max_content_length,
+            content_offset,
+        )
+
     async def get_entries(
         self,
         entries: List[Dict[str, str]],
@@ -214,6 +232,10 @@ class AsyncZimOperations:
             Main page content
         """
         return await asyncio.to_thread(self._ops.get_main_page, zim_file_path)
+
+    async def get_main_page_data(self, zim_file_path: str) -> "EntryResponse":
+        """Structured variant of ``get_main_page`` (async)."""
+        return await asyncio.to_thread(self._ops.get_main_page_data, zim_file_path)
 
     async def list_namespaces(self, zim_file_path: str) -> str:
         """List all namespaces in a ZIM file (async).
@@ -456,7 +478,7 @@ class AsyncZimOperations:
         zim_file_path: str,
         entry_path: str,
         max_words: int = 200,
-    ) -> dict:
+    ) -> "EntrySummaryResponse":
         """Structured variant of ``get_entry_summary`` (async)."""
         return await asyncio.to_thread(
             self._ops.get_entry_summary_data, zim_file_path, entry_path, max_words

--- a/openzim_mcp/async_operations.py
+++ b/openzim_mcp/async_operations.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
         FindEntryResponse,
         SearchAllResponse,
         SearchResponse,
+        SearchSuggestionsResponse,
         SearchWithFiltersResponse,
     )
 
@@ -335,7 +336,7 @@ class AsyncZimOperations:
         zim_file_path: str,
         partial_query: str,
         limit: int = 10,
-    ) -> dict:
+    ) -> "SearchSuggestionsResponse":
         """Structured variant of ``get_search_suggestions`` (async)."""
         return await asyncio.to_thread(
             self._ops.get_search_suggestions_data,

--- a/openzim_mcp/async_operations.py
+++ b/openzim_mcp/async_operations.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
         SearchResponse,
         SearchSuggestionsResponse,
         SearchWithFiltersResponse,
+        TableOfContentsResponse,
         WalkNamespaceResponse,
     )
 
@@ -479,7 +480,7 @@ class AsyncZimOperations:
         self,
         zim_file_path: str,
         entry_path: str,
-    ) -> dict:
+    ) -> "TableOfContentsResponse":
         """Structured variant of ``get_table_of_contents`` (async)."""
         return await asyncio.to_thread(
             self._ops.get_table_of_contents_data, zim_file_path, entry_path

--- a/openzim_mcp/async_operations.py
+++ b/openzim_mcp/async_operations.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 from .zim_operations import ZimOperations
 
 if TYPE_CHECKING:
-    from .tool_schemas import SearchResponse
+    from .tool_schemas import SearchAllResponse, SearchResponse
 
 logger = logging.getLogger(__name__)
 
@@ -527,7 +527,9 @@ class AsyncZimOperations:
         """Search across every ZIM file in allowed dirs (async)."""
         return await asyncio.to_thread(self._ops.search_all, query, limit_per_file)
 
-    async def search_all_data(self, query: str, limit_per_file: int = 5) -> dict:
+    async def search_all_data(
+        self, query: str, limit_per_file: int = 5
+    ) -> "SearchAllResponse":
         """Structured variant of ``search_all`` (async)."""
         return await asyncio.to_thread(self._ops.search_all_data, query, limit_per_file)
 

--- a/openzim_mcp/async_operations.py
+++ b/openzim_mcp/async_operations.py
@@ -15,6 +15,7 @@ from .zim_operations import ZimOperations
 if TYPE_CHECKING:
     from .tool_schemas import (
         ArticleStructureResponse,
+        BatchEntryResponse,
         BinaryEntryResponse,
         BrowseNamespaceResponse,
         EntryResponse,
@@ -199,7 +200,7 @@ class AsyncZimOperations:
         self,
         entries: List[Dict[str, str]],
         max_content_length: Optional[int] = None,
-    ) -> dict:
+    ) -> "BatchEntryResponse":
         """Structured variant of ``get_entries`` (async)."""
         return await asyncio.to_thread(
             self._ops.get_entries_data,

--- a/openzim_mcp/async_operations.py
+++ b/openzim_mcp/async_operations.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from .tool_schemas import (
         BrowseNamespaceResponse,
         FindEntryResponse,
+        LinksResponse,
         ListNamespacesResponse,
         SearchAllResponse,
         SearchResponse,
@@ -384,16 +385,16 @@ class AsyncZimOperations:
         entry_path: str,
         limit: int = 100,
         offset: int = 0,
-        kind: Optional[str] = None,
+        kind: str = "internal",
     ) -> str:
         """Extract links from an article (async, paginated).
 
         Args:
             zim_file_path: Path to the ZIM file
             entry_path: Path to the entry
-            limit: Max items per category (1-500)
-            offset: Starting offset within each category
-            kind: Optional filter — "internal", "external", or "media"
+            limit: Max items per page (1-500)
+            offset: Starting offset within the requested category
+            kind: Which category — "internal" (default), "external", or "media"
 
         Returns:
             Links as JSON string
@@ -413,8 +414,8 @@ class AsyncZimOperations:
         entry_path: str,
         limit: int = 100,
         offset: int = 0,
-        kind: Optional[str] = None,
-    ) -> dict:
+        kind: str = "internal",
+    ) -> "LinksResponse":
         """Structured variant of ``extract_article_links`` (async, paginated)."""
         return await asyncio.to_thread(
             self._ops.extract_article_links_data,

--- a/openzim_mcp/async_operations.py
+++ b/openzim_mcp/async_operations.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
         SearchWithFiltersResponse,
         TableOfContentsResponse,
         WalkNamespaceResponse,
+        ZimMetadataResponse,
     )
 
 logger = logging.getLogger(__name__)
@@ -199,7 +200,7 @@ class AsyncZimOperations:
         """
         return await asyncio.to_thread(self._ops.get_zim_metadata, zim_file_path)
 
-    async def get_zim_metadata_data(self, zim_file_path: str) -> dict:
+    async def get_zim_metadata_data(self, zim_file_path: str) -> "ZimMetadataResponse":
         """Structured variant of ``get_zim_metadata`` (async)."""
         return await asyncio.to_thread(self._ops.get_zim_metadata_data, zim_file_path)
 

--- a/openzim_mcp/async_operations.py
+++ b/openzim_mcp/async_operations.py
@@ -14,6 +14,7 @@ from .zim_operations import ZimOperations
 
 if TYPE_CHECKING:
     from .tool_schemas import (
+        FindEntryResponse,
         SearchAllResponse,
         SearchResponse,
         SearchWithFiltersResponse,
@@ -579,7 +580,7 @@ class AsyncZimOperations:
         title: str,
         cross_file: bool = False,
         limit: int = 10,
-    ) -> dict:
+    ) -> "FindEntryResponse":
         """Structured variant of ``find_entry_by_title`` (async)."""
         return await asyncio.to_thread(
             self._ops.find_entry_by_title_data,

--- a/openzim_mcp/async_operations.py
+++ b/openzim_mcp/async_operations.py
@@ -14,6 +14,7 @@ from .zim_operations import ZimOperations
 
 if TYPE_CHECKING:
     from .tool_schemas import (
+        BrowseNamespaceResponse,
         FindEntryResponse,
         SearchAllResponse,
         SearchResponse,
@@ -249,7 +250,7 @@ class AsyncZimOperations:
         namespace: str = "C",
         limit: int = 50,
         offset: int = 0,
-    ) -> dict:
+    ) -> "BrowseNamespaceResponse":
         """Structured variant of ``browse_namespace`` (async)."""
         return await asyncio.to_thread(
             self._ops.browse_namespace_data,

--- a/openzim_mcp/async_operations.py
+++ b/openzim_mcp/async_operations.py
@@ -8,9 +8,12 @@ the event loop during I/O-bound operations.
 
 import asyncio
 import logging
-from typing import Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 from .zim_operations import ZimOperations
+
+if TYPE_CHECKING:
+    from .tool_schemas import SearchResponse
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +98,22 @@ class AsyncZimOperations:
         """
         return await asyncio.to_thread(
             self._ops.search_zim_file, zim_file_path, query, limit, offset
+        )
+
+    async def search_zim_file_data(
+        self,
+        zim_file_path: str,
+        query: str,
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> "SearchResponse":
+        """Structured variant of ``search_zim_file`` (async)."""
+        return await asyncio.to_thread(
+            self._ops.search_zim_file_data,
+            zim_file_path,
+            query,
+            limit,
+            offset,
         )
 
     async def get_zim_entry(

--- a/openzim_mcp/async_operations.py
+++ b/openzim_mcp/async_operations.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
         FindEntryResponse,
         LinksResponse,
         ListNamespacesResponse,
+        RelatedArticlesResponse,
         SearchAllResponse,
         SearchResponse,
         SearchSuggestionsResponse,
@@ -619,7 +620,7 @@ class AsyncZimOperations:
         zim_file_path: str,
         entry_path: str,
         limit: int = 10,
-    ) -> dict:
+    ) -> "RelatedArticlesResponse":
         """Structured variant of ``get_related_articles`` (async)."""
         return await asyncio.to_thread(
             self._ops.get_related_articles_data,

--- a/openzim_mcp/async_operations.py
+++ b/openzim_mcp/async_operations.py
@@ -15,6 +15,7 @@ from .zim_operations import ZimOperations
 if TYPE_CHECKING:
     from .tool_schemas import (
         ArticleStructureResponse,
+        BinaryEntryResponse,
         BrowseNamespaceResponse,
         FindEntryResponse,
         LinksResponse,
@@ -519,7 +520,7 @@ class AsyncZimOperations:
         entry_path: str,
         max_size_bytes: Optional[int] = None,
         include_data: bool = True,
-    ) -> dict:
+    ) -> "BinaryEntryResponse":
         """Structured variant of ``get_binary_entry`` (async)."""
         return await asyncio.to_thread(
             self._ops.get_binary_entry_data,

--- a/openzim_mcp/compact_renderers.py
+++ b/openzim_mcp/compact_renderers.py
@@ -222,9 +222,7 @@ def render_walk_namespace(data: Mapping[str, Any]) -> str:
             f"(archive total: {archive_total:,})"
         )
     else:
-        header = (
-            f"# Namespace `{ns}` — entries {offset + 1}-{offset + returned}"
-        )
+        header = f"# Namespace `{ns}` — entries {offset + 1}-{offset + returned}"
     lines = [header, ""]
     for e in entries:
         if not isinstance(e, dict):

--- a/openzim_mcp/compact_renderers.py
+++ b/openzim_mcp/compact_renderers.py
@@ -14,7 +14,7 @@ keeps each renderer trivially unit-testable in isolation.
 from __future__ import annotations
 
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Mapping
 
 
 def compact_structure_payload(payload: Dict[str, Any]) -> str:
@@ -112,7 +112,7 @@ def render_links(data: Dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def render_find_by_title(data: Dict[str, Any], title: str) -> str:
+def render_find_by_title(data: Mapping[str, Any], title: str) -> str:
     """Render a find_by_title payload as a compact markdown list.
 
     Saves the LLM from parsing nested JSON to extract the path it

--- a/openzim_mcp/compact_renderers.py
+++ b/openzim_mcp/compact_renderers.py
@@ -17,7 +17,7 @@ import json
 from typing import Any, Dict, Mapping, Optional
 
 
-def compact_structure_payload(payload: Dict[str, Any]) -> str:
+def compact_structure_payload(payload: Mapping[str, Any]) -> str:
     """Render a compact JSON view of an article-structure payload.
 
     Drops the per-heading ``preview`` field (~3000 chars each, the

--- a/openzim_mcp/compact_renderers.py
+++ b/openzim_mcp/compact_renderers.py
@@ -180,24 +180,37 @@ def render_related(data: Dict[str, Any], entry_path: str) -> str:
     return "\n".join(lines)
 
 
-def render_walk_namespace(data: Dict[str, Any]) -> str:
-    """Render a walk_namespace payload as a compact entry list."""
+def render_walk_namespace(data: Mapping[str, Any]) -> str:
+    """Render a walk_namespace payload as a compact entry list.
+
+    Reads the v2 Phase B contract: ``results`` / ``next_cursor`` (opaque
+    str) / ``done`` / ``page_info`` plus walk-specific extras
+    (``archive_entry_count``). ``total`` is always None for walk; the
+    header reports the file-level count from ``archive_entry_count`` to
+    give callers a sense of scale.
+    """
     if not isinstance(data, dict):
         return json.dumps(data)
     ns = data.get("namespace", "?")
-    cursor = data.get("cursor", 0)
     next_cursor = data.get("next_cursor")
-    returned = data.get("returned_count", 0)
-    total = data.get("total_in_namespace") or data.get("total_entries", 0)
-    is_lower_bound = data.get("total_in_namespace_is_lower_bound", False)
-    entries = data.get("entries") or []
+    page_info = data.get("page_info") or {}
+    offset = page_info.get("offset", 0)
+    returned = page_info.get("returned_count", 0)
+    # walk doesn't know per-namespace total mid-scan; surface the
+    # file-level archive count as a scale hint instead.
+    archive_total = data.get("archive_entry_count", 0)
+    entries = data.get("results") or []
     done = data.get("done", False)
 
-    total_str = f"~{total:,}" if is_lower_bound else f"{total:,}"
-    header = (
-        f"# Namespace `{ns}` — entries {cursor + 1}-{cursor + returned} "
-        f"of {total_str}"
-    )
+    if archive_total:
+        header = (
+            f"# Namespace `{ns}` — entries {offset + 1}-{offset + returned} "
+            f"(archive total: {archive_total:,})"
+        )
+    else:
+        header = (
+            f"# Namespace `{ns}` — entries {offset + 1}-{offset + returned}"
+        )
     lines = [header, ""]
     for e in entries:
         if not isinstance(e, dict):
@@ -210,7 +223,7 @@ def render_walk_namespace(data: Dict[str, Any]) -> str:
             lines.append(f"- `{p}`")
     lines.append("")
     if not done and next_cursor is not None:
-        lines.append(f"---\nPass `offset={next_cursor}` for the next page.")
+        lines.append(f"---\nPass `cursor={next_cursor}` for the next page.")
     else:
         lines.append("---\n_End of namespace._")
     return "\n".join(lines)

--- a/openzim_mcp/compact_renderers.py
+++ b/openzim_mcp/compact_renderers.py
@@ -159,19 +159,20 @@ def render_find_by_title(data: Mapping[str, Any], title: str) -> str:
     return "\n".join(lines)
 
 
-def render_related(data: Dict[str, Any], entry_path: str) -> str:
+def render_related(data: Mapping[str, Any], entry_path: str) -> str:
     """Render a get_related_articles payload as a compact list."""
     if not isinstance(data, dict):
         return json.dumps(data)
-    # The data shape is ``{entry_path, outbound_results: [{path,
-    # title, link_text}], outbound_error?}``. Errors surface as the
-    # backend's textual reason — preserve that for diagnosability.
+    # v2 Phase B contract shape: ``{entry_path, results: [{path,
+    # title, link_text}], next_cursor, total, done, page_info,
+    # outbound_error?}``. Errors surface as the backend's textual
+    # reason — preserve that for diagnosability.
     if data.get("outbound_error"):
         return (
             f'**Could not extract related articles for "{entry_path}"**\n\n'
             f"{data['outbound_error']}"
         )
-    outbound = data.get("outbound_results") or []
+    outbound = data.get("results") or []
     if not outbound:
         return (
             f'No outbound article links found for "{entry_path}".\n\n'

--- a/openzim_mcp/compact_renderers.py
+++ b/openzim_mcp/compact_renderers.py
@@ -229,8 +229,13 @@ def render_walk_namespace(data: Mapping[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def render_namespaces(data: Dict[str, Any]) -> str:
-    """Render a list_namespaces payload as a compact namespace table."""
+def render_namespaces(data: Mapping[str, Any]) -> str:
+    """Render a list_namespaces payload as a compact namespace table.
+
+    Accepts ``Mapping`` rather than ``Dict`` so the typed
+    ``ListNamespacesResponse`` TypedDict from the v2 Phase B migration
+    flows through without an explicit ``cast`` at call sites.
+    """
     if not isinstance(data, dict):
         return json.dumps(data)
     total_entries = data.get("total_entries", 0)
@@ -245,15 +250,16 @@ def render_namespaces(data: Dict[str, Any]) -> str:
         "",
     ]
     # Sort by entry count (descending) so the most populous
-    # namespaces — usually C — surface first.
+    # namespaces — usually C — surface first. Phase B v2: per-namespace
+    # count moved from ``count`` to ``total``.
     items = sorted(
         namespaces.items(),
-        key=lambda kv: (-(kv[1].get("count", 0) if isinstance(kv[1], dict) else 0)),
+        key=lambda kv: (-(kv[1].get("total", 0) if isinstance(kv[1], dict) else 0)),
     )
     for ns, info in items:
         if not isinstance(info, dict):
             continue
-        count = info.get("count", 0)
+        count = info.get("total", 0)
         desc = info.get("description") or ""
         lines.append(f"- **`{ns}`** — {count:,} entries: {desc}")
     return "\n".join(lines)

--- a/openzim_mcp/compact_renderers.py
+++ b/openzim_mcp/compact_renderers.py
@@ -14,7 +14,7 @@ keeps each renderer trivially unit-testable in isolation.
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, Mapping
+from typing import Any, Dict, Mapping, Optional
 
 
 def compact_structure_payload(payload: Dict[str, Any]) -> str:
@@ -54,27 +54,36 @@ def compact_structure_payload(payload: Dict[str, Any]) -> str:
     return json.dumps(compact)
 
 
-def render_links(data: Dict[str, Any]) -> str:
-    """Render a links payload as a flat markdown list.
+def render_links(
+    internal_data: Mapping[str, Any],
+    external_data: Optional[Mapping[str, Any]] = None,
+) -> str:
+    """Render a v2 Phase B links payload as a flat markdown list.
 
-    The legacy ``extract_article_links`` JSON shape allocates ~150
-    chars per link (object with url/text/title/type fields). On a
-    Wikipedia-scale article that's ~36k chars of response. The
-    compact variant uses ``- text -> path`` per link, drops media
+    v2 Phase B contract delivers a single category per
+    ``extract_article_links_data`` call, so the compact view fetches
+    internal + external separately and stitches them here. ``title``,
+    ``path``, and ``category_totals`` are read from ``internal_data``
+    (both responses share them). ``external_data`` may be omitted for
+    callers that only want the internal block.
+
+    The compact variant uses ``- text -> path`` per link, drops media
     items entirely (rarely useful for navigation), and surfaces the
     full counts in a header so the caller can request more via
     ``offset`` if they need them.
     """
-    if not isinstance(data, dict):
-        return json.dumps(data)
+    if not isinstance(internal_data, dict):
+        return json.dumps(internal_data)
 
-    title = data.get("title") or ""
-    path = data.get("path") or ""
-    internal = data.get("internal_links") or []
-    external = data.get("external_links") or []
-    total_int = data.get("total_internal_links", len(internal))
-    total_ext = data.get("total_external_links", len(external))
-    pagination = data.get("pagination") or {}
+    title = internal_data.get("title") or ""
+    path = internal_data.get("path") or ""
+    internal = internal_data.get("results") or []
+    external = (
+        external_data.get("results") if isinstance(external_data, dict) else []
+    ) or []
+    category_totals = internal_data.get("category_totals") or {}
+    total_int = category_totals.get("internal", len(internal))
+    total_ext = category_totals.get("external", len(external))
 
     lines = []
     if title or path:
@@ -99,9 +108,13 @@ def render_links(data: Dict[str, Any]) -> str:
         lines.extend(_fmt_one(link) for link in external if isinstance(link, dict))
         lines.append("")
 
-    if pagination.get("has_more"):
-        offset = pagination.get("offset", 0)
-        limit = pagination.get("limit", len(internal) + len(external))
+    has_more = (not internal_data.get("done", True)) or (
+        external_data is not None and not external_data.get("done", True)
+    )
+    if has_more:
+        page_info = internal_data.get("page_info") or {}
+        offset = page_info.get("offset", 0)
+        limit = page_info.get("limit", len(internal) + len(external))
         lines.append(
             f"---\nMore links available — pass `offset={offset + limit}` "
             f"for the next page."

--- a/openzim_mcp/pagination.py
+++ b/openzim_mcp/pagination.py
@@ -11,6 +11,7 @@ of a JSON object:
   raises ``CursorMismatchError`` instead of silently misbehaving).
 * ``s`` carries the per-tool paging state — offset/limit/query for search,
   scan_at for walk_namespace, etc.
+* Cross-tool reuse raises ``CursorMismatchError`` (a ``ValueError`` subclass).
 
 Decode failures and tool mismatches both subclass ``ValueError`` so a single
 except-clause in tool wrappers catches both.
@@ -20,9 +21,30 @@ from __future__ import annotations
 
 import base64
 import json
-from typing import Any, Dict
+from typing import TypedDict, cast
 
 CURRENT_VERSION = 1
+
+
+class CursorState(TypedDict, total=False):
+    """Tool-specific state inside a cursor payload."""
+
+    o: int          # offset (search, browse, links)
+    l: int          # limit
+    q: str          # query (search, search_all per-file)
+    ns: str         # namespace (browse_namespace)
+    scan_at: int    # entry id (walk_namespace — replaces today's int cursor)
+    ep: str         # entry path (extract_article_links)
+    k: str          # kind: "internal" | "external" | "media"
+    ct: str         # content_type (search_with_filters)
+
+
+class CursorPayload(TypedDict):
+    """Full cursor payload: version, tool name, and tool-specific state."""
+
+    v: int                       # cursor version, currently 1
+    t: str                       # tool name (e.g., "browse_namespace")
+    s: CursorState               # tool-specific state
 
 
 class CursorMismatchError(ValueError):
@@ -33,7 +55,7 @@ class Cursor:
     """Encode/decode opaque pagination cursors."""
 
     @staticmethod
-    def encode(*, tool: str, state: Dict[str, Any], version: int = CURRENT_VERSION) -> str:
+    def encode(*, tool: str, state: "CursorState", version: int = CURRENT_VERSION) -> str:
         """Encode a cursor payload as URL-safe base64 JSON.
 
         Args:
@@ -44,12 +66,12 @@ class Cursor:
         Returns:
             URL-safe base64 string suitable for ``next_cursor`` in a tool response.
         """
-        payload: Dict[str, Any] = {"v": version, "t": tool, "s": state}
+        payload: CursorPayload = {"v": version, "t": tool, "s": state}
         raw = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
         return base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
 
     @staticmethod
-    def decode(token: str, *, expected_tool: str) -> Dict[str, Any]:
+    def decode(token: str, *, expected_tool: str) -> "CursorPayload":
         """Decode a cursor and verify it was issued by ``expected_tool``.
 
         Args:
@@ -87,4 +109,4 @@ class Cursor:
             raise CursorMismatchError(
                 f"Cursor was issued by '{payload['t']}', cannot be used by '{expected_tool}'"
             )
-        return payload
+        return cast("CursorPayload", payload)

--- a/openzim_mcp/pagination.py
+++ b/openzim_mcp/pagination.py
@@ -1,0 +1,90 @@
+"""Pagination cursor primitives — versioned, tool-bound, opaque.
+
+v2 Phase B promotes the v1 ``PaginationCursor`` (offset/limit/query only) to
+a tool-bound, versioned cursor. The wire format is a URL-safe base64 encoding
+of a JSON object:
+
+    {"v": 1, "t": "<tool_name>", "s": {<tool-specific state>}}
+
+* ``v`` lets us add new required fields later without a wire-format break.
+* ``t`` rejects cross-tool cursor reuse (a search cursor passed to browse
+  raises ``CursorMismatchError`` instead of silently misbehaving).
+* ``s`` carries the per-tool paging state — offset/limit/query for search,
+  scan_at for walk_namespace, etc.
+
+Decode failures and tool mismatches both subclass ``ValueError`` so a single
+except-clause in tool wrappers catches both.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any, Dict
+
+CURRENT_VERSION = 1
+
+
+class CursorMismatchError(ValueError):
+    """Raised when a cursor's ``t`` field doesn't match ``expected_tool``."""
+
+
+class Cursor:
+    """Encode/decode opaque pagination cursors."""
+
+    @staticmethod
+    def encode(*, tool: str, state: Dict[str, Any], version: int = CURRENT_VERSION) -> str:
+        """Encode a cursor payload as URL-safe base64 JSON.
+
+        Args:
+            tool: Tool name. Decoders verify this matches their expected tool.
+            state: Tool-specific paging state (offset/limit/query/scan_at/etc.).
+            version: Cursor format version. Defaults to ``CURRENT_VERSION``.
+
+        Returns:
+            URL-safe base64 string suitable for ``next_cursor`` in a tool response.
+        """
+        payload: Dict[str, Any] = {"v": version, "t": tool, "s": state}
+        raw = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+        return base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+
+    @staticmethod
+    def decode(token: str, *, expected_tool: str) -> Dict[str, Any]:
+        """Decode a cursor and verify it was issued by ``expected_tool``.
+
+        Args:
+            token: A previously-encoded cursor. Padding-stripped tokens are tolerated.
+            expected_tool: The tool whose state ``token`` is expected to carry.
+
+        Returns:
+            The decoded payload dict with keys ``v``, ``t``, ``s``.
+
+        Raises:
+            ValueError: Token isn't valid base64 / JSON, or is missing required
+                fields, or carries an unsupported version. Subclasses include:
+            CursorMismatchError: Token's ``t`` field doesn't match ``expected_tool``.
+        """
+        try:
+            padded = token + "=" * (-len(token) % 4)
+            raw = base64.urlsafe_b64decode(padded.encode("ascii")).decode("utf-8")
+            payload = json.loads(raw)
+        except Exception as e:
+            raise ValueError(f"Invalid pagination cursor: {e}") from e
+
+        if not isinstance(payload, dict):
+            raise ValueError("Invalid pagination cursor: payload must be an object")
+        if "v" not in payload or "t" not in payload or "s" not in payload:
+            raise ValueError("Invalid pagination cursor: missing required fields (v, t, s)")
+        if payload["v"] != CURRENT_VERSION:
+            raise ValueError(
+                f"Unsupported cursor version: got v={payload['v']}, expected v={CURRENT_VERSION}"
+            )
+        if not isinstance(payload["t"], str):
+            raise ValueError("Invalid pagination cursor: 't' must be a string")
+        if not isinstance(payload["s"], dict):
+            raise ValueError("Invalid pagination cursor: 's' must be an object")
+        if payload["t"] != expected_tool:
+            raise CursorMismatchError(
+                f"Cursor was issued by '{payload['t']}', cannot be used by '{expected_tool}'"
+            )
+        return payload

--- a/openzim_mcp/pagination.py
+++ b/openzim_mcp/pagination.py
@@ -29,22 +29,22 @@ CURRENT_VERSION = 1
 class CursorState(TypedDict, total=False):
     """Tool-specific state inside a cursor payload."""
 
-    o: int          # offset (search, browse, links)
+    o: int  # offset (search, browse, links)
     l: int  # noqa: E741 — single-letter wire-format key, kept short to keep cursors small
-    q: str          # query (search, search_all per-file)
-    ns: str         # namespace (browse_namespace)
-    scan_at: int    # entry id (walk_namespace — replaces today's int cursor)
-    ep: str         # entry path (extract_article_links)
-    k: str          # kind: "internal" | "external" | "media"
-    ct: str         # content_type (search_with_filters)
+    q: str  # query (search, search_all per-file)
+    ns: str  # namespace (browse_namespace)
+    scan_at: int  # entry id (walk_namespace — replaces today's int cursor)
+    ep: str  # entry path (extract_article_links)
+    k: str  # kind: "internal" | "external" | "media"
+    ct: str  # content_type (search_with_filters)
 
 
 class CursorPayload(TypedDict):
     """Full cursor payload: version, tool name, and tool-specific state."""
 
-    v: int                       # cursor version, currently 1
-    t: str                       # tool name (e.g., "browse_namespace")
-    s: CursorState               # tool-specific state
+    v: int  # cursor version, currently 1
+    t: str  # tool name (e.g., "browse_namespace")
+    s: CursorState  # tool-specific state
 
 
 class CursorMismatchError(ValueError):
@@ -55,7 +55,9 @@ class Cursor:
     """Encode/decode opaque pagination cursors."""
 
     @staticmethod
-    def encode(*, tool: str, state: "CursorState", version: int = CURRENT_VERSION) -> str:
+    def encode(
+        *, tool: str, state: "CursorState", version: int = CURRENT_VERSION
+    ) -> str:
         """Encode a cursor payload as URL-safe base64 JSON.
 
         Args:
@@ -96,7 +98,9 @@ class Cursor:
         if not isinstance(payload, dict):
             raise ValueError("Invalid pagination cursor: payload must be an object")
         if "v" not in payload or "t" not in payload or "s" not in payload:
-            raise ValueError("Invalid pagination cursor: missing required fields (v, t, s)")
+            raise ValueError(
+                "Invalid pagination cursor: missing required fields (v, t, s)"
+            )
         if payload["v"] != CURRENT_VERSION:
             raise ValueError(
                 f"Unsupported cursor version: got v={payload['v']}, expected v={CURRENT_VERSION}"

--- a/openzim_mcp/pagination.py
+++ b/openzim_mcp/pagination.py
@@ -30,7 +30,7 @@ class CursorState(TypedDict, total=False):
     """Tool-specific state inside a cursor payload."""
 
     o: int          # offset (search, browse, links)
-    l: int          # limit
+    l: int  # noqa: E741 — single-letter wire-format key, kept short to keep cursors small
     q: str          # query (search, search_all per-file)
     ns: str         # namespace (browse_namespace)
     scan_at: int    # entry id (walk_namespace — replaces today's int cursor)

--- a/openzim_mcp/responses.py
+++ b/openzim_mcp/responses.py
@@ -8,7 +8,7 @@ helpers in this module standardize the shapes used for error responses
 so every tool emits a recognisable envelope on failure.
 """
 
-from typing import Any, Dict, NotRequired, Optional, TypedDict
+from typing import NotRequired, Optional, TypedDict
 
 
 class ToolErrorPayload(TypedDict):
@@ -31,7 +31,7 @@ def tool_error(
     operation: str,
     message: str,
     context: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> ToolErrorPayload:
     """Build a structured error payload for a failed tool invocation.
 
     Args:
@@ -42,11 +42,8 @@ def tool_error(
         context: Optional contextual hint (file path, query, etc.).
 
     Returns:
-        A ``ToolErrorPayload``-shaped dict; the broader ``Dict[str, Any]``
-        return annotation lets the result be assigned/returned from MCP
-        tool functions (which annotate ``-> Dict[str, Any]``) without
-        casting. ``ToolErrorPayload`` remains the documented schema for
-        the payload's keys.
+        A ``ToolErrorPayload`` envelope ready to be returned from an MCP
+        tool function whose return type is ``Union[..., ToolErrorPayload]``.
     """
     payload: ToolErrorPayload = {
         "error": True,
@@ -55,6 +52,4 @@ def tool_error(
     }
     if context is not None:
         payload["context"] = context
-    # Explicit dict() conversion so mypy sees the wider return type the
-    # signature advertises rather than the narrower TypedDict.
-    return dict(payload)
+    return payload

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -993,10 +993,16 @@ class SimpleToolsHandler:
             # ``- text -> path`` per link, dropping the per-link object
             # shape entirely. Drops the response from ~36k to ~2k chars.
             limit = options.get("limit") or 20
-            data = self.zim_operations.extract_article_links_data(
-                zim_file_path, entry_path, limit=limit, offset=0
+            # v2 Phase B: extract_article_links_data returns one category
+            # per call. The compact view shows internal + external; fetch
+            # both and pass merged data to the renderer.
+            internal = self.zim_operations.extract_article_links_data(
+                zim_file_path, entry_path, limit=limit, offset=0, kind="internal"
             )
-            return compact_renderers.render_links(data)
+            external = self.zim_operations.extract_article_links_data(
+                zim_file_path, entry_path, limit=limit, offset=0, kind="external"
+            )
+            return compact_renderers.render_links(internal, external)
         return self.zim_operations.extract_article_links(zim_file_path, entry_path)
 
     def _handle_binary(

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -1129,7 +1129,8 @@ class SimpleToolsHandler:
             payload = self.zim_operations.search_zim_file_data(
                 zim_file_path, search_query, limit, offset
             )
-            if payload.get("total_results", 0) == 0:
+            # Phase B: ``total`` replaces ``total_results``.
+            if payload.get("total", 0) == 0:
                 # Let handle_zim_query's footer step render the structured
                 # suggestion footer (format_footer empty-result variant).
                 meta = payload.get("_meta", {})

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -1392,22 +1392,29 @@ class SimpleToolsHandler:
         params: Dict[str, Any],
         options: Dict[str, Any],
     ) -> str:
-        # ``offset`` semantically maps to ``cursor`` here — a resume token,
-        # not pagination skip — but it's the only general-purpose passthrough
-        # channel so we honour it.
+        # ``offset`` semantically maps to ``scan_at`` here — a resume
+        # entry id, not pagination skip — but it's the only
+        # general-purpose passthrough channel so we honour it. v2 walk
+        # takes the decoded cursor-state dict directly so callers don't
+        # have to round-trip through base64.
+        offset = int(options.get("offset", 0) or 0)
+        limit = options.get("limit", 200)
+        cursor_state: Optional[Dict[str, Any]] = (
+            {"scan_at": offset, "l": limit} if offset > 0 else None
+        )
         if options.get("compact", False):
             data = self.zim_operations.walk_namespace_data(
                 zim_file_path,
                 params.get("namespace", "C"),
-                cursor=options.get("offset", 0),
-                limit=options.get("limit", 200),
+                cursor_state=cursor_state,
+                limit=limit,
             )
             return compact_renderers.render_walk_namespace(data)
         return self.zim_operations.walk_namespace(
             zim_file_path,
             params.get("namespace", "C"),
-            cursor=options.get("offset", 0),
-            limit=options.get("limit", 200),
+            cursor=cursor_state,
+            limit=limit,
         )
 
     def _handle_find_by_title(

--- a/openzim_mcp/tool_schemas.py
+++ b/openzim_mcp/tool_schemas.py
@@ -265,6 +265,9 @@ class RelatedArticlesResponse(TypedDict):
     page_info: PageInfo
     _meta: MetaEnvelope
     entry_path: str
+    # Set on partial-success when archive- or extraction-level failure
+    # downgrades the response to an empty list with a textual reason.
+    outbound_error: NotRequired[str]
 
 
 class _BatchEntryItem(TypedDict):

--- a/openzim_mcp/tool_schemas.py
+++ b/openzim_mcp/tool_schemas.py
@@ -75,8 +75,20 @@ class WalkEntry(TypedDict):
 
 
 class LinkItem(TypedDict):
-    target: str
-    label: str
+    """One extracted link record. Shape varies slightly per category:
+
+    Internal/external entries carry ``url``, ``text``, ``title``, ``type``,
+    and (for external links) ``domain``. Media entries carry ``url``,
+    ``type``, ``alt``, and ``title``. All fields except ``url`` and ``type``
+    are ``NotRequired`` because they're absent on at least one category.
+    """
+
+    url: str
+    type: NotRequired[str]
+    text: NotRequired[str]
+    title: NotRequired[str]
+    domain: NotRequired[str]
+    alt: NotRequired[str]
 
 
 class FileSummary(TypedDict):
@@ -230,6 +242,8 @@ class LinksResponse(TypedDict):
     content_type: str
     kind: str
     category_totals: dict[str, int]
+    # Set when content_type is non-HTML; explains why results is empty.
+    message: NotRequired[str]
 
 
 class ListZimFilesResponse(TypedDict):

--- a/openzim_mcp/tool_schemas.py
+++ b/openzim_mcp/tool_schemas.py
@@ -271,7 +271,9 @@ class RelatedArticlesResponse(TypedDict):
 
 
 class _BatchEntryItem(TypedDict):
-    path: str
+    index: int
+    zim_file_path: str
+    entry_path: str
     success: bool
     content: NotRequired[str]
     error: NotRequired[str]

--- a/openzim_mcp/tool_schemas.py
+++ b/openzim_mcp/tool_schemas.py
@@ -193,7 +193,9 @@ class WalkNamespaceResponse(TypedDict):
     _meta: MetaEnvelope
     namespace: str
     scanned_count: int
-    scanned_through_id: int
+    # ``None`` when the loop never advanced past ``scan_at`` (e.g. the cursor
+    # was already at/past the archive end so no entries were examined).
+    scanned_through_id: Optional[int]
     archive_entry_count: int
 
 

--- a/openzim_mcp/tool_schemas.py
+++ b/openzim_mcp/tool_schemas.py
@@ -326,9 +326,12 @@ class EntrySummaryResponse(TypedDict):
 class TableOfContentsResponse(TypedDict):
     title: str
     path: str
+    content_type: NotRequired[str]
     toc: list[dict[str, Any]]
     heading_count: int
     max_depth: int
+    # Set when content_type is non-HTML; explains why toc is empty.
+    message: NotRequired[str]
     _meta: MetaEnvelope
 
 

--- a/openzim_mcp/tool_schemas.py
+++ b/openzim_mcp/tool_schemas.py
@@ -157,6 +157,7 @@ class FindEntryResponse(TypedDict):
     _meta: MetaEnvelope
     query: str
     fast_path_hit: bool
+    fuzzy_path_hit: bool
     files_searched: int
 
 

--- a/openzim_mcp/tool_schemas.py
+++ b/openzim_mcp/tool_schemas.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 from typing import Any, NotRequired, Optional, TypedDict
 
-
 # ---------- shared sub-shapes ----------
 
 

--- a/openzim_mcp/tool_schemas.py
+++ b/openzim_mcp/tool_schemas.py
@@ -1,0 +1,320 @@
+"""Per-tool response TypedDicts for v2 Phase B.
+
+Every dict-returning tool's ``_data`` method returns one of these
+TypedDicts (or ``ToolErrorPayload`` from openzim_mcp.responses on
+failure). FastMCP reads the function's return annotation to generate
+the output schema and emits the payload at the top level of
+``structuredContent`` — no ``{"result": ...}`` wrapper.
+
+Every list-returning tool's TypedDict carries the five contract keys
+(``results``, ``next_cursor``, ``total``, ``done``, ``page_info``)
+plus ``_meta``. See the design spec for shape details:
+docs/superpowers/specs/2026-05-08-v2-phase-b-response-contract-design.md
+"""
+
+from __future__ import annotations
+
+from typing import Any, NotRequired, Optional, TypedDict
+
+
+# ---------- shared sub-shapes ----------
+
+
+class PageInfo(TypedDict):
+    offset: int
+    limit: int
+    returned_count: int
+    total_is_lower_bound: NotRequired[bool]
+
+
+class MetaEnvelope(TypedDict, total=False):
+    tokens_est: int
+    chars: int
+    truncated: bool
+    more_at_offset: int
+    total_chars: int
+    suggestions: list[dict[str, str]]
+    reason: str
+
+
+# ---------- per-item shapes ----------
+
+
+class SearchHit(TypedDict):
+    path: str
+    title: str
+    snippet: str
+    # search_all carries archive identity per-hit; per-archive search omits it.
+    zim_file: NotRequired[str]
+
+
+class FindEntryHit(TypedDict):
+    path: str
+    title: str
+    score: float
+    zim_file: NotRequired[str]
+    match_type: NotRequired[str]
+
+
+class SuggestionItem(TypedDict):
+    text: str
+    path: str
+    type: str
+
+
+class NamespaceEntry(TypedDict):
+    path: str
+    title: str
+    content_type: NotRequired[str]
+    preview: NotRequired[str]
+
+
+class WalkEntry(TypedDict):
+    path: str
+    title: str
+
+
+class LinkItem(TypedDict):
+    target: str
+    label: str
+
+
+class FileSummary(TypedDict):
+    name: str
+    path: str
+    directory: str
+    size: str
+    size_bytes: int
+    modified: str
+
+
+class RelatedArticle(TypedDict):
+    path: str
+    title: str
+    link_text: NotRequired[str]
+
+
+class NamespaceSummary(TypedDict):
+    total: int
+    is_authoritative: bool
+
+
+# ---------- list-returning tool responses ----------
+
+
+class SearchResponse(TypedDict):
+    # Contract keys
+    results: list[SearchHit]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    # Tool-specific extras
+    query: str
+
+
+class _SearchAllPerFile(TypedDict):
+    zim_file_path: str
+    name: str
+    has_hits: bool
+    result: SearchResponse
+
+
+class SearchAllResponse(TypedDict):
+    results: list[_SearchAllPerFile]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    # Tool-specific extras
+    query: str
+    files_searched: int
+    files_with_hits: int
+    files_searched_successfully: int
+    files_failed: int
+
+
+class SearchWithFiltersResponse(TypedDict):
+    results: list[SearchHit]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    query: str
+    namespace_filter: Optional[str]
+    content_type_filter: Optional[str]
+
+
+class FindEntryResponse(TypedDict):
+    results: list[FindEntryHit]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    query: str
+    fast_path_hit: bool
+    files_searched: int
+
+
+class SearchSuggestionsResponse(TypedDict):
+    results: list[SuggestionItem]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    partial_query: str
+
+
+class BrowseNamespaceResponse(TypedDict):
+    results: list[NamespaceEntry]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    namespace: str
+    discovery_method: str
+    sampling_based: bool
+    results_may_be_incomplete: bool
+
+
+class WalkNamespaceResponse(TypedDict):
+    results: list[WalkEntry]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    namespace: str
+    scanned_count: int
+    scanned_through_id: int
+    archive_entry_count: int
+
+
+class LinksResponse(TypedDict):
+    results: list[LinkItem]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    title: str
+    path: str
+    content_type: str
+    kind: str
+    category_totals: dict[str, int]
+
+
+class ListZimFilesResponse(TypedDict):
+    results: list[FileSummary]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    name_filter: Optional[str]
+    directories_count: int
+
+
+class RelatedArticlesResponse(TypedDict):
+    results: list[RelatedArticle]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    entry_path: str
+
+
+class _BatchEntryItem(TypedDict):
+    path: str
+    success: bool
+    content: NotRequired[str]
+    error: NotRequired[str]
+
+
+class BatchEntryResponse(TypedDict):
+    results: list[_BatchEntryItem]
+    next_cursor: Optional[str]
+    total: Optional[int]
+    done: bool
+    page_info: PageInfo
+    _meta: MetaEnvelope
+    succeeded: int
+    failed: int
+
+
+# ---------- non-list tool responses ----------
+
+
+class ZimMetadataResponse(TypedDict):
+    entry_count: int
+    all_entry_count: int
+    article_count: int
+    media_count: int
+    metadata_entries: NotRequired[dict[str, Any]]
+    _meta: MetaEnvelope
+
+
+class ListNamespacesResponse(TypedDict):
+    total_entries: int
+    sampled_entries: int
+    has_new_namespace_scheme: bool
+    is_total_authoritative: bool
+    discovery_method: str
+    namespaces: dict[str, NamespaceSummary]
+    _meta: MetaEnvelope
+
+
+class EntryResponse(TypedDict):
+    path: str
+    title: str
+    content: str
+    content_type: NotRequired[str]
+    _meta: MetaEnvelope
+
+
+class EntrySummaryResponse(TypedDict):
+    path: str
+    title: str
+    summary: str
+    word_count: NotRequired[int]
+    _meta: MetaEnvelope
+
+
+class TableOfContentsResponse(TypedDict):
+    title: str
+    path: str
+    toc: list[dict[str, Any]]
+    heading_count: int
+    max_depth: int
+    _meta: MetaEnvelope
+
+
+class ArticleStructureResponse(TypedDict):
+    title: str
+    path: str
+    content_type: str
+    headings: list[dict[str, Any]]
+    sections: list[dict[str, Any]]
+    metadata: dict[str, Any]
+    word_count: int
+    character_count: int
+    _meta: MetaEnvelope
+
+
+class BinaryEntryResponse(TypedDict):
+    path: str
+    title: str
+    mime_type: str
+    size: int
+    size_human: str
+    encoding: Optional[str]
+    truncated: bool
+    data: NotRequired[Optional[str]]
+    _meta: MetaEnvelope

--- a/openzim_mcp/tool_schemas.py
+++ b/openzim_mcp/tool_schemas.py
@@ -95,8 +95,27 @@ class RelatedArticle(TypedDict):
 
 
 class NamespaceSummary(TypedDict):
+    # Per-namespace count. ``total`` replaces the legacy ``count`` field
+    # so this aligns with the Phase B canonical naming used elsewhere
+    # (PaginatedResponse.total, etc.). For full-iteration buckets it is
+    # exact; for sampled buckets it is the projected estimate
+    # (``estimated_total``).
     total: int
+    # True when the bucket was discovered exhaustively (full iteration,
+    # or a deterministic source like ``archive.metadata_keys`` /
+    # canonical-probes-only). False when the bucket's ``total`` was
+    # extrapolated from random sampling.
     is_authoritative: bool
+    # Diagnostic fields surfaced for callers that want to reason about
+    # the discovery method. ``description`` and ``sample_entries`` come
+    # from every namespace; ``sampled_count`` / ``probed_count`` /
+    # ``estimated_total`` are populated whether discovery was full or
+    # sampled (sampled-only namespaces just zero the unused half).
+    description: NotRequired[str]
+    sample_entries: NotRequired[list[dict[str, str]]]
+    sampled_count: NotRequired[int]
+    probed_count: NotRequired[int]
+    estimated_total: NotRequired[int]
 
 
 # ---------- list-returning tool responses ----------

--- a/openzim_mcp/tool_schemas.py
+++ b/openzim_mcp/tool_schemas.py
@@ -356,4 +356,5 @@ class BinaryEntryResponse(TypedDict):
     encoding: Optional[str]
     truncated: bool
     data: NotRequired[Optional[str]]
+    message: NotRequired[str]
     _meta: MetaEnvelope

--- a/openzim_mcp/tool_schemas.py
+++ b/openzim_mcp/tool_schemas.py
@@ -315,6 +315,15 @@ class EntryResponse(TypedDict):
     title: str
     content: str
     content_type: NotRequired[str]
+    # ``requested_path`` is set when the resolved entry differs from the
+    # requested path (redirect or fallback search); callers can use it to
+    # confirm what they asked for vs. what they got.
+    requested_path: NotRequired[str]
+    # ``content_offset`` and ``total_chars`` are populated when the caller
+    # passed a non-zero offset, so they can page through long articles
+    # without re-fetching the prefix.
+    content_offset: NotRequired[int]
+    total_chars: NotRequired[int]
     _meta: MetaEnvelope
 
 
@@ -323,6 +332,12 @@ class EntrySummaryResponse(TypedDict):
     title: str
     summary: str
     word_count: NotRequired[int]
+    # ``content_type`` and ``is_truncated`` are always emitted by the
+    # current implementation; declared NotRequired so future code paths
+    # that omit them (e.g. errors short-circuited before extraction)
+    # remain schema-conformant.
+    content_type: NotRequired[str]
+    is_truncated: NotRequired[bool]
     _meta: MetaEnvelope
 
 

--- a/openzim_mcp/tools/content_tools.py
+++ b/openzim_mcp/tools/content_tools.py
@@ -1,7 +1,7 @@
 """Content retrieval tools for OpenZIM MCP server."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
 from ..constants import (
     INPUT_LIMIT_ENTRY_PATH,
@@ -153,14 +153,17 @@ def _register_get_zim_entries(server: "OpenZimMcpServer") -> None:
                 for _ in entries or []:
                     server.rate_limiter.check_rate_limit("get_zim_entries")
             except OpenZimMcpRateLimitError as e:
-                return tool_error(
-                    operation="batch get entries",
-                    message=server._create_enhanced_error_message(
+                return cast(
+                    Dict[str, Any],
+                    tool_error(
                         operation="batch get entries",
-                        error=e,
+                        message=server._create_enhanced_error_message(
+                            operation="batch get entries",
+                            error=e,
+                            context=f"Batch size: {batch_size}",
+                        ),
                         context=f"Batch size: {batch_size}",
                     ),
-                    context=f"Batch size: {batch_size}",
                 )
 
             # Normalise each entry into a {zim_file_path, entry_path} dict,
@@ -196,12 +199,15 @@ def _register_get_zim_entries(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error in get_zim_entries: {e}")
-            return tool_error(
-                operation="batch get entries",
-                message=server._create_enhanced_error_message(
+            return cast(
+                Dict[str, Any],
+                tool_error(
                     operation="batch get entries",
-                    error=e,
+                    message=server._create_enhanced_error_message(
+                        operation="batch get entries",
+                        error=e,
+                        context=f"Batch size: {batch_size}",
+                    ),
                     context=f"Batch size: {batch_size}",
                 ),
-                context=f"Batch size: {batch_size}",
             )

--- a/openzim_mcp/tools/content_tools.py
+++ b/openzim_mcp/tools/content_tools.py
@@ -1,15 +1,16 @@
 """Content retrieval tools for OpenZIM MCP server."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
 from ..constants import (
     INPUT_LIMIT_ENTRY_PATH,
     INPUT_LIMIT_FILE_PATH,
 )
 from ..exceptions import OpenZimMcpRateLimitError
-from ..responses import tool_error
+from ..responses import ToolErrorPayload, tool_error
 from ..security import sanitize_input
+from ..tool_schemas import EntryResponse
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
@@ -30,7 +31,7 @@ def _register_get_zim_entry(server: "OpenZimMcpServer") -> None:
         entry_path: str,
         max_content_length: Optional[int] = None,
         content_offset: int = 0,
-    ) -> str:
+    ) -> Union[EntryResponse, ToolErrorPayload]:
         """Get detailed content of a specific entry in a ZIM file.
 
         Args:
@@ -42,16 +43,24 @@ def _register_get_zim_entry(server: "OpenZimMcpServer") -> None:
                 without re-fetching the prefix each time.
 
         Returns:
-            Entry content text
+            ``EntryResponse``-shaped dict with ``path``, ``title``,
+            ``content``, optionally ``content_type``/``requested_path``/
+            ``content_offset``/``total_chars``, plus the ``_meta``
+            envelope. On failure, returns a ``ToolErrorPayload`` envelope
+            (see ``responses.tool_error``).
         """
         try:
             # Check rate limit
             try:
                 server.rate_limiter.check_rate_limit("get_entry")
             except OpenZimMcpRateLimitError as e:
-                return server._create_enhanced_error_message(
+                return tool_error(
                     operation="get ZIM entry",
-                    error=e,
+                    message=server._create_enhanced_error_message(
+                        operation="get ZIM entry",
+                        error=e,
+                        context=f"Entry: {entry_path}",
+                    ),
                     context=f"Entry: {entry_path}",
                 )
 
@@ -61,35 +70,48 @@ def _register_get_zim_entry(server: "OpenZimMcpServer") -> None:
 
             # Validate parameters
             if max_content_length is not None and max_content_length < 100:
-                return (
-                    "**Parameter Validation Error**\n\n"
-                    f"**Issue**: max_content_length must be at least 100 characters "
-                    f"(provided: {max_content_length})\n\n"
-                    "**Troubleshooting**: Increase the max_content_length parameter "
-                    "or omit it to use the default.\n"
-                    "**Example**: Use `max_content_length=500` for a short preview, "
-                    "`5000` for longer content, or omit for default."
+                return tool_error(
+                    operation="get ZIM entry",
+                    message=(
+                        "**Parameter Validation Error**\n\n"
+                        f"**Issue**: max_content_length must be at least 100 "
+                        f"characters (provided: {max_content_length})\n\n"
+                        "**Troubleshooting**: Increase the max_content_length "
+                        "parameter or omit it to use the default.\n"
+                        "**Example**: Use `max_content_length=500` for a short "
+                        "preview, `5000` for longer content, or omit for default."
+                    ),
+                    context=f"Entry: {entry_path}",
                 )
 
             if content_offset < 0:
-                return (
-                    "**Parameter Validation Error**\n\n"
-                    f"**Issue**: content_offset must be non-negative "
-                    f"(provided: {content_offset})\n\n"
-                    "**Troubleshooting**: Use 0 to read from the start, or a "
-                    "positive integer to skip that many leading characters."
+                return tool_error(
+                    operation="get ZIM entry",
+                    message=(
+                        "**Parameter Validation Error**\n\n"
+                        f"**Issue**: content_offset must be non-negative "
+                        f"(provided: {content_offset})\n\n"
+                        "**Troubleshooting**: Use 0 to read from the start, "
+                        "or a positive integer to skip that many leading "
+                        "characters."
+                    ),
+                    context=f"Entry: {entry_path}",
                 )
 
             # Use async operations to avoid blocking
-            return await server.async_zim_operations.get_zim_entry(
+            return await server.async_zim_operations.get_zim_entry_data(
                 zim_file_path, entry_path, max_content_length, content_offset
             )
 
         except Exception as e:
             logger.error(f"Error getting ZIM entry: {e}")
-            return server._create_enhanced_error_message(
+            return tool_error(
                 operation="get ZIM entry",
-                error=e,
+                message=server._create_enhanced_error_message(
+                    operation="get ZIM entry",
+                    error=e,
+                    context=f"File: {zim_file_path}, Entry: {entry_path}",
+                ),
                 context=f"File: {zim_file_path}, Entry: {entry_path}",
             )
 

--- a/openzim_mcp/tools/content_tools.py
+++ b/openzim_mcp/tools/content_tools.py
@@ -1,7 +1,7 @@
 """Content retrieval tools for OpenZIM MCP server."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from ..constants import (
     INPUT_LIMIT_ENTRY_PATH,
@@ -10,7 +10,7 @@ from ..constants import (
 from ..exceptions import OpenZimMcpRateLimitError
 from ..responses import ToolErrorPayload, tool_error
 from ..security import sanitize_input
-from ..tool_schemas import EntryResponse
+from ..tool_schemas import BatchEntryResponse, EntryResponse
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
@@ -122,7 +122,7 @@ def _register_get_zim_entries(server: "OpenZimMcpServer") -> None:
         entries: List[Any],
         zim_file_path: Optional[str] = None,
         max_content_length: Optional[int] = None,
-    ) -> Dict[str, Any]:
+    ) -> Union[BatchEntryResponse, ToolErrorPayload]:
         """Fetch multiple ZIM entries in one call.
 
         Pairs naturally with HTTP transport, where round-trip cost matters.
@@ -145,10 +145,14 @@ def _register_get_zim_entries(server: "OpenZimMcpServer") -> None:
             max_content_length: per-entry max content length.
 
         Returns:
-            Dict ``{"results": [...], "succeeded": N, "failed": N}``. Each
-            result includes ``index``, ``success``, and either ``content`` or
-            ``error``. On failure, returns a ``{"error": True, ...}`` envelope
-            (see ``responses.tool_error``).
+            ``BatchEntryResponse``-shaped dict carrying ``results``,
+            ``next_cursor`` (always ``None``), ``total``, ``done`` (always
+            ``True``), ``page_info``, plus the tool-specific ``succeeded``
+            and ``failed`` counters and the ``_meta`` envelope. Each result
+            includes ``index``, ``zim_file_path``, ``entry_path``,
+            ``success``, and either ``content`` or ``error``. On failure,
+            returns a ``ToolErrorPayload`` envelope (see
+            ``responses.tool_error``).
 
         Notes:
             Rate limit is charged per entry, not per batch (anti-bypass).
@@ -175,17 +179,14 @@ def _register_get_zim_entries(server: "OpenZimMcpServer") -> None:
                 for _ in entries or []:
                     server.rate_limiter.check_rate_limit("get_zim_entries")
             except OpenZimMcpRateLimitError as e:
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
+                return tool_error(
+                    operation="batch get entries",
+                    message=server._create_enhanced_error_message(
                         operation="batch get entries",
-                        message=server._create_enhanced_error_message(
-                            operation="batch get entries",
-                            error=e,
-                            context=f"Batch size: {batch_size}",
-                        ),
+                        error=e,
                         context=f"Batch size: {batch_size}",
                     ),
+                    context=f"Batch size: {batch_size}",
                 )
 
             # Normalise each entry into a {zim_file_path, entry_path} dict,
@@ -221,15 +222,12 @@ def _register_get_zim_entries(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error in get_zim_entries: {e}")
-            return cast(
-                Dict[str, Any],
-                tool_error(
+            return tool_error(
+                operation="batch get entries",
+                message=server._create_enhanced_error_message(
                     operation="batch get entries",
-                    message=server._create_enhanced_error_message(
-                        operation="batch get entries",
-                        error=e,
-                        context=f"Batch size: {batch_size}",
-                    ),
+                    error=e,
                     context=f"Batch size: {batch_size}",
                 ),
+                context=f"Batch size: {batch_size}",
             )

--- a/openzim_mcp/tools/file_tools.py
+++ b/openzim_mcp/tools/file_tools.py
@@ -1,12 +1,13 @@
 """File listing tools for OpenZIM MCP server."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, cast
+from typing import TYPE_CHECKING, Union
 
 from ..constants import INPUT_LIMIT_QUERY
 from ..exceptions import OpenZimMcpRateLimitError
-from ..responses import tool_error
+from ..responses import ToolErrorPayload, tool_error
 from ..security import sanitize_input
+from ..tool_schemas import ListZimFilesResponse
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
@@ -23,7 +24,9 @@ def register_file_tools(server: "OpenZimMcpServer") -> None:
     """
 
     @server.mcp.tool()
-    async def list_zim_files(name_filter: str = "") -> Dict[str, Any]:
+    async def list_zim_files(
+        name_filter: str = "",
+    ) -> Union[ListZimFilesResponse, ToolErrorPayload]:
         """List all ZIM files in allowed directories.
 
         Args:
@@ -32,26 +35,28 @@ def register_file_tools(server: "OpenZimMcpServer") -> None:
                 listings (e.g. "wikipedia", "nginx"). Empty string lists all.
 
         Returns:
-            Dict with keys ``count``, ``directories_count``, ``name_filter``,
-            ``files`` (list of per-file dicts: name, path, directory, size,
-            size_bytes, modified). On failure, returns a ``{"error": True, ...}``
-            envelope (see ``responses.tool_error``).
+            ``ListZimFilesResponse``-shaped dict carrying ``results`` (per-file
+            dicts: name, path, directory, size, size_bytes, modified),
+            ``next_cursor`` (always ``None``), ``total``, ``done`` (always
+            ``True``), ``page_info``, plus the tool-specific
+            ``directories_count`` and ``name_filter`` fields and the ``_meta``
+            envelope. ``list_zim_files`` is non-paginated; the contract keys
+            are present for uniformity with other list-shaped tools. On
+            failure, returns a ``ToolErrorPayload`` envelope (see
+            ``responses.tool_error``).
         """
         try:
             try:
                 server.rate_limiter.check_rate_limit("default")
             except OpenZimMcpRateLimitError as e:
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
+                return tool_error(
+                    operation="list ZIM files",
+                    message=server._create_enhanced_error_message(
                         operation="list ZIM files",
-                        message=server._create_enhanced_error_message(
-                            operation="list ZIM files",
-                            error=e,
-                            context="Listing available ZIM files",
-                        ),
+                        error=e,
                         context="Listing available ZIM files",
                     ),
+                    context="Listing available ZIM files",
                 )
 
             # Strip control characters and cap length, matching the
@@ -70,15 +75,12 @@ def register_file_tools(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error listing ZIM files: {e}")
-            return cast(
-                Dict[str, Any],
-                tool_error(
+            return tool_error(
+                operation="list ZIM files",
+                message=server._create_enhanced_error_message(
                     operation="list ZIM files",
-                    message=server._create_enhanced_error_message(
-                        operation="list ZIM files",
-                        error=e,
-                        context="Scanning allowed directories for ZIM files",
-                    ),
+                    error=e,
                     context="Scanning allowed directories for ZIM files",
                 ),
+                context="Scanning allowed directories for ZIM files",
             )

--- a/openzim_mcp/tools/file_tools.py
+++ b/openzim_mcp/tools/file_tools.py
@@ -1,7 +1,7 @@
 """File listing tools for OpenZIM MCP server."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any, Dict, cast
 
 from ..constants import INPUT_LIMIT_QUERY
 from ..exceptions import OpenZimMcpRateLimitError
@@ -41,14 +41,17 @@ def register_file_tools(server: "OpenZimMcpServer") -> None:
             try:
                 server.rate_limiter.check_rate_limit("default")
             except OpenZimMcpRateLimitError as e:
-                return tool_error(
-                    operation="list ZIM files",
-                    message=server._create_enhanced_error_message(
+                return cast(
+                    Dict[str, Any],
+                    tool_error(
                         operation="list ZIM files",
-                        error=e,
+                        message=server._create_enhanced_error_message(
+                            operation="list ZIM files",
+                            error=e,
+                            context="Listing available ZIM files",
+                        ),
                         context="Listing available ZIM files",
                     ),
-                    context="Listing available ZIM files",
                 )
 
             # Strip control characters and cap length, matching the
@@ -67,12 +70,15 @@ def register_file_tools(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error listing ZIM files: {e}")
-            return tool_error(
-                operation="list ZIM files",
-                message=server._create_enhanced_error_message(
+            return cast(
+                Dict[str, Any],
+                tool_error(
                     operation="list ZIM files",
-                    error=e,
+                    message=server._create_enhanced_error_message(
+                        operation="list ZIM files",
+                        error=e,
+                        context="Scanning allowed directories for ZIM files",
+                    ),
                     context="Scanning allowed directories for ZIM files",
                 ),
-                context="Scanning allowed directories for ZIM files",
             )

--- a/openzim_mcp/tools/metadata_tools.py
+++ b/openzim_mcp/tools/metadata_tools.py
@@ -7,7 +7,7 @@ from ..constants import INPUT_LIMIT_FILE_PATH
 from ..exceptions import OpenZimMcpRateLimitError
 from ..responses import ToolErrorPayload, tool_error
 from ..security import sanitize_input
-from ..tool_schemas import ListNamespacesResponse, ZimMetadataResponse
+from ..tool_schemas import EntryResponse, ListNamespacesResponse, ZimMetadataResponse
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
@@ -77,23 +77,34 @@ def register_metadata_tools(server: "OpenZimMcpServer") -> None:
             )
 
     @server.mcp.tool()
-    async def get_main_page(zim_file_path: str) -> str:
+    async def get_main_page(
+        zim_file_path: str,
+    ) -> Union[EntryResponse, ToolErrorPayload]:
         """Get the main page entry from W namespace.
 
         Args:
             zim_file_path: Path to the ZIM file
 
         Returns:
-            Main page content or information about main page
+            ``EntryResponse``-shaped dict with ``path``, ``title``,
+            ``content``, optionally ``content_type``, plus the ``_meta``
+            envelope. When the archive has no designated main page, the
+            response carries an empty ``path`` and a textual notice in
+            ``content``. On failure, returns a ``ToolErrorPayload``
+            envelope (see ``responses.tool_error``).
         """
         try:
             # Check rate limit
             try:
                 server.rate_limiter.check_rate_limit("get_entry")
             except OpenZimMcpRateLimitError as e:
-                return server._create_enhanced_error_message(
+                return tool_error(
                     operation="get main page",
-                    error=e,
+                    message=server._create_enhanced_error_message(
+                        operation="get main page",
+                        error=e,
+                        context=f"File: {zim_file_path}",
+                    ),
                     context=f"File: {zim_file_path}",
                 )
 
@@ -101,13 +112,17 @@ def register_metadata_tools(server: "OpenZimMcpServer") -> None:
             zim_file_path = sanitize_input(zim_file_path, INPUT_LIMIT_FILE_PATH)
 
             # Use async operations
-            return await server.async_zim_operations.get_main_page(zim_file_path)
+            return await server.async_zim_operations.get_main_page_data(zim_file_path)
 
         except Exception as e:
             logger.error(f"Error getting main page: {e}")
-            return server._create_enhanced_error_message(
+            return tool_error(
                 operation="get main page",
-                error=e,
+                message=server._create_enhanced_error_message(
+                    operation="get main page",
+                    error=e,
+                    context=f"File: {zim_file_path}",
+                ),
                 context=f"File: {zim_file_path}",
             )
 

--- a/openzim_mcp/tools/metadata_tools.py
+++ b/openzim_mcp/tools/metadata_tools.py
@@ -1,12 +1,13 @@
 """Metadata and namespace listing tools for OpenZIM MCP server."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, cast
+from typing import TYPE_CHECKING, Any, Dict, Union, cast
 
 from ..constants import INPUT_LIMIT_FILE_PATH
 from ..exceptions import OpenZimMcpRateLimitError
-from ..responses import tool_error
+from ..responses import ToolErrorPayload, tool_error
 from ..security import sanitize_input
+from ..tool_schemas import ListNamespacesResponse
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
@@ -113,34 +114,38 @@ def register_metadata_tools(server: "OpenZimMcpServer") -> None:
             )
 
     @server.mcp.tool()
-    async def list_namespaces(zim_file_path: str) -> Dict[str, Any]:
+    async def list_namespaces(
+        zim_file_path: str,
+    ) -> Union[ListNamespacesResponse, ToolErrorPayload]:
         """List available namespaces and their entry counts.
 
         Args:
             zim_file_path: Path to the ZIM file
 
         Returns:
-            Dict with keys: total_entries, sampled_entries,
-            has_new_namespace_scheme, is_total_authoritative,
-            discovery_method, namespaces. On failure, returns a
-            ``{"error": True, ...}`` envelope (see ``responses.tool_error``).
+            ``ListNamespacesResponse``-shaped dict on success: top-level
+            ``total_entries`` / ``sampled_entries`` /
+            ``has_new_namespace_scheme`` / ``is_total_authoritative`` /
+            ``discovery_method`` / ``namespaces`` keys plus the universal
+            ``_meta`` envelope. Each entry in ``namespaces`` is a
+            ``NamespaceSummary`` (``total`` / ``is_authoritative`` plus
+            optional diagnostic fields). v2 BREAKING: per-namespace
+            ``count`` was renamed to ``total``. On failure, returns a
+            ``ToolErrorPayload`` envelope (see ``responses.tool_error``).
         """
         try:
             # Check rate limit
             try:
                 server.rate_limiter.check_rate_limit("get_metadata")
             except OpenZimMcpRateLimitError as e:
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
+                return tool_error(
+                    operation="list namespaces",
+                    message=server._create_enhanced_error_message(
                         operation="list namespaces",
-                        message=server._create_enhanced_error_message(
-                            operation="list namespaces",
-                            error=e,
-                            context=f"File: {zim_file_path}",
-                        ),
+                        error=e,
                         context=f"File: {zim_file_path}",
                     ),
+                    context=f"File: {zim_file_path}",
                 )
 
             # Sanitize inputs
@@ -151,15 +156,12 @@ def register_metadata_tools(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error listing namespaces: {e}")
-            return cast(
-                Dict[str, Any],
-                tool_error(
+            return tool_error(
+                operation="list namespaces",
+                message=server._create_enhanced_error_message(
                     operation="list namespaces",
-                    message=server._create_enhanced_error_message(
-                        operation="list namespaces",
-                        error=e,
-                        context=f"File: {zim_file_path}",
-                    ),
+                    error=e,
                     context=f"File: {zim_file_path}",
                 ),
+                context=f"File: {zim_file_path}",
             )

--- a/openzim_mcp/tools/metadata_tools.py
+++ b/openzim_mcp/tools/metadata_tools.py
@@ -1,7 +1,7 @@
 """Metadata and namespace listing tools for OpenZIM MCP server."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any, Dict, cast
 
 from ..constants import INPUT_LIMIT_FILE_PATH
 from ..exceptions import OpenZimMcpRateLimitError
@@ -41,14 +41,17 @@ def register_metadata_tools(server: "OpenZimMcpServer") -> None:
             try:
                 server.rate_limiter.check_rate_limit("get_metadata")
             except OpenZimMcpRateLimitError as e:
-                return tool_error(
-                    operation="get ZIM metadata",
-                    message=server._create_enhanced_error_message(
+                return cast(
+                    Dict[str, Any],
+                    tool_error(
                         operation="get ZIM metadata",
-                        error=e,
+                        message=server._create_enhanced_error_message(
+                            operation="get ZIM metadata",
+                            error=e,
+                            context=f"File: {zim_file_path}",
+                        ),
                         context=f"File: {zim_file_path}",
                     ),
-                    context=f"File: {zim_file_path}",
                 )
 
             # Sanitize inputs
@@ -61,14 +64,17 @@ def register_metadata_tools(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error getting ZIM metadata: {e}")
-            return tool_error(
-                operation="get ZIM metadata",
-                message=server._create_enhanced_error_message(
+            return cast(
+                Dict[str, Any],
+                tool_error(
                     operation="get ZIM metadata",
-                    error=e,
+                    message=server._create_enhanced_error_message(
+                        operation="get ZIM metadata",
+                        error=e,
+                        context=f"File: {zim_file_path}",
+                    ),
                     context=f"File: {zim_file_path}",
                 ),
-                context=f"File: {zim_file_path}",
             )
 
     @server.mcp.tool()
@@ -124,14 +130,17 @@ def register_metadata_tools(server: "OpenZimMcpServer") -> None:
             try:
                 server.rate_limiter.check_rate_limit("get_metadata")
             except OpenZimMcpRateLimitError as e:
-                return tool_error(
-                    operation="list namespaces",
-                    message=server._create_enhanced_error_message(
+                return cast(
+                    Dict[str, Any],
+                    tool_error(
                         operation="list namespaces",
-                        error=e,
+                        message=server._create_enhanced_error_message(
+                            operation="list namespaces",
+                            error=e,
+                            context=f"File: {zim_file_path}",
+                        ),
                         context=f"File: {zim_file_path}",
                     ),
-                    context=f"File: {zim_file_path}",
                 )
 
             # Sanitize inputs
@@ -142,12 +151,15 @@ def register_metadata_tools(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error listing namespaces: {e}")
-            return tool_error(
-                operation="list namespaces",
-                message=server._create_enhanced_error_message(
+            return cast(
+                Dict[str, Any],
+                tool_error(
                     operation="list namespaces",
-                    error=e,
+                    message=server._create_enhanced_error_message(
+                        operation="list namespaces",
+                        error=e,
+                        context=f"File: {zim_file_path}",
+                    ),
                     context=f"File: {zim_file_path}",
                 ),
-                context=f"File: {zim_file_path}",
             )

--- a/openzim_mcp/tools/metadata_tools.py
+++ b/openzim_mcp/tools/metadata_tools.py
@@ -1,13 +1,13 @@
 """Metadata and namespace listing tools for OpenZIM MCP server."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Union, cast
+from typing import TYPE_CHECKING, Union
 
 from ..constants import INPUT_LIMIT_FILE_PATH
 from ..exceptions import OpenZimMcpRateLimitError
 from ..responses import ToolErrorPayload, tool_error
 from ..security import sanitize_input
-from ..tool_schemas import ListNamespacesResponse
+from ..tool_schemas import ListNamespacesResponse, ZimMetadataResponse
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
@@ -24,35 +24,36 @@ def register_metadata_tools(server: "OpenZimMcpServer") -> None:
     """
 
     @server.mcp.tool()
-    async def get_zim_metadata(zim_file_path: str) -> Dict[str, Any]:
+    async def get_zim_metadata(
+        zim_file_path: str,
+    ) -> Union[ZimMetadataResponse, ToolErrorPayload]:
         """Get ZIM file metadata from M namespace entries.
 
         Args:
             zim_file_path: Path to the ZIM file
 
         Returns:
-            Dict with keys: entry_count, all_entry_count, article_count,
-            media_count, and (when available) metadata_entries (a dict of
-            common M-namespace fields like Title, Description, Language,
-            Creator, etc.). On failure, returns a ``{"error": True, ...}``
-            envelope (see ``responses.tool_error``).
+            ``ZimMetadataResponse``-shaped dict with keys ``entry_count``,
+            ``all_entry_count``, ``article_count``, ``media_count``, and
+            (when available) ``metadata_entries`` (a dict of common
+            M-namespace fields like Title, Description, Language, Creator,
+            etc.) plus the universal ``_meta`` envelope. On failure,
+            returns a ``ToolErrorPayload`` envelope (see
+            ``responses.tool_error``).
         """
         try:
             # Check rate limit
             try:
                 server.rate_limiter.check_rate_limit("get_metadata")
             except OpenZimMcpRateLimitError as e:
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
+                return tool_error(
+                    operation="get ZIM metadata",
+                    message=server._create_enhanced_error_message(
                         operation="get ZIM metadata",
-                        message=server._create_enhanced_error_message(
-                            operation="get ZIM metadata",
-                            error=e,
-                            context=f"File: {zim_file_path}",
-                        ),
+                        error=e,
                         context=f"File: {zim_file_path}",
                     ),
+                    context=f"File: {zim_file_path}",
                 )
 
             # Sanitize inputs
@@ -65,17 +66,14 @@ def register_metadata_tools(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error getting ZIM metadata: {e}")
-            return cast(
-                Dict[str, Any],
-                tool_error(
+            return tool_error(
+                operation="get ZIM metadata",
+                message=server._create_enhanced_error_message(
                     operation="get ZIM metadata",
-                    message=server._create_enhanced_error_message(
-                        operation="get ZIM metadata",
-                        error=e,
-                        context=f"File: {zim_file_path}",
-                    ),
+                    error=e,
                     context=f"File: {zim_file_path}",
                 ),
+                context=f"File: {zim_file_path}",
             )
 
     @server.mcp.tool()

--- a/openzim_mcp/tools/navigation_tools.py
+++ b/openzim_mcp/tools/navigation_tools.py
@@ -77,30 +77,36 @@ def _register_browse_namespace(server: "OpenZimMcpServer") -> None:
 
             # Validate parameters
             if limit < 1 or limit > 200:
-                return tool_error(
-                    operation="browse namespace",
-                    message=(
-                        "**Parameter Validation Error**\n\n"
-                        f"**Issue**: limit must be between 1 and 200 "
-                        f"(provided: {limit})\n\n"
-                        "**Troubleshooting**: Adjust the limit parameter to a "
-                        "value within the valid range.\n"
-                        "**Example**: Use `limit=50` for reasonable pagination."
+                return cast(
+                    Dict[str, Any],
+                    tool_error(
+                        operation="browse namespace",
+                        message=(
+                            "**Parameter Validation Error**\n\n"
+                            f"**Issue**: limit must be between 1 and 200 "
+                            f"(provided: {limit})\n\n"
+                            "**Troubleshooting**: Adjust the limit parameter to a "
+                            "value within the valid range.\n"
+                            "**Example**: Use `limit=50` for reasonable pagination."
+                        ),
+                        context=f"Namespace: {namespace}, Limit: {limit}",
                     ),
-                    context=f"Namespace: {namespace}, Limit: {limit}",
                 )
             if offset < 0:
-                return tool_error(
-                    operation="browse namespace",
-                    message=(
-                        "**Parameter Validation Error**\n\n"
-                        f"**Issue**: offset must be non-negative "
-                        f"(provided: {offset})\n\n"
-                        "**Troubleshooting**: Use offset=0 to start from the "
-                        "beginning, or a positive number to skip entries.\n"
-                        "**Example**: Use `offset=50` to skip the first 50 entries."
+                return cast(
+                    Dict[str, Any],
+                    tool_error(
+                        operation="browse namespace",
+                        message=(
+                            "**Parameter Validation Error**\n\n"
+                            f"**Issue**: offset must be non-negative "
+                            f"(provided: {offset})\n\n"
+                            "**Troubleshooting**: Use offset=0 to start from the "
+                            "beginning, or a positive number to skip entries.\n"
+                            "**Example**: Use `offset=50` to skip the first 50 entries."
+                        ),
+                        context=f"Namespace: {namespace}, Offset: {offset}",
                     ),
-                    context=f"Namespace: {namespace}, Offset: {offset}",
                 )
 
             # Use async operations
@@ -194,30 +200,36 @@ def _register_walk_namespace(server: "OpenZimMcpServer") -> None:
             # without this check, callers could open the libzim Archive
             # for arbitrarily oversized requests before being rejected.
             if limit < 1 or limit > 500:
-                return tool_error(
-                    operation="walk namespace",
-                    message=(
-                        "**Parameter Validation Error**\n\n"
-                        f"**Issue**: limit must be between 1 and 500 "
-                        f"(provided: {limit})\n\n"
-                        "**Troubleshooting**: Adjust the limit parameter to a "
-                        "value within the valid range.\n"
-                        "**Example**: Use `limit=200` for the default page size."
+                return cast(
+                    Dict[str, Any],
+                    tool_error(
+                        operation="walk namespace",
+                        message=(
+                            "**Parameter Validation Error**\n\n"
+                            f"**Issue**: limit must be between 1 and 500 "
+                            f"(provided: {limit})\n\n"
+                            "**Troubleshooting**: Adjust the limit parameter to a "
+                            "value within the valid range.\n"
+                            "**Example**: Use `limit=200` for the default page size."
+                        ),
+                        context=f"Namespace: {namespace}, Limit: {limit}",
                     ),
-                    context=f"Namespace: {namespace}, Limit: {limit}",
                 )
             if cursor < 0:
-                return tool_error(
-                    operation="walk namespace",
-                    message=(
-                        "**Parameter Validation Error**\n\n"
-                        f"**Issue**: cursor must be non-negative "
-                        f"(provided: {cursor})\n\n"
-                        "**Troubleshooting**: Use cursor=0 to start, or pass the "
-                        "`next_cursor` value returned by a previous call.\n"
-                        "**Example**: `cursor=0` on the first call."
+                return cast(
+                    Dict[str, Any],
+                    tool_error(
+                        operation="walk namespace",
+                        message=(
+                            "**Parameter Validation Error**\n\n"
+                            f"**Issue**: cursor must be non-negative "
+                            f"(provided: {cursor})\n\n"
+                            "**Troubleshooting**: Use cursor=0 to start, or pass the "
+                            "`next_cursor` value returned by a previous call.\n"
+                            "**Example**: `cursor=0` on the first call."
+                        ),
+                        context=f"Namespace: {namespace}, Cursor: {cursor}",
                     ),
-                    context=f"Namespace: {namespace}, Cursor: {cursor}",
                 )
 
             return await server.async_zim_operations.walk_namespace_data(
@@ -367,17 +379,20 @@ def _register_get_search_suggestions(server: "OpenZimMcpServer") -> None:
 
             # Validate parameters
             if limit < 1 or limit > 50:
-                return tool_error(
-                    operation="get search suggestions",
-                    message=(
-                        "**Parameter Validation Error**\n\n"
-                        f"**Issue**: limit must be between 1 and 50 "
-                        f"(provided: {limit})\n\n"
-                        "**Troubleshooting**: Adjust the limit parameter to a "
-                        "value within the valid range.\n"
-                        "**Example**: Use `limit=10` for reasonable suggestions."
+                return cast(
+                    Dict[str, Any],
+                    tool_error(
+                        operation="get search suggestions",
+                        message=(
+                            "**Parameter Validation Error**\n\n"
+                            f"**Issue**: limit must be between 1 and 50 "
+                            f"(provided: {limit})\n\n"
+                            "**Troubleshooting**: Adjust the limit parameter to a "
+                            "value within the valid range.\n"
+                            "**Example**: Use `limit=10` for reasonable suggestions."
+                        ),
+                        context=f"Query: '{partial_query}', Limit: {limit}",
                     ),
-                    context=f"Query: '{partial_query}', Limit: {limit}",
                 )
 
             # Use async operations

--- a/openzim_mcp/tools/navigation_tools.py
+++ b/openzim_mcp/tools/navigation_tools.py
@@ -1,7 +1,7 @@
 """Navigation and browsing tools for OpenZIM MCP server."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from ..constants import (
     INPUT_LIMIT_CONTENT_TYPE,
@@ -17,6 +17,7 @@ from ..tool_schemas import (
     BrowseNamespaceResponse,
     SearchSuggestionsResponse,
     SearchWithFiltersResponse,
+    WalkNamespaceResponse,
 )
 
 if TYPE_CHECKING:
@@ -165,119 +166,125 @@ def _register_walk_namespace(server: "OpenZimMcpServer") -> None:
     async def walk_namespace(
         zim_file_path: str,
         namespace: str,
-        cursor: int = 0,
         limit: int = 200,
-    ) -> Dict[str, Any]:
+        cursor: Optional[str] = None,
+    ) -> Union[WalkNamespaceResponse, ToolErrorPayload]:
         """Iterate every entry in a namespace via deterministic cursor pagination.
 
         Unlike browse_namespace (which samples and may cap at 200 entries
-        for large archives), walk_namespace scans the archive by entry ID
-        from `cursor` onward. Pair the returned `next_cursor` with a
-        follow-up call to walk the rest. `done: true` indicates iteration
-        is complete.
+        for large archives), walk_namespace scans the archive by entry ID.
+        Pair the returned ``next_cursor`` with a follow-up call to walk
+        the rest. ``done: true`` indicates iteration is complete.
 
         Use this when you need exhaustive enumeration of a namespace —
         e.g. to dump every M/* metadata entry, or to find an entry whose
         path doesn't follow common patterns.
 
+        v2 BREAKING: ``cursor`` was previously an ``int`` entry id and is
+        now an opaque ``str`` token. Pass ``None`` (or omit) on the first
+        call; pass back the ``next_cursor`` value from a prior response
+        to resume.
+
         Args:
             zim_file_path: Path to the ZIM file
             namespace: Namespace to walk (C, M, W, X, A, I, etc.)
-            cursor: Entry ID to resume from (default: 0)
-            limit: Max entries per page (1-500, default: 200)
+            limit: Max entries per page (1-500, default: 200). When a
+                ``cursor`` is supplied, the limit encoded in the cursor
+                wins per response-contract spec.
+            cursor: Opaque pagination token from a previous result's
+                ``next_cursor`` field. ``None`` starts from the beginning.
 
         Returns:
-            Dict with keys: namespace, cursor, limit, returned_count,
-            scanned_count, next_cursor, done, scanned_through_id,
-            archive_entry_count, total_in_namespace,
-            total_in_namespace_is_lower_bound, total_entries, entries.
-            ``archive_entry_count`` is the file-level entry count;
-            ``total_in_namespace`` is the namespace-specific count (None
-            when not derivable without a full scan, i.e. old-scheme
-            archives). ``total_entries`` is a deprecated alias of
-            ``archive_entry_count`` retained for v1.1.0 callers.
-            On failure, returns a ``{"error": True, ...}`` envelope (see
-            ``responses.tool_error``).
+            ``WalkNamespaceResponse``-shaped dict on success (Phase B
+            contract: top-level ``results`` / ``next_cursor`` (opaque str)
+            / ``total`` (always None — walk doesn't know the per-namespace
+            total mid-scan) / ``done`` / ``page_info`` plus ``namespace``
+            / ``scanned_count`` / ``scanned_through_id`` /
+            ``archive_entry_count`` extras); ``ToolErrorPayload`` envelope
+            on failure.
         """
         try:
+            # Phase B: cursor wins on conflict per response-contract spec.
+            cursor_state: Optional[Dict[str, Any]] = None
+            if cursor is not None:
+                from ..pagination import Cursor, CursorMismatchError
+
+                try:
+                    decoded = Cursor.decode(
+                        cursor, expected_tool="walk_namespace"
+                    )
+                except CursorMismatchError as e:
+                    return tool_error(
+                        operation="walk namespace",
+                        message=str(e),
+                        context="Tool: walk_namespace, cursor=<truncated>",
+                    )
+                except ValueError as e:
+                    return tool_error(
+                        operation="walk namespace",
+                        message=f"Invalid pagination cursor: {e}",
+                        context="Tool: walk_namespace",
+                    )
+                cursor_state = dict(decoded["s"])
+                if "l" in cursor_state:
+                    limit = cursor_state["l"]
+
             try:
                 server.rate_limiter.check_rate_limit("browse_namespace")
             except OpenZimMcpRateLimitError as e:
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
+                return tool_error(
+                    operation="walk namespace",
+                    message=server._create_enhanced_error_message(
                         operation="walk namespace",
-                        message=server._create_enhanced_error_message(
-                            operation="walk namespace",
-                            error=e,
-                            context=f"Namespace: {namespace}",
-                        ),
+                        error=e,
                         context=f"Namespace: {namespace}",
                     ),
+                    context=f"Namespace: {namespace}",
                 )
 
             zim_file_path = sanitize_input(zim_file_path, INPUT_LIMIT_FILE_PATH)
             namespace = sanitize_input(namespace, INPUT_LIMIT_NAMESPACE)
 
             # Validate parameters before any backend call. The docstring
-            # promises ``limit: 1-500`` and a non-negative ``cursor``;
-            # without this check, callers could open the libzim Archive
-            # for arbitrarily oversized requests before being rejected.
+            # promises ``limit: 1-500``; without this check, callers could
+            # open the libzim Archive for arbitrarily oversized requests
+            # before being rejected.
             if limit < 1 or limit > 500:
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
-                        operation="walk namespace",
-                        message=(
-                            "**Parameter Validation Error**\n\n"
-                            f"**Issue**: limit must be between 1 and 500 "
-                            f"(provided: {limit})\n\n"
-                            "**Troubleshooting**: Adjust the limit parameter to a "
-                            "value within the valid range.\n"
-                            "**Example**: Use `limit=200` for the default page size."
-                        ),
-                        context=f"Namespace: {namespace}, Limit: {limit}",
+                return tool_error(
+                    operation="walk namespace",
+                    message=(
+                        "**Parameter Validation Error**\n\n"
+                        f"**Issue**: limit must be between 1 and 500 "
+                        f"(provided: {limit})\n\n"
+                        "**Troubleshooting**: Adjust the limit parameter to a "
+                        "value within the valid range.\n"
+                        "**Example**: Use `limit=200` for the default page size."
                     ),
-                )
-            if cursor < 0:
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
-                        operation="walk namespace",
-                        message=(
-                            "**Parameter Validation Error**\n\n"
-                            f"**Issue**: cursor must be non-negative "
-                            f"(provided: {cursor})\n\n"
-                            "**Troubleshooting**: Use cursor=0 to start, or pass the "
-                            "`next_cursor` value returned by a previous call.\n"
-                            "**Example**: `cursor=0` on the first call."
-                        ),
-                        context=f"Namespace: {namespace}, Cursor: {cursor}",
-                    ),
+                    context=f"Namespace: {namespace}, Limit: {limit}",
                 )
 
             return await server.async_zim_operations.walk_namespace_data(
-                zim_file_path, namespace, cursor, limit
+                zim_file_path,
+                namespace,
+                cursor_state=cursor_state,
+                limit=limit,
             )
 
         except Exception as e:
             logger.error(f"Error in walk_namespace: {e}")
-            return cast(
-                Dict[str, Any],
-                tool_error(
+            return tool_error(
+                operation="walk namespace",
+                message=server._create_enhanced_error_message(
                     operation="walk namespace",
-                    message=server._create_enhanced_error_message(
-                        operation="walk namespace",
-                        error=e,
-                        context=(
-                            f"File: {zim_file_path}, Namespace: {namespace}, "
-                            f"Cursor: {cursor}, Limit: {limit}"
-                        ),
-                    ),
+                    error=e,
                     context=(
                         f"File: {zim_file_path}, Namespace: {namespace}, "
-                        f"Cursor: {cursor}, Limit: {limit}"
+                        f"Limit: {limit}"
                     ),
+                ),
+                context=(
+                    f"File: {zim_file_path}, Namespace: {namespace}, "
+                    f"Limit: {limit}"
                 ),
             )
 

--- a/openzim_mcp/tools/navigation_tools.py
+++ b/openzim_mcp/tools/navigation_tools.py
@@ -68,9 +68,7 @@ def _register_browse_namespace(server: "OpenZimMcpServer") -> None:
                 from ..pagination import Cursor, CursorMismatchError
 
                 try:
-                    decoded = Cursor.decode(
-                        cursor, expected_tool="browse_namespace"
-                    )
+                    decoded = Cursor.decode(cursor, expected_tool="browse_namespace")
                 except CursorMismatchError as e:
                     return tool_error(
                         operation="browse namespace",
@@ -210,9 +208,7 @@ def _register_walk_namespace(server: "OpenZimMcpServer") -> None:
                 from ..pagination import Cursor, CursorMismatchError
 
                 try:
-                    decoded = Cursor.decode(
-                        cursor, expected_tool="walk_namespace"
-                    )
+                    decoded = Cursor.decode(cursor, expected_tool="walk_namespace")
                 except CursorMismatchError as e:
                     return tool_error(
                         operation="walk namespace",
@@ -283,8 +279,7 @@ def _register_walk_namespace(server: "OpenZimMcpServer") -> None:
                     ),
                 ),
                 context=(
-                    f"File: {zim_file_path}, Namespace: {namespace}, "
-                    f"Limit: {limit}"
+                    f"File: {zim_file_path}, Namespace: {namespace}, " f"Limit: {limit}"
                 ),
             )
 
@@ -329,9 +324,7 @@ def _register_search_with_filters(server: "OpenZimMcpServer") -> None:
                 from ..pagination import Cursor, CursorMismatchError
 
                 try:
-                    decoded = Cursor.decode(
-                        cursor, expected_tool="search_with_filters"
-                    )
+                    decoded = Cursor.decode(cursor, expected_tool="search_with_filters")
                 except CursorMismatchError as e:
                     return tool_error(
                         operation="search with filters",

--- a/openzim_mcp/tools/navigation_tools.py
+++ b/openzim_mcp/tools/navigation_tools.py
@@ -13,7 +13,7 @@ from ..constants import (
 from ..exceptions import OpenZimMcpRateLimitError
 from ..responses import ToolErrorPayload, tool_error
 from ..security import sanitize_input
-from ..tool_schemas import SearchWithFiltersResponse
+from ..tool_schemas import SearchSuggestionsResponse, SearchWithFiltersResponse
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
@@ -411,38 +411,38 @@ def _register_get_search_suggestions(server: "OpenZimMcpServer") -> None:
     @server.mcp.tool()
     async def get_search_suggestions(
         zim_file_path: str, partial_query: str, limit: int = 10
-    ) -> Dict[str, Any]:
+    ) -> Union[SearchSuggestionsResponse, ToolErrorPayload]:
         """Get search suggestions and auto-complete for partial queries.
 
         Args:
             zim_file_path: Path to the ZIM file
             partial_query: Partial search query. Must be at least 2 characters
                 after stripping whitespace; shorter queries return an empty
-                suggestion list with an explanatory ``message`` field.
+                results list with the contract envelope (``done=True``,
+                ``total=0``).
             limit: Maximum number of suggestions to return (1-50, default: 10)
 
         Returns:
-            Dict with keys: partial_query, suggestions (list of {text, path,
-            type}), count. For very short queries, returns
-            ``{"suggestions": [], "message": "..."}``. On failure, returns a
-            ``{"error": True, ...}`` envelope (see ``responses.tool_error``).
+            ``SearchSuggestionsResponse``-shaped dict on success (Phase B
+            contract: top-level ``results`` / ``next_cursor`` / ``total`` /
+            ``done`` / ``page_info`` plus ``partial_query`` extra);
+            ``ToolErrorPayload`` envelope on failure. ``get_search_suggestions``
+            is non-paginated: ``done`` is always ``True`` and ``next_cursor``
+            is always ``None``.
         """
         try:
             # Check rate limit
             try:
                 server.rate_limiter.check_rate_limit("suggestions")
             except OpenZimMcpRateLimitError as e:
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
+                return tool_error(
+                    operation="get search suggestions",
+                    message=server._create_enhanced_error_message(
                         operation="get search suggestions",
-                        message=server._create_enhanced_error_message(
-                            operation="get search suggestions",
-                            error=e,
-                            context=f"Query: '{partial_query}'",
-                        ),
+                        error=e,
                         context=f"Query: '{partial_query}'",
                     ),
+                    context=f"Query: '{partial_query}'",
                 )
 
             # Sanitize inputs
@@ -451,20 +451,17 @@ def _register_get_search_suggestions(server: "OpenZimMcpServer") -> None:
 
             # Validate parameters
             if limit < 1 or limit > 50:
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
-                        operation="get search suggestions",
-                        message=(
-                            "**Parameter Validation Error**\n\n"
-                            f"**Issue**: limit must be between 1 and 50 "
-                            f"(provided: {limit})\n\n"
-                            "**Troubleshooting**: Adjust the limit parameter to a "
-                            "value within the valid range.\n"
-                            "**Example**: Use `limit=10` for reasonable suggestions."
-                        ),
-                        context=f"Query: '{partial_query}', Limit: {limit}",
+                return tool_error(
+                    operation="get search suggestions",
+                    message=(
+                        "**Parameter Validation Error**\n\n"
+                        f"**Issue**: limit must be between 1 and 50 "
+                        f"(provided: {limit})\n\n"
+                        "**Troubleshooting**: Adjust the limit parameter to a "
+                        "value within the valid range.\n"
+                        "**Example**: Use `limit=10` for reasonable suggestions."
                     ),
+                    context=f"Query: '{partial_query}', Limit: {limit}",
                 )
 
             # Use async operations
@@ -474,15 +471,12 @@ def _register_get_search_suggestions(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error getting search suggestions: {e}")
-            return cast(
-                Dict[str, Any],
-                tool_error(
+            return tool_error(
+                operation="get search suggestions",
+                message=server._create_enhanced_error_message(
                     operation="get search suggestions",
-                    message=server._create_enhanced_error_message(
-                        operation="get search suggestions",
-                        error=e,
-                        context=f"File: {zim_file_path}, Query: {partial_query}",
-                    ),
+                    error=e,
                     context=f"File: {zim_file_path}, Query: {partial_query}",
                 ),
+                context=f"File: {zim_file_path}, Query: {partial_query}",
             )

--- a/openzim_mcp/tools/navigation_tools.py
+++ b/openzim_mcp/tools/navigation_tools.py
@@ -1,7 +1,7 @@
 """Navigation and browsing tools for OpenZIM MCP server."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Optional, cast
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union, cast
 
 from ..constants import (
     INPUT_LIMIT_CONTENT_TYPE,
@@ -11,8 +11,9 @@ from ..constants import (
     INPUT_LIMIT_QUERY,
 )
 from ..exceptions import OpenZimMcpRateLimitError
-from ..responses import tool_error
+from ..responses import ToolErrorPayload, tool_error
 from ..security import sanitize_input
+from ..tool_schemas import SearchWithFiltersResponse
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
@@ -262,38 +263,95 @@ def _register_search_with_filters(server: "OpenZimMcpServer") -> None:
     @server.mcp.tool()
     async def search_with_filters(
         zim_file_path: str,
-        query: str,
+        query: Optional[str] = None,
         namespace: Optional[str] = None,
         content_type: Optional[str] = None,
         limit: Optional[int] = None,
         offset: int = 0,
-    ) -> str:
+        cursor: Optional[str] = None,
+    ) -> Union[SearchWithFiltersResponse, ToolErrorPayload]:
         """Search within ZIM file content with namespace and content type filters.
 
         Args:
             zim_file_path: Path to the ZIM file
-            query: Search query term
+            query: Search query term. Required unless ``cursor`` is provided,
+                in which case the query encoded in the cursor is reused.
             namespace: Optional namespace filter (C, M, W, X, etc.)
             content_type: Optional content type filter (text/html, text/plain, etc.)
             limit: Maximum number of results to return (default from config)
             offset: Result starting offset (for pagination)
+            cursor: Opaque pagination token from a previous result's
+                ``next_cursor`` field. When provided, overrides ``offset``,
+                ``limit``, ``query``, ``namespace``, and ``content_type``
+                with the values encoded in the token (cursor wins on
+                conflict per response-contract spec).
 
         Returns:
-            Search result text
+            ``SearchWithFiltersResponse``-shaped dict on success (Phase B
+            contract: top-level ``results`` / ``next_cursor`` / ``total`` /
+            ``done`` / ``page_info`` plus ``query`` / ``namespace_filter``
+            / ``content_type_filter`` extras); ``ToolErrorPayload``
+            envelope on failure.
         """
         try:
+            # Phase B: cursor wins on conflict per response-contract spec.
+            if cursor is not None:
+                from ..pagination import Cursor, CursorMismatchError
+
+                try:
+                    decoded = Cursor.decode(
+                        cursor, expected_tool="search_with_filters"
+                    )
+                except CursorMismatchError as e:
+                    return tool_error(
+                        operation="search with filters",
+                        message=str(e),
+                        context="Tool: search_with_filters, cursor=<truncated>",
+                    )
+                except ValueError as e:
+                    return tool_error(
+                        operation="search with filters",
+                        message=f"Invalid pagination cursor: {e}",
+                        context="Tool: search_with_filters",
+                    )
+                offset = decoded["s"]["o"]
+                if "l" in decoded["s"]:
+                    limit = decoded["s"]["l"]
+                if "q" in decoded["s"]:
+                    query = decoded["s"]["q"]
+                if "ns" in decoded["s"]:
+                    namespace = decoded["s"]["ns"]
+                if "ct" in decoded["s"]:
+                    content_type = decoded["s"]["ct"]
+
             # Check rate limit
             try:
                 server.rate_limiter.check_rate_limit("search_with_filters")
             except OpenZimMcpRateLimitError as e:
-                return server._create_enhanced_error_message(
-                    operation="filtered search",
-                    error=e,
+                return tool_error(
+                    operation="search with filters",
+                    message=server._create_enhanced_error_message(
+                        operation="filtered search",
+                        error=e,
+                        context=f"Query: '{query}'",
+                    ),
                     context=f"Query: '{query}'",
                 )
 
-            # Sanitize inputs
+            # Sanitize file path eagerly; query is sanitized once resolved.
             zim_file_path = sanitize_input(zim_file_path, INPUT_LIMIT_FILE_PATH)
+
+            if not query:
+                return tool_error(
+                    operation="search with filters",
+                    message=(
+                        "`query` is required when `cursor` is not provided. "
+                        "Pass a search term as `query`, or pass a `cursor` "
+                        "from a prior search response to resume pagination."
+                    ),
+                    context="Tool: search_with_filters",
+                )
+
             query = sanitize_input(query, INPUT_LIMIT_QUERY)
             if namespace:
                 namespace = sanitize_input(
@@ -304,34 +362,48 @@ def _register_search_with_filters(server: "OpenZimMcpServer") -> None:
 
             # Validate parameters
             if limit is not None and (limit < 1 or limit > 100):
-                return (
-                    "**Parameter Validation Error**\n\n"
-                    f"**Issue**: limit must be between 1 and 100 "
-                    f"(provided: {limit})\n\n"
-                    "**Troubleshooting**: Adjust the limit parameter or "
-                    "omit it to use the default.\n"
-                    "**Example**: Use `limit=20` for a reasonable number."
+                return tool_error(
+                    operation="search with filters",
+                    message=(
+                        "**Parameter Validation Error**\n\n"
+                        f"**Issue**: limit must be between 1 and 100 "
+                        f"(provided: {limit})\n\n"
+                        "**Troubleshooting**: Adjust the limit parameter or "
+                        "omit it to use the default.\n"
+                        "**Example**: Use `limit=20` for a reasonable number."
+                    ),
+                    context=f"Query: '{query}', Limit: {limit}",
                 )
             if offset < 0:
-                return (
-                    "**Parameter Validation Error**\n\n"
-                    f"**Issue**: offset must be non-negative (provided: {offset})\n\n"
-                    "**Troubleshooting**: Use offset=0 to start from the beginning, "
-                    "or a positive number for pagination.\n"
-                    "**Example**: Use `offset=20` to get the next page of results."
+                return tool_error(
+                    operation="search with filters",
+                    message=(
+                        "**Parameter Validation Error**\n\n"
+                        f"**Issue**: offset must be non-negative "
+                        f"(provided: {offset})\n\n"
+                        "**Troubleshooting**: Use offset=0 to start from the "
+                        "beginning, or a positive number for pagination.\n"
+                        "**Example**: Use `offset=20` to get the next page."
+                    ),
+                    context=f"Query: '{query}', Offset: {offset}",
                 )
 
             # Perform the filtered search using async operations
-            return await server.async_zim_operations.search_with_filters(
+            # (structured payload).
+            return await server.async_zim_operations.search_with_filters_data(
                 zim_file_path, query, namespace, content_type, limit, offset
             )
 
         except Exception as e:
             logger.error(f"Error in filtered search: {e}")
-            return server._create_enhanced_error_message(
-                operation="filtered search",
-                error=e,
-                context=f"File: {zim_file_path}, Query: {query}",
+            return tool_error(
+                operation="search with filters",
+                message=server._create_enhanced_error_message(
+                    operation="filtered search",
+                    error=e,
+                    context=f"File: {zim_file_path}, Query: {query}",
+                ),
+                context=f"File: {zim_file_path}, Query: '{query}'",
             )
 
 

--- a/openzim_mcp/tools/navigation_tools.py
+++ b/openzim_mcp/tools/navigation_tools.py
@@ -13,7 +13,11 @@ from ..constants import (
 from ..exceptions import OpenZimMcpRateLimitError
 from ..responses import ToolErrorPayload, tool_error
 from ..security import sanitize_input
-from ..tool_schemas import SearchSuggestionsResponse, SearchWithFiltersResponse
+from ..tool_schemas import (
+    BrowseNamespaceResponse,
+    SearchSuggestionsResponse,
+    SearchWithFiltersResponse,
+)
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
@@ -36,7 +40,8 @@ def _register_browse_namespace(server: "OpenZimMcpServer") -> None:
         namespace: str,
         limit: int = 50,
         offset: int = 0,
-    ) -> Dict[str, Any]:
+        cursor: Optional[str] = None,
+    ) -> Union[BrowseNamespaceResponse, ToolErrorPayload]:
         """Browse entries in a specific namespace with pagination.
 
         Args:
@@ -44,30 +49,57 @@ def _register_browse_namespace(server: "OpenZimMcpServer") -> None:
             namespace: Namespace to browse (C, M, W, X, A, I for old; domains for new)
             limit: Maximum number of entries to return (1-200, default: 50)
             offset: Starting offset for pagination (default: 0)
+            cursor: Opaque pagination token from a previous result's
+                ``next_cursor`` field. When provided, overrides ``offset``,
+                ``limit``, and ``namespace`` with the values encoded in the
+                token (cursor wins on conflict per response-contract spec).
 
         Returns:
-            Dict with keys: namespace, total_in_namespace, offset, limit,
-            returned_count, has_more, next_cursor, entries, sampling_based,
-            discovery_method, is_total_authoritative, results_may_be_incomplete.
-            On failure, returns a ``{"error": True, ...}`` envelope (see
-            ``responses.tool_error``).
+            ``BrowseNamespaceResponse``-shaped dict on success (Phase B
+            contract: top-level ``results`` / ``next_cursor`` / ``total`` /
+            ``done`` / ``page_info`` plus ``namespace`` / ``discovery_method``
+            / ``sampling_based`` / ``results_may_be_incomplete`` extras);
+            ``ToolErrorPayload`` envelope on failure.
         """
         try:
+            # Phase B: cursor wins on conflict per response-contract spec.
+            if cursor is not None:
+                from ..pagination import Cursor, CursorMismatchError
+
+                try:
+                    decoded = Cursor.decode(
+                        cursor, expected_tool="browse_namespace"
+                    )
+                except CursorMismatchError as e:
+                    return tool_error(
+                        operation="browse namespace",
+                        message=str(e),
+                        context="Tool: browse_namespace, cursor=<truncated>",
+                    )
+                except ValueError as e:
+                    return tool_error(
+                        operation="browse namespace",
+                        message=f"Invalid pagination cursor: {e}",
+                        context="Tool: browse_namespace",
+                    )
+                offset = decoded["s"]["o"]
+                if "l" in decoded["s"]:
+                    limit = decoded["s"]["l"]
+                if "ns" in decoded["s"]:
+                    namespace = decoded["s"]["ns"]
+
             # Check rate limit
             try:
                 server.rate_limiter.check_rate_limit("browse_namespace")
             except OpenZimMcpRateLimitError as e:
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
+                return tool_error(
+                    operation="browse namespace",
+                    message=server._create_enhanced_error_message(
                         operation="browse namespace",
-                        message=server._create_enhanced_error_message(
-                            operation="browse namespace",
-                            error=e,
-                            context=f"Namespace: {namespace}",
-                        ),
+                        error=e,
                         context=f"Namespace: {namespace}",
                     ),
+                    context=f"Namespace: {namespace}",
                 )
 
             # Sanitize inputs
@@ -78,36 +110,30 @@ def _register_browse_namespace(server: "OpenZimMcpServer") -> None:
 
             # Validate parameters
             if limit < 1 or limit > 200:
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
-                        operation="browse namespace",
-                        message=(
-                            "**Parameter Validation Error**\n\n"
-                            f"**Issue**: limit must be between 1 and 200 "
-                            f"(provided: {limit})\n\n"
-                            "**Troubleshooting**: Adjust the limit parameter to a "
-                            "value within the valid range.\n"
-                            "**Example**: Use `limit=50` for reasonable pagination."
-                        ),
-                        context=f"Namespace: {namespace}, Limit: {limit}",
+                return tool_error(
+                    operation="browse namespace",
+                    message=(
+                        "**Parameter Validation Error**\n\n"
+                        f"**Issue**: limit must be between 1 and 200 "
+                        f"(provided: {limit})\n\n"
+                        "**Troubleshooting**: Adjust the limit parameter to a "
+                        "value within the valid range.\n"
+                        "**Example**: Use `limit=50` for reasonable pagination."
                     ),
+                    context=f"Namespace: {namespace}, Limit: {limit}",
                 )
             if offset < 0:
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
-                        operation="browse namespace",
-                        message=(
-                            "**Parameter Validation Error**\n\n"
-                            f"**Issue**: offset must be non-negative "
-                            f"(provided: {offset})\n\n"
-                            "**Troubleshooting**: Use offset=0 to start from the "
-                            "beginning, or a positive number to skip entries.\n"
-                            "**Example**: Use `offset=50` to skip the first 50 entries."
-                        ),
-                        context=f"Namespace: {namespace}, Offset: {offset}",
+                return tool_error(
+                    operation="browse namespace",
+                    message=(
+                        "**Parameter Validation Error**\n\n"
+                        f"**Issue**: offset must be non-negative "
+                        f"(provided: {offset})\n\n"
+                        "**Troubleshooting**: Use offset=0 to start from the "
+                        "beginning, or a positive number to skip entries.\n"
+                        "**Example**: Use `offset=50` to skip the first 50 entries."
                     ),
+                    context=f"Namespace: {namespace}, Offset: {offset}",
                 )
 
             # Use async operations
@@ -117,22 +143,19 @@ def _register_browse_namespace(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error browsing namespace: {e}")
-            return cast(
-                Dict[str, Any],
-                tool_error(
+            return tool_error(
+                operation="browse namespace",
+                message=server._create_enhanced_error_message(
                     operation="browse namespace",
-                    message=server._create_enhanced_error_message(
-                        operation="browse namespace",
-                        error=e,
-                        context=(
-                            f"File: {zim_file_path}, Namespace: {namespace}, "
-                            f"Limit: {limit}, Offset: {offset}"
-                        ),
-                    ),
+                    error=e,
                     context=(
                         f"File: {zim_file_path}, Namespace: {namespace}, "
                         f"Limit: {limit}, Offset: {offset}"
                     ),
+                ),
+                context=(
+                    f"File: {zim_file_path}, Namespace: {namespace}, "
+                    f"Limit: {limit}, Offset: {offset}"
                 ),
             )
 

--- a/openzim_mcp/tools/search_tools.py
+++ b/openzim_mcp/tools/search_tools.py
@@ -1,13 +1,13 @@
 """Search tools for OpenZIM MCP server."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union, cast
+from typing import TYPE_CHECKING, Optional, Union
 
 from ..constants import INPUT_LIMIT_FILE_PATH, INPUT_LIMIT_QUERY
 from ..exceptions import OpenZimMcpRateLimitError
 from ..responses import ToolErrorPayload, tool_error
 from ..security import sanitize_input
-from ..tool_schemas import SearchAllResponse, SearchResponse
+from ..tool_schemas import FindEntryResponse, SearchAllResponse, SearchResponse
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
@@ -232,7 +232,7 @@ def _register_find_entry_by_title(server: "OpenZimMcpServer") -> None:
         title: str,
         cross_file: bool = False,
         limit: int = 10,
-    ) -> Dict[str, Any]:
+    ) -> Union[FindEntryResponse, ToolErrorPayload]:
         """Resolve a title to one or more entry paths.
 
         Cheaper than full-text search when the caller knows the article title.
@@ -247,26 +247,26 @@ def _register_find_entry_by_title(server: "OpenZimMcpServer") -> None:
             limit: Max results to return (1-50, default: 10)
 
         Returns:
-            Dict with keys: query, results (list of {path, title, score,
-            zim_file}), fast_path_hit (bool), files_searched (int). On
-            failure, returns a ``{"error": True, ...}`` envelope (see
-            ``responses.tool_error``).
+            ``FindEntryResponse``-shaped dict on success (Phase B contract:
+            top-level ``results`` / ``next_cursor`` / ``total`` / ``done`` /
+            ``page_info`` plus ``query`` / ``fast_path_hit`` /
+            ``fuzzy_path_hit`` / ``files_searched`` extras);
+            ``ToolErrorPayload`` envelope on failure. ``find_entry_by_title``
+            is non-paginated: ``done`` is always ``True`` and
+            ``next_cursor`` is always ``None``.
         """
         try:
             try:
                 server.rate_limiter.check_rate_limit("find_entry_by_title")
             except OpenZimMcpRateLimitError as e:
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
+                return tool_error(
+                    operation="find entry by title",
+                    message=server._create_enhanced_error_message(
                         operation="find entry by title",
-                        message=server._create_enhanced_error_message(
-                            operation="find entry by title",
-                            error=e,
-                            context=f"Title: '{title}'",
-                        ),
+                        error=e,
                         context=f"Title: '{title}'",
                     ),
+                    context=f"Title: '{title}'",
                 )
 
             title = sanitize_input(title, INPUT_LIMIT_QUERY)
@@ -281,15 +281,12 @@ def _register_find_entry_by_title(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error in find_entry_by_title: {e}")
-            return cast(
-                Dict[str, Any],
-                tool_error(
+            return tool_error(
+                operation="find entry by title",
+                message=server._create_enhanced_error_message(
                     operation="find entry by title",
-                    message=server._create_enhanced_error_message(
-                        operation="find entry by title",
-                        error=e,
-                        context=f"File: {zim_file_path}, Title: '{title}'",
-                    ),
+                    error=e,
                     context=f"File: {zim_file_path}, Title: '{title}'",
                 ),
+                context=f"File: {zim_file_path}, Title: '{title}'",
             )

--- a/openzim_mcp/tools/search_tools.py
+++ b/openzim_mcp/tools/search_tools.py
@@ -1,12 +1,13 @@
 """Search tools for OpenZIM MCP server."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union, cast
 
 from ..constants import INPUT_LIMIT_FILE_PATH, INPUT_LIMIT_QUERY
 from ..exceptions import OpenZimMcpRateLimitError
-from ..responses import tool_error
+from ..responses import ToolErrorPayload, tool_error
 from ..security import sanitize_input
+from ..tool_schemas import SearchResponse
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
@@ -29,7 +30,7 @@ def _register_search_zim_file(server: "OpenZimMcpServer") -> None:
         limit: Optional[int] = None,
         offset: int = 0,
         cursor: Optional[str] = None,
-    ) -> str:
+    ) -> Union[SearchResponse, ToolErrorPayload]:
         """Search within ZIM file content.
 
         Args:
@@ -39,109 +40,110 @@ def _register_search_zim_file(server: "OpenZimMcpServer") -> None:
             limit: Maximum number of results to return (default from config)
             offset: Result starting offset (for pagination)
             cursor: Opaque pagination token from a previous result's
-                ``next_cursor`` field. When provided, overrides ``offset`` and
-                ``limit`` with the values encoded in the token, and supplies
-                ``query`` if it was not given explicitly.
+                ``next_cursor`` field. When provided, overrides ``offset``,
+                ``limit``, and ``query`` with the values encoded in the
+                token (cursor wins on conflict per response-contract spec).
 
         Returns:
-            Search result text
+            ``SearchResponse``-shaped dict on success (Phase B contract:
+            top-level ``results`` / ``next_cursor`` / ``total`` / ``done`` /
+            ``page_info``); ``ToolErrorPayload`` envelope on failure.
         """
         try:
+            # Phase B: cursor wins on conflict per response-contract spec.
+            if cursor is not None:
+                from ..pagination import Cursor, CursorMismatchError
+
+                try:
+                    decoded = Cursor.decode(cursor, expected_tool="search_zim_file")
+                except CursorMismatchError as e:
+                    return tool_error(
+                        operation="search ZIM file",
+                        message=str(e),
+                        context="Tool: search_zim_file, cursor=<truncated>",
+                    )
+                except ValueError as e:
+                    return tool_error(
+                        operation="search ZIM file",
+                        message=f"Invalid pagination cursor: {e}",
+                        context="Tool: search_zim_file",
+                    )
+                offset = decoded["s"]["o"]
+                if "l" in decoded["s"]:
+                    limit = decoded["s"]["l"]
+                # Cursor's q overrides the query argument so the cursor
+                # round-trips cleanly even if a caller forgets to pass query
+                # alongside.
+                if "q" in decoded["s"]:
+                    query = decoded["s"]["q"]
+
             # Check rate limit
             try:
                 server.rate_limiter.check_rate_limit("search")
             except OpenZimMcpRateLimitError as e:
-                return server._create_enhanced_error_message(
+                return tool_error(
                     operation="search ZIM file",
-                    error=e,
+                    message=server._create_enhanced_error_message(
+                        operation="search ZIM file",
+                        error=e,
+                        context=f"Query: '{query}'",
+                    ),
                     context=f"Query: '{query}'",
                 )
 
             # Sanitize file path eagerly; query is sanitized once resolved.
             zim_file_path = sanitize_input(zim_file_path, INPUT_LIMIT_FILE_PATH)
 
-            # Resolve cursor before validating offset/limit so cursor-supplied
-            # values are subject to the same bounds checks. The cursor also
-            # carries the original query, which is used when the caller did
-            # not pass `query` explicitly.
-            if cursor:
-                from ..zim_operations import PaginationCursor
-
-                try:
-                    decoded = PaginationCursor.decode(cursor)
-                except ValueError as e:
-                    return (
-                        "**Parameter Validation Error**\n\n"
-                        f"**Issue**: {e}\n\n"
-                        "**Troubleshooting**: Use the exact `next_cursor` "
-                        "value from a prior search response, or fall back to "
-                        "explicit `offset`/`limit` parameters."
-                    )
-                offset = decoded["o"]
-                limit = decoded["l"]
-                cursor_query = decoded.get("q")
-                if query is None:
-                    query = cursor_query
-                elif cursor_query and cursor_query != query:
-                    # Cursors encode the query they were paired with;
-                    # honoring a different `query` would silently return the
-                    # wrong page of the wrong query. Reject instead.
-                    return (
-                        "**Parameter Validation Error**\n\n"
-                        f"**Issue**: `cursor` was issued for query "
-                        f"{cursor_query!r} but the request supplied "
-                        f"query {query!r}. Cursors are only valid for "
-                        "the query they were issued for.\n\n"
-                        "**Troubleshooting**: Either drop `cursor` and "
-                        "start a fresh search with the new `query`, or "
-                        "omit `query` so the cursor's embedded query is "
-                        "reused."
-                    )
-
             if not query:
-                return (
-                    "**Parameter Validation Error**\n\n"
-                    "**Issue**: `query` is required when `cursor` is not "
-                    "provided.\n\n"
-                    "**Troubleshooting**: Pass a search term as `query`, or "
-                    "pass a `cursor` from a prior search response to resume "
-                    "pagination."
+                return tool_error(
+                    operation="search ZIM file",
+                    message=(
+                        "`query` is required when `cursor` is not provided. "
+                        "Pass a search term as `query`, or pass a `cursor` "
+                        "from a prior search response to resume pagination."
+                    ),
+                    context="Tool: search_zim_file",
                 )
 
             query = sanitize_input(query, INPUT_LIMIT_QUERY)
 
             # Validate parameters
             if limit is not None and (limit < 1 or limit > 100):
-                return (
-                    "**Parameter Validation Error**\n\n"
-                    f"**Issue**: Search limit must be between 1 and 100 "
-                    f"(provided: {limit})\n\n"
-                    "**Troubleshooting**: Adjust the limit parameter to be "
-                    "within the valid range.\n"
-                    "**Example**: Use `limit=10` for 10 results or "
-                    "`limit=50` for more results."
+                return tool_error(
+                    operation="search ZIM file",
+                    message=(
+                        f"Search limit must be between 1 and 100 "
+                        f"(provided: {limit}). Use `limit=10` for 10 results "
+                        f"or `limit=50` for more results."
+                    ),
+                    context=f"Query: '{query}'",
                 )
 
             if offset < 0:
-                return (
-                    "**Parameter Validation Error**\n\n"
-                    f"**Issue**: Offset must be non-negative (provided: {offset})\n\n"
-                    "**Troubleshooting**: Use `offset=0` to start from the "
-                    "beginning, or a positive number to skip results.\n"
-                    "**Example**: Use `offset=0` for first page, "
-                    "`offset=10` for second page with limit=10."
+                return tool_error(
+                    operation="search ZIM file",
+                    message=(
+                        f"Offset must be non-negative (provided: {offset}). "
+                        "Use `offset=0` to start from the beginning, or a "
+                        "positive number to skip results."
+                    ),
+                    context=f"Query: '{query}'",
                 )
 
-            # Perform the search using async operations
-            return await server.async_zim_operations.search_zim_file(
+            # Perform the search using async operations (structured payload).
+            return await server.async_zim_operations.search_zim_file_data(
                 zim_file_path, query, limit, offset
             )
 
         except Exception as e:
             logger.error(f"Error searching ZIM file: {e}")
-            return server._create_enhanced_error_message(
+            return tool_error(
                 operation="search ZIM file",
-                error=e,
+                message=server._create_enhanced_error_message(
+                    operation="search ZIM file",
+                    error=e,
+                    context=f"File: {zim_file_path}, Query: '{query}'",
+                ),
                 context=f"File: {zim_file_path}, Query: '{query}'",
             )
 
@@ -176,14 +178,17 @@ def _register_search_all(server: "OpenZimMcpServer") -> None:
             try:
                 server.rate_limiter.check_rate_limit("search")
             except OpenZimMcpRateLimitError as e:
-                return tool_error(
-                    operation="search across ZIM files",
-                    message=server._create_enhanced_error_message(
+                return cast(
+                    Dict[str, Any],
+                    tool_error(
                         operation="search across ZIM files",
-                        error=e,
+                        message=server._create_enhanced_error_message(
+                            operation="search across ZIM files",
+                            error=e,
+                            context=f"Query: '{query}'",
+                        ),
                         context=f"Query: '{query}'",
                     ),
-                    context=f"Query: '{query}'",
                 )
 
             query = sanitize_input(query, INPUT_LIMIT_QUERY)
@@ -193,13 +198,16 @@ def _register_search_all(server: "OpenZimMcpServer") -> None:
                 effective_limit = 5
 
             if effective_limit < 1 or effective_limit > 50:
-                return tool_error(
-                    operation="search across ZIM files",
-                    message=(
-                        f"limit_per_file must be between 1 and 50 "
-                        f"(provided: {effective_limit})"
+                return cast(
+                    Dict[str, Any],
+                    tool_error(
+                        operation="search across ZIM files",
+                        message=(
+                            f"limit_per_file must be between 1 and 50 "
+                            f"(provided: {effective_limit})"
+                        ),
+                        context=f"Query: '{query}'",
                     ),
-                    context=f"Query: '{query}'",
                 )
 
             return await server.async_zim_operations.search_all_data(
@@ -208,14 +216,17 @@ def _register_search_all(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error in search_all: {e}")
-            return tool_error(
-                operation="search across ZIM files",
-                message=server._create_enhanced_error_message(
+            return cast(
+                Dict[str, Any],
+                tool_error(
                     operation="search across ZIM files",
-                    error=e,
+                    message=server._create_enhanced_error_message(
+                        operation="search across ZIM files",
+                        error=e,
+                        context=f"Query: '{query}'",
+                    ),
                     context=f"Query: '{query}'",
                 ),
-                context=f"Query: '{query}'",
             )
 
 
@@ -250,14 +261,17 @@ def _register_find_entry_by_title(server: "OpenZimMcpServer") -> None:
             try:
                 server.rate_limiter.check_rate_limit("find_entry_by_title")
             except OpenZimMcpRateLimitError as e:
-                return tool_error(
-                    operation="find entry by title",
-                    message=server._create_enhanced_error_message(
+                return cast(
+                    Dict[str, Any],
+                    tool_error(
                         operation="find entry by title",
-                        error=e,
+                        message=server._create_enhanced_error_message(
+                            operation="find entry by title",
+                            error=e,
+                            context=f"Title: '{title}'",
+                        ),
                         context=f"Title: '{title}'",
                     ),
-                    context=f"Title: '{title}'",
                 )
 
             title = sanitize_input(title, INPUT_LIMIT_QUERY)
@@ -272,12 +286,15 @@ def _register_find_entry_by_title(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error in find_entry_by_title: {e}")
-            return tool_error(
-                operation="find entry by title",
-                message=server._create_enhanced_error_message(
+            return cast(
+                Dict[str, Any],
+                tool_error(
                     operation="find entry by title",
-                    error=e,
+                    message=server._create_enhanced_error_message(
+                        operation="find entry by title",
+                        error=e,
+                        context=f"File: {zim_file_path}, Title: '{title}'",
+                    ),
                     context=f"File: {zim_file_path}, Title: '{title}'",
                 ),
-                context=f"File: {zim_file_path}, Title: '{title}'",
             )

--- a/openzim_mcp/tools/search_tools.py
+++ b/openzim_mcp/tools/search_tools.py
@@ -7,7 +7,7 @@ from ..constants import INPUT_LIMIT_FILE_PATH, INPUT_LIMIT_QUERY
 from ..exceptions import OpenZimMcpRateLimitError
 from ..responses import ToolErrorPayload, tool_error
 from ..security import sanitize_input
-from ..tool_schemas import SearchResponse
+from ..tool_schemas import SearchAllResponse, SearchResponse
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
@@ -154,7 +154,7 @@ def _register_search_all(server: "OpenZimMcpServer") -> None:
         query: str,
         limit_per_file: Optional[int] = None,
         limit: Optional[int] = None,
-    ) -> Dict[str, Any]:
+    ) -> Union[SearchAllResponse, ToolErrorPayload]:
         """Search across every ZIM file in the allowed directories.
 
         Returns merged per-file results so the caller doesn't need to know
@@ -170,25 +170,26 @@ def _register_search_all(server: "OpenZimMcpServer") -> None:
                 wins.
 
         Returns:
-            Dict with per-file result groups. Each ``per_file[].result`` is
-            itself a structured search payload (no nested markdown strings).
-            On failure, returns a ``{"error": True, ...}`` envelope.
+            ``SearchAllResponse``-shaped dict on success (Phase B contract:
+            top-level ``results`` / ``next_cursor`` / ``total`` / ``done`` /
+            ``page_info``, with each ``results[].result`` itself a
+            ``SearchResponse``); ``ToolErrorPayload`` envelope on failure.
+            ``search_all`` does not paginate at the top level — fan-out
+            across archives happens in one shot, so ``done`` is always
+            ``True`` and ``next_cursor`` is always ``None``.
         """
         try:
             try:
                 server.rate_limiter.check_rate_limit("search")
             except OpenZimMcpRateLimitError as e:
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
+                return tool_error(
+                    operation="search across ZIM files",
+                    message=server._create_enhanced_error_message(
                         operation="search across ZIM files",
-                        message=server._create_enhanced_error_message(
-                            operation="search across ZIM files",
-                            error=e,
-                            context=f"Query: '{query}'",
-                        ),
+                        error=e,
                         context=f"Query: '{query}'",
                     ),
+                    context=f"Query: '{query}'",
                 )
 
             query = sanitize_input(query, INPUT_LIMIT_QUERY)
@@ -198,16 +199,13 @@ def _register_search_all(server: "OpenZimMcpServer") -> None:
                 effective_limit = 5
 
             if effective_limit < 1 or effective_limit > 50:
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
-                        operation="search across ZIM files",
-                        message=(
-                            f"limit_per_file must be between 1 and 50 "
-                            f"(provided: {effective_limit})"
-                        ),
-                        context=f"Query: '{query}'",
+                return tool_error(
+                    operation="search across ZIM files",
+                    message=(
+                        f"limit_per_file must be between 1 and 50 "
+                        f"(provided: {effective_limit})"
                     ),
+                    context=f"Query: '{query}'",
                 )
 
             return await server.async_zim_operations.search_all_data(
@@ -216,17 +214,14 @@ def _register_search_all(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error in search_all: {e}")
-            return cast(
-                Dict[str, Any],
-                tool_error(
+            return tool_error(
+                operation="search across ZIM files",
+                message=server._create_enhanced_error_message(
                     operation="search across ZIM files",
-                    message=server._create_enhanced_error_message(
-                        operation="search across ZIM files",
-                        error=e,
-                        context=f"Query: '{query}'",
-                    ),
+                    error=e,
                     context=f"Query: '{query}'",
                 ),
+                context=f"Query: '{query}'",
             )
 
 

--- a/openzim_mcp/tools/server_tools.py
+++ b/openzim_mcp/tools/server_tools.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple, cast
 
 from ..constants import CACHE_HIGH_HIT_RATE_THRESHOLD, CACHE_LOW_HIT_RATE_THRESHOLD
 from ..responses import tool_error
@@ -251,14 +251,17 @@ def _build_health_report(server: "OpenZimMcpServer") -> Dict[str, Any]:
 
     except Exception as e:
         logger.error(f"Error getting server health: {e}")
-        return tool_error(
-            operation="get server health",
-            message=server._create_enhanced_error_message(
+        return cast(
+            Dict[str, Any],
+            tool_error(
                 operation="get server health",
-                error=e,
+                message=server._create_enhanced_error_message(
+                    operation="get server health",
+                    error=e,
+                    context="Checking server health and performance metrics",
+                ),
                 context="Checking server health and performance metrics",
             ),
-            context="Checking server health and performance metrics",
         )
 
 
@@ -322,12 +325,15 @@ def _build_configuration_report(server: "OpenZimMcpServer") -> Dict[str, Any]:
         return result
     except Exception as e:
         logger.error(f"Error getting server configuration: {e}")
-        return tool_error(
-            operation="get server configuration",
-            message=server._create_enhanced_error_message(
+        return cast(
+            Dict[str, Any],
+            tool_error(
                 operation="get server configuration",
-                error=e,
+                message=server._create_enhanced_error_message(
+                    operation="get server configuration",
+                    error=e,
+                    context="Configuration diagnostics",
+                ),
                 context="Configuration diagnostics",
             ),
-            context="Configuration diagnostics",
         )

--- a/openzim_mcp/tools/structure_tools.py
+++ b/openzim_mcp/tools/structure_tools.py
@@ -1,12 +1,13 @@
 """Article structure and content analysis tools for OpenZIM MCP server."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Optional, cast
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union, cast
 
 from ..constants import INPUT_LIMIT_ENTRY_PATH, INPUT_LIMIT_FILE_PATH
 from ..exceptions import OpenZimMcpRateLimitError
-from ..responses import tool_error
+from ..responses import ToolErrorPayload, tool_error
 from ..security import sanitize_input
+from ..tool_schemas import LinksResponse
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
@@ -97,47 +98,83 @@ def _register_extract_article_links(server: "OpenZimMcpServer") -> None:
         entry_path: str,
         limit: int = 100,
         offset: int = 0,
-        kind: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        """Extract internal and external links from an article (paginated).
+        kind: str = "internal",
+        cursor: Optional[str] = None,
+    ) -> Union[LinksResponse, ToolErrorPayload]:
+        """Extract one category of links from an article (paginated).
 
-        Heavy articles (e.g. Wikipedia "Evolution") carry hundreds of links;
-        the response is paged per category to fit within MCP token budgets.
-        ``total_internal_links`` / ``total_external_links`` /
-        ``total_media_links`` always report the full counts so callers can
-        request the next page.
+        v2 BREAKING: each call returns a single category in ``results``.
+        ``kind`` is required-with-default (``"internal"``). To enumerate
+        every category, issue three calls with ``kind="internal"``,
+        ``kind="external"``, and ``kind="media"``. ``category_totals``
+        echoes counts for all three so callers can plan their fetches.
 
         Args:
             zim_file_path: Path to the ZIM file
             entry_path: Entry path, e.g., 'C/Some_Article'
-            limit: Max items per category in the response (1-500, default 100).
-            offset: Starting offset within each category (default 0).
-            kind: Optional filter — ``"internal"``, ``"external"``, or
-                ``"media"``. When set, the other categories are returned as
-                empty lists; their totals are still reported.
+            limit: Max items per page (1-500, default 100).
+            offset: Starting offset within the requested category (default 0).
+            kind: Which category — ``"internal"`` (default), ``"external"``,
+                or ``"media"``.
+            cursor: Opaque pagination token from a previous result's
+                ``next_cursor`` field. ``None`` starts from ``offset``.
 
         Returns:
-            Dict with paged links plus per-category totals and a
-            ``pagination`` block (``offset``, ``limit``, ``has_more``,
-            ``has_more_internal``, ``has_more_external``, ``has_more_media``,
-            ``kind``). On failure, returns a ``{"error": True, ...}``
-            envelope (see ``responses.tool_error``).
+            ``LinksResponse``-shaped dict on success (Phase B contract:
+            top-level ``results`` / ``next_cursor`` / ``total`` / ``done``
+            / ``page_info`` plus ``title`` / ``path`` / ``content_type`` /
+            ``kind`` / ``category_totals``); ``ToolErrorPayload`` envelope
+            on failure.
         """
         try:
+            # Phase B: cursor wins on conflict per response-contract spec.
+            if cursor is not None:
+                from ..pagination import Cursor, CursorMismatchError
+
+                try:
+                    decoded = Cursor.decode(
+                        cursor, expected_tool="extract_article_links"
+                    )
+                except CursorMismatchError as e:
+                    return tool_error(
+                        operation="extract article links",
+                        message=str(e),
+                        context="Tool: extract_article_links, cursor=<truncated>",
+                    )
+                except ValueError as e:
+                    return tool_error(
+                        operation="extract article links",
+                        message=f"Invalid pagination cursor: {e}",
+                        context="Tool: extract_article_links",
+                    )
+                state = decoded["s"]
+                offset = state["o"]
+                limit = state.get("l", limit)
+                entry_path = state.get("ep", entry_path)
+                kind = state.get("k", kind)
+
             try:
                 server.rate_limiter.check_rate_limit("get_structure")
             except OpenZimMcpRateLimitError as e:
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
+                return tool_error(
+                    operation="extract article links",
+                    message=server._create_enhanced_error_message(
                         operation="extract article links",
-                        message=server._create_enhanced_error_message(
-                            operation="extract article links",
-                            error=e,
-                            context=f"Entry: {entry_path}",
-                        ),
+                        error=e,
                         context=f"Entry: {entry_path}",
                     ),
+                    context=f"Entry: {entry_path}",
+                )
+
+            if kind not in ("internal", "external", "media"):
+                return tool_error(
+                    operation="extract article links",
+                    message=(
+                        "**Parameter Validation Error**\n\n"
+                        f"**Issue**: kind must be one of 'internal', "
+                        f"'external', 'media' (provided: {kind!r})"
+                    ),
+                    context=f"Entry: {entry_path}, kind: {kind!r}",
                 )
 
             zim_file_path = sanitize_input(zim_file_path, INPUT_LIMIT_FILE_PATH)
@@ -153,17 +190,14 @@ def _register_extract_article_links(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error extracting article links: {e}")
-            return cast(
-                Dict[str, Any],
-                tool_error(
+            return tool_error(
+                operation="extract article links",
+                message=server._create_enhanced_error_message(
                     operation="extract article links",
-                    message=server._create_enhanced_error_message(
-                        operation="extract article links",
-                        error=e,
-                        context=f"File: {zim_file_path}, Entry: {entry_path}",
-                    ),
+                    error=e,
                     context=f"File: {zim_file_path}, Entry: {entry_path}",
                 ),
+                context=f"File: {zim_file_path}, Entry: {entry_path}",
             )
 
 

--- a/openzim_mcp/tools/structure_tools.py
+++ b/openzim_mcp/tools/structure_tools.py
@@ -1,7 +1,7 @@
 """Article structure and content analysis tools for OpenZIM MCP server."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union, cast
+from typing import TYPE_CHECKING, Optional, Union
 
 from ..constants import INPUT_LIMIT_ENTRY_PATH, INPUT_LIMIT_FILE_PATH
 from ..exceptions import OpenZimMcpRateLimitError
@@ -10,6 +10,7 @@ from ..security import sanitize_input
 from ..tool_schemas import (
     ArticleStructureResponse,
     BinaryEntryResponse,
+    EntrySummaryResponse,
     LinksResponse,
     RelatedArticlesResponse,
     TableOfContentsResponse,
@@ -207,7 +208,7 @@ def _register_get_entry_summary(server: "OpenZimMcpServer") -> None:
         zim_file_path: str,
         entry_path: str,
         max_words: int = 200,
-    ) -> Dict[str, Any]:
+    ) -> Union[EntrySummaryResponse, ToolErrorPayload]:
         """Get a concise summary of an article without returning the full content.
 
         This tool extracts the opening paragraph(s) or introduction section,
@@ -220,14 +221,10 @@ def _register_get_entry_summary(server: "OpenZimMcpServer") -> None:
             max_words: Maximum number of words in the summary (default: 200, max: 1000)
 
         Returns:
-            Dict containing:
-            - title: Article title
-            - path: Entry path
-            - summary: Extracted summary text
-            - word_count: Number of words in summary
-            - is_truncated: Whether the summary was truncated
-
-            On failure, returns a ``{"error": True, ...}`` envelope (see
+            ``EntrySummaryResponse``-shaped dict with ``path``, ``title``,
+            ``summary``, optionally ``word_count``/``content_type``/
+            ``is_truncated``, plus the ``_meta`` envelope. On failure,
+            returns a ``ToolErrorPayload`` envelope (see
             ``responses.tool_error``).
 
         Examples:
@@ -238,37 +235,31 @@ def _register_get_entry_summary(server: "OpenZimMcpServer") -> None:
             try:
                 server.rate_limiter.check_rate_limit("get_entry")
             except OpenZimMcpRateLimitError as e:
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
+                return tool_error(
+                    operation="get entry summary",
+                    message=server._create_enhanced_error_message(
                         operation="get entry summary",
-                        message=server._create_enhanced_error_message(
-                            operation="get entry summary",
-                            error=e,
-                            context=f"Entry: {entry_path}",
-                        ),
+                        error=e,
                         context=f"Entry: {entry_path}",
                     ),
+                    context=f"Entry: {entry_path}",
                 )
 
             zim_file_path = sanitize_input(zim_file_path, INPUT_LIMIT_FILE_PATH)
             entry_path = sanitize_input(entry_path, INPUT_LIMIT_ENTRY_PATH)
 
             if max_words < 1 or max_words > 1000:
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
-                        operation="get entry summary",
-                        message=(
-                            "**Parameter Validation Error**\n\n"
-                            f"**Issue**: max_words must be between 1 and 1000 "
-                            f"(provided: {max_words})\n\n"
-                            "**Troubleshooting**: Adjust max_words to a value within "
-                            "the valid range.\n"
-                            "**Example**: Use `max_words=200` for a typical summary."
-                        ),
-                        context=f"Entry: {entry_path}, max_words: {max_words}",
+                return tool_error(
+                    operation="get entry summary",
+                    message=(
+                        "**Parameter Validation Error**\n\n"
+                        f"**Issue**: max_words must be between 1 and 1000 "
+                        f"(provided: {max_words})\n\n"
+                        "**Troubleshooting**: Adjust max_words to a value within "
+                        "the valid range.\n"
+                        "**Example**: Use `max_words=200` for a typical summary."
                     ),
+                    context=f"Entry: {entry_path}, max_words: {max_words}",
                 )
 
             return await server.async_zim_operations.get_entry_summary_data(
@@ -277,17 +268,14 @@ def _register_get_entry_summary(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error getting entry summary: {e}")
-            return cast(
-                Dict[str, Any],
-                tool_error(
+            return tool_error(
+                operation="get entry summary",
+                message=server._create_enhanced_error_message(
                     operation="get entry summary",
-                    message=server._create_enhanced_error_message(
-                        operation="get entry summary",
-                        error=e,
-                        context=f"File: {zim_file_path}, Entry: {entry_path}",
-                    ),
+                    error=e,
                     context=f"File: {zim_file_path}, Entry: {entry_path}",
                 ),
+                context=f"File: {zim_file_path}, Entry: {entry_path}",
             )
 
 

--- a/openzim_mcp/tools/structure_tools.py
+++ b/openzim_mcp/tools/structure_tools.py
@@ -423,9 +423,7 @@ def _register_get_binary_entry(server: "OpenZimMcpServer") -> None:
                         "chunks via repeated calls or use include_data=False to "
                         "fetch metadata only."
                     ),
-                    context=(
-                        f"Entry: {entry_path}, max_size_bytes: {max_size_bytes}"
-                    ),
+                    context=(f"Entry: {entry_path}, max_size_bytes: {max_size_bytes}"),
                 )
 
             zim_file_path = sanitize_input(zim_file_path, INPUT_LIMIT_FILE_PATH)

--- a/openzim_mcp/tools/structure_tools.py
+++ b/openzim_mcp/tools/structure_tools.py
@@ -7,7 +7,7 @@ from ..constants import INPUT_LIMIT_ENTRY_PATH, INPUT_LIMIT_FILE_PATH
 from ..exceptions import OpenZimMcpRateLimitError
 from ..responses import ToolErrorPayload, tool_error
 from ..security import sanitize_input
-from ..tool_schemas import LinksResponse, TableOfContentsResponse
+from ..tool_schemas import ArticleStructureResponse, LinksResponse, TableOfContentsResponse
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
@@ -34,7 +34,7 @@ def _register_get_article_structure(server: "OpenZimMcpServer") -> None:
     @server.mcp.tool()
     async def get_article_structure(
         zim_file_path: str, entry_path: str
-    ) -> Dict[str, Any]:
+    ) -> Union[ArticleStructureResponse, ToolErrorPayload]:
         """Extract article structure including headings, sections, and key metadata.
 
         Note: depends on heading markup in the source HTML. ZIM builds with
@@ -55,17 +55,14 @@ def _register_get_article_structure(server: "OpenZimMcpServer") -> None:
             try:
                 server.rate_limiter.check_rate_limit("get_structure")
             except OpenZimMcpRateLimitError as e:
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
+                return tool_error(
+                    operation="get article structure",
+                    message=server._create_enhanced_error_message(
                         operation="get article structure",
-                        message=server._create_enhanced_error_message(
-                            operation="get article structure",
-                            error=e,
-                            context=f"Entry: {entry_path}",
-                        ),
+                        error=e,
                         context=f"Entry: {entry_path}",
                     ),
+                    context=f"Entry: {entry_path}",
                 )
 
             zim_file_path = sanitize_input(zim_file_path, INPUT_LIMIT_FILE_PATH)
@@ -77,17 +74,14 @@ def _register_get_article_structure(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error getting article structure: {e}")
-            return cast(
-                Dict[str, Any],
-                tool_error(
+            return tool_error(
+                operation="get article structure",
+                message=server._create_enhanced_error_message(
                     operation="get article structure",
-                    message=server._create_enhanced_error_message(
-                        operation="get article structure",
-                        error=e,
-                        context=f"File: {zim_file_path}, Entry: {entry_path}",
-                    ),
+                    error=e,
                     context=f"File: {zim_file_path}, Entry: {entry_path}",
                 ),
+                context=f"File: {zim_file_path}, Entry: {entry_path}",
             )
 
 

--- a/openzim_mcp/tools/structure_tools.py
+++ b/openzim_mcp/tools/structure_tools.py
@@ -11,6 +11,7 @@ from ..tool_schemas import (
     ArticleStructureResponse,
     BinaryEntryResponse,
     LinksResponse,
+    RelatedArticlesResponse,
     TableOfContentsResponse,
 )
 
@@ -465,7 +466,7 @@ def _register_get_related_articles(server: "OpenZimMcpServer") -> None:
         zim_file_path: str,
         entry_path: str,
         limit: int = 10,
-    ) -> Dict[str, Any]:
+    ) -> Union[RelatedArticlesResponse, ToolErrorPayload]:
         """Find articles related to entry_path via outbound links.
 
         Composes extract_article_links and deduplicates internal links,
@@ -473,36 +474,40 @@ def _register_get_related_articles(server: "OpenZimMcpServer") -> None:
         removed — it required a bounded full-archive scan that was too
         expensive for interactive use; reach for full-text search instead.)
 
+        v2 BREAKING: ``outbound_results`` renamed to ``results``.
+        Anticipates Phase E inbound-link feature where ``direction`` becomes
+        a parameter; the ``results`` field then covers either side.
+
         Args:
             zim_file_path: Path to the ZIM file
             entry_path: Source entry, e.g. 'C/Some_Article'
             limit: Max results (1-100, default: 10)
 
         Returns:
-            Dict with ``entry_path`` and ``outbound_results`` (a list of
-            ``{path, title, link_text}`` records). ``title`` is the linked
-            entry's actual archive title (resolved by archive lookup;
-            falls back to ``path`` when the entry is missing). ``link_text``
-            is the original anchor text from the source article — useful
-            when the source article links to the target with a different
-            display string. On failure, returns a ``{"error": True, ...}``
-            envelope (see ``responses.tool_error``).
+            ``RelatedArticlesResponse``-shaped dict on success (Phase B
+            contract: top-level ``results`` / ``next_cursor`` / ``total``
+            / ``done`` / ``page_info`` plus tool-specific ``entry_path``;
+            ``outbound_error`` set on partial-success). ``results`` is a
+            list of ``{path, title, link_text}`` records. ``title`` is the
+            linked entry's actual archive title (resolved by archive
+            lookup; falls back to ``path`` when the entry is missing).
+            ``link_text`` is the original anchor text from the source
+            article — useful when the source links to the target with a
+            different display string. On failure, returns a
+            ``ToolErrorPayload`` envelope (see ``responses.tool_error``).
         """
         try:
             try:
                 server.rate_limiter.check_rate_limit("get_related_articles")
             except OpenZimMcpRateLimitError as e:
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
+                return tool_error(
+                    operation="get related articles",
+                    message=server._create_enhanced_error_message(
                         operation="get related articles",
-                        message=server._create_enhanced_error_message(
-                            operation="get related articles",
-                            error=e,
-                            context=f"Entry: {entry_path}",
-                        ),
+                        error=e,
                         context=f"Entry: {entry_path}",
                     ),
+                    context=f"Entry: {entry_path}",
                 )
 
             zim_file_path = sanitize_input(zim_file_path, INPUT_LIMIT_FILE_PATH)
@@ -516,15 +521,12 @@ def _register_get_related_articles(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error in get_related_articles: {e}")
-            return cast(
-                Dict[str, Any],
-                tool_error(
+            return tool_error(
+                operation="get related articles",
+                message=server._create_enhanced_error_message(
                     operation="get related articles",
-                    message=server._create_enhanced_error_message(
-                        operation="get related articles",
-                        error=e,
-                        context=f"File: {zim_file_path}, Entry: {entry_path}",
-                    ),
+                    error=e,
                     context=f"File: {zim_file_path}, Entry: {entry_path}",
                 ),
+                context=f"File: {zim_file_path}, Entry: {entry_path}",
             )

--- a/openzim_mcp/tools/structure_tools.py
+++ b/openzim_mcp/tools/structure_tools.py
@@ -1,7 +1,7 @@
 """Article structure and content analysis tools for OpenZIM MCP server."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional, cast
 
 from ..constants import INPUT_LIMIT_ENTRY_PATH, INPUT_LIMIT_FILE_PATH
 from ..exceptions import OpenZimMcpRateLimitError
@@ -54,14 +54,17 @@ def _register_get_article_structure(server: "OpenZimMcpServer") -> None:
             try:
                 server.rate_limiter.check_rate_limit("get_structure")
             except OpenZimMcpRateLimitError as e:
-                return tool_error(
-                    operation="get article structure",
-                    message=server._create_enhanced_error_message(
+                return cast(
+                    Dict[str, Any],
+                    tool_error(
                         operation="get article structure",
-                        error=e,
+                        message=server._create_enhanced_error_message(
+                            operation="get article structure",
+                            error=e,
+                            context=f"Entry: {entry_path}",
+                        ),
                         context=f"Entry: {entry_path}",
                     ),
-                    context=f"Entry: {entry_path}",
                 )
 
             zim_file_path = sanitize_input(zim_file_path, INPUT_LIMIT_FILE_PATH)
@@ -73,14 +76,17 @@ def _register_get_article_structure(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error getting article structure: {e}")
-            return tool_error(
-                operation="get article structure",
-                message=server._create_enhanced_error_message(
+            return cast(
+                Dict[str, Any],
+                tool_error(
                     operation="get article structure",
-                    error=e,
+                    message=server._create_enhanced_error_message(
+                        operation="get article structure",
+                        error=e,
+                        context=f"File: {zim_file_path}, Entry: {entry_path}",
+                    ),
                     context=f"File: {zim_file_path}, Entry: {entry_path}",
                 ),
-                context=f"File: {zim_file_path}, Entry: {entry_path}",
             )
 
 
@@ -121,14 +127,17 @@ def _register_extract_article_links(server: "OpenZimMcpServer") -> None:
             try:
                 server.rate_limiter.check_rate_limit("get_structure")
             except OpenZimMcpRateLimitError as e:
-                return tool_error(
-                    operation="extract article links",
-                    message=server._create_enhanced_error_message(
+                return cast(
+                    Dict[str, Any],
+                    tool_error(
                         operation="extract article links",
-                        error=e,
+                        message=server._create_enhanced_error_message(
+                            operation="extract article links",
+                            error=e,
+                            context=f"Entry: {entry_path}",
+                        ),
                         context=f"Entry: {entry_path}",
                     ),
-                    context=f"Entry: {entry_path}",
                 )
 
             zim_file_path = sanitize_input(zim_file_path, INPUT_LIMIT_FILE_PATH)
@@ -144,14 +153,17 @@ def _register_extract_article_links(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error extracting article links: {e}")
-            return tool_error(
-                operation="extract article links",
-                message=server._create_enhanced_error_message(
+            return cast(
+                Dict[str, Any],
+                tool_error(
                     operation="extract article links",
-                    error=e,
+                    message=server._create_enhanced_error_message(
+                        operation="extract article links",
+                        error=e,
+                        context=f"File: {zim_file_path}, Entry: {entry_path}",
+                    ),
                     context=f"File: {zim_file_path}, Entry: {entry_path}",
                 ),
-                context=f"File: {zim_file_path}, Entry: {entry_path}",
             )
 
 
@@ -192,31 +204,37 @@ def _register_get_entry_summary(server: "OpenZimMcpServer") -> None:
             try:
                 server.rate_limiter.check_rate_limit("get_entry")
             except OpenZimMcpRateLimitError as e:
-                return tool_error(
-                    operation="get entry summary",
-                    message=server._create_enhanced_error_message(
+                return cast(
+                    Dict[str, Any],
+                    tool_error(
                         operation="get entry summary",
-                        error=e,
+                        message=server._create_enhanced_error_message(
+                            operation="get entry summary",
+                            error=e,
+                            context=f"Entry: {entry_path}",
+                        ),
                         context=f"Entry: {entry_path}",
                     ),
-                    context=f"Entry: {entry_path}",
                 )
 
             zim_file_path = sanitize_input(zim_file_path, INPUT_LIMIT_FILE_PATH)
             entry_path = sanitize_input(entry_path, INPUT_LIMIT_ENTRY_PATH)
 
             if max_words < 1 or max_words > 1000:
-                return tool_error(
-                    operation="get entry summary",
-                    message=(
-                        "**Parameter Validation Error**\n\n"
-                        f"**Issue**: max_words must be between 1 and 1000 "
-                        f"(provided: {max_words})\n\n"
-                        "**Troubleshooting**: Adjust max_words to a value within "
-                        "the valid range.\n"
-                        "**Example**: Use `max_words=200` for a typical summary."
+                return cast(
+                    Dict[str, Any],
+                    tool_error(
+                        operation="get entry summary",
+                        message=(
+                            "**Parameter Validation Error**\n\n"
+                            f"**Issue**: max_words must be between 1 and 1000 "
+                            f"(provided: {max_words})\n\n"
+                            "**Troubleshooting**: Adjust max_words to a value within "
+                            "the valid range.\n"
+                            "**Example**: Use `max_words=200` for a typical summary."
+                        ),
+                        context=f"Entry: {entry_path}, max_words: {max_words}",
                     ),
-                    context=f"Entry: {entry_path}, max_words: {max_words}",
                 )
 
             return await server.async_zim_operations.get_entry_summary_data(
@@ -225,14 +243,17 @@ def _register_get_entry_summary(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error getting entry summary: {e}")
-            return tool_error(
-                operation="get entry summary",
-                message=server._create_enhanced_error_message(
+            return cast(
+                Dict[str, Any],
+                tool_error(
                     operation="get entry summary",
-                    error=e,
+                    message=server._create_enhanced_error_message(
+                        operation="get entry summary",
+                        error=e,
+                        context=f"File: {zim_file_path}, Entry: {entry_path}",
+                    ),
                     context=f"File: {zim_file_path}, Entry: {entry_path}",
                 ),
-                context=f"File: {zim_file_path}, Entry: {entry_path}",
             )
 
 
@@ -281,14 +302,17 @@ def _register_get_table_of_contents(server: "OpenZimMcpServer") -> None:
             try:
                 server.rate_limiter.check_rate_limit("get_structure")
             except OpenZimMcpRateLimitError as e:
-                return tool_error(
-                    operation="get table of contents",
-                    message=server._create_enhanced_error_message(
+                return cast(
+                    Dict[str, Any],
+                    tool_error(
                         operation="get table of contents",
-                        error=e,
+                        message=server._create_enhanced_error_message(
+                            operation="get table of contents",
+                            error=e,
+                            context=f"Entry: {entry_path}",
+                        ),
                         context=f"Entry: {entry_path}",
                     ),
-                    context=f"Entry: {entry_path}",
                 )
 
             zim_file_path = sanitize_input(zim_file_path, INPUT_LIMIT_FILE_PATH)
@@ -300,14 +324,17 @@ def _register_get_table_of_contents(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error getting table of contents: {e}")
-            return tool_error(
-                operation="get table of contents",
-                message=server._create_enhanced_error_message(
+            return cast(
+                Dict[str, Any],
+                tool_error(
                     operation="get table of contents",
-                    error=e,
+                    message=server._create_enhanced_error_message(
+                        operation="get table of contents",
+                        error=e,
+                        context=f"File: {zim_file_path}, Entry: {entry_path}",
+                    ),
                     context=f"File: {zim_file_path}, Entry: {entry_path}",
                 ),
-                context=f"File: {zim_file_path}, Entry: {entry_path}",
             )
 
 
@@ -356,31 +383,39 @@ def _register_get_binary_entry(server: "OpenZimMcpServer") -> None:
             try:
                 server.rate_limiter.check_rate_limit("get_binary_entry")
             except OpenZimMcpRateLimitError as e:
-                return tool_error(
-                    operation="retrieve binary entry",
-                    message=server._create_enhanced_error_message(
+                return cast(
+                    Dict[str, Any],
+                    tool_error(
                         operation="retrieve binary entry",
-                        error=e,
+                        message=server._create_enhanced_error_message(
+                            operation="retrieve binary entry",
+                            error=e,
+                            context=f"Entry: {entry_path}",
+                        ),
                         context=f"Entry: {entry_path}",
                     ),
-                    context=f"Entry: {entry_path}",
                 )
 
             if max_size_bytes is not None and (
                 max_size_bytes < 1 or max_size_bytes > _MAX_BINARY_LIMIT
             ):
-                return tool_error(
-                    operation="retrieve binary entry",
-                    message=(
-                        "**Parameter Validation Error**\n\n"
-                        f"**Issue**: max_size_bytes must be between 1 and "
-                        f"{_MAX_BINARY_LIMIT} bytes (100 MB), got "
-                        f"{max_size_bytes}.\n"
-                        "**Tip**: For larger entries, retrieve the entry in "
-                        "chunks via repeated calls or use include_data=False to "
-                        "fetch metadata only."
+                return cast(
+                    Dict[str, Any],
+                    tool_error(
+                        operation="retrieve binary entry",
+                        message=(
+                            "**Parameter Validation Error**\n\n"
+                            f"**Issue**: max_size_bytes must be between 1 and "
+                            f"{_MAX_BINARY_LIMIT} bytes (100 MB), got "
+                            f"{max_size_bytes}.\n"
+                            "**Tip**: For larger entries, retrieve the entry in "
+                            "chunks via repeated calls or use include_data=False to "
+                            "fetch metadata only."
+                        ),
+                        context=(
+                            f"Entry: {entry_path}, max_size_bytes: {max_size_bytes}"
+                        ),
                     ),
-                    context=f"Entry: {entry_path}, max_size_bytes: {max_size_bytes}",
                 )
 
             zim_file_path = sanitize_input(zim_file_path, INPUT_LIMIT_FILE_PATH)
@@ -392,14 +427,17 @@ def _register_get_binary_entry(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error retrieving binary entry: {e}")
-            return tool_error(
-                operation="retrieve binary entry",
-                message=server._create_enhanced_error_message(
+            return cast(
+                Dict[str, Any],
+                tool_error(
                     operation="retrieve binary entry",
-                    error=e,
+                    message=server._create_enhanced_error_message(
+                        operation="retrieve binary entry",
+                        error=e,
+                        context=f"File: {zim_file_path}, Entry: {entry_path}",
+                    ),
                     context=f"File: {zim_file_path}, Entry: {entry_path}",
                 ),
-                context=f"File: {zim_file_path}, Entry: {entry_path}",
             )
 
 
@@ -436,14 +474,17 @@ def _register_get_related_articles(server: "OpenZimMcpServer") -> None:
             try:
                 server.rate_limiter.check_rate_limit("get_related_articles")
             except OpenZimMcpRateLimitError as e:
-                return tool_error(
-                    operation="get related articles",
-                    message=server._create_enhanced_error_message(
+                return cast(
+                    Dict[str, Any],
+                    tool_error(
                         operation="get related articles",
-                        error=e,
+                        message=server._create_enhanced_error_message(
+                            operation="get related articles",
+                            error=e,
+                            context=f"Entry: {entry_path}",
+                        ),
                         context=f"Entry: {entry_path}",
                     ),
-                    context=f"Entry: {entry_path}",
                 )
 
             zim_file_path = sanitize_input(zim_file_path, INPUT_LIMIT_FILE_PATH)
@@ -457,12 +498,15 @@ def _register_get_related_articles(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error in get_related_articles: {e}")
-            return tool_error(
-                operation="get related articles",
-                message=server._create_enhanced_error_message(
+            return cast(
+                Dict[str, Any],
+                tool_error(
                     operation="get related articles",
-                    error=e,
+                    message=server._create_enhanced_error_message(
+                        operation="get related articles",
+                        error=e,
+                        context=f"File: {zim_file_path}, Entry: {entry_path}",
+                    ),
                     context=f"File: {zim_file_path}, Entry: {entry_path}",
                 ),
-                context=f"File: {zim_file_path}, Entry: {entry_path}",
             )

--- a/openzim_mcp/tools/structure_tools.py
+++ b/openzim_mcp/tools/structure_tools.py
@@ -7,7 +7,7 @@ from ..constants import INPUT_LIMIT_ENTRY_PATH, INPUT_LIMIT_FILE_PATH
 from ..exceptions import OpenZimMcpRateLimitError
 from ..responses import ToolErrorPayload, tool_error
 from ..security import sanitize_input
-from ..tool_schemas import LinksResponse
+from ..tool_schemas import LinksResponse, TableOfContentsResponse
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
@@ -296,7 +296,7 @@ def _register_get_table_of_contents(server: "OpenZimMcpServer") -> None:
     async def get_table_of_contents(
         zim_file_path: str,
         entry_path: str,
-    ) -> Dict[str, Any]:
+    ) -> Union[TableOfContentsResponse, ToolErrorPayload]:
         """Extract a hierarchical table of contents from an article.
 
         Returns a structured TOC tree based on heading levels (h1-h6),
@@ -336,17 +336,14 @@ def _register_get_table_of_contents(server: "OpenZimMcpServer") -> None:
             try:
                 server.rate_limiter.check_rate_limit("get_structure")
             except OpenZimMcpRateLimitError as e:
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
+                return tool_error(
+                    operation="get table of contents",
+                    message=server._create_enhanced_error_message(
                         operation="get table of contents",
-                        message=server._create_enhanced_error_message(
-                            operation="get table of contents",
-                            error=e,
-                            context=f"Entry: {entry_path}",
-                        ),
+                        error=e,
                         context=f"Entry: {entry_path}",
                     ),
+                    context=f"Entry: {entry_path}",
                 )
 
             zim_file_path = sanitize_input(zim_file_path, INPUT_LIMIT_FILE_PATH)
@@ -358,17 +355,14 @@ def _register_get_table_of_contents(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error getting table of contents: {e}")
-            return cast(
-                Dict[str, Any],
-                tool_error(
+            return tool_error(
+                operation="get table of contents",
+                message=server._create_enhanced_error_message(
                     operation="get table of contents",
-                    message=server._create_enhanced_error_message(
-                        operation="get table of contents",
-                        error=e,
-                        context=f"File: {zim_file_path}, Entry: {entry_path}",
-                    ),
+                    error=e,
                     context=f"File: {zim_file_path}, Entry: {entry_path}",
                 ),
+                context=f"File: {zim_file_path}, Entry: {entry_path}",
             )
 
 

--- a/openzim_mcp/tools/structure_tools.py
+++ b/openzim_mcp/tools/structure_tools.py
@@ -7,7 +7,12 @@ from ..constants import INPUT_LIMIT_ENTRY_PATH, INPUT_LIMIT_FILE_PATH
 from ..exceptions import OpenZimMcpRateLimitError
 from ..responses import ToolErrorPayload, tool_error
 from ..security import sanitize_input
-from ..tool_schemas import ArticleStructureResponse, LinksResponse, TableOfContentsResponse
+from ..tool_schemas import (
+    ArticleStructureResponse,
+    BinaryEntryResponse,
+    LinksResponse,
+    TableOfContentsResponse,
+)
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
@@ -367,7 +372,7 @@ def _register_get_binary_entry(server: "OpenZimMcpServer") -> None:
         entry_path: str,
         max_size_bytes: Optional[int] = None,
         include_data: bool = True,
-    ) -> Dict[str, Any]:
+    ) -> Union[BinaryEntryResponse, ToolErrorPayload]:
         """Retrieve binary content from a ZIM entry.
 
         This tool returns raw binary content encoded in base64, enabling
@@ -405,38 +410,32 @@ def _register_get_binary_entry(server: "OpenZimMcpServer") -> None:
             try:
                 server.rate_limiter.check_rate_limit("get_binary_entry")
             except OpenZimMcpRateLimitError as e:
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
+                return tool_error(
+                    operation="retrieve binary entry",
+                    message=server._create_enhanced_error_message(
                         operation="retrieve binary entry",
-                        message=server._create_enhanced_error_message(
-                            operation="retrieve binary entry",
-                            error=e,
-                            context=f"Entry: {entry_path}",
-                        ),
+                        error=e,
                         context=f"Entry: {entry_path}",
                     ),
+                    context=f"Entry: {entry_path}",
                 )
 
             if max_size_bytes is not None and (
                 max_size_bytes < 1 or max_size_bytes > _MAX_BINARY_LIMIT
             ):
-                return cast(
-                    Dict[str, Any],
-                    tool_error(
-                        operation="retrieve binary entry",
-                        message=(
-                            "**Parameter Validation Error**\n\n"
-                            f"**Issue**: max_size_bytes must be between 1 and "
-                            f"{_MAX_BINARY_LIMIT} bytes (100 MB), got "
-                            f"{max_size_bytes}.\n"
-                            "**Tip**: For larger entries, retrieve the entry in "
-                            "chunks via repeated calls or use include_data=False to "
-                            "fetch metadata only."
-                        ),
-                        context=(
-                            f"Entry: {entry_path}, max_size_bytes: {max_size_bytes}"
-                        ),
+                return tool_error(
+                    operation="retrieve binary entry",
+                    message=(
+                        "**Parameter Validation Error**\n\n"
+                        f"**Issue**: max_size_bytes must be between 1 and "
+                        f"{_MAX_BINARY_LIMIT} bytes (100 MB), got "
+                        f"{max_size_bytes}.\n"
+                        "**Tip**: For larger entries, retrieve the entry in "
+                        "chunks via repeated calls or use include_data=False to "
+                        "fetch metadata only."
+                    ),
+                    context=(
+                        f"Entry: {entry_path}, max_size_bytes: {max_size_bytes}"
                     ),
                 )
 
@@ -449,17 +448,14 @@ def _register_get_binary_entry(server: "OpenZimMcpServer") -> None:
 
         except Exception as e:
             logger.error(f"Error retrieving binary entry: {e}")
-            return cast(
-                Dict[str, Any],
-                tool_error(
+            return tool_error(
+                operation="retrieve binary entry",
+                message=server._create_enhanced_error_message(
                     operation="retrieve binary entry",
-                    message=server._create_enhanced_error_message(
-                        operation="retrieve binary entry",
-                        error=e,
-                        context=f"File: {zim_file_path}, Entry: {entry_path}",
-                    ),
+                    error=e,
                     context=f"File: {zim_file_path}, Entry: {entry_path}",
                 ),
+                context=f"File: {zim_file_path}, Entry: {entry_path}",
             )
 
 

--- a/openzim_mcp/zim/__init__.py
+++ b/openzim_mcp/zim/__init__.py
@@ -8,7 +8,6 @@ shim). The shim re-exports everything below.
 from openzim_mcp.zim.archive import (  # noqa: F401
     ARCHIVE_OPEN_TIMEOUT,
     MAX_REDIRECT_DEPTH,
-    PaginationCursor,
     ZimOperations,
     zim_archive,
 )
@@ -16,7 +15,6 @@ from openzim_mcp.zim.archive import (  # noqa: F401
 __all__ = [
     "ARCHIVE_OPEN_TIMEOUT",
     "MAX_REDIRECT_DEPTH",
-    "PaginationCursor",
     "ZimOperations",
     "zim_archive",
 ]

--- a/openzim_mcp/zim/archive.py
+++ b/openzim_mcp/zim/archive.py
@@ -242,8 +242,11 @@ class ZimOperations(_SearchMixin, _ContentMixin, _StructureMixin, _NamespaceMixi
             List of dictionaries containing ZIM file information.
             Each dict has: name, path, directory, size, size_bytes, modified
         """
-        # Cache key bumped to v2b (Phase B) so v1.x cached responses (old
-        # shape: files/count keys) don't leak through after the upgrade.
+        # Cache key bumped to v2b (Phase B) so v1.x cached per-file list
+        # entries don't leak through if the inner shape ever drifts. Today
+        # the per-file dict shape (name/path/directory/size/size_bytes/
+        # modified) is unchanged; the v2b rename happens one layer up in
+        # ``list_zim_files_summary_data`` (files→results, count→total).
         cache_key = "zim_files_list_data_v2b"
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:

--- a/openzim_mcp/zim/archive.py
+++ b/openzim_mcp/zim/archive.py
@@ -242,7 +242,9 @@ class ZimOperations(_SearchMixin, _ContentMixin, _StructureMixin, _NamespaceMixi
             List of dictionaries containing ZIM file information.
             Each dict has: name, path, directory, size, size_bytes, modified
         """
-        cache_key = "zim_files_list_data"
+        # Cache key bumped to v2b (Phase B) so v1.x cached responses (old
+        # shape: files/count keys) don't leak through after the upgrade.
+        cache_key = "zim_files_list_data_v2b"
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug("Returning cached ZIM files list data")

--- a/openzim_mcp/zim/archive.py
+++ b/openzim_mcp/zim/archive.py
@@ -26,7 +26,7 @@ import logging
 from contextlib import contextmanager, suppress
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Generator, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Tuple, cast
 
 from libzim.reader import Archive  # type: ignore[import-untyped]
 from libzim.search import (  # type: ignore[import-untyped]
@@ -53,6 +53,9 @@ from openzim_mcp.zim.content import _ContentMixin
 from openzim_mcp.zim.namespace import _NamespaceMixin
 from openzim_mcp.zim.search import _SearchMixin
 from openzim_mcp.zim.structure import _StructureMixin
+
+if TYPE_CHECKING:
+    from openzim_mcp.tool_schemas import ZimMetadataResponse
 
 __all__ = [
     "ARCHIVE_OPEN_TIMEOUT",
@@ -373,7 +376,7 @@ class ZimOperations(_SearchMixin, _ContentMixin, _StructureMixin, _NamespaceMixi
         result_text += json.dumps(all_zim_files, indent=2, ensure_ascii=False)
         return result_text
 
-    def get_zim_metadata_data(self, zim_file_path: str) -> Dict[str, Any]:
+    def get_zim_metadata_data(self, zim_file_path: str) -> "ZimMetadataResponse":
         """Structured variant of ``get_zim_metadata``.
 
         Returns the metadata dict directly (not a JSON string) so MCP
@@ -395,7 +398,7 @@ class ZimOperations(_SearchMixin, _ContentMixin, _StructureMixin, _NamespaceMixi
             logger.debug(f"Returning cached metadata dict for: {validated_path}")
             if "_meta" not in cached_result:
                 cached_result = attach_meta(dict(cached_result))
-            return cached_result  # type: ignore[no-any-return]
+            return cast("ZimMetadataResponse", cached_result)
 
         # Late-bound lookup so test patches against
         # ``openzim_mcp.zim_operations.zim_archive`` apply here too.
@@ -408,7 +411,7 @@ class ZimOperations(_SearchMixin, _ContentMixin, _StructureMixin, _NamespaceMixi
             # Cache the result
             self.cache.set(cache_key, metadata)
             logger.info(f"Retrieved metadata for: {validated_path}")
-            return attach_meta(metadata)
+            return cast("ZimMetadataResponse", attach_meta(metadata))
 
         except Exception as e:
             logger.error(f"Metadata retrieval failed for {validated_path}: {e}")

--- a/openzim_mcp/zim/archive.py
+++ b/openzim_mcp/zim/archive.py
@@ -12,8 +12,6 @@ Layout:
 
 * ``zim_archive`` — context manager that opens an archive with a timeout
   and surfaces a consistent error type.
-* ``PaginationCursor`` — base64-encoded pagination tokens used across the
-  search/browse surfaces.
 * ``ZimOperations`` — coordinator class that mixes in
   ``_SearchMixin``/``_ContentMixin``/``_StructureMixin``/``_NamespaceMixin``
   for the bulk of the surface. Methods that don't fit a single domain
@@ -65,7 +63,6 @@ __all__ = [
     "ARCHIVE_OPEN_TIMEOUT",
     "Archive",
     "MAX_REDIRECT_DEPTH",
-    "PaginationCursor",
     "Query",
     "Searcher",
     "SuggestionSearcher",
@@ -80,73 +77,6 @@ ARCHIVE_OPEN_TIMEOUT = 30.0
 # Maximum redirect chain length before bailing out. See
 # ``ContentDefaults.MAX_REDIRECT_DEPTH`` in ``defaults.py``.
 MAX_REDIRECT_DEPTH = CONTENT.MAX_REDIRECT_DEPTH
-
-
-class PaginationCursor:
-    """Compatibility shim over ``openzim_mcp.pagination.Cursor``.
-
-    v1.x callers used ``PaginationCursor.create_next_cursor`` and
-    ``PaginationCursor.decode`` with no tool identity. v2 Phase B migrates
-    each caller to ``openzim_mcp.pagination.Cursor`` (tool-bound). Until
-    every caller has been migrated, this shim emits cursors with
-    ``t="legacy"`` and a permissive decoder that accepts both legacy
-    cursors and the new Phase B cursors.
-
-    Removed at the end of Phase B (see plan Task 22).
-    """
-
-    @staticmethod
-    def _encode(offset: int, limit: int, query: Optional[str] = None) -> str:
-        """Encode pagination state into a base64 cursor token (legacy shape)."""
-        from openzim_mcp.pagination import Cursor, CursorState
-
-        state: CursorState = {"o": offset, "l": limit}
-        if query:
-            state["q"] = query
-        return Cursor.encode(tool="legacy", state=state)
-
-    @staticmethod
-    def create_next_cursor(
-        current_offset: int, limit: int, total: int, query: Optional[str] = None
-    ) -> Optional[str]:
-        next_offset = current_offset + limit
-        if next_offset >= total:
-            return None
-        return PaginationCursor._encode(next_offset, limit, query)
-
-    @staticmethod
-    def decode(token: str) -> dict[str, Any]:
-        """Decode a legacy (or new) cursor into the legacy ``{o, l, q?}`` shape.
-
-        Tolerates both v1 cursors (raw JSON without the v/t/s envelope) and
-        v2 cursors (tool-bound, versioned). Raises ``ValueError`` on malformed
-        tokens.
-        """
-        import base64
-        import json
-
-        try:
-            padded = token + "=" * (-len(token) % 4)
-            raw = base64.urlsafe_b64decode(padded.encode()).decode()
-            data = json.loads(raw)
-        except Exception as e:
-            raise ValueError(f"Invalid pagination cursor: {e}") from e
-        if not isinstance(data, dict):
-            raise ValueError("Cursor must decode to a JSON object")
-        # v2 envelope: {v, t, s} — return s as the legacy shape.
-        if "s" in data and "v" in data and "t" in data:
-            inner = data["s"]
-            if not isinstance(inner, dict) or "o" not in inner or "l" not in inner:
-                raise ValueError("Cursor missing required fields ('o', 'l')")
-            if not isinstance(inner["o"], int) or not isinstance(inner["l"], int):
-                raise ValueError("Cursor offset and limit must be integers")
-            return inner
-        # v1 raw shape.
-        if "o" not in data or "l" not in data:
-            raise ValueError("Cursor missing required fields ('o', 'l')")
-        if not isinstance(data["o"], int) or not isinstance(data["l"], int):
-            raise ValueError("Cursor offset and limit must be integers")
-        return data
 
 
 logger = logging.getLogger(__name__)

--- a/openzim_mcp/zim/archive.py
+++ b/openzim_mcp/zim/archive.py
@@ -91,9 +91,9 @@ class PaginationCursor:
     @staticmethod
     def _encode(offset: int, limit: int, query: Optional[str] = None) -> str:
         """Encode pagination state into a base64 cursor token (legacy shape)."""
-        from openzim_mcp.pagination import Cursor
+        from openzim_mcp.pagination import Cursor, CursorState
 
-        state: dict[str, Any] = {"o": offset, "l": limit}
+        state: CursorState = {"o": offset, "l": limit}
         if query:
             state["q"] = query
         return Cursor.encode(tool="legacy", state=state)

--- a/openzim_mcp/zim/archive.py
+++ b/openzim_mcp/zim/archive.py
@@ -21,7 +21,6 @@ Layout:
   the class here.
 """
 
-import base64
 import json
 import logging
 from contextlib import contextmanager, suppress
@@ -77,65 +76,66 @@ MAX_REDIRECT_DEPTH = CONTENT.MAX_REDIRECT_DEPTH
 
 
 class PaginationCursor:
-    """Utility class for creating and parsing pagination cursors.
+    """Compatibility shim over ``openzim_mcp.pagination.Cursor``.
 
-    Cursors encode pagination state as base64 tokens, making it easy for
-    clients to continue from where they left off without tracking offset manually.
+    v1.x callers used ``PaginationCursor.create_next_cursor`` and
+    ``PaginationCursor.decode`` with no tool identity. v2 Phase B migrates
+    each caller to ``openzim_mcp.pagination.Cursor`` (tool-bound). Until
+    every caller has been migrated, this shim emits cursors with
+    ``t="legacy"`` and a permissive decoder that accepts both legacy
+    cursors and the new Phase B cursors.
+
+    Removed at the end of Phase B (see plan Task 22).
     """
 
     @staticmethod
     def _encode(offset: int, limit: int, query: Optional[str] = None) -> str:
-        """Encode pagination state into a base64 cursor token."""
-        cursor_data: Dict[str, Any] = {"o": offset, "l": limit}
+        """Encode pagination state into a base64 cursor token (legacy shape)."""
+        from openzim_mcp.pagination import Cursor
+
+        state: dict[str, Any] = {"o": offset, "l": limit}
         if query:
-            cursor_data["q"] = query
-        json_str = json.dumps(cursor_data, separators=(",", ":"))
-        return base64.urlsafe_b64encode(json_str.encode()).decode()
+            state["q"] = query
+        return Cursor.encode(tool="legacy", state=state)
 
     @staticmethod
     def create_next_cursor(
         current_offset: int, limit: int, total: int, query: Optional[str] = None
     ) -> Optional[str]:
-        """Create cursor for the next page, or None if no more results.
-
-        Args:
-            current_offset: Current offset position
-            limit: Page size
-            total: Total number of results
-            query: Optional query string
-
-        Returns:
-            Next page cursor or None if at end
-        """
         next_offset = current_offset + limit
         if next_offset >= total:
             return None
         return PaginationCursor._encode(next_offset, limit, query)
 
     @staticmethod
-    def decode(token: str) -> Dict[str, Any]:
-        """Decode a base64 cursor token back to its pagination state.
+    def decode(token: str) -> dict[str, Any]:
+        """Decode a legacy (or new) cursor into the legacy ``{o, l, q?}`` shape.
 
-        Args:
-            token: A cursor previously emitted by ``create_next_cursor``.
-
-        Returns:
-            Dict with keys ``o`` (offset, int), ``l`` (limit, int), and
-            optionally ``q`` (query, str).
-
-        Raises:
-            ValueError: If the token isn't valid base64 or doesn't decode to
-                the expected JSON shape. Callers should treat this as a
-                client error (malformed cursor).
+        Tolerates both v1 cursors (raw JSON without the v/t/s envelope) and
+        v2 cursors (tool-bound, versioned). Raises ``ValueError`` on malformed
+        tokens.
         """
+        import base64
+        import json
+
         try:
-            # Accept urlsafe and standard base64 since some clients normalise.
             padded = token + "=" * (-len(token) % 4)
             raw = base64.urlsafe_b64decode(padded.encode()).decode()
             data = json.loads(raw)
         except Exception as e:
             raise ValueError(f"Invalid pagination cursor: {e}") from e
-        if not isinstance(data, dict) or "o" not in data or "l" not in data:
+        if not isinstance(data, dict):
+            raise ValueError("Cursor must decode to a JSON object")
+        # v2 envelope: {v, t, s} — return s as the legacy shape.
+        if "s" in data and "v" in data and "t" in data:
+            inner = data["s"]
+            if not isinstance(inner, dict) or "o" not in inner or "l" not in inner:
+                raise ValueError("Cursor missing required fields ('o', 'l')")
+            if not isinstance(inner["o"], int) or not isinstance(inner["l"], int):
+                raise ValueError("Cursor offset and limit must be integers")
+            return inner
+        # v1 raw shape.
+        if "o" not in data or "l" not in data:
             raise ValueError("Cursor missing required fields ('o', 'l')")
         if not isinstance(data["o"], int) or not isinstance(data["l"], int):
             raise ValueError("Cursor offset and limit must be integers")

--- a/openzim_mcp/zim/archive.py
+++ b/openzim_mcp/zim/archive.py
@@ -55,7 +55,11 @@ from openzim_mcp.zim.search import _SearchMixin
 from openzim_mcp.zim.structure import _StructureMixin
 
 if TYPE_CHECKING:
-    from openzim_mcp.tool_schemas import EntryResponse, ZimMetadataResponse
+    from openzim_mcp.tool_schemas import (
+        EntryResponse,
+        ListZimFilesResponse,
+        ZimMetadataResponse,
+    )
 
 __all__ = [
     "ARCHIVE_OPEN_TIMEOUT",
@@ -325,28 +329,46 @@ class ZimOperations(_SearchMixin, _ContentMixin, _StructureMixin, _NamespaceMixi
 
     def list_zim_files_summary_data(
         self, name_filter: Optional[str] = None
-    ) -> Dict[str, Any]:
+    ) -> "ListZimFilesResponse":
         """Structured ``list_zim_files`` payload.
 
-        Wraps :py:meth:`list_zim_files_data` with the count/directories
-        metadata that the legacy markdown-header string variant carries
-        in its prose preamble, so MCP clients consuming the structured
-        output get the same context without reparsing a header.
+        Wraps :py:meth:`list_zim_files_data` with the directories metadata
+        that the legacy markdown-header string variant carries in its
+        prose preamble, so MCP clients consuming the structured output
+        get the same context without reparsing a header.
+
+        v2 Phase B contract: the response carries the canonical pagination
+        keys (``results`` / ``next_cursor`` / ``total`` / ``done`` /
+        ``page_info``) plus the tool-specific ``directories_count`` and
+        ``name_filter`` fields. ``list_zim_files`` is non-paginated — every
+        matching file in the allowed directories is returned in a single
+        call — so ``next_cursor`` is always ``None`` and ``done`` is
+        always ``True``. The contract is applied for uniformity with the
+        other list-shaped responses.
 
         Returns:
-            ``{count, directories_count, name_filter, files}`` where
-            ``files`` is the list ``list_zim_files_data`` already returns
-            (per-file dicts with name/path/directory/size/size_bytes/modified).
+            ``ListZimFilesResponse``-shaped dict carrying ``results`` (the
+            per-file dicts with name/path/directory/size/size_bytes/modified
+            — formerly ``files``), ``next_cursor`` (always ``None``),
+            ``total`` (the count, formerly ``count``), ``done`` (always
+            ``True``), ``page_info``, plus ``directories_count``,
+            ``name_filter``, and the ``_meta`` envelope.
         """
-        files = self.list_zim_files_data(name_filter=name_filter)
-        return attach_meta(
-            {
-                "count": len(files),
-                "directories_count": len(self.config.allowed_directories),
-                "name_filter": name_filter or "",
-                "files": files,
-            }
-        )
+        files_list = self.list_zim_files_data(name_filter=name_filter)
+        payload: Dict[str, Any] = {
+            "name_filter": name_filter or "",
+            "directories_count": len(self.config.allowed_directories),
+            "results": files_list,
+            "next_cursor": None,
+            "total": len(files_list),
+            "done": True,
+            "page_info": {
+                "offset": 0,
+                "limit": len(files_list),
+                "returned_count": len(files_list),
+            },
+        }
+        return cast("ListZimFilesResponse", attach_meta(payload))
 
     def list_zim_files(self, name_filter: Optional[str] = None) -> str:
         """List all ZIM files in allowed directories.

--- a/openzim_mcp/zim/archive.py
+++ b/openzim_mcp/zim/archive.py
@@ -55,7 +55,7 @@ from openzim_mcp.zim.search import _SearchMixin
 from openzim_mcp.zim.structure import _StructureMixin
 
 if TYPE_CHECKING:
-    from openzim_mcp.tool_schemas import ZimMetadataResponse
+    from openzim_mcp.tool_schemas import EntryResponse, ZimMetadataResponse
 
 __all__ = [
     "ARCHIVE_OPEN_TIMEOUT",
@@ -678,6 +678,174 @@ class ZimOperations(_SearchMixin, _ContentMixin, _StructureMixin, _NamespaceMixi
         except Exception as e:
             logger.error(f"Error getting main page: {e}")
             return f"# Main Page\n\nError retrieving main page: {e}", False
+
+    def get_main_page_data(
+        self, zim_file_path: str, *, compact: bool = False
+    ) -> "EntryResponse":
+        """Structured variant of ``get_main_page``.
+
+        Returns the entry dict directly (path/title/content/content_type)
+        so MCP tools can hand it to FastMCP's structured-content path.
+
+        Raises:
+            OpenZimMcpFileNotFoundError: If ZIM file not found
+            OpenZimMcpArchiveError: If main page retrieval fails
+        """
+        validated_path = self.path_validator.validate_path(zim_file_path)
+        validated_path = self.path_validator.validate_zim_file(validated_path)
+
+        # Cache key distinct from the legacy text cache so old persisted
+        # entries (which hold strings) don't collide with the new dict shape.
+        cache_key = f"main_page_data:{validated_path}:compact={compact}"
+        cached_result = self.cache.get(cache_key)
+        if cached_result is not None:
+            logger.debug(f"Returning cached main page dict for: {validated_path}")
+            if "_meta" not in cached_result:
+                cached_result = attach_meta(
+                    dict(cached_result),
+                    truncated=bool(cached_result.get("_truncated")),
+                )
+            return cast("EntryResponse", cached_result)
+
+        # Late-bound lookup so test patches against
+        # ``openzim_mcp.zim_operations.zim_archive`` apply here too.
+        import openzim_mcp.zim_operations as _zim_ops_shim
+
+        try:
+            with _zim_ops_shim.zim_archive(validated_path) as archive:
+                payload, content_ok = self._get_main_page_data_content(
+                    archive, compact=compact
+                )
+        except Exception as e:
+            logger.error(f"Main page retrieval failed for {validated_path}: {e}")
+            raise OpenZimMcpArchiveError(f"Main page retrieval failed: {e}") from e
+
+        if content_ok:
+            self.cache.set(cache_key, dict(payload))
+        truncated = bool(payload.pop("_truncated", False))
+        total_chars = payload.pop("_total_chars", None)
+        logger.info(f"Retrieved main page data for: {validated_path}")
+        return cast(
+            "EntryResponse",
+            attach_meta(
+                payload,
+                truncated=truncated,
+                total_chars=total_chars,
+            ),
+        )
+
+    def _get_main_page_data_content(  # NOSONAR(python:S3776)
+        self, archive: Archive, *, compact: bool = False
+    ) -> Tuple[Dict[str, Any], bool]:
+        """Build the main-page dict payload from an open archive.
+
+        Mirrors ``_get_main_page_content`` but emits a structured dict
+        rather than formatted markdown. Same redirect-handling and
+        fallback-paths logic.
+
+        Returns:
+            ``(payload, content_ok)`` — ``content_ok`` is False when MIME
+            processing raised; the caller must skip caching it.
+        """
+
+        def _follow_redirect(entry: Any) -> Any:
+            seen: set[str] = set()
+            for _ in range(MAX_REDIRECT_DEPTH):
+                if not getattr(entry, "is_redirect", False):
+                    return entry
+                if entry.path in seen:
+                    raise OpenZimMcpArchiveError(
+                        f"Redirect cycle detected at {entry.path}"
+                    )
+                seen.add(entry.path)
+                entry = entry.get_redirect_entry()
+            if getattr(entry, "is_redirect", False):
+                raise OpenZimMcpArchiveError(
+                    f"Redirect chain too deep (>{MAX_REDIRECT_DEPTH}) "
+                    f"in main-page lookup"
+                )
+            return entry
+
+        def _build(entry_obj: Any) -> Tuple[Dict[str, Any], bool]:
+            title = entry_obj.title or "Main Page"
+            path = entry_obj.path
+            try:
+                item = entry_obj.get_item()
+                mime_type = item.mimetype or ""
+                content = self.content_processor.process_mime_content(
+                    bytes(item.content), mime_type, compact=compact
+                )
+                total_length = len(content)
+                truncated_content = self.content_processor.truncate_content(
+                    content, DEFAULT_MAIN_PAGE_TRUNCATION
+                )
+                was_truncated = len(truncated_content) < total_length
+                payload: Dict[str, Any] = {
+                    "path": path,
+                    "title": title,
+                    "content": truncated_content,
+                }
+                if mime_type:
+                    payload["content_type"] = mime_type
+                if was_truncated:
+                    payload["_truncated"] = True
+                    payload["_total_chars"] = total_length
+                return payload, True
+            except Exception as e:
+                logger.warning(f"Error getting main page content: {e}")
+                return (
+                    {
+                        "path": path,
+                        "title": title,
+                        "content": f"(Error retrieving content: {e})",
+                    },
+                    False,
+                )
+
+        try:
+            if hasattr(archive, "main_entry") and archive.main_entry:
+                main_entry = _follow_redirect(archive.main_entry)
+                return _build(main_entry)
+
+            # Fallback: try common main page paths. Entry-zero is NOT a
+            # candidate (libzim's internal ordering doesn't map to the
+            # ZIM main-page pointer), so we only probe named paths.
+            main_page_paths = ["W/mainPage", "A/Main_Page", "A/index"]
+            for path in main_page_paths:
+                try:
+                    entry = archive.get_entry_by_path(path)
+                    if entry:
+                        entry = _follow_redirect(entry)
+                        payload, ok = _build(entry)
+                        if ok:
+                            return payload, True
+                except Exception:  # nosec B112 - intentional fallback
+                    continue
+
+            # No main page found — structural property of the archive,
+            # safe to cache.
+            return (
+                {
+                    "path": "",
+                    "title": "Main Page",
+                    "content": (
+                        "No main page found in this ZIM file. "
+                        "The archive may not have a designated main page entry."
+                    ),
+                },
+                True,
+            )
+
+        except Exception as e:
+            logger.error(f"Error getting main page: {e}")
+            return (
+                {
+                    "path": "",
+                    "title": "Main Page",
+                    "content": f"Error retrieving main page: {e}",
+                },
+                False,
+            )
 
     def _resolve_entry_with_fallback(
         self, archive: Archive, entry_path: str

--- a/openzim_mcp/zim/content.py
+++ b/openzim_mcp/zim/content.py
@@ -13,7 +13,7 @@ import base64
 import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
 
 from libzim.reader import Archive  # type: ignore[import-untyped]
 
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from openzim_mcp.config import OpenZimMcpConfig
     from openzim_mcp.content_processor import ContentProcessor
     from openzim_mcp.security import PathValidator
+    from openzim_mcp.tool_schemas import BinaryEntryResponse
 
 logger = logging.getLogger(__name__)
 
@@ -600,7 +601,7 @@ class _ContentMixin:
         entry_path: str,
         max_size_bytes: Optional[int] = None,
         include_data: bool = True,
-    ) -> Dict[str, Any]:
+    ) -> "BinaryEntryResponse":
         """Structured variant of ``get_binary_entry``.
 
         Returns the result dict directly (not a JSON string) so MCP tools
@@ -644,7 +645,10 @@ class _ContentMixin:
             payload = self._format_binary_response(
                 cached_meta, include_data, max_size_bytes, data=None
             )
-            return attach_meta(payload, truncated=payload.get("truncated", False))
+            return cast(
+                "BinaryEntryResponse",
+                attach_meta(payload, truncated=payload.get("truncated", False)),
+            )
 
         try:
             with _zim_ops_mod.zim_archive(validated_path) as archive:
@@ -711,7 +715,10 @@ class _ContentMixin:
                 payload = self._format_binary_response(
                     meta, include_data, max_size_bytes, data=encoded_data
                 )
-                result = attach_meta(payload, truncated=payload.get("truncated", False))
+                result = cast(
+                    "BinaryEntryResponse",
+                    attach_meta(payload, truncated=payload.get("truncated", False)),
+                )
                 logger.info(
                     f"Retrieved binary entry: {entry_path} "
                     f"({meta['mime_type']}, {self._format_size(content_size)})"

--- a/openzim_mcp/zim/content.py
+++ b/openzim_mcp/zim/content.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from openzim_mcp.content_processor import ContentProcessor
     from openzim_mcp.security import PathValidator
     from openzim_mcp.tool_schemas import (
+        BatchEntryResponse,
         BinaryEntryResponse,
         EntryResponse,
         EntrySummaryResponse,
@@ -485,7 +486,7 @@ class _ContentMixin:
         max_content_length: Optional[int] = None,
         *,
         compact: bool = False,
-    ) -> Dict[str, Any]:
+    ) -> "BatchEntryResponse":
         """Structured variant of ``get_entries``.
 
         Returns the result dict directly (not a JSON string) so MCP tools
@@ -495,12 +496,23 @@ class _ContentMixin:
         Each result carries the input ``index`` so callers can correlate
         responses with their original request order.
 
+        v2 Phase B contract: the response carries the canonical pagination
+        keys (``results`` / ``next_cursor`` / ``total`` / ``done`` /
+        ``page_info``) plus the tool-specific ``succeeded`` / ``failed``
+        counters. Batch fetch is non-paginated — every requested entry is
+        attempted, so ``next_cursor`` is always ``None`` and ``done`` is
+        always ``True``. The contract is applied for uniformity with the
+        other list-shaped responses.
+
         Args:
             entries: list of ``{"zim_file_path", "entry_path"}`` dicts.
             max_content_length: per-entry max content length.
 
         Returns:
-            Dict ``{"results": [...], "succeeded": N, "failed": N}``.
+            ``BatchEntryResponse``-shaped dict carrying ``results``,
+            ``next_cursor`` (always ``None``), ``total``, ``done`` (always
+            ``True``), ``page_info``, ``succeeded``, ``failed``, plus
+            ``_meta``.
 
         Raises:
             OpenZimMcpValidationError: empty list or > MAX_BATCH_SIZE.
@@ -615,9 +627,20 @@ class _ContentMixin:
         # they submitted entries (grouping is a transparent optimisation).
         results.sort(key=lambda r: r["index"])
 
-        return attach_meta(
-            {"results": results, "succeeded": succeeded, "failed": failed}
-        )
+        payload: Dict[str, Any] = {
+            "results": results,
+            "next_cursor": None,
+            "total": len(results),
+            "done": True,
+            "page_info": {
+                "offset": 0,
+                "limit": len(entries),
+                "returned_count": len(results),
+            },
+            "succeeded": succeeded,
+            "failed": failed,
+        }
+        return cast("BatchEntryResponse", attach_meta(payload))
 
     def get_entries(
         self,

--- a/openzim_mcp/zim/content.py
+++ b/openzim_mcp/zim/content.py
@@ -29,7 +29,11 @@ if TYPE_CHECKING:
     from openzim_mcp.config import OpenZimMcpConfig
     from openzim_mcp.content_processor import ContentProcessor
     from openzim_mcp.security import PathValidator
-    from openzim_mcp.tool_schemas import BinaryEntryResponse
+    from openzim_mcp.tool_schemas import (
+        BinaryEntryResponse,
+        EntryResponse,
+        EntrySummaryResponse,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -203,6 +207,277 @@ class _ContentMixin:
             self.cache.set(cache_key, result)
         logger.info(f"Retrieved entry: {entry_path}")
         return result
+
+    def get_zim_entry_data(
+        self,
+        zim_file_path: str,
+        entry_path: str,
+        max_content_length: Optional[int] = None,
+        content_offset: int = 0,
+        *,
+        compact: bool = False,
+    ) -> "EntryResponse":
+        """Structured variant of ``get_zim_entry``.
+
+        Returns the entry dict directly (path/title/content/content_type)
+        so MCP tools can hand it to FastMCP's structured-content path.
+        Honours the same smart-retrieval and path-mapping logic as the
+        legacy text variant.
+
+        Args:
+            zim_file_path: Path to the ZIM file
+            entry_path: Entry path, e.g., 'A/Some_Article'
+            max_content_length: Maximum length of content to return
+            content_offset: Character offset to start reading from (default 0)
+
+        Returns:
+            ``EntryResponse``-shaped dict with ``path``, ``title``,
+            ``content``, optionally ``content_type``/``requested_path``/
+            ``content_offset``/``total_chars``, plus ``_meta``.
+
+        Raises:
+            OpenZimMcpFileNotFoundError: If ZIM file not found
+            OpenZimMcpArchiveError: If entry retrieval fails
+        """
+        if max_content_length is None:
+            max_content_length = self.config.content.max_content_length
+        if content_offset < 0:
+            content_offset = 0
+
+        validated_path = self.path_validator.validate_path(zim_file_path)
+        validated_path = self.path_validator.validate_zim_file(validated_path)
+
+        # Cache key distinct from the legacy string cache so old persisted
+        # entries (text payloads) don't collide with the new dict shape.
+        cache_key = (
+            f"entry_data:{validated_path}:{entry_path}:"
+            f"{max_content_length}:{content_offset}:compact={compact}"
+        )
+        cached_result = self.cache.get(cache_key)
+        if cached_result is not None:
+            logger.debug(f"Returning cached entry dict for: {entry_path}")
+            if "_meta" not in cached_result:
+                cached_result = attach_meta(
+                    dict(cached_result),
+                    truncated=bool(cached_result.get("_truncated")),
+                )
+            return cast("EntryResponse", cached_result)
+
+        try:
+            with _zim_ops_mod.zim_archive(validated_path) as archive:
+                payload, content_ok = self._get_entry_data_from_archive(
+                    archive,
+                    entry_path,
+                    max_content_length,
+                    validated_path,
+                    content_offset,
+                    compact=compact,
+                )
+        except OpenZimMcpArchiveError:
+            raise
+        except Exception as e:
+            logger.error(f"Entry retrieval failed for {entry_path}: {e}")
+            raise OpenZimMcpArchiveError(
+                f"Entry retrieval failed for '{entry_path}': {e}. "
+                f"This may be due to file access issues or ZIM file corruption. "
+                f"Try using search_zim_file() to verify the file is accessible."
+            ) from e
+
+        # Only cache on success. ``_truncated`` is an internal hint used
+        # to set ``_meta.truncated`` on the cached path; it's stripped
+        # before the dict is returned (and never reaches the wire).
+        if content_ok:
+            self.cache.set(cache_key, dict(payload))
+        truncated = bool(payload.pop("_truncated", False))
+        total_chars = payload.pop("_total_chars", None)
+        logger.info(f"Retrieved entry data: {entry_path}")
+        return cast(
+            "EntryResponse",
+            attach_meta(
+                payload,
+                truncated=truncated,
+                total_chars=total_chars,
+                current_offset=content_offset,
+            ),
+        )
+
+    def _get_entry_data_from_archive(  # NOSONAR(python:S3776)
+        self,
+        archive: Archive,
+        entry_path: str,
+        max_content_length: int,
+        validated_path: Path,
+        content_offset: int = 0,
+        *,
+        compact: bool = False,
+    ) -> Tuple[Dict[str, Any], bool]:
+        """Resolve an entry against an open archive and build its dict payload.
+
+        Mirrors ``_get_entry_content`` but returns a structured dict
+        instead of formatted markdown. Reuses the same smart-retrieval
+        path-mapping cache so a hit on the legacy text path also speeds up
+        the dict path (the cache stores the resolved actual_path, not the
+        body).
+
+        Returns:
+            ``(payload, content_ok)`` — ``content_ok`` is False when MIME
+            processing raised and ``payload["content"]`` is the error
+            sentinel; the caller must not cache the response in that case.
+        """
+        requested_path = entry_path
+        path_cache_key = f"path_mapping:{validated_path}:{entry_path}"
+        cached_actual_path = self.cache.get(path_cache_key)
+
+        # Try cached path mapping first.
+        if cached_actual_path:
+            try:
+                payload, content_ok, _resolved = self._build_entry_payload(
+                    archive,
+                    cached_actual_path,
+                    requested_path,
+                    max_content_length,
+                    content_offset,
+                    compact=compact,
+                )
+                return payload, content_ok
+            except Exception as e:
+                logger.warning(f"Cached path mapping failed: {e}")
+                self.cache.delete(path_cache_key)
+
+        # Direct access first.
+        try:
+            payload, content_ok, resolved_path = self._build_entry_payload(
+                archive,
+                entry_path,
+                requested_path,
+                max_content_length,
+                content_offset,
+                compact=compact,
+            )
+            self.cache.set(path_cache_key, resolved_path)
+            return payload, content_ok
+        except OpenZimMcpArchiveError:
+            raise
+        except Exception as direct_error:
+            logger.debug(f"Direct entry access failed for {entry_path}: {direct_error}")
+            try:
+                actual_path = self._find_entry_by_search(archive, entry_path)
+                if actual_path:
+                    payload, content_ok, resolved_path = self._build_entry_payload(
+                        archive,
+                        actual_path,
+                        requested_path,
+                        max_content_length,
+                        content_offset,
+                        compact=compact,
+                    )
+                    self.cache.set(path_cache_key, resolved_path)
+                    return payload, content_ok
+                raise OpenZimMcpArchiveError(
+                    f"Entry not found: '{entry_path}'. "
+                    f"The entry path may not exist in this ZIM file. "
+                    f"Try using search_zim_file() to find available entries, "
+                    f"or browse_namespace() to explore the file structure."
+                )
+            except OpenZimMcpArchiveError:
+                raise
+            except Exception as search_error:
+                logger.error(
+                    f"Search-based retrieval failed for {entry_path}: "
+                    f"{search_error}"
+                )
+                raise OpenZimMcpArchiveError(
+                    f"Failed to retrieve entry '{entry_path}'. "
+                    f"Direct access failed: {direct_error}. "
+                    f"Search-based fallback failed: {search_error}. "
+                    f"The entry may not exist or the path format may be incorrect. "
+                    f"Try using search_zim_file() to find the correct entry path."
+                ) from search_error
+
+    def _build_entry_payload(  # NOSONAR(python:S3776)
+        self,
+        archive: Archive,
+        actual_path: str,
+        requested_path: str,
+        max_content_length: int,
+        content_offset: int = 0,
+        *,
+        compact: bool = False,
+    ) -> Tuple[Dict[str, Any], bool, str]:
+        """Construct the dict payload for a resolved entry.
+
+        Mirrors ``_get_entry_content_direct`` but emits a structured dict
+        rather than formatted markdown. Resolves redirects with the same
+        cycle/depth checks.
+        """
+        entry = archive.get_entry_by_path(actual_path)
+
+        seen_paths: set[str] = set()
+        depth = 0
+        while entry.is_redirect:
+            if depth >= _zim_ops_mod.MAX_REDIRECT_DEPTH:
+                raise OpenZimMcpArchiveError(
+                    f"Redirect chain too deep (>{_zim_ops_mod.MAX_REDIRECT_DEPTH}) "
+                    f"starting at {actual_path}"
+                )
+            if entry.path in seen_paths:
+                raise OpenZimMcpArchiveError(f"Redirect cycle detected at {entry.path}")
+            seen_paths.add(entry.path)
+            entry = entry.get_redirect_entry()
+            depth += 1
+
+        actual_path = entry.path
+        title = entry.title or "Untitled"
+
+        content = ""
+        content_type = ""
+        content_ok = True
+        try:
+            item = entry.get_item()
+            content_type = item.mimetype or ""
+            content = self.content_processor.process_mime_content(
+                bytes(item.content), content_type, compact=compact
+            )
+        except Exception as e:
+            logger.warning(f"Error getting entry content: {e}")
+            content = f"(Error retrieving content: {e})"
+            content_ok = False
+
+        total_length = len(content)
+        offset_applied = False
+        if content_offset and content_offset > 0:
+            if content_offset >= total_length:
+                content = ""
+            else:
+                content = content[content_offset:]
+            offset_applied = True
+
+        # Truncate post-offset so max_content_length governs the *returned*
+        # slice, matching the legacy text path.
+        truncated_content = self.content_processor.truncate_content(
+            content, max_content_length
+        )
+        was_truncated = len(truncated_content) < len(content)
+        content = truncated_content
+
+        payload: Dict[str, Any] = {
+            "path": actual_path,
+            "title": title,
+            "content": content,
+        }
+        if content_type:
+            payload["content_type"] = content_type
+        if actual_path != requested_path:
+            payload["requested_path"] = requested_path
+        if offset_applied:
+            payload["content_offset"] = content_offset
+            payload["total_chars"] = total_length
+        # Hints stripped before the dict is returned to the caller; they
+        # drive the eventual ``attach_meta`` call.
+        if was_truncated or offset_applied:
+            payload["_truncated"] = was_truncated
+            payload["_total_chars"] = total_length
+        return payload, content_ok, actual_path
 
     def get_entries_data(  # NOSONAR(python:S3776)
         self,
@@ -817,7 +1092,7 @@ class _ContentMixin:
         max_words: int = 200,
         *,
         compact: bool = False,
-    ) -> Dict[str, Any]:
+    ) -> "EntrySummaryResponse":
         """Structured variant of ``get_entry_summary``.
 
         Returns the result dict directly (not a JSON string) so MCP tools
@@ -853,7 +1128,7 @@ class _ContentMixin:
                     dict(cached_result),
                     truncated=bool(cached_result.get("is_truncated")),
                 )
-            return cached_result  # type: ignore[no-any-return]
+            return cast("EntrySummaryResponse", cached_result)
 
         try:
             with _zim_ops_mod.zim_archive(validated_path) as archive:
@@ -864,9 +1139,12 @@ class _ContentMixin:
             # Cache the result (pre-_meta so cached payload stays compact)
             self.cache.set(cache_key, result)
             logger.info(f"Extracted summary for: {entry_path}")
-            return attach_meta(
-                result,
-                truncated=bool(result.get("is_truncated")),
+            return cast(
+                "EntrySummaryResponse",
+                attach_meta(
+                    result,
+                    truncated=bool(result.get("is_truncated")),
+                ),
             )
 
         except Exception as e:

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -545,7 +545,7 @@ class _NamespaceMixin:
         validated_path = self.path_validator.validate_zim_file(validated_path)
 
         # Cache key bumped to v2b (Phase B) so v1.x cached responses (old
-        # shape: entries/total_in_namespace/has_more/...) don't leak through
+        # shape: entries/total_in_namespace/...) don't leak through
         # after the upgrade.
         cache_key = f"browse_ns_data:v2b:{validated_path}:{namespace}:{limit}:{offset}"
         cached_result = self.cache.get(cache_key)
@@ -566,7 +566,7 @@ class _NamespaceMixin:
                 )
 
             # ``_browse_namespace_entries`` still returns the legacy inner
-            # shape (entries / total_in_namespace / has_more / ...). Adapt
+            # shape (entries / total_in_namespace / is_total_authoritative / ...). Adapt
             # to the v2 Phase B contract here so internal callers and tests
             # that target the helper aren't forced through the rename.
             entries = raw.get("entries", [])

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -91,9 +91,9 @@ class _NamespaceMixin:
         validated_path = self.path_validator.validate_path(zim_file_path)
         validated_path = self.path_validator.validate_zim_file(validated_path)
 
-        # Cache key bumped to v2 so v1.x cached responses (per-namespace
-        # ``count`` field) don't leak through after the rename to ``total``.
-        cache_key = f"namespaces_data:v2:{validated_path}"
+        # Cache key bumped to v2b (Phase B) so v1.x cached responses (old
+        # shape: entry_count key) don't leak through after the rename to ``total``.
+        cache_key = f"namespaces_data:v2b:{validated_path}"
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug(f"Returning cached namespaces dict for: {validated_path}")

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from openzim_mcp.config import OpenZimMcpConfig
     from openzim_mcp.content_processor import ContentProcessor
     from openzim_mcp.security import PathValidator
-    from openzim_mcp.tool_schemas import BrowseNamespaceResponse
+    from openzim_mcp.tool_schemas import BrowseNamespaceResponse, WalkNamespaceResponse
 
 logger = logging.getLogger(__name__)
 
@@ -994,17 +994,32 @@ class _NamespaceMixin:
         self,
         zim_file_path: str,
         namespace: str,
-        cursor: int = 0,
+        cursor_state: Optional[Dict[str, Any]] = None,
         limit: int = 200,
-    ) -> Dict[str, Any]:
+    ) -> "WalkNamespaceResponse":
         """Structured variant of ``walk_namespace``.
 
         Returns the result dict directly (not a JSON string) so MCP tools
         can hand it straight to FastMCP's structured-content path.
 
+        Phase B contract: top-level ``results`` / ``next_cursor`` (opaque
+        str) / ``total`` (always None — walk doesn't know the per-namespace
+        total mid-scan) / ``done`` / ``page_info`` plus ``namespace`` /
+        ``scanned_count`` / ``scanned_through_id`` / ``archive_entry_count``
+        extras. ``next_cursor`` is encoded with ``tool="walk_namespace"``
+        and state ``{scan_at, l}``.
+
+        ``cursor_state`` carries the decoded ``s`` dict from a v2 cursor.
+        The tool layer is responsible for decoding the opaque wire token;
+        this method works with the decoded shape directly so non-tool
+        callers (legacy ``walk_namespace`` JSON wrapper, simple_tools)
+        don't have to round-trip through base64.
+
         Raises:
             OpenZimMcpValidationError: If ``limit`` is outside ``1..500``.
         """
+        from openzim_mcp.pagination import Cursor
+
         # Caller-input validation surfaces as OpenZimMcpValidationError so
         # the tool layer can render a targeted validation message and so
         # other call sites (e.g. simple_tools) can distinguish it from
@@ -1013,8 +1028,18 @@ class _NamespaceMixin:
             raise OpenZimMcpValidationError(
                 f"limit must be between 1 and 500 (provided: {limit})"
             )
-        if cursor < 0:
-            cursor = 0
+
+        # Decoded cursor state ``s`` for walk_namespace carries
+        # ``{scan_at: int, l: int}``. Both are optional defensively —
+        # missing/negative ``scan_at`` clamps to 0, missing ``l`` falls
+        # back to the function-arg default.
+        scan_at_raw = (cursor_state or {}).get("scan_at", 0)
+        try:
+            scan_at = int(scan_at_raw)
+        except (TypeError, ValueError):
+            scan_at = 0
+        if scan_at < 0:
+            scan_at = 0
 
         # Canonicalise user input (e.g. "c" -> "C") so the comparison
         # against ``_extract_namespace_from_path`` (canonical form) does
@@ -1036,33 +1061,37 @@ class _NamespaceMixin:
                 # dedicated walker so callers see real metadata entries
                 # instead of zero matches after a full archive scan.
                 if has_new_scheme and namespace == "M":
-                    return attach_meta(
-                        self._walk_new_scheme_metadata(
-                            archive, cursor, limit, archive_entry_count
-                        )
+                    return cast(
+                        "WalkNamespaceResponse",
+                        attach_meta(
+                            self._walk_new_scheme_metadata(
+                                archive, scan_at, limit, archive_entry_count
+                            )
+                        ),
                     )
                 # Other-than-C namespaces in new-scheme aren't on the
                 # iterable surface; short-circuit so callers don't pay the
                 # full-archive scan to discover that.
                 if has_new_scheme and namespace != "C":
-                    return attach_meta(
-                        self._build_walk_result(
-                            namespace=namespace,
-                            cursor=cursor,
-                            limit=limit,
-                            entries=[],
-                            scanned_count=0,
-                            scanned_through_id=None,
-                            done=True,
-                            next_cursor=None,
-                            archive_entry_count=archive_entry_count,
-                            total_in_namespace=0,
-                            total_in_namespace_is_lower_bound=False,
-                        )
+                    return cast(
+                        "WalkNamespaceResponse",
+                        attach_meta(
+                            self._build_walk_result(
+                                namespace=namespace,
+                                scan_at=scan_at,
+                                limit=limit,
+                                entries=[],
+                                scanned_count=0,
+                                scanned_through_id=None,
+                                done=True,
+                                next_cursor=None,
+                                archive_entry_count=archive_entry_count,
+                            )
+                        ),
                     )
 
                 entries: List[Dict[str, Any]] = []
-                entry_id = cursor
+                entry_id = scan_at
                 while entry_id < archive_entry_count and len(entries) < limit:
                     try:
                         entry = archive._get_entry_by_id(entry_id)
@@ -1084,41 +1113,32 @@ class _NamespaceMixin:
                     entry_id += 1
 
                 done = entry_id >= archive_entry_count
-                next_cursor = None if done else entry_id
                 # scanned_through_id reflects the last ID we examined regardless
                 # of whether it matched the filter. None if we never entered the
-                # loop (cursor was already past the end).
-                scanned_through_id = entry_id - 1 if entry_id > cursor else None
-
-                # Namespace count is only authoritative for new-scheme C
-                # (iterator emits exactly C). Old-scheme would need a full
-                # archive scan to derive it; report None rather than mislead.
-                # ``is_lower_bound`` is meaningless when the count is None,
-                # so report None there too — saying ``False`` alongside a
-                # null count would read as "this null is the exact count".
-                total_in_namespace: Optional[int]
-                is_lower_bound: Optional[bool]
-                if has_new_scheme:
-                    total_in_namespace = archive_entry_count
-                    is_lower_bound = False
-                else:
-                    total_in_namespace = None
-                    is_lower_bound = None
-
-                return attach_meta(
-                    self._build_walk_result(
-                        namespace=namespace,
-                        cursor=cursor,
-                        limit=limit,
-                        entries=entries,
-                        scanned_count=entry_id - cursor,
-                        scanned_through_id=scanned_through_id,
-                        done=done,
-                        next_cursor=next_cursor,
-                        archive_entry_count=archive_entry_count,
-                        total_in_namespace=total_in_namespace,
-                        total_in_namespace_is_lower_bound=is_lower_bound,
+                # loop (scan_at was already at/past the end).
+                scanned_through_id = entry_id - 1 if entry_id > scan_at else None
+                next_cursor: Optional[str] = None
+                if not done:
+                    next_cursor = Cursor.encode(
+                        tool="walk_namespace",
+                        state={"scan_at": entry_id, "l": limit},
                     )
+
+                return cast(
+                    "WalkNamespaceResponse",
+                    attach_meta(
+                        self._build_walk_result(
+                            namespace=namespace,
+                            scan_at=scan_at,
+                            limit=limit,
+                            entries=entries,
+                            scanned_count=entry_id - scan_at,
+                            scanned_through_id=scanned_through_id,
+                            done=done,
+                            next_cursor=next_cursor,
+                            archive_entry_count=archive_entry_count,
+                        )
+                    ),
                 )
         except OpenZimMcpArchiveError:
             raise
@@ -1129,82 +1149,88 @@ class _NamespaceMixin:
     def _build_walk_result(
         *,
         namespace: str,
-        cursor: int,
+        scan_at: int,
         limit: int,
         entries: List[Dict[str, Any]],
         scanned_count: int,
         scanned_through_id: Optional[int],
         done: bool,
-        next_cursor: Optional[int],
+        next_cursor: Optional[str],
         archive_entry_count: int,
-        total_in_namespace: Optional[int],
-        total_in_namespace_is_lower_bound: Optional[bool],
     ) -> Dict[str, Any]:
-        """Assemble the walk_namespace result dict.
+        """Assemble the walk_namespace v2 contract result dict.
 
-        ``archive_entry_count`` is the file-level entry count.
-        ``total_in_namespace`` is the namespace-specific count (None when
-        not derivable without a full scan, e.g. old-scheme archives).
-        ``total_in_namespace_is_lower_bound`` is False when authoritative,
-        True when sampling-derived, None when ``total_in_namespace`` is
-        also None (no count means no lower-bound semantics).
-        ``total_entries`` is kept as a deprecated alias of
-        ``archive_entry_count`` for v1.1.0 callers; remove in a future major.
+        Five-key contract (``results`` / ``next_cursor`` / ``total`` /
+        ``done`` / ``page_info``) plus walk-specific extras.
+
+        ``total`` is always None: walk_namespace doesn't know the
+        per-namespace total mid-scan. Callers that need a count can use
+        ``browse_namespace`` (sampled) or wait for ``done=True``.
+
+        ``archive_entry_count`` is the file-level entry count, distinct
+        from the (unknown) namespace count.
         """
+        returned_count = len(entries)
         return {
             "namespace": namespace,
-            "cursor": cursor,
-            "limit": limit,
-            "returned_count": len(entries),
-            "scanned_count": scanned_count,
+            "results": entries,
             "next_cursor": next_cursor,
+            "total": None,
             "done": done,
+            "page_info": {
+                "offset": scan_at,
+                "limit": limit,
+                "returned_count": returned_count,
+            },
+            "scanned_count": scanned_count,
             "scanned_through_id": scanned_through_id,
             "archive_entry_count": archive_entry_count,
-            "total_in_namespace": total_in_namespace,
-            "total_in_namespace_is_lower_bound": total_in_namespace_is_lower_bound,
-            "total_entries": archive_entry_count,  # deprecated alias
-            "entries": entries,
         }
 
     @classmethod
     def _walk_new_scheme_metadata(
         cls,
         archive: Archive,
-        cursor: int,
+        scan_at: int,
         limit: int,
         archive_entry_count: int,
     ) -> Dict[str, Any]:
         """Walk M (metadata) entries in a new-scheme archive via metadata_keys."""
+        from openzim_mcp.pagination import Cursor
+
         try:
             keys = list(getattr(archive, "metadata_keys", []) or [])
         except Exception as e:
             logger.debug(f"metadata_keys read failed: {e}")
             keys = []
         total = len(keys)
-        start = cursor
+        start = scan_at
         end = min(start + limit, total)
         entries = [{"path": f"M/{k}", "title": k} for k in keys[start:end]]
         done = end >= total
+        next_cursor: Optional[str] = None
+        if not done:
+            next_cursor = Cursor.encode(
+                tool="walk_namespace",
+                state={"scan_at": end, "l": limit},
+            )
         return cls._build_walk_result(
             namespace="M",
-            cursor=cursor,
+            scan_at=scan_at,
             limit=limit,
             entries=entries,
             scanned_count=end - start,
             scanned_through_id=end - 1 if end > start else None,
             done=done,
-            next_cursor=None if done else end,
+            next_cursor=next_cursor,
             archive_entry_count=archive_entry_count,
-            total_in_namespace=total,
-            total_in_namespace_is_lower_bound=False,
         )
 
     def walk_namespace(
         self,
         zim_file_path: str,
         namespace: str,
-        cursor: int = 0,
+        cursor: Optional[Dict[str, Any]] = None,
         limit: int = 200,
     ) -> str:
         """Legacy JSON-string variant of ``walk_namespace_data``.
@@ -1220,8 +1246,11 @@ class _NamespaceMixin:
         Args:
             zim_file_path: Path to the ZIM file
             namespace: Namespace to walk (C, M, W, X, A, I, etc.)
-            cursor: Entry ID to resume from (default 0; use the value from
-                ``next_cursor`` of the previous call)
+            cursor: Decoded cursor-state dict (e.g.
+                ``{"scan_at": 42, "l": 200}``). ``None`` starts from the
+                beginning. Tool callers should prefer the MCP
+                ``walk_namespace`` tool which accepts an opaque wire
+                cursor and decodes for you.
             limit: Maximum entries to return per page (1–500, default 200)
 
         Returns:
@@ -1232,7 +1261,9 @@ class _NamespaceMixin:
             OpenZimMcpValidationError: If ``limit`` is outside ``1..500``.
         """
         return json.dumps(
-            self.walk_namespace_data(zim_file_path, namespace, cursor, limit),
+            self.walk_namespace_data(
+                zim_file_path, namespace, cursor_state=cursor, limit=limit
+            ),
             indent=2,
             ensure_ascii=False,
         )

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -32,7 +32,11 @@ if TYPE_CHECKING:
     from openzim_mcp.config import OpenZimMcpConfig
     from openzim_mcp.content_processor import ContentProcessor
     from openzim_mcp.security import PathValidator
-    from openzim_mcp.tool_schemas import BrowseNamespaceResponse, WalkNamespaceResponse
+    from openzim_mcp.tool_schemas import (
+        BrowseNamespaceResponse,
+        ListNamespacesResponse,
+        WalkNamespaceResponse,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -64,13 +68,20 @@ class _NamespaceMixin:
         cache: "OpenZimMcpCache"
         content_processor: "ContentProcessor"
 
-    def list_namespaces_data(self, zim_file_path: str) -> Dict[str, Any]:
+    def list_namespaces_data(self, zim_file_path: str) -> "ListNamespacesResponse":
         """Structured variant of ``list_namespaces``.
 
         Returns the same payload as ``list_namespaces`` but as a Python
         dict, so MCP tool functions can hand it straight to FastMCP's
         structured-output path without the json.dumps + re-parse round
         trip the legacy string variant required.
+
+        Phase B v2: this is the one list-shaped result that does NOT carry
+        the PaginatedResponse contract — it returns a dict-of-summaries,
+        not a list. Top-level keys are ``total_entries`` /
+        ``sampled_entries`` / ``has_new_namespace_scheme`` /
+        ``is_total_authoritative`` / ``discovery_method`` / ``namespaces``
+        plus the universal ``_meta`` envelope.
 
         Raises:
             OpenZimMcpFileNotFoundError: If ZIM file not found
@@ -80,15 +91,15 @@ class _NamespaceMixin:
         validated_path = self.path_validator.validate_path(zim_file_path)
         validated_path = self.path_validator.validate_zim_file(validated_path)
 
-        # Cache key distinct from the legacy string cache so old persisted
-        # entries (which hold strings) don't collide with the new dict shape.
-        cache_key = f"namespaces_data:{validated_path}"
+        # Cache key bumped to v2 so v1.x cached responses (per-namespace
+        # ``count`` field) don't leak through after the rename to ``total``.
+        cache_key = f"namespaces_data:v2:{validated_path}"
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug(f"Returning cached namespaces dict for: {validated_path}")
             if "_meta" not in cached_result:
                 cached_result = attach_meta(dict(cached_result))
-            return cached_result  # type: ignore[no-any-return]
+            return cast("ListNamespacesResponse", cached_result)
 
         try:
             with _zim_ops_mod.zim_archive(validated_path) as archive:
@@ -96,7 +107,7 @@ class _NamespaceMixin:
 
             self.cache.set(cache_key, result)
             logger.info(f"Listed namespaces for: {validated_path}")
-            return attach_meta(result)
+            return cast("ListNamespacesResponse", attach_meta(result))
 
         except Exception as e:
             logger.error(f"Namespace listing failed for {validated_path}: {e}")
@@ -183,8 +194,11 @@ class _NamespaceMixin:
             return
         if not keys:
             return
+        # ``metadata_keys`` is an exhaustive enumeration of M, so the
+        # bucket is authoritative — we know the total without sampling.
         ns_info = {
-            "count": len(keys),
+            "total": len(keys),
+            "is_authoritative": True,
             "description": _NAMESPACE_DESCRIPTIONS["M"],
             "sample_entries": [{"path": f"M/{k}", "title": k} for k in keys[:5]],
             "sampled_count": len(keys),
@@ -219,8 +233,14 @@ class _NamespaceMixin:
                 probes.append(("W/favicon", "favicon"))
         if not probes:
             return
+        # Probed-only buckets are authoritative existence proofs but the
+        # ``total`` is a lower bound — we know these specific paths exist
+        # but not how many other W entries the archive holds. We mark
+        # ``is_authoritative=False`` to reflect that the count is not the
+        # whole namespace, just confirmed canonical paths.
         namespaces["W"] = {
-            "count": len(probes),
+            "total": len(probes),
+            "is_authoritative": False,
             "description": _NAMESPACE_DESCRIPTIONS["W"],
             "sample_entries": [{"path": p, "title": t} for p, t in probes],
             "sampled_count": 0,
@@ -255,7 +275,15 @@ class _NamespaceMixin:
             ns_info = namespaces.setdefault(
                 namespace,
                 {
-                    "count": 0,
+                    # ``total`` is the per-namespace count (renamed from
+                    # ``count`` in v2 Phase B for consistency with
+                    # PaginatedResponse.total). For full-iteration buckets
+                    # this is exact; for sampled buckets it is overwritten
+                    # with the projected estimate during finalisation.
+                    "total": 0,
+                    # Set during finalisation: True for full iteration,
+                    # False for sampled / probed-only buckets.
+                    "is_authoritative": False,
                     "description": _NAMESPACE_DESCRIPTIONS.get(
                         namespace, f"Namespace '{namespace}'"
                     ),
@@ -268,7 +296,7 @@ class _NamespaceMixin:
                 ns_info["_probed_count"] += 1
             else:
                 ns_info["_sampled_count"] += 1
-            ns_info["count"] += 1
+            ns_info["total"] += 1
             if len(ns_info["sample_entries"]) < 5:
                 ns_info["sample_entries"].append({"path": path, "title": title or path})
 
@@ -292,8 +320,11 @@ class _NamespaceMixin:
     def _finalise_full_iteration(namespaces: Dict[str, Dict[str, Any]]) -> None:
         """Collapse internal counters into the public shape after full scan."""
         for ns_info in namespaces.values():
-            ns_info["sampled_count"] = ns_info["count"]
-            ns_info["estimated_total"] = ns_info["count"]
+            # Full iteration enumerates every entry — the bucket's total
+            # is exact and the bucket is authoritative.
+            ns_info["sampled_count"] = ns_info["total"]
+            ns_info["estimated_total"] = ns_info["total"]
+            ns_info["is_authoritative"] = True
             ns_info.pop("_probed_count", None)
             ns_info.pop("_sampled_count", None)
 
@@ -374,7 +405,9 @@ class _NamespaceMixin:
             ns_info["sampled_count"] = sampled
             ns_info["probed_count"] = probed
             ns_info["estimated_total"] = estimated_total
-            ns_info["count"] = estimated_total
+            ns_info["total"] = estimated_total
+            # Sampling-derived counts are projections, not exact totals.
+            ns_info["is_authoritative"] = False
             ns_info.pop("_probed_count", None)
             ns_info.pop("_sampled_count", None)
 

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -11,7 +11,7 @@ shim's symbols continue to work without changes.
 import contextlib
 import json
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
 
 from libzim.reader import Archive  # type: ignore[import-untyped]
 
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from openzim_mcp.config import OpenZimMcpConfig
     from openzim_mcp.content_processor import ContentProcessor
     from openzim_mcp.security import PathValidator
+    from openzim_mcp.tool_schemas import BrowseNamespaceResponse
 
 logger = logging.getLogger(__name__)
 
@@ -469,11 +470,17 @@ class _NamespaceMixin:
 
     def browse_namespace_data(
         self, zim_file_path: str, namespace: str, limit: int = 50, offset: int = 0
-    ) -> Dict[str, Any]:
+    ) -> "BrowseNamespaceResponse":
         """Structured variant of ``browse_namespace``.
 
         Returns the result dict directly (not a JSON string) so MCP tools
         can hand it straight to FastMCP's structured-content path.
+
+        Phase B contract: top-level ``results`` / ``next_cursor`` /
+        ``total`` / ``done`` / ``page_info`` plus the ``namespace`` /
+        ``discovery_method`` / ``sampling_based`` /
+        ``results_may_be_incomplete`` extras. ``next_cursor`` is encoded
+        with ``tool="browse_namespace"`` and state ``{o, l, ns}``.
 
         Raises:
             OpenZimMcpValidationError: If parameter validation fails (limit,
@@ -481,6 +488,8 @@ class _NamespaceMixin:
             OpenZimMcpFileNotFoundError: If ZIM file not found
             OpenZimMcpArchiveError: If browsing fails
         """
+        from openzim_mcp.pagination import Cursor
+
         # Validate parameters. These are caller-input errors, distinct from
         # archive-access failures, so they surface as
         # OpenZimMcpValidationError to let the tool layer render a targeted
@@ -502,19 +511,20 @@ class _NamespaceMixin:
         validated_path = self.path_validator.validate_path(zim_file_path)
         validated_path = self.path_validator.validate_zim_file(validated_path)
 
-        # Cache key distinct from the legacy string cache so old persisted
-        # entries (which hold strings) don't collide with the new dict shape.
-        cache_key = f"browse_ns_data:{validated_path}:{namespace}:{limit}:{offset}"
+        # Cache key bumped to v2b (Phase B) so v1.x cached responses (old
+        # shape: entries/total_in_namespace/has_more/...) don't leak through
+        # after the upgrade.
+        cache_key = f"browse_ns_data:v2b:{validated_path}:{namespace}:{limit}:{offset}"
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug(f"Returning cached namespace browse dict for: {namespace}")
             if "_meta" not in cached_result:
                 cached_result = attach_meta(dict(cached_result))
-            return cached_result  # type: ignore[no-any-return]
+            return cast("BrowseNamespaceResponse", cached_result)
 
         try:
             with _zim_ops_mod.zim_archive(validated_path) as archive:
-                result = self._browse_namespace_entries(
+                raw = self._browse_namespace_entries(
                     archive,
                     namespace,
                     limit,
@@ -522,12 +532,52 @@ class _NamespaceMixin:
                     archive_path=str(validated_path),
                 )
 
-            # Cache the result
-            self.cache.set(cache_key, result)
+            # ``_browse_namespace_entries`` still returns the legacy inner
+            # shape (entries / total_in_namespace / has_more / ...). Adapt
+            # to the v2 Phase B contract here so internal callers and tests
+            # that target the helper aren't forced through the rename.
+            entries = raw.get("entries", [])
+            total_in_namespace = raw.get("total_in_namespace", 0)
+            is_total_authoritative = raw.get("is_total_authoritative", True)
+            discovery_method = raw.get("discovery_method", "unknown")
+            sampling_based = raw.get("sampling_based", False)
+            results_may_be_incomplete = raw.get("results_may_be_incomplete", False)
+
+            returned_count = len(entries)
+            last_index = offset + returned_count
+            done = last_index >= total_in_namespace
+            next_cursor: Optional[str] = None
+            if not done:
+                next_cursor = Cursor.encode(
+                    tool="browse_namespace",
+                    state={"o": last_index, "l": limit, "ns": namespace},
+                )
+
+            page_info: Dict[str, Any] = {
+                "offset": offset,
+                "limit": limit,
+                "returned_count": returned_count,
+            }
+            if not is_total_authoritative:
+                page_info["total_is_lower_bound"] = True
+
+            payload: Dict[str, Any] = {
+                "namespace": namespace,
+                "results": entries,
+                "next_cursor": next_cursor,
+                "total": total_in_namespace,
+                "done": done,
+                "page_info": page_info,
+                "discovery_method": discovery_method,
+                "sampling_based": sampling_based,
+                "results_may_be_incomplete": results_may_be_incomplete,
+            }
+
+            self.cache.set(cache_key, payload)
             logger.info(
                 f"Browsed namespace {namespace}: {limit} entries from offset {offset}"
             )
-            return attach_meta(result)
+            return cast("BrowseNamespaceResponse", attach_meta(payload))
 
         except Exception as e:
             logger.error(f"Namespace browsing failed for {namespace}: {e}")

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -3,9 +3,9 @@
 This mixin handles namespace listing, browsing, and walking — anything
 that surfaces or iterates over the archive's namespace structure.
 
-``zim_archive`` and ``PaginationCursor`` are accessed through
-``openzim_mcp.zim_operations`` so existing test patches against the
-shim's symbols continue to work without changes.
+``zim_archive`` is accessed through ``openzim_mcp.zim_operations`` so
+existing test patches against the shim's symbols continue to work
+without changes.
 """
 
 import contextlib
@@ -700,16 +700,9 @@ class _NamespaceMixin:
                 logger.warning(f"Error processing entry {entry_path}: {e}")
                 continue
 
-        # Build result with pagination cursor. Base has_more on the slice
-        # bounds, not on len(entries) — entries can be shorter than the page
-        # when individual entries fail to load, and we don't want to advertise
-        # a non-existent next page in that case.
-        has_more = end_idx < total_in_namespace
-        next_cursor = None
-        if has_more:
-            next_cursor = _zim_ops_mod.PaginationCursor.create_next_cursor(
-                offset, limit, total_in_namespace
-            )
+        # ``next_cursor`` and ``has_more`` are intentionally omitted here.
+        # ``browse_namespace_data`` (the sole caller) rebuilds both fields
+        # itself using ``Cursor.encode(tool="browse_namespace", ...)``.
 
         # When the sample hits NAMESPACE_MAX_ENTRIES, total_in_namespace is a
         # sample-bound, not the true count. has_more=False just means the sample
@@ -731,8 +724,6 @@ class _NamespaceMixin:
             "offset": offset,
             "limit": limit,
             "returned_count": len(entries),
-            "has_more": has_more,
-            "next_cursor": next_cursor,
             "entries": entries,
             "sampling_based": not full_iteration,
             "discovery_method": "full_iteration" if full_iteration else "sampling",

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -17,7 +17,7 @@ import logging
 import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
 
 from libzim.reader import Archive  # type: ignore[import-untyped]
 
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from openzim_mcp.config import OpenZimMcpConfig
     from openzim_mcp.content_processor import ContentProcessor
     from openzim_mcp.security import PathValidator
+    from openzim_mcp.tool_schemas import SearchResponse
 
 logger = logging.getLogger(__name__)
 
@@ -186,7 +187,7 @@ class _SearchMixin:
         query: str,
         limit: Optional[int] = None,
         offset: int = 0,
-    ) -> Dict[str, Any]:
+    ) -> "SearchResponse":
         """Structured variant of ``search_zim_file``.
 
         Returns the raw search payload as a Python dict so MCP tool functions
@@ -205,15 +206,15 @@ class _SearchMixin:
         validated_path = self.path_validator.validate_path(zim_file_path)
         validated_path = self.path_validator.validate_zim_file(validated_path)
 
-        # Cache key distinct from the legacy string cache so old persisted
-        # entries (which hold strings) don't collide with the new dict shape.
-        cache_key = f"search_data:{validated_path}:{query}:{limit}:{offset}"
+        # Cache key bumped to v2b (Phase B) so v1.x cached responses (old shape)
+        # don't leak through after the upgrade.
+        cache_key = f"search_v2b:{validated_path}:{query}:{limit}:{offset}"
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug(f"Returning cached search dict for query: {query}")
             if "_meta" not in cached_result:
                 cached_result = attach_meta(dict(cached_result))
-            return cached_result  # type: ignore[no-any-return]
+            return cast("SearchResponse", cached_result)
 
         try:
             with _zim_ops_mod.zim_archive(validated_path) as archive:
@@ -252,10 +253,13 @@ class _SearchMixin:
                 except Exception as e:
                     logger.debug(f"alt_archive suggestion build failed: {e}")
 
-            return attach_meta(
-                payload,
-                reason=reason,
-                suggestions=suggestions if suggestions else None,
+            return cast(
+                "SearchResponse",
+                attach_meta(
+                    payload,
+                    reason=reason,
+                    suggestions=suggestions if suggestions else None,
+                ),
             )
 
         except OpenZimMcpArchiveError:
@@ -276,59 +280,57 @@ class _SearchMixin:
             to decide whether the response is safe to cache. The payload
             shape is documented on ``search_zim_file_data``.
         """
-        # Create searcher and execute search
+        from openzim_mcp.pagination import Cursor
+
         query_obj = _zim_ops_mod.Query().set_query(query)
         searcher = _zim_ops_mod.Searcher(archive)
         search = searcher.search(query_obj)
 
-        # Get total results
         total_results = search.getEstimatedMatches()
 
         if total_results == 0:
             return (
                 {
                     "query": query,
-                    "total_results": 0,
-                    "offset": offset,
-                    "limit": limit,
                     "results": [],
-                    "pagination": {"has_more": False},
+                    "next_cursor": None,
+                    "total": 0,
+                    "done": True,
+                    "page_info": {
+                        "offset": offset,
+                        "limit": limit,
+                        "returned_count": 0,
+                    },
                 },
                 0,
             )
 
-        # Guard against offset exceeding total results (would produce negative count)
         if offset >= total_results:
             return (
                 {
                     "query": query,
-                    "total_results": total_results,
-                    "offset": offset,
-                    "limit": limit,
                     "results": [],
-                    "pagination": {
-                        "has_more": False,
-                        "offset_exceeds_total": True,
+                    "next_cursor": None,
+                    "total": total_results,
+                    "done": True,
+                    "page_info": {
+                        "offset": offset,
+                        "limit": limit,
+                        "returned_count": 0,
                     },
                 },
                 total_results,
             )
 
         result_count = min(limit, total_results - offset)
-
-        # Get search results
         result_entries = list(search.getResults(offset, result_count))
 
-        # Collect search results
         results: List[Dict[str, Any]] = []
         for i, entry_id in enumerate(result_entries):
             try:
                 entry = archive.get_entry_by_path(entry_id)
                 title = entry.title or "Untitled"
-
-                # Get content snippet
                 snippet = self._get_entry_snippet(entry, query=query)
-
                 results.append({"path": entry_id, "title": title, "snippet": snippet})
             except Exception as e:
                 logger.warning(f"Error processing search result {entry_id}: {e}")
@@ -340,47 +342,46 @@ class _SearchMixin:
                     }
                 )
 
-        has_more = (offset + len(results)) < total_results
-        pagination: Dict[str, Any] = {
-            "has_more": has_more,
-            "showing_start": offset + 1,
-            "showing_end": offset + len(results),
-        }
-        if has_more:
-            next_cursor = _zim_ops_mod.PaginationCursor.create_next_cursor(
-                offset, limit, total_results, query
+        returned_count = len(results)
+        last_index = offset + returned_count
+        done = last_index >= total_results
+        next_cursor: Optional[str] = None
+        if not done:
+            next_cursor = Cursor.encode(
+                tool="search_zim_file",
+                state={"o": last_index, "l": limit, "q": query},
             )
-            # Partial-page case: has_more can be True (offset+len(results)
-            # < total_results) while offset+limit >= total_results, in which
-            # case create_next_cursor returns None. Omit the cursor key in
-            # that case — the caller falls back to the offset hint.
-            if next_cursor is not None:
-                pagination["next_cursor"] = next_cursor
 
         return (
             {
                 "query": query,
-                "total_results": total_results,
-                "offset": offset,
-                "limit": limit,
                 "results": results,
-                "pagination": pagination,
+                "next_cursor": next_cursor,
+                "total": total_results,
+                "done": done,
+                "page_info": {
+                    "offset": offset,
+                    "limit": limit,
+                    "returned_count": returned_count,
+                },
             },
             total_results,
         )
 
-    def _format_search_text(self, payload: Dict[str, Any]) -> str:
+    def _format_search_text(self, payload: "SearchResponse") -> str:
         """Render a structured search payload as the legacy markdown text.
 
         Mirrors the original ``_perform_search`` output exactly so callers
         (and tests) that consume the rendered text keep working unchanged.
         """
         query = payload["query"]
-        total_results = payload["total_results"]
-        offset = payload["offset"]
-        limit = payload["limit"]
+        total_results = payload["total"] or 0
+        page_info = payload["page_info"]
+        offset = page_info["offset"]
+        limit = page_info["limit"]
         results = payload["results"]
-        pagination = payload.get("pagination", {})
+        done = payload["done"]
+        next_cursor = payload.get("next_cursor")
 
         if total_results == 0:
             # Append actionable next-step hints so an LLM caller knows
@@ -400,7 +401,9 @@ class _SearchMixin:
                 f"- A shorter or differently-cased query"
             )
 
-        if pagination.get("offset_exceeds_total"):
+        # Phase B: ``offset_exceeds_total`` is no longer surfaced as a flag —
+        # detect via ``total < offset`` plus an empty results list.
+        if not results and offset >= total_results:
             return (
                 f'Found {total_results} matches for "{query}", '
                 f"but offset {offset} exceeds total results."
@@ -419,10 +422,9 @@ class _SearchMixin:
         # Compact one-liner footer — see the matching comment in the simple
         # search renderer above for rationale.
         result_text += "---\n"
-        has_more = pagination.get("has_more", False)
-        if has_more:
+        if not done:
             next_offset = offset + limit
-            if pagination.get("next_cursor") is None:
+            if next_cursor is None:
                 # Filtered/limited path that doesn't know the next-page
                 # boundary precisely; advance by what we actually returned.
                 next_offset = offset + len(results)
@@ -1612,12 +1614,18 @@ class _SearchMixin:
                 continue
             try:
                 payload = self.search_zim_file_data(path, query, limit_per_file, 0)
+                # Task 6: search_all shape migration. ``total_results`` was
+                # renamed to ``total`` in Phase B, but this aggregator's
+                # response shape is rewritten by Task 6 — read both keys for
+                # the transitional window so search_all's ``has_hits`` flag
+                # still works while Task 5 lands.
+                _total = payload.get("total", payload.get("total_results", 0))
                 per_file.append(
                     {
                         "zim_file_path": path,
                         "name": file_info.get("name"),
                         "result": payload,
-                        "has_hits": payload.get("total_results", 0) > 0,
+                        "has_hits": (_total or 0) > 0,
                     }
                 )
             except Exception as e:

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from openzim_mcp.content_processor import ContentProcessor
     from openzim_mcp.security import PathValidator
     from openzim_mcp.tool_schemas import (
+        FindEntryResponse,
         SearchAllResponse,
         SearchResponse,
         SearchWithFiltersResponse,
@@ -1446,7 +1447,7 @@ class _SearchMixin:
         title: str,
         cross_file: bool = False,
         limit: int = 10,
-    ) -> Dict[str, Any]:
+    ) -> "FindEntryResponse":
         """Structured variant of ``find_entry_by_title``.
 
         Returns the result dict directly (not a JSON string) so MCP tools
@@ -1615,16 +1616,33 @@ class _SearchMixin:
 
         reason = None if aggregate_results else "0_hits"
 
-        return attach_meta(
-            {
-                "query": title,
-                "results": aggregate_results[:limit],
-                "fast_path_hit": fast_path_hit,
-                "fuzzy_path_hit": fuzzy_path_hit,
-                "files_searched": len(files),
+        # Trim to limit and build the contract envelope. ``find_entry_by_title``
+        # is non-paginated (no cursor input, no offset), but the v2 Phase B
+        # contract still applies for uniformity: ``next_cursor=None``,
+        # ``done=True``, ``total=len(results)``, ``page_info.offset=0``.
+        trimmed_results = aggregate_results[:limit]
+        payload: Dict[str, Any] = {
+            "query": title,
+            "results": trimmed_results,
+            "next_cursor": None,
+            "total": len(trimmed_results),
+            "done": True,
+            "page_info": {
+                "offset": 0,
+                "limit": limit,
+                "returned_count": len(trimmed_results),
             },
-            suggestions=suggestions if suggestions else None,
-            reason=reason,
+            "fast_path_hit": fast_path_hit,
+            "fuzzy_path_hit": fuzzy_path_hit,
+            "files_searched": len(files),
+        }
+        return cast(
+            "FindEntryResponse",
+            attach_meta(
+                payload,
+                suggestions=suggestions if suggestions else None,
+                reason=reason,
+            ),
         )
 
     def find_entry_by_title(

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -1051,9 +1051,9 @@ class _SearchMixin:
         validated_path = self.path_validator.validate_path(zim_file_path)
         validated_path = self.path_validator.validate_zim_file(validated_path)
 
-        # Cache key distinct from the legacy string cache so old persisted
-        # entries (which hold strings) don't collide with the new dict shape.
-        cache_key = f"suggestions_data:{validated_path}:{partial_query}:{limit}"
+        # Cache key bumped to v2b (Phase B) so v1.x cached responses (old
+        # shape: suggestions/count keys) don't leak through after the upgrade.
+        cache_key = f"suggestions_data:v2b:{validated_path}:{partial_query}:{limit}"
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug(f"Returning cached suggestions dict for: {partial_query}")

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -603,9 +603,7 @@ class _SearchMixin:
         )
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
-            logger.debug(
-                f"Returning cached filtered search dict for query: {query}"
-            )
+            logger.debug(f"Returning cached filtered search dict for query: {query}")
             if "_meta" not in cached_result:
                 cached_result = attach_meta(dict(cached_result))
             return cast("SearchWithFiltersResponse", cached_result)
@@ -640,8 +638,7 @@ class _SearchMixin:
         # Surface that via ``page_info.total_is_lower_bound`` so the contract
         # ``total`` stays honest.
         done = (
-            last_index >= scan.filtered_count
-            and not scan.total_filtered_is_lower_bound
+            last_index >= scan.filtered_count and not scan.total_filtered_is_lower_bound
         )
         next_cursor: Optional[str] = None
         if not done:
@@ -751,9 +748,7 @@ class _SearchMixin:
             try:
                 title = entry.title or "Untitled"
                 snippet = self._get_entry_snippet(entry, query=query)
-                results.append(
-                    {"path": entry_id, "title": title, "snippet": snippet}
-                )
+                results.append({"path": entry_id, "title": title, "snippet": snippet})
             except Exception as e:
                 logger.warning(
                     f"Error processing filtered search result {entry_id}: {e}"
@@ -1063,9 +1058,7 @@ class _SearchMixin:
 
         try:
             with _zim_ops_mod.zim_archive(validated_path) as archive:
-                raw = self._generate_search_suggestions(
-                    archive, partial_query, limit
-                )
+                raw = self._generate_search_suggestions(archive, partial_query, limit)
 
             # ``_generate_search_suggestions`` returns the legacy
             # {partial_query, suggestions, count} shape. Adapt to the

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
         FindEntryResponse,
         SearchAllResponse,
         SearchResponse,
+        SearchSuggestionsResponse,
         SearchWithFiltersResponse,
     )
 
@@ -1016,11 +1017,16 @@ class _SearchMixin:
 
     def get_search_suggestions_data(
         self, zim_file_path: str, partial_query: str, limit: int = 10
-    ) -> Dict[str, Any]:
+    ) -> "SearchSuggestionsResponse":
         """Structured variant of ``get_search_suggestions``.
 
         Returns the result dict directly (not a JSON string) so MCP tools
         can hand it straight to FastMCP's structured-content path.
+
+        ``get_search_suggestions`` is non-paginated (no cursor input,
+        no offset), but the v2 Phase B contract still applies for
+        uniformity: ``next_cursor=None``, ``done=True``,
+        ``total=len(results)``, ``page_info.offset=0``.
 
         Raises:
             OpenZimMcpFileNotFoundError: If ZIM file not found
@@ -1031,9 +1037,15 @@ class _SearchMixin:
         if limit < 1 or limit > 50:
             raise OpenZimMcpValidationError("Limit must be between 1 and 50")
         if not partial_query or len(partial_query.strip()) < 2:
-            return attach_meta(
-                {"suggestions": [], "message": "Query too short for suggestions"}
-            )
+            empty_payload: Dict[str, Any] = {
+                "partial_query": partial_query,
+                "results": [],
+                "next_cursor": None,
+                "total": 0,
+                "done": True,
+                "page_info": {"offset": 0, "limit": limit, "returned_count": 0},
+            }
+            return cast("SearchSuggestionsResponse", attach_meta(empty_payload))
 
         # Validate and resolve file path
         validated_path = self.path_validator.validate_path(zim_file_path)
@@ -1047,26 +1059,44 @@ class _SearchMixin:
             logger.debug(f"Returning cached suggestions dict for: {partial_query}")
             if "_meta" not in cached_result:
                 cached_result = attach_meta(dict(cached_result))
-            return cached_result  # type: ignore[no-any-return]
+            return cast("SearchSuggestionsResponse", cached_result)
 
         try:
             with _zim_ops_mod.zim_archive(validated_path) as archive:
-                result = self._generate_search_suggestions(
+                raw = self._generate_search_suggestions(
                     archive, partial_query, limit
                 )
 
-            # Read the count straight off the dict for accurate logging and
-            # to decide whether the response is worth caching. A cold-cache
-            # request that hits before the libzim title index has warmed up
-            # can return zero suggestions for a query that will produce
-            # results moments later — caching that empty payload locks the
-            # query into "no suggestions" for the full TTL.
-            actual_count = result.get("count", len(result.get("suggestions", [])))
-            count_for_gate = actual_count if isinstance(actual_count, int) else 0
-            if count_for_gate > 0:
-                self.cache.set(cache_key, result)
+            # ``_generate_search_suggestions`` returns the legacy
+            # {partial_query, suggestions, count} shape. Adapt to the
+            # contract here: rename ``suggestions`` → ``results`` at the
+            # top level (the Phase A ``_meta.suggestions[]`` recovery
+            # candidates are unrelated and live inside ``_meta``).
+            suggestions = raw.get("suggestions", [])
+            actual_count = len(suggestions)
+
+            payload: Dict[str, Any] = {
+                "partial_query": partial_query,
+                "results": suggestions,
+                "next_cursor": None,
+                "total": actual_count,
+                "done": True,
+                "page_info": {
+                    "offset": 0,
+                    "limit": limit,
+                    "returned_count": actual_count,
+                },
+            }
+
+            # A cold-cache request that hits before the libzim title index
+            # has warmed up can return zero suggestions for a query that
+            # will produce results moments later — caching that empty
+            # payload locks the query into "no suggestions" for the full
+            # TTL. Only cache non-empty results.
+            if actual_count > 0:
+                self.cache.set(cache_key, payload)
             logger.info(f"Generated {actual_count} suggestions for: {partial_query}")
-            return attach_meta(result)
+            return cast("SearchSuggestionsResponse", attach_meta(payload))
 
         except OpenZimMcpArchiveError:
             # Inner helper already raised a typed archive error with full

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from openzim_mcp.config import OpenZimMcpConfig
     from openzim_mcp.content_processor import ContentProcessor
     from openzim_mcp.security import PathValidator
-    from openzim_mcp.tool_schemas import SearchResponse
+    from openzim_mcp.tool_schemas import SearchAllResponse, SearchResponse
 
 logger = logging.getLogger(__name__)
 
@@ -1578,8 +1578,14 @@ class _SearchMixin:
         self,
         query: str,
         limit_per_file: int = 5,
-    ) -> Dict[str, Any]:
-        """Structured variant of ``search_all``.
+    ) -> "SearchAllResponse":
+        """Structured variant of ``search_all`` (Phase B contract).
+
+        Top-level shape is a non-paginated ``PaginatedResponse[per_file]``
+        — ``done`` is always ``True`` and ``next_cursor`` is always
+        ``None`` because fan-out across archives happens in one shot.
+        Each ``results[].result`` is itself a Phase B ``SearchResponse``
+        carrying its own per-archive cursor.
 
         Per-file results are real dicts (the structured payload from
         ``search_zim_file_data``) rather than markdown strings — fixing
@@ -1592,9 +1598,12 @@ class _SearchMixin:
             limit_per_file: Maximum hits to return per ZIM file (1-50, default 5)
 
         Returns:
-            Dict with per-file result groups and aggregate counts. Each
-            ``per_file[].result`` is the structured search payload from
-            ``search_zim_file_data`` — a dict, not a string.
+            ``SearchAllResponse``-shaped dict. Each ``results[].result``
+            is the structured search payload from ``search_zim_file_data``
+            — a dict, not a string. Aggregate counts (``files_searched``,
+            ``files_with_hits``, ``files_searched_successfully``,
+            ``files_failed``) live at the top level alongside the
+            contract keys.
         """
         if not query or not query.strip():
             raise OpenZimMcpValidationError(
@@ -1614,18 +1623,13 @@ class _SearchMixin:
                 continue
             try:
                 payload = self.search_zim_file_data(path, query, limit_per_file, 0)
-                # Task 6: search_all shape migration. ``total_results`` was
-                # renamed to ``total`` in Phase B, but this aggregator's
-                # response shape is rewritten by Task 6 — read both keys for
-                # the transitional window so search_all's ``has_hits`` flag
-                # still works while Task 5 lands.
-                _total = payload.get("total", payload.get("total_results", 0))
+                _total = payload.get("total", 0) or 0
                 per_file.append(
                     {
                         "zim_file_path": path,
                         "name": file_info.get("name"),
                         "result": payload,
-                        "has_hits": (_total or 0) > 0,
+                        "has_hits": _total > 0,
                     }
                 )
             except Exception as e:
@@ -1638,17 +1642,29 @@ class _SearchMixin:
                     }
                 )
 
-        return attach_meta(
-            {
-                "query": query,
-                "files_searched": len(files),
-                "files_with_hits": sum(1 for r in per_file if r.get("has_hits")),
-                "files_searched_successfully": sum(
-                    1 for r in per_file if "result" in r
-                ),
-                "files_failed": sum(1 for r in per_file if "error" in r),
-                "per_file": per_file,
-            }
+        files_searched = len(files)
+        return cast(
+            "SearchAllResponse",
+            attach_meta(
+                {
+                    "query": query,
+                    "files_searched": files_searched,
+                    "files_with_hits": sum(1 for r in per_file if r.get("has_hits")),
+                    "files_searched_successfully": sum(
+                        1 for r in per_file if "result" in r
+                    ),
+                    "files_failed": sum(1 for r in per_file if "error" in r),
+                    "results": per_file,
+                    "next_cursor": None,
+                    "total": files_searched,
+                    "done": True,
+                    "page_info": {
+                        "offset": 0,
+                        "limit": files_searched,
+                        "returned_count": len(per_file),
+                    },
+                }
+            ),
         )
 
     def search_all(

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -33,7 +33,11 @@ if TYPE_CHECKING:
     from openzim_mcp.config import OpenZimMcpConfig
     from openzim_mcp.content_processor import ContentProcessor
     from openzim_mcp.security import PathValidator
-    from openzim_mcp.tool_schemas import SearchAllResponse, SearchResponse
+    from openzim_mcp.tool_schemas import (
+        SearchAllResponse,
+        SearchResponse,
+        SearchWithFiltersResponse,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -450,7 +454,12 @@ class _SearchMixin:
         limit: Optional[int] = None,
         offset: int = 0,
     ) -> str:
-        """Search within ZIM file content with namespace and content type filters.
+        """Markdown-rendered filtered search (legacy surface).
+
+        See ``search_with_filters_data`` for the structured variant. This
+        wrapper renders the structured payload to the legacy markdown text
+        block so existing callers (and tests) that consume the rendered
+        text keep working unchanged.
 
         Args:
             zim_file_path: Path to the ZIM file
@@ -489,7 +498,7 @@ class _SearchMixin:
         validated_path = self.path_validator.validate_path(zim_file_path)
         validated_path = self.path_validator.validate_zim_file(validated_path)
 
-        # Check cache
+        # Check cache (legacy markdown cache, separate from the v2b dict cache).
         cache_key = (
             f"search_filtered:{validated_path}:{query}:{namespace}:"
             f"{content_type}:{limit}:{offset}"
@@ -531,6 +540,230 @@ class _SearchMixin:
             raise OpenZimMcpArchiveError(
                 f"Filtered search operation failed: {e}"
             ) from e
+
+    def search_with_filters_data(
+        self,
+        zim_file_path: str,
+        query: str,
+        namespace: Optional[str] = None,
+        content_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> "SearchWithFiltersResponse":
+        """Structured filtered-search response. v2 Phase B contract.
+
+        Same shape as ``search_zim_file_data`` (top-level ``results`` /
+        ``next_cursor`` / ``total`` / ``done`` / ``page_info``) plus
+        tool-specific extras ``query`` / ``namespace_filter`` /
+        ``content_type_filter``. Cursor ``t="search_with_filters"``.
+
+        The libzim-level filtering pipeline (``_scan_filtered_search`` →
+        ``_materialise_filtered_entry``) is preserved verbatim — only the
+        response shape is changing. That pipeline streams search hits in
+        bounded batches and applies cheap path-prefix namespace filtering
+        before the per-entry archive lookups required for content_type
+        filtering, which would otherwise multiply ``offset + limit`` entry
+        materialisations across every candidate.
+
+        Raises:
+            OpenZimMcpFileNotFoundError: If ZIM file not found
+            OpenZimMcpValidationError: If parameter validation fails
+                (limit out of range, negative offset, malformed namespace).
+            OpenZimMcpArchiveError: If search operation fails
+        """
+        from openzim_mcp.pagination import Cursor
+
+        if limit is None:
+            limit = self.config.content.default_search_limit
+
+        # Caller-input validation surfaces as OpenZimMcpValidationError so
+        # the tool layer can render a targeted "bad parameter" message
+        # instead of formatting it as an archive failure.
+        if limit < 1 or limit > 100:
+            raise OpenZimMcpValidationError("Limit must be between 1 and 100")
+        if offset < 0:
+            raise OpenZimMcpValidationError("Offset must be non-negative")
+        if namespace and (len(namespace) > 50 or not namespace.strip()):
+            raise OpenZimMcpValidationError(
+                "Namespace must be a non-empty string (max 50 characters)"
+            )
+
+        # Validate and resolve file path
+        validated_path = self.path_validator.validate_path(zim_file_path)
+        validated_path = self.path_validator.validate_zim_file(validated_path)
+
+        # Cache key bumped to v2b (Phase B) so v1.x cached responses (markdown
+        # strings under the legacy ``search_filtered:`` prefix) don't leak
+        # through after the upgrade — different prefix, different cache slot.
+        cache_key = (
+            f"search_filtered_v2b:{validated_path}:{query}:{namespace}:"
+            f"{content_type}:{limit}:{offset}"
+        )
+        cached_result = self.cache.get(cache_key)
+        if cached_result is not None:
+            logger.debug(
+                f"Returning cached filtered search dict for query: {query}"
+            )
+            if "_meta" not in cached_result:
+                cached_result = attach_meta(dict(cached_result))
+            return cast("SearchWithFiltersResponse", cached_result)
+
+        try:
+            with _zim_ops_mod.zim_archive(validated_path) as archive:
+                results, scan = self._perform_filtered_search_data(
+                    archive, query, namespace, content_type, limit, offset
+                )
+        except OpenZimMcpValidationError:
+            raise
+        except OpenZimMcpArchiveError:
+            raise
+        except Exception as e:
+            logger.error(f"Filtered search failed for {validated_path}: {e}")
+            raise OpenZimMcpArchiveError(
+                f"Filtered search operation failed: {e}"
+            ) from e
+
+        # Build the contract envelope. ``done`` / ``next_cursor`` mirror
+        # the search_zim_file_data semantics: when the scan filled a full
+        # page short of exhausting the unfiltered hit list, more pages may
+        # exist; emit a cursor so callers can resume.
+        returned_count = len(results)
+        last_index = offset + returned_count
+        # ``filtered_count`` is the number of post-filter hits the scanner
+        # tallied through ``last_index``. It can be a lower bound when the
+        # scan filled the page short of exhausting the unfiltered list.
+        total_filtered: Optional[int] = scan.filtered_count
+        # When the scan capped (10k) without exhausting the result list,
+        # ``filtered_count`` is a lower bound — we don't know the true total.
+        # Surface that via ``page_info.total_is_lower_bound`` so the contract
+        # ``total`` stays honest.
+        done = (
+            last_index >= scan.filtered_count
+            and not scan.total_filtered_is_lower_bound
+        )
+        next_cursor: Optional[str] = None
+        if not done:
+            cursor_state: Dict[str, Any] = {"o": last_index, "l": limit, "q": query}
+            if namespace:
+                cursor_state["ns"] = namespace
+            if content_type:
+                cursor_state["ct"] = content_type
+            next_cursor = Cursor.encode(
+                tool="search_with_filters",
+                state=cast(Any, cursor_state),
+            )
+
+        page_info: Dict[str, Any] = {
+            "offset": offset,
+            "limit": limit,
+            "returned_count": returned_count,
+        }
+        if scan.total_filtered_is_lower_bound:
+            page_info["total_is_lower_bound"] = True
+
+        payload: Dict[str, Any] = {
+            "query": query,
+            "namespace_filter": namespace,
+            "content_type_filter": content_type,
+            "results": results,
+            "next_cursor": next_cursor,
+            "total": total_filtered,
+            "done": done,
+            "page_info": page_info,
+        }
+
+        # Don't cache zero-result responses: libzim's lazy index warm-up
+        # can return 0 matches transiently, and a TTL-cached "no results"
+        # would mask the index becoming ready.
+        if scan.filtered_count > 0:
+            self.cache.set(cache_key, payload)
+        logger.info(
+            f"Filtered search completed: query='{query}', "
+            f"namespace={namespace}, type={content_type}, "
+            f"results={returned_count}"
+        )
+        reason = "0_hits" if scan.filtered_count == 0 else None
+        return cast(
+            "SearchWithFiltersResponse",
+            attach_meta(payload, reason=reason),
+        )
+
+    def _perform_filtered_search_data(
+        self,
+        archive: Archive,
+        query: str,
+        namespace: Optional[str],
+        content_type: Optional[str],
+        limit: int,
+        offset: int,
+    ) -> Tuple[List[Dict[str, Any]], "_FilteredScanState"]:
+        """Run the libzim-level filtered scan and return structured hits.
+
+        Mirrors ``_perform_filtered_search`` but returns
+        ``(results_list, scan_state)`` instead of a rendered markdown
+        string. The same streaming-with-skip-counter scan applies — see
+        ``_scan_filtered_search`` for the bounded-batch rationale.
+
+        Returns:
+            (results, scan) — ``results`` is a list of hit dicts shaped
+            like ``SearchHit`` (path/title/snippet); ``scan`` carries the
+            ``_FilteredScanState`` aggregate (filtered_count,
+            total_filtered_is_lower_bound, etc.) that the caller uses to
+            decide pagination semantics.
+        """
+        # Canonicalise user-supplied namespace ("c" -> "C", "content" -> "C")
+        # so the comparison against namespace prefixes derived from libzim
+        # paths (which always surface in canonical form) does not silently
+        # filter every result when callers pass lowercase or long-form names.
+        if namespace:
+            namespace = self._canonicalise_namespace(namespace.strip())
+
+        query_obj = _zim_ops_mod.Query().set_query(query)
+        searcher = _zim_ops_mod.Searcher(archive)
+        search = searcher.search(query_obj)
+        total_results = search.getEstimatedMatches()
+        if total_results == 0:
+            return [], _FilteredScanState(
+                filtered_count=0,
+                scanned=0,
+                scan_cap_hit=False,
+                total_filtered_is_lower_bound=False,
+            )
+
+        page, scan = self._scan_filtered_search(
+            archive, search, total_results, namespace, content_type, limit, offset
+        )
+
+        if scan.filtered_count == 0:
+            return [], scan
+        if offset >= scan.filtered_count:
+            return [], scan
+
+        # Project (entry_id, entry, namespace, content_mime) tuples onto
+        # SearchHit-shaped dicts. Per-hit ``namespace`` / ``content_type``
+        # fields are dropped: the response contract reports the active
+        # filters once at the top level (``namespace_filter`` /
+        # ``content_type_filter``) rather than repeating them per hit.
+        results: List[Dict[str, Any]] = []
+        for i, (entry_id, entry, _entry_namespace, _content_mime) in enumerate(page):
+            try:
+                title = entry.title or "Untitled"
+                snippet = self._get_entry_snippet(entry, query=query)
+                results.append(
+                    {"path": entry_id, "title": title, "snippet": snippet}
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Error processing filtered search result {entry_id}: {e}"
+                )
+                results.append(
+                    {
+                        "path": entry_id,
+                        "title": f"Entry {offset + i + 1}",
+                        "snippet": f"(Error getting entry details: {e})",
+                    }
+                )
+        return results, scan
 
     def _perform_filtered_search(
         self,

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -13,19 +13,21 @@ without changes.
 import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
 
 from libzim.reader import Archive  # type: ignore[import-untyped]
 
 import openzim_mcp.zim_operations as _zim_ops_mod
 from openzim_mcp.exceptions import OpenZimMcpArchiveError, OpenZimMcpValidationError
 from openzim_mcp.meta import attach_meta
+from openzim_mcp.pagination import Cursor
 
 if TYPE_CHECKING:
     from openzim_mcp.cache import OpenZimMcpCache
     from openzim_mcp.config import OpenZimMcpConfig
     from openzim_mcp.content_processor import ContentProcessor
     from openzim_mcp.security import PathValidator
+    from openzim_mcp.tool_schemas import LinksResponse
 
 logger = logging.getLogger(__name__)
 
@@ -174,33 +176,32 @@ class _StructureMixin:
         entry_path: str,
         limit: int = 100,
         offset: int = 0,
-        kind: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        """Structured variant of ``extract_article_links``.
+        kind: str = "internal",
+    ) -> "LinksResponse":
+        """Structured variant of ``extract_article_links``. v2 Phase B contract.
 
         Returns the result dict directly (not a JSON string) so MCP tools
         can hand it straight to FastMCP's structured-content path.
 
-        Heavy articles (e.g. Wikipedia "Evolution") carry hundreds of links;
-        the unbounded variant routinely overflowed MCP response budgets. This
-        method paginates per category (internal / external / media) and
-        always reports the full ``total_*_links`` so callers can size their
-        next request.
+        v2 Phase B: ``kind`` is required-with-default. Each call returns
+        exactly one category in ``results``; ``category_totals`` reports
+        the full counts for all three categories so callers can size
+        their next request. To enumerate all three categories, issue
+        three calls with different ``kind`` values.
 
         Args:
             zim_file_path: Path to the ZIM file
             entry_path: Entry path, e.g., 'C/Some_Article'
-            limit: Max items per category in the response (1-500, default 100).
-            offset: Starting offset within each category (default 0).
-            kind: Optional filter — ``"internal"``, ``"external"``, or
-                ``"media"``. When set, the other categories are returned as
-                empty lists; their totals are still reported.
+            limit: Max items per page (1-500, default 100).
+            offset: Starting offset within the requested category (default 0).
+            kind: Which category to return — ``"internal"`` (default),
+                ``"external"``, or ``"media"``.
 
         Returns:
-            Dict with ``internal_links``, ``external_links``, ``media_links``
-            (paged subsets), ``total_*_links`` (full counts), and a
-            ``pagination`` block (``offset``, ``limit``, ``has_more``,
-            ``kind``).
+            ``LinksResponse``: ``results`` (paged subset of one category),
+            top-level contract keys (``next_cursor``, ``total``, ``done``,
+            ``page_info``), plus ``title``, ``path``, ``content_type``,
+            ``kind``, and ``category_totals`` (full counts per category).
 
         Raises:
             OpenZimMcpValidationError: limit/offset/kind out of range.
@@ -218,9 +219,9 @@ class _StructureMixin:
             raise OpenZimMcpValidationError(
                 f"offset must be non-negative (provided: {offset})"
             )
-        if kind is not None and kind not in {"internal", "external", "media"}:
+        if kind not in {"internal", "external", "media"}:
             raise OpenZimMcpValidationError(
-                f"kind must be one of internal/external/media or omitted "
+                f"kind must be one of 'internal', 'external', 'media' "
                 f"(provided: {kind!r})"
             )
 
@@ -232,12 +233,61 @@ class _StructureMixin:
             extraction = self._get_or_load_link_extraction(
                 str(validated_path), entry_path
             )
-            result = self._render_paged_links(extraction, limit, offset, kind)
+
+            full_internal: List[Any] = extraction["internal"]
+            full_external: List[Any] = extraction["external"]
+            full_media: List[Any] = extraction["media"]
+            by_kind = {
+                "internal": full_internal,
+                "external": full_external,
+                "media": full_media,
+            }
+            full_list = by_kind[kind]
+            total_for_kind = len(full_list)
+            page = full_list[offset : offset + limit]
+            returned_count = len(page)
+            last_index = offset + returned_count
+            done = last_index >= total_for_kind
+            next_cursor: Optional[str] = None
+            if not done:
+                next_cursor = Cursor.encode(
+                    tool="extract_article_links",
+                    state={
+                        "o": last_index,
+                        "l": limit,
+                        "ep": entry_path,
+                        "k": kind,
+                    },
+                )
+
+            payload: Dict[str, Any] = {
+                "title": extraction["title"],
+                "path": extraction["path"],
+                "content_type": extraction["content_type"],
+                "kind": kind,
+                "results": page,
+                "next_cursor": next_cursor,
+                "total": total_for_kind,
+                "done": done,
+                "page_info": {
+                    "offset": offset,
+                    "limit": limit,
+                    "returned_count": returned_count,
+                },
+                "category_totals": {
+                    "internal": len(full_internal),
+                    "external": len(full_external),
+                    "media": len(full_media),
+                },
+            }
+            if extraction.get("message"):
+                payload["message"] = extraction["message"]
+
             logger.info(
                 f"Extracted links for: {entry_path} "
                 f"(limit={limit}, offset={offset}, kind={kind})"
             )
-            return attach_meta(result)
+            return cast("LinksResponse", attach_meta(payload))
 
         except OpenZimMcpValidationError:
             raise
@@ -255,23 +305,23 @@ class _StructureMixin:
         entry_path: str,
         limit: int = 100,
         offset: int = 0,
-        kind: Optional[str] = None,
+        kind: str = "internal",
     ) -> str:
         """Legacy JSON-string variant of ``extract_article_links_data``.
 
-        Extract internal and external links from an article, with pagination.
+        Extract links of one category from an article, with pagination.
 
         Args:
             zim_file_path: Path to the ZIM file
             entry_path: Entry path, e.g., 'C/Some_Article'
-            limit: Max items per category in the response (1-500, default 100).
-            offset: Starting offset within each category (default 0).
-            kind: Optional filter — ``"internal"``, ``"external"``, or
-                ``"media"``.
+            limit: Max items per page (1-500, default 100).
+            offset: Starting offset within the requested category (default 0).
+            kind: Which category — ``"internal"`` (default), ``"external"``,
+                or ``"media"``.
 
         Returns:
-            JSON string containing extracted links, totals, and pagination
-            metadata.
+            JSON string containing the v2 Phase B ``LinksResponse`` payload
+            (single-category ``results`` plus pagination contract).
 
         Raises:
             OpenZimMcpValidationError: limit/offset/kind out of range.
@@ -349,55 +399,6 @@ class _StructureMixin:
         except Exception as e:
             logger.error(f"Error extracting links for {entry_path}: {e}")
             raise OpenZimMcpArchiveError(f"Failed to extract article links: {e}") from e
-
-    @staticmethod
-    def _render_paged_links(
-        extraction: Dict[str, Any],
-        limit: int,
-        offset: int,
-        kind: Optional[str],
-    ) -> Dict[str, Any]:
-        """Slice cached extraction into a paged response dict."""
-        full_internal: List[Any] = extraction["internal"]
-        full_external: List[Any] = extraction["external"]
-        full_media: List[Any] = extraction["media"]
-
-        def _page(full: List[Any], include: bool) -> Tuple[List[Any], bool]:
-            if not include:
-                return [], False
-            end = offset + limit
-            page = full[offset:end]
-            return page, end < len(full)
-
-        internal_page, internal_more = _page(full_internal, kind in (None, "internal"))
-        external_page, external_more = _page(full_external, kind in (None, "external"))
-        media_page, media_more = _page(full_media, kind in (None, "media"))
-
-        links_data: Dict[str, Any] = {
-            "title": extraction["title"],
-            "path": extraction["path"],
-            "content_type": extraction["content_type"],
-            "internal_links": internal_page,
-            "external_links": external_page,
-            "media_links": media_page,
-            "total_internal_links": len(full_internal),
-            "total_external_links": len(full_external),
-            "total_media_links": len(full_media),
-            "total_links": (len(full_internal) + len(full_external) + len(full_media)),
-            "pagination": {
-                "offset": offset,
-                "limit": limit,
-                "kind": kind,
-                "has_more": internal_more or external_more or media_more,
-                "has_more_internal": internal_more,
-                "has_more_external": external_more,
-                "has_more_media": media_more,
-            },
-        }
-        if extraction.get("message"):
-            links_data["message"] = extraction["message"]
-
-        return links_data
 
     def get_table_of_contents_data(
         self, zim_file_path: str, entry_path: str
@@ -646,8 +647,14 @@ class _StructureMixin:
         try:
             # Use the dict-returning extract_article_links_data so we don't
             # round-trip through json.dumps + json.loads just to walk the
-            # outbound link graph.
-            links_data = self.extract_article_links_data(validated_str, entry_path)
+            # outbound link graph. v2 Phase B: ask for the internal bucket
+            # explicitly; ``results`` carries the internal links.
+            links_data = self.extract_article_links_data(
+                validated_str,
+                entry_path,
+                limit=500,
+                kind="internal",
+            )
             # extract_article_links_data resolves redirects internally and
             # stores the post-redirect entry path in ``links_data["path"]``.
             # Resolve relative links against THAT path, not the caller-supplied
@@ -657,7 +664,7 @@ class _StructureMixin:
             resolved_source = links_data.get("path") or entry_path
             seen: set[str] = set()
             outbound: List[Dict[str, Any]] = []
-            for link in links_data.get("internal_links", []):
+            for link in links_data.get("results", []):
                 target = self._resolve_link_to_entry_path(
                     link.get("url", ""), resolved_source
                 )

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -355,7 +355,9 @@ class _StructureMixin:
         dict in-memory; callers paging through results pay the HTML parse
         cost exactly once per (archive, entry) pair instead of once per page.
         """
-        cache_key = f"links_full:{validated_path}:{entry_path}"
+        # Cache key bumped to v2b (Phase B) so v1.x cached responses (old
+        # shape: parallel arrays/multi-category) don't leak through after upgrade.
+        cache_key = f"links_full:v2b:{validated_path}:{entry_path}"
         cached = self.cache.get(cache_key)
         if cached is not None:
             logger.debug(f"Returning cached link extraction for: {entry_path}")

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from openzim_mcp.tool_schemas import (
         ArticleStructureResponse,
         LinksResponse,
+        RelatedArticlesResponse,
         TableOfContentsResponse,
     )
 
@@ -617,11 +618,19 @@ class _StructureMixin:
         zim_file_path: str,
         entry_path: str,
         limit: int = 10,
-    ) -> Dict[str, Any]:
+    ) -> "RelatedArticlesResponse":
         """Structured variant of ``get_related_articles``.
 
         Returns the result dict directly (not a JSON string) so MCP tools
         can hand it straight to FastMCP's structured-content path.
+
+        v2 Phase B contract: the response carries ``results`` /
+        ``next_cursor`` / ``total`` / ``done`` / ``page_info`` plus the
+        tool-specific ``entry_path``. This tool is non-paginated, so
+        ``next_cursor`` is always ``None`` and ``done`` is always ``True``.
+        The contract is applied for uniformity and anticipates Phase E's
+        inbound-link feature where ``direction`` becomes a parameter and
+        ``results`` covers either side.
 
         Each outbound result carries:
 
@@ -646,7 +655,8 @@ class _StructureMixin:
         validated_path = self.path_validator.validate_zim_file(validated_path)
         validated_str = str(validated_path)
 
-        result: Dict[str, Any] = {"entry_path": entry_path}
+        outbound: List[Dict[str, Any]] = []
+        outbound_error: Optional[str] = None
 
         try:
             # Use the dict-returning extract_article_links_data so we don't
@@ -667,7 +677,6 @@ class _StructureMixin:
             # dirname produces non-existent paths.
             resolved_source = links_data.get("path") or entry_path
             seen: set[str] = set()
-            outbound: List[Dict[str, Any]] = []
             for link in links_data.get("results", []):
                 target = self._resolve_link_to_entry_path(
                     link.get("url", ""), resolved_source
@@ -692,7 +701,6 @@ class _StructureMixin:
                 if len(outbound) >= limit:
                     break
             self._resolve_outbound_titles(validated_str, outbound)
-            result["outbound_results"] = outbound
         except OpenZimMcpArchiveError as e:
             # Partial-success contract: an archive- or extraction-level
             # failure surfaces as an empty result with an error string,
@@ -701,10 +709,23 @@ class _StructureMixin:
             # so they propagate up to the tool layer and become real
             # tool_error envelopes instead of fake successes.
             logger.debug(f"get_related_articles outbound failed: {e}")
-            result["outbound_results"] = []
-            result["outbound_error"] = str(e)
+            outbound_error = str(e)
 
-        return attach_meta(result)
+        payload: Dict[str, Any] = {
+            "entry_path": entry_path,
+            "results": outbound,
+            "next_cursor": None,
+            "total": len(outbound),
+            "done": True,
+            "page_info": {
+                "offset": 0,
+                "limit": limit,
+                "returned_count": len(outbound),
+            },
+        }
+        if outbound_error is not None:
+            payload["outbound_error"] = outbound_error
+        return cast("RelatedArticlesResponse", attach_meta(payload))
 
     @staticmethod
     def _resolve_outbound_titles(

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -27,7 +27,11 @@ if TYPE_CHECKING:
     from openzim_mcp.config import OpenZimMcpConfig
     from openzim_mcp.content_processor import ContentProcessor
     from openzim_mcp.security import PathValidator
-    from openzim_mcp.tool_schemas import LinksResponse, TableOfContentsResponse
+    from openzim_mcp.tool_schemas import (
+        ArticleStructureResponse,
+        LinksResponse,
+        TableOfContentsResponse,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +55,7 @@ class _StructureMixin:
 
     def get_article_structure_data(
         self, zim_file_path: str, entry_path: str
-    ) -> Dict[str, Any]:
+    ) -> "ArticleStructureResponse":
         """Structured variant of ``get_article_structure``.
 
         Returns the result dict directly (not a JSON string) so MCP tools
@@ -73,7 +77,7 @@ class _StructureMixin:
             logger.debug(f"Returning cached structure dict for: {entry_path}")
             if "_meta" not in cached_result:
                 cached_result = attach_meta(dict(cached_result))
-            return cached_result  # type: ignore[no-any-return]
+            return cast("ArticleStructureResponse", cached_result)
 
         try:
             with _zim_ops_mod.zim_archive(validated_path) as archive:
@@ -82,7 +86,7 @@ class _StructureMixin:
             # Cache the result
             self.cache.set(cache_key, result)
             logger.info(f"Extracted structure for: {entry_path}")
-            return attach_meta(result)
+            return cast("ArticleStructureResponse", attach_meta(result))
 
         except OpenZimMcpArchiveError:
             # Inner helper already raised a typed archive error with full

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from openzim_mcp.config import OpenZimMcpConfig
     from openzim_mcp.content_processor import ContentProcessor
     from openzim_mcp.security import PathValidator
-    from openzim_mcp.tool_schemas import LinksResponse
+    from openzim_mcp.tool_schemas import LinksResponse, TableOfContentsResponse
 
 logger = logging.getLogger(__name__)
 
@@ -402,7 +402,7 @@ class _StructureMixin:
 
     def get_table_of_contents_data(
         self, zim_file_path: str, entry_path: str
-    ) -> Dict[str, Any]:
+    ) -> "TableOfContentsResponse":
         """Structured variant of ``get_table_of_contents``.
 
         Returns the result dict directly (not a JSON string) so MCP tools
@@ -424,7 +424,7 @@ class _StructureMixin:
             logger.debug(f"Returning cached TOC dict for: {entry_path}")
             if "_meta" not in cached_result:
                 cached_result = attach_meta(dict(cached_result))
-            return cached_result  # type: ignore[no-any-return]
+            return cast("TableOfContentsResponse", cached_result)
 
         try:
             with _zim_ops_mod.zim_archive(validated_path) as archive:
@@ -433,7 +433,7 @@ class _StructureMixin:
             # Cache the result
             self.cache.set(cache_key, result)
             logger.info(f"Extracted TOC for: {entry_path}")
-            return attach_meta(result)
+            return cast("TableOfContentsResponse", attach_meta(result))
 
         except OpenZimMcpArchiveError:
             # Inner helper already raised a typed archive error with full

--- a/openzim_mcp/zim_operations.py
+++ b/openzim_mcp/zim_operations.py
@@ -4,9 +4,9 @@ The real implementation lives in :mod:`openzim_mcp.zim` (a small package
 of mixins coordinated by :class:`openzim_mcp.zim.archive.ZimOperations`).
 External callers that historically imported from this module continue to
 work via the re-exports below — both for the public API
-(``ZimOperations``, ``zim_archive``, ``PaginationCursor``) and for the
-internal symbols that tests patch (``Archive``, ``Query``, ``Searcher``,
-``SuggestionSearcher``, ``MAX_REDIRECT_DEPTH``).
+(``ZimOperations``, ``zim_archive``) and for the internal symbols that
+tests patch (``Archive``, ``Query``, ``Searcher``, ``SuggestionSearcher``,
+``MAX_REDIRECT_DEPTH``).
 
 The mixin modules look up these symbols on this module at *call time*
 (via ``import openzim_mcp.zim_operations as ...``), so test patches like
@@ -18,7 +18,6 @@ from openzim_mcp.zim.archive import (  # noqa: F401
     ARCHIVE_OPEN_TIMEOUT,
     MAX_REDIRECT_DEPTH,
     Archive,
-    PaginationCursor,
     Query,
     Searcher,
     SuggestionSearcher,
@@ -30,7 +29,6 @@ __all__ = [
     "ARCHIVE_OPEN_TIMEOUT",
     "Archive",
     "MAX_REDIRECT_DEPTH",
-    "PaginationCursor",
     "Query",
     "Searcher",
     "SuggestionSearcher",

--- a/tests/data/goldens/v2_phase_b/browse_A_10.json
+++ b/tests/data/goldens/v2_phase_b/browse_A_10.json
@@ -1,0 +1,20 @@
+{
+  "_meta": {
+    "chars": 241,
+    "tokens_est": 79,
+    "truncated": false
+  },
+  "discovery_method": "full_iteration",
+  "done": true,
+  "namespace": "A",
+  "next_cursor": null,
+  "page_info": {
+    "limit": 10,
+    "offset": 0,
+    "returned_count": 0
+  },
+  "results": [],
+  "results_may_be_incomplete": false,
+  "sampling_based": false,
+  "total": 0
+}

--- a/tests/data/goldens/v2_phase_b/browse_A_10.json
+++ b/tests/data/goldens/v2_phase_b/browse_A_10.json
@@ -1,13 +1,10 @@
 {
   "_meta": {
-    "chars": 241,
-    "tokens_est": 79,
     "truncated": false
   },
   "discovery_method": "full_iteration",
   "done": true,
   "namespace": "A",
-  "next_cursor": null,
   "page_info": {
     "limit": 10,
     "offset": 0,

--- a/tests/data/goldens/v2_phase_b/find_einstein.json
+++ b/tests/data/goldens/v2_phase_b/find_einstein.json
@@ -1,14 +1,11 @@
 {
   "_meta": {
-    "chars": 398,
-    "tokens_est": 162,
     "truncated": false
   },
   "done": true,
   "fast_path_hit": true,
   "files_searched": 1,
   "fuzzy_path_hit": false,
-  "next_cursor": null,
   "page_info": {
     "limit": 10,
     "offset": 0,
@@ -19,8 +16,7 @@
     {
       "path": "A/Einstein",
       "score": 1.0,
-      "title": "Einstein",
-      "zim_file": "/private/var/folders/53/yj9nrj8n4wbb2kr2hv9zlx0r0000gn/T/pytest-of-cameron/pytest-124/v2-golden0/v2_phase_a.zim"
+      "title": "Einstein"
     }
   ],
   "total": 1

--- a/tests/data/goldens/v2_phase_b/find_einstein.json
+++ b/tests/data/goldens/v2_phase_b/find_einstein.json
@@ -1,0 +1,27 @@
+{
+  "_meta": {
+    "chars": 398,
+    "tokens_est": 162,
+    "truncated": false
+  },
+  "done": true,
+  "fast_path_hit": true,
+  "files_searched": 1,
+  "fuzzy_path_hit": false,
+  "next_cursor": null,
+  "page_info": {
+    "limit": 10,
+    "offset": 0,
+    "returned_count": 1
+  },
+  "query": "Einstein",
+  "results": [
+    {
+      "path": "A/Einstein",
+      "score": 1.0,
+      "title": "Einstein",
+      "zim_file": "/private/var/folders/53/yj9nrj8n4wbb2kr2hv9zlx0r0000gn/T/pytest-of-cameron/pytest-124/v2-golden0/v2_phase_a.zim"
+    }
+  ],
+  "total": 1
+}

--- a/tests/data/goldens/v2_phase_b/links_einstein_internal.json
+++ b/tests/data/goldens/v2_phase_b/links_einstein_internal.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "chars": 280,
+    "tokens_est": 100,
+    "truncated": false
+  },
+  "category_totals": {
+    "external": 0,
+    "internal": 0,
+    "media": 0
+  },
+  "content_type": "text/html",
+  "done": true,
+  "kind": "internal",
+  "next_cursor": null,
+  "page_info": {
+    "limit": 100,
+    "offset": 0,
+    "returned_count": 0
+  },
+  "path": "A/Einstein",
+  "results": [],
+  "title": "Einstein",
+  "total": 0
+}

--- a/tests/data/goldens/v2_phase_b/links_einstein_internal.json
+++ b/tests/data/goldens/v2_phase_b/links_einstein_internal.json
@@ -1,7 +1,5 @@
 {
   "_meta": {
-    "chars": 280,
-    "tokens_est": 100,
     "truncated": false
   },
   "category_totals": {
@@ -12,7 +10,6 @@
   "content_type": "text/html",
   "done": true,
   "kind": "internal",
-  "next_cursor": null,
   "page_info": {
     "limit": 100,
     "offset": 0,

--- a/tests/data/goldens/v2_phase_b/list_namespaces.json
+++ b/tests/data/goldens/v2_phase_b/list_namespaces.json
@@ -1,0 +1,67 @@
+{
+  "_meta": {
+    "chars": 1009,
+    "tokens_est": 322,
+    "truncated": false
+  },
+  "discovery_method": "full_iteration",
+  "has_new_namespace_scheme": true,
+  "is_total_authoritative": true,
+  "namespaces": {
+    "C": {
+      "description": "User content entries (articles, main content)",
+      "estimated_total": 4,
+      "is_authoritative": true,
+      "sample_entries": [
+        {
+          "path": "A/Einstein",
+          "title": "Einstein"
+        },
+        {
+          "path": "A/LongArticle",
+          "title": "LongArticle"
+        },
+        {
+          "path": "A/MultiTable",
+          "title": "MultiTable"
+        },
+        {
+          "path": "A/PlainArticle",
+          "title": "PlainArticle"
+        }
+      ],
+      "sampled_count": 4,
+      "total": 4
+    },
+    "M": {
+      "description": "ZIM metadata (title, description, language, etc.)",
+      "estimated_total": 1,
+      "is_authoritative": true,
+      "probed_count": 0,
+      "sample_entries": [
+        {
+          "path": "M/Counter",
+          "title": "Counter"
+        }
+      ],
+      "sampled_count": 1,
+      "total": 1
+    },
+    "W": {
+      "description": "Well-known entries (MainPage, Favicon, navigation)",
+      "estimated_total": 1,
+      "is_authoritative": false,
+      "probed_count": 1,
+      "sample_entries": [
+        {
+          "path": "W/mainPage",
+          "title": "mainPage"
+        }
+      ],
+      "sampled_count": 0,
+      "total": 1
+    }
+  },
+  "sampled_entries": 4,
+  "total_entries": 4
+}

--- a/tests/data/goldens/v2_phase_b/list_namespaces.json
+++ b/tests/data/goldens/v2_phase_b/list_namespaces.json
@@ -1,7 +1,5 @@
 {
   "_meta": {
-    "chars": 1009,
-    "tokens_est": 322,
     "truncated": false
   },
   "discovery_method": "full_iteration",

--- a/tests/data/goldens/v2_phase_b/search_einstein_2.json
+++ b/tests/data/goldens/v2_phase_b/search_einstein_2.json
@@ -1,0 +1,23 @@
+{
+  "_meta": {
+    "chars": 406,
+    "tokens_est": 142,
+    "truncated": false
+  },
+  "done": true,
+  "next_cursor": null,
+  "page_info": {
+    "limit": 2,
+    "offset": 0,
+    "returned_count": 1
+  },
+  "query": "Einstein",
+  "results": [
+    {
+      "path": "A/Einstein",
+      "snippet": "Born| 14 March 1879  \n---|---  \nDied| 18 April 1955  \nField| Theoretical physics  \n  \nAlbert **Einstein** was a German-born theoretical physicist. He developed the theory of relativity, one of the...",
+      "title": "Einstein"
+    }
+  ],
+  "total": 1
+}

--- a/tests/data/goldens/v2_phase_b/search_einstein_2.json
+++ b/tests/data/goldens/v2_phase_b/search_einstein_2.json
@@ -1,11 +1,8 @@
 {
   "_meta": {
-    "chars": 406,
-    "tokens_est": 142,
     "truncated": false
   },
   "done": true,
-  "next_cursor": null,
   "page_info": {
     "limit": 2,
     "offset": 0,

--- a/tests/data/goldens/v2_phase_b/suggest_ein.json
+++ b/tests/data/goldens/v2_phase_b/suggest_ein.json
@@ -1,11 +1,8 @@
 {
   "_meta": {
-    "chars": 218,
-    "tokens_est": 78,
     "truncated": false
   },
   "done": true,
-  "next_cursor": null,
   "page_info": {
     "limit": 5,
     "offset": 0,

--- a/tests/data/goldens/v2_phase_b/suggest_ein.json
+++ b/tests/data/goldens/v2_phase_b/suggest_ein.json
@@ -1,0 +1,23 @@
+{
+  "_meta": {
+    "chars": 218,
+    "tokens_est": 78,
+    "truncated": false
+  },
+  "done": true,
+  "next_cursor": null,
+  "page_info": {
+    "limit": 5,
+    "offset": 0,
+    "returned_count": 1
+  },
+  "partial_query": "Ein",
+  "results": [
+    {
+      "path": "A/Einstein",
+      "text": "Einstein",
+      "type": "title_start_match"
+    }
+  ],
+  "total": 1
+}

--- a/tests/data/goldens/v2_phase_b/walk_A_10.json
+++ b/tests/data/goldens/v2_phase_b/walk_A_10.json
@@ -1,13 +1,10 @@
 {
   "_meta": {
-    "chars": 219,
-    "tokens_est": 77,
     "truncated": false
   },
   "archive_entry_count": 4,
   "done": true,
   "namespace": "A",
-  "next_cursor": null,
   "page_info": {
     "limit": 10,
     "offset": 0,

--- a/tests/data/goldens/v2_phase_b/walk_A_10.json
+++ b/tests/data/goldens/v2_phase_b/walk_A_10.json
@@ -1,0 +1,20 @@
+{
+  "_meta": {
+    "chars": 219,
+    "tokens_est": 77,
+    "truncated": false
+  },
+  "archive_entry_count": 4,
+  "done": true,
+  "namespace": "A",
+  "next_cursor": null,
+  "page_info": {
+    "limit": 10,
+    "offset": 0,
+    "returned_count": 0
+  },
+  "results": [],
+  "scanned_count": 0,
+  "scanned_through_id": null,
+  "total": null
+}

--- a/tests/test_async_operations.py
+++ b/tests/test_async_operations.py
@@ -203,12 +203,15 @@ class TestAsyncZimOperations:
     async def test_extract_article_links(
         self, async_ops: AsyncZimOperations, mock_zim_operations: MagicMock
     ):
-        """Test async extract_article_links."""
+        """Test async extract_article_links.
+
+        v2 Phase B: ``kind`` defaults to ``"internal"`` (was ``None``).
+        """
         result = await async_ops.extract_article_links("/path/to/file.zim", "C/Article")
 
         assert result == '{"links": []}'
         mock_zim_operations.extract_article_links.assert_called_once_with(
-            "/path/to/file.zim", "C/Article", 100, 0, None
+            "/path/to/file.zim", "C/Article", 100, 0, "internal"
         )
 
     @pytest.mark.asyncio

--- a/tests/test_batch_get_entries.py
+++ b/tests/test_batch_get_entries.py
@@ -45,7 +45,15 @@ async def test_get_zim_entries_tool_passes_through(
     """Calling the registered tool function delegates to async_zim_operations."""
     server = OpenZimMcpServer(test_config)
     server.async_zim_operations.get_entries_data = AsyncMock(
-        return_value={"results": [], "succeeded": 0, "failed": 0}
+        return_value={
+            "results": [],
+            "next_cursor": None,
+            "total": 0,
+            "done": True,
+            "page_info": {"offset": 0, "limit": 1, "returned_count": 0},
+            "succeeded": 0,
+            "failed": 0,
+        }
     )
     server.rate_limiter.check_rate_limit = MagicMock()
 
@@ -59,6 +67,10 @@ async def test_get_zim_entries_tool_passes_through(
     )
     assert isinstance(result, dict)
     assert result["succeeded"] == 0
+    # Contract keys are present on the success path.
+    assert result["next_cursor"] is None
+    assert result["done"] is True
+    assert result["total"] == 0
     server.async_zim_operations.get_entries_data.assert_awaited_once()
 
 
@@ -69,7 +81,15 @@ async def test_get_zim_entries_tool_sanitizes_inputs(
     """Per-entry paths go through sanitize_input before delegation."""
     server = OpenZimMcpServer(test_config)
     server.async_zim_operations.get_entries_data = AsyncMock(
-        return_value={"results": [], "succeeded": 0, "failed": 0}
+        return_value={
+            "results": [],
+            "next_cursor": None,
+            "total": 0,
+            "done": True,
+            "page_info": {"offset": 0, "limit": 1, "returned_count": 0},
+            "succeeded": 0,
+            "failed": 0,
+        }
     )
     server.rate_limiter.check_rate_limit = MagicMock()
 
@@ -145,7 +165,15 @@ async def test_get_zim_entries_tool_accepts_string_paths_with_default_archive(
     server = OpenZimMcpServer(test_config)
     server.rate_limiter.check_rate_limit = MagicMock()
     server.async_zim_operations.get_entries_data = AsyncMock(
-        return_value={"results": [], "succeeded": 0, "failed": 0}
+        return_value={
+            "results": [],
+            "next_cursor": None,
+            "total": 0,
+            "done": True,
+            "page_info": {"offset": 0, "limit": 2, "returned_count": 0},
+            "succeeded": 0,
+            "failed": 0,
+        }
     )
 
     tool = server.mcp._tool_manager._tools["get_zim_entries"]
@@ -208,6 +236,15 @@ class TestGetEntriesDataMeta:
         assert result["_meta"]["tokens_est"] > 0
         assert result["_meta"]["chars"] > 0
         assert result["_meta"]["truncated"] is False
+        # v2 Phase B contract: list-shaped response carries the canonical
+        # pagination keys. Batch fetch is non-paginated, so next_cursor is
+        # None and done is True.
+        assert result["next_cursor"] is None
+        assert result["done"] is True
+        assert result["total"] == len(result["results"])
+        assert result["page_info"]["offset"] == 0
+        assert result["page_info"]["limit"] == 1
+        assert result["page_info"]["returned_count"] == len(result["results"])
 
     def test_get_entries_data_attaches_meta_on_validation_failure(
         self, zim_ops, temp_dir
@@ -217,6 +254,13 @@ class TestGetEntriesDataMeta:
             entries=[{"zim_file_path": "/no/such/file.zim", "entry_path": "A/X"}]
         )
         assert "_meta" in result, "validation-failure path must attach _meta"
+        # Contract keys still emitted on the validation-failure path.
+        assert result["next_cursor"] is None
+        assert result["done"] is True
+        assert result["total"] == 1
+        # Per-entry failure surfaces in `failed`, not in `succeeded`.
+        assert result["failed"] == 1
+        assert result["succeeded"] == 0
 
 
 @pytest.mark.asyncio
@@ -227,7 +271,15 @@ async def test_get_zim_entries_tool_coerces_non_string_non_dict_entries(
     server = OpenZimMcpServer(test_config)
     server.rate_limiter.check_rate_limit = MagicMock()
     server.async_zim_operations.get_entries_data = AsyncMock(
-        return_value={"results": [], "succeeded": 0, "failed": 0}
+        return_value={
+            "results": [],
+            "next_cursor": None,
+            "total": 0,
+            "done": True,
+            "page_info": {"offset": 0, "limit": 3, "returned_count": 0},
+            "succeeded": 0,
+            "failed": 0,
+        }
     )
 
     tool = server.mcp._tool_manager._tools["get_zim_entries"]

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -190,13 +190,13 @@ def test_get_search_suggestions_does_not_cache_on_error(
     validated_path = zim_operations.path_validator.validate_path(str(zim_file))
     validated_path = zim_operations.path_validator.validate_zim_file(validated_path)
     # The legacy ``suggestions:`` key was retired in favour of the
-    # dict-shaped ``suggestions_data:`` cache. Neither key should hold a
+    # dict-shaped ``suggestions_data:v2b:`` cache. Neither key should hold a
     # sentinel response when generation raised.
     assert (
         zim_operations.cache.get(f"suggestions:{validated_path}:warmup:10") is None
     ), "legacy suggestion cache key should not hold an errored response"
     assert (
-        zim_operations.cache.get(f"suggestions_data:{validated_path}:warmup:10") is None
+        zim_operations.cache.get(f"suggestions_data:v2b:{validated_path}:warmup:10") is None
     ), "errored suggestion response should not be cached"
 
 

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -196,7 +196,8 @@ def test_get_search_suggestions_does_not_cache_on_error(
         zim_operations.cache.get(f"suggestions:{validated_path}:warmup:10") is None
     ), "legacy suggestion cache key should not hold an errored response"
     assert (
-        zim_operations.cache.get(f"suggestions_data:v2b:{validated_path}:warmup:10") is None
+        zim_operations.cache.get(f"suggestions_data:v2b:{validated_path}:warmup:10")
+        is None
     ), "errored suggestion response should not be cached"
 
 

--- a/tests/test_content_tools.py
+++ b/tests/test_content_tools.py
@@ -75,7 +75,10 @@ class TestGetZimEntryTool:
             entry_path="A/Article",
             max_content_length=50,
         )
-        assert "must be at least 100" in result
+        # v2: validation errors return a structured tool_error envelope.
+        assert isinstance(result, dict)
+        assert result.get("error") is True
+        assert "must be at least 100" in result.get("message", "")
 
     @pytest.mark.asyncio
     async def test_get_zim_entry_rate_limit_error(self, server: OpenZimMcpServer):

--- a/tests/test_extract_article_links_pagination.py
+++ b/tests/test_extract_article_links_pagination.py
@@ -4,9 +4,13 @@ Background: large articles can carry hundreds-to-thousands of internal/external
 links. Without pagination, ``extract_article_links`` returns the full set in
 one response and risks blowing the MCP response token budget. The fix adds
 ``limit``, ``offset``, and ``kind`` parameters and surfaces ``has_more``.
+
+v2 Phase B: ``kind`` is required-with-default (``"internal"``); response
+returns a single ``results`` list per call. ``category_totals`` reports
+all three counts. Pagination uses the canonical
+``next_cursor``/``done``/``page_info`` contract.
 """
 
-import json
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -79,13 +83,12 @@ def big_links_html() -> str:
 class TestExtractArticleLinksPagination:
     """Pagination contract for extract_article_links."""
 
-    def test_default_caps_internal_links(
+    def test_default_kind_is_internal_and_category_totals_all_present(
         self, ops_with_synthetic_archive, temp_dir, big_links_html
     ):
-        """Default response must report full totals even when paged.
-
-        The default page size protects the response budget; the caller can
-        still see ``total_*_links`` to decide whether to fetch more.
+        """Default response returns the internal bucket; ``category_totals``
+        reports counts for all three categories regardless of the requested
+        ``kind``.
         """
         zim = temp_dir / "test.zim"
         zim.touch()
@@ -94,37 +97,40 @@ class TestExtractArticleLinksPagination:
             mock_archive_ctx.return_value.__enter__.return_value = (
                 _patch_archive_with_html(big_links_html)
             )
-            raw = ops_with_synthetic_archive.extract_article_links(str(zim), "Test")
-        data = json.loads(raw)
-        # Default limit is 100 per category, so 50 fits and 30 fits and 20 fits.
-        # Switch to a clearly oversize fixture for the cap assertion below.
-        assert "internal_links" in data
-        # Total counts must report the *real* total, even if links are paged.
-        assert data["total_internal_links"] == 50
-        assert data["total_external_links"] == 30
-        assert data["total_media_links"] == 20
+            data = ops_with_synthetic_archive.extract_article_links_data(
+                str(zim), "Test"
+            )
+        assert data["kind"] == "internal"
+        assert "results" in data
+        # Default limit is 100, so all 50 internal fit in one page.
+        assert len(data["results"]) == 50
+        assert data["total"] == 50
+        assert data["done"] is True
+        # Category totals report ALL three counts even though only one
+        # category is in `results`.
+        assert data["category_totals"]["internal"] == 50
+        assert data["category_totals"]["external"] == 30
+        assert data["category_totals"]["media"] == 20
 
-    def test_limit_truncates_with_has_more(
+    def test_limit_truncates_with_next_cursor(
         self, ops_with_synthetic_archive, temp_dir, big_links_html
     ):
-        """limit=10 returns 10 internal links and signals has_more=True."""
+        """limit=10 returns 10 internal links and signals not done with cursor."""
         zim = temp_dir / "test.zim"
         zim.touch()
         with patch("openzim_mcp.zim_operations.zim_archive") as mock_archive_ctx:
             mock_archive_ctx.return_value.__enter__.return_value = (
                 _patch_archive_with_html(big_links_html)
             )
-            raw = ops_with_synthetic_archive.extract_article_links(
-                str(zim), "Test", limit=10
+            data = ops_with_synthetic_archive.extract_article_links_data(
+                str(zim), "Test", limit=10, kind="internal"
             )
-        data = json.loads(raw)
-        assert len(data["internal_links"]) == 10
-        assert data["pagination"]["has_more"] is True
-        assert data["pagination"]["limit"] == 10
-        assert data["pagination"]["offset"] == 0
-        # Externals and media share the same limit cap
-        assert len(data["external_links"]) == 10
-        assert len(data["media_links"]) == 10
+        assert len(data["results"]) == 10
+        assert data["done"] is False
+        assert data["next_cursor"] is not None
+        assert data["page_info"]["limit"] == 10
+        assert data["page_info"]["offset"] == 0
+        assert data["page_info"]["returned_count"] == 10
 
     def test_offset_skips_prefix(
         self, ops_with_synthetic_archive, temp_dir, big_links_html
@@ -136,52 +142,72 @@ class TestExtractArticleLinksPagination:
             mock_archive_ctx.return_value.__enter__.return_value = (
                 _patch_archive_with_html(big_links_html)
             )
-            raw = ops_with_synthetic_archive.extract_article_links(
-                str(zim), "Test", limit=5, offset=20
+            data = ops_with_synthetic_archive.extract_article_links_data(
+                str(zim), "Test", limit=5, offset=20, kind="internal"
             )
-        data = json.loads(raw)
-        assert len(data["internal_links"]) == 5
+        assert len(data["results"]) == 5
         # The first link in the paged window points to Page_20 (links emitted
         # in source order).
         assert any(
             "Page_20" in (link.get("url") or link.get("href", ""))
-            for link in data["internal_links"]
-        ), data["internal_links"][:3]
+            for link in data["results"]
+        ), data["results"][:3]
 
-    def test_kind_internal_only_excludes_external(
+    def test_kind_internal_returns_only_internal(
         self, ops_with_synthetic_archive, temp_dir, big_links_html
     ):
-        """kind='internal' returns only internal_links; external/media empty."""
+        """kind='internal' returns only the internal category in `results`."""
         zim = temp_dir / "test.zim"
         zim.touch()
         with patch("openzim_mcp.zim_operations.zim_archive") as mock_archive_ctx:
             mock_archive_ctx.return_value.__enter__.return_value = (
                 _patch_archive_with_html(big_links_html)
             )
-            raw = ops_with_synthetic_archive.extract_article_links(
+            data = ops_with_synthetic_archive.extract_article_links_data(
                 str(zim), "Test", limit=200, kind="internal"
             )
-        data = json.loads(raw)
-        assert len(data["internal_links"]) == 50
-        assert data["external_links"] == []
-        assert data["media_links"] == []
+        assert data["kind"] == "internal"
+        assert len(data["results"]) == 50
+        assert data["total"] == 50
+        assert data["category_totals"]["external"] == 30
+        assert data["category_totals"]["media"] == 20
 
     def test_kind_external_only(
         self, ops_with_synthetic_archive, temp_dir, big_links_html
     ):
-        """kind='external' must isolate the external bucket."""
+        """kind='external' returns only external links in `results`."""
         zim = temp_dir / "test.zim"
         zim.touch()
         with patch("openzim_mcp.zim_operations.zim_archive") as mock_archive_ctx:
             mock_archive_ctx.return_value.__enter__.return_value = (
                 _patch_archive_with_html(big_links_html)
             )
-            raw = ops_with_synthetic_archive.extract_article_links(
+            data = ops_with_synthetic_archive.extract_article_links_data(
                 str(zim), "Test", limit=200, kind="external"
             )
-        data = json.loads(raw)
-        assert data["internal_links"] == []
-        assert len(data["external_links"]) == 30
+        assert data["kind"] == "external"
+        assert len(data["results"]) == 30
+        assert data["total"] == 30
+        # Category totals still expose the other categories' counts.
+        assert data["category_totals"]["internal"] == 50
+        assert data["category_totals"]["media"] == 20
+
+    def test_kind_media_only(
+        self, ops_with_synthetic_archive, temp_dir, big_links_html
+    ):
+        """kind='media' returns only media links in `results`."""
+        zim = temp_dir / "test.zim"
+        zim.touch()
+        with patch("openzim_mcp.zim_operations.zim_archive") as mock_archive_ctx:
+            mock_archive_ctx.return_value.__enter__.return_value = (
+                _patch_archive_with_html(big_links_html)
+            )
+            data = ops_with_synthetic_archive.extract_article_links_data(
+                str(zim), "Test", limit=200, kind="media"
+            )
+        assert data["kind"] == "media"
+        assert len(data["results"]) == 20
+        assert data["total"] == 20
 
     def test_invalid_limit_rejected(self, ops_with_synthetic_archive, temp_dir):
         """Reject limit < 1 or > 500 with a validation error."""
@@ -190,9 +216,11 @@ class TestExtractArticleLinksPagination:
         zim = temp_dir / "test.zim"
         zim.touch()
         with pytest.raises(OpenZimMcpValidationError):
-            ops_with_synthetic_archive.extract_article_links(str(zim), "Test", limit=0)
+            ops_with_synthetic_archive.extract_article_links_data(
+                str(zim), "Test", limit=0
+            )
         with pytest.raises(OpenZimMcpValidationError):
-            ops_with_synthetic_archive.extract_article_links(
+            ops_with_synthetic_archive.extract_article_links_data(
                 str(zim), "Test", limit=501
             )
 
@@ -203,6 +231,6 @@ class TestExtractArticleLinksPagination:
         zim = temp_dir / "test.zim"
         zim.touch()
         with pytest.raises(OpenZimMcpValidationError):
-            ops_with_synthetic_archive.extract_article_links(
+            ops_with_synthetic_archive.extract_article_links_data(
                 str(zim), "Test", kind="bogus"
             )

--- a/tests/test_extract_links_cache_sharing.py
+++ b/tests/test_extract_links_cache_sharing.py
@@ -6,7 +6,6 @@ Cache the parsed link lists once under a stable key and slice from
 cache for subsequent pages.
 """
 
-import json
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -97,11 +96,11 @@ def test_paged_requests_share_one_html_parse(ops_with_cache, temp_dir, big_links
         mock_archive_ctx.return_value.__enter__.return_value = _patch_archive_with_html(
             big_links_html
         )
-        first = json.loads(
-            ops_with_cache.extract_article_links(str(zim), "Test", limit=10, offset=0)
+        first = ops_with_cache.extract_article_links_data(
+            str(zim), "Test", limit=10, offset=0, kind="internal"
         )
-        second = json.loads(
-            ops_with_cache.extract_article_links(str(zim), "Test", limit=10, offset=10)
+        second = ops_with_cache.extract_article_links_data(
+            str(zim), "Test", limit=10, offset=10, kind="internal"
         )
 
     # Both pages came from the same parse → only one call.
@@ -110,13 +109,13 @@ def test_paged_requests_share_one_html_parse(ops_with_cache, temp_dir, big_links
         f"re-parsing instead of slicing from cache"
     )
     # And the page contents are correct.
-    assert len(first["internal_links"]) == 10
-    assert len(second["internal_links"]) == 10
+    assert len(first["results"]) == 10
+    assert len(second["results"]) == 10
     # Pages are distinct slices.
     first_urls = {
-        link.get("url") or link.get("href") for link in first["internal_links"]
+        link.get("url") or link.get("href") for link in first["results"]
     }
     second_urls = {
-        link.get("url") or link.get("href") for link in second["internal_links"]
+        link.get("url") or link.get("href") for link in second["results"]
     }
     assert first_urls.isdisjoint(second_urls), (first_urls, second_urls)

--- a/tests/test_extract_links_cache_sharing.py
+++ b/tests/test_extract_links_cache_sharing.py
@@ -112,10 +112,6 @@ def test_paged_requests_share_one_html_parse(ops_with_cache, temp_dir, big_links
     assert len(first["results"]) == 10
     assert len(second["results"]) == 10
     # Pages are distinct slices.
-    first_urls = {
-        link.get("url") or link.get("href") for link in first["results"]
-    }
-    second_urls = {
-        link.get("url") or link.get("href") for link in second["results"]
-    }
+    first_urls = {link.get("url") or link.get("href") for link in first["results"]}
+    second_urls = {link.get("url") or link.get("href") for link in second["results"]}
     assert first_urls.isdisjoint(second_urls), (first_urls, second_urls)

--- a/tests/test_file_tools.py
+++ b/tests/test_file_tools.py
@@ -36,10 +36,13 @@ class TestListZimFilesToolNameFilter:
         # backend that returns a dict envelope rather than a JSON string.
         server.async_zim_operations.list_zim_files_summary_data = AsyncMock(
             return_value={
-                "count": 0,
+                "results": [],
+                "next_cursor": None,
+                "total": 0,
+                "done": True,
+                "page_info": {"offset": 0, "limit": 0, "returned_count": 0},
                 "directories_count": 0,
                 "name_filter": "",
-                "files": [],
             }
         )
         server.rate_limiter.check_rate_limit = MagicMock()

--- a/tests/test_file_tools_extended.py
+++ b/tests/test_file_tools_extended.py
@@ -33,10 +33,13 @@ class TestListZimFilesToolInvocation:
         """Test successful ZIM file listing through tool handler."""
         advanced_server.async_zim_operations.list_zim_files_summary_data = AsyncMock(
             return_value={
-                "count": 1,
+                "results": [{"path": "/test/file.zim", "size": 1024}],
+                "next_cursor": None,
+                "total": 1,
+                "done": True,
+                "page_info": {"offset": 0, "limit": 1, "returned_count": 1},
                 "directories_count": 1,
                 "name_filter": "",
-                "files": [{"path": "/test/file.zim", "size": 1024}],
             }
         )
 
@@ -45,8 +48,11 @@ class TestListZimFilesToolInvocation:
             tool_handler = tools["list_zim_files"].fn
             result = await tool_handler()
             assert isinstance(result, dict)
-            assert result["count"] == 1
-            assert result["files"][0]["path"] == "/test/file.zim"
+            assert result["total"] == 1
+            assert result["results"][0]["path"] == "/test/file.zim"
+            assert result["next_cursor"] is None
+            assert result["done"] is True
+            assert result["page_info"]["returned_count"] == 1
 
     @pytest.mark.asyncio
     async def test_list_zim_files_rate_limit_error(self, advanced_server):
@@ -100,10 +106,13 @@ class TestEmptyZimFilesList:
         """Test list_zim_files when no ZIM files are found."""
         advanced_server.async_zim_operations.list_zim_files_summary_data = AsyncMock(
             return_value={
-                "count": 0,
+                "results": [],
+                "next_cursor": None,
+                "total": 0,
+                "done": True,
+                "page_info": {"offset": 0, "limit": 0, "returned_count": 0},
                 "directories_count": 1,
                 "name_filter": "",
-                "files": [],
             }
         )
 
@@ -112,5 +121,8 @@ class TestEmptyZimFilesList:
             tool_handler = tools["list_zim_files"].fn
             result = await tool_handler()
             assert isinstance(result, dict)
-            assert result["count"] == 0
-            assert result["files"] == []
+            assert result["total"] == 0
+            assert result["results"] == []
+            assert result["next_cursor"] is None
+            assert result["done"] is True
+            assert result["page_info"]["returned_count"] == 0

--- a/tests/test_find_entry_by_title.py
+++ b/tests/test_find_entry_by_title.py
@@ -67,6 +67,13 @@ class TestFindEntryByTitle:
         assert result["fast_path_hit"] is True
         assert len(result["results"]) == 1
         assert result["results"][0]["path"] == "C/Python_(programming_language)"
+        # Phase B contract keys (non-paginated tool, but contract still applies).
+        assert result["next_cursor"] is None
+        assert result["done"] is True
+        assert result["total"] == len(result["results"])
+        assert result["page_info"]["offset"] == 0
+        assert result["page_info"]["limit"] == 10
+        assert result["page_info"]["returned_count"] == len(result["results"])
 
     def test_no_matches_returns_empty(self, server: OpenZimMcpServer, monkeypatch):
         """No matches returns empty results, not an error."""
@@ -104,6 +111,13 @@ class TestFindEntryByTitle:
         assert result["results"] == []
         assert result["fast_path_hit"] is False
         assert result["files_searched"] == 1
+        # Phase B contract keys (non-paginated tool, but contract still applies).
+        assert result["next_cursor"] is None
+        assert result["done"] is True
+        assert result["total"] == 0
+        assert result["page_info"]["offset"] == 0
+        assert result["page_info"]["limit"] == 10
+        assert result["page_info"]["returned_count"] == 0
 
     def test_cross_file_aggregates_and_skips_failures(
         self, server: OpenZimMcpServer, monkeypatch
@@ -137,6 +151,13 @@ class TestFindEntryByTitle:
         assert result["files_searched"] == 2
         assert len(result["results"]) == 1
         assert result["results"][0]["zim_file"] == "/zim/good.zim"
+        # Phase B contract keys (non-paginated tool, but contract still applies).
+        assert result["next_cursor"] is None
+        assert result["done"] is True
+        assert result["total"] == len(result["results"])
+        assert result["page_info"]["offset"] == 0
+        assert result["page_info"]["limit"] == 10
+        assert result["page_info"]["returned_count"] == len(result["results"])
 
 
 def _ctx(value):
@@ -321,6 +342,13 @@ class TestTypoTolerantFallback:
         hit = result["results"][0]
         assert hit["path"] == "C/Einstein"
         assert hit["title"] == "Einstein"
+        # Phase B contract keys (non-paginated tool, but contract still applies).
+        assert result["next_cursor"] is None
+        assert result["done"] is True
+        assert result["total"] == len(result["results"])
+        assert result["page_info"]["offset"] == 0
+        assert result["page_info"]["limit"] == 10
+        assert result["page_info"]["returned_count"] == len(result["results"])
         # Below 0.95 so a real suggestion-top in another file would
         # outrank a fuzzy hit. ``pytest.approx`` rather than ``==`` so
         # SonarCloud S1244 (float-equality bug rule) doesn't flag the
@@ -497,6 +525,13 @@ class TestMetaSuggestionsAndReason:
         )
         assert result["results"] == []
         assert result["_meta"].get("reason") == "0_hits"
+        # Phase B contract keys (non-paginated tool, but contract still applies).
+        assert result["next_cursor"] is None
+        assert result["done"] is True
+        assert result["total"] == 0
+        assert result["page_info"]["offset"] == 0
+        assert result["page_info"]["limit"] == 10
+        assert result["page_info"]["returned_count"] == 0
 
     def test_find_entry_meta_reason_absent_on_hits(self, server, monkeypatch):
         """When results found, _meta.reason should be absent (None → omitted)."""

--- a/tests/test_find_entry_by_title_quality.py
+++ b/tests/test_find_entry_by_title_quality.py
@@ -92,6 +92,13 @@ class TestFindEntryByTitleCaseInsensitiveFastPath:
         top = out["results"][0]
         assert top["title"].lower() == "climate change"
         assert abs(top["score"] - 1.0) < _SCORE_EPS
+        # Phase B contract keys (non-paginated tool, but contract still applies).
+        assert out["next_cursor"] is None
+        assert out["done"] is True
+        assert out["total"] == len(out["results"])
+        assert out["page_info"]["offset"] == 0
+        assert out["page_info"]["limit"] == 10  # default
+        assert out["page_info"]["returned_count"] == len(out["results"])
 
     def test_uppercase_query_hits_fast_path(
         self,
@@ -128,6 +135,13 @@ class TestFindEntryByTitleScoring:
         )
         scores = [r["score"] for r in out["results"]]
         assert len(scores) >= 2, out
+        # Phase B contract keys (non-paginated tool, but contract still applies).
+        assert out["next_cursor"] is None
+        assert out["done"] is True
+        assert out["total"] == len(out["results"])
+        assert out["page_info"]["offset"] == 0
+        assert out["page_info"]["limit"] == 10
+        assert out["page_info"]["returned_count"] == len(out["results"])
         # Reject the legacy "all hits scored 0.8" bug behaviour. Use a small
         # tolerance window so static analysis doesn't flag float equality.
         all_legacy = all(abs(s - 0.8) < _SCORE_EPS for s in scores)

--- a/tests/test_get_related_articles.py
+++ b/tests/test_get_related_articles.py
@@ -67,14 +67,15 @@ class TestGetRelatedArticles:
         """
         server.zim_operations.extract_article_links_data = MagicMock(
             return_value={
-                "internal_links": [
+                "kind": "internal",
+                "results": [
                     # Bare relative href — resolves to "C/Linked_A".
                     {"url": "Linked_A", "text": "Linked A"},
                     {"url": "Linked_B", "text": "Linked B"},
                     {"url": "Linked_A", "text": "Linked A"},  # dup
                     # Anchor-only — should be ignored.
                     {"url": "#section", "text": "anchor"},
-                ]
+                ],
             }
         )
 
@@ -145,7 +146,8 @@ class TestGetRelatedArticles:
         server.zim_operations.extract_article_links_data = MagicMock(
             return_value={
                 "path": "C/Source",
-                "internal_links": [
+                "kind": "internal",
+                "results": [
                     # Anchor text differs from the target's actual title.
                     {"url": "Animal", "text": "Animalia"},
                 ],
@@ -200,7 +202,8 @@ class TestGetRelatedArticles:
         server.zim_operations.extract_article_links_data = MagicMock(
             return_value={
                 "path": "C/Source",
-                "internal_links": [
+                "kind": "internal",
+                "results": [
                     {"url": "Animal", "text": "Animalia"},
                 ],
             }
@@ -248,7 +251,8 @@ class TestGetRelatedArticles:
         server.zim_operations.extract_article_links_data = MagicMock(
             return_value={
                 "path": "C/Source",
-                "internal_links": [
+                "kind": "internal",
+                "results": [
                     {"url": "Missing_Article", "text": "see Missing"},
                 ],
             }

--- a/tests/test_get_related_articles.py
+++ b/tests/test_get_related_articles.py
@@ -83,11 +83,18 @@ class TestGetRelatedArticles:
             "/zim/test.zim", "C/Source", limit=10
         )
         result = json.loads(result_json)
-        assert len(result["outbound_results"]) == 2  # deduped, anchor dropped
-        assert {r["path"] for r in result["outbound_results"]} == {
+        assert len(result["results"]) == 2  # deduped, anchor dropped
+        assert {r["path"] for r in result["results"]} == {
             "C/Linked_A",
             "C/Linked_B",
         }
+        # v2 Phase B contract keys (non-paginated tool, but uniform shape).
+        assert result["next_cursor"] is None
+        assert result["done"] is True
+        assert result["total"] == len(result["results"])
+        assert result["page_info"]["limit"] == 10
+        assert result["page_info"]["offset"] == 0
+        assert result["page_info"]["returned_count"] == len(result["results"])
 
     def test_invalid_limit_raises(self, server: OpenZimMcpServer):
         """An out-of-range limit raises OpenZimMcpValidationError."""
@@ -114,8 +121,13 @@ class TestGetRelatedArticles:
         result = server.zim_operations.get_related_articles_data(
             "/zim/test.zim", "C/Missing", limit=10
         )
-        assert result["outbound_results"] == []
+        assert result["results"] == []
         assert "entry not found" in result["outbound_error"]
+        # Contract keys still present on partial-success.
+        assert result["next_cursor"] is None
+        assert result["done"] is True
+        assert result["total"] == 0
+        assert result["page_info"]["limit"] == 10
 
     def test_unexpected_exception_propagates(self, server: OpenZimMcpServer):
         """Programming errors (e.g. TypeError) must NOT be swallowed.
@@ -165,7 +177,7 @@ class TestGetRelatedArticles:
         result = server.zim_operations.get_related_articles_data(
             "/zim/test.zim", "C/Source", limit=10
         )
-        outbound = result["outbound_results"]
+        outbound = result["results"]
         assert len(outbound) == 1
         assert outbound[0]["path"] == "C/Animal"
         assert outbound[0]["title"] == "Animal"
@@ -265,7 +277,7 @@ class TestGetRelatedArticles:
         result = server.zim_operations.get_related_articles_data(
             "/zim/test.zim", "C/Source", limit=10
         )
-        outbound = result["outbound_results"]
+        outbound = result["results"]
         assert len(outbound) == 1
         assert outbound[0]["path"] == "C/Missing_Article"
         # No title resolvable -> falls back to the target path

--- a/tests/test_golden_v2_phase_b.py
+++ b/tests/test_golden_v2_phase_b.py
@@ -17,9 +17,12 @@ Notes
 -----
 * ``_strip_volatile`` removes keys whose values change across runs or environments:
   ``tokens_est``, ``chars`` (depend on rendered content length),
-  ``path``, ``directory``, ``size_bytes``, ``modified``, ``size``
-  (environment-specific file-system metadata), and ``next_cursor``
-  (encodes archive identity which can vary between tmp paths).
+  ``directory``, ``size_bytes``, ``modified``, ``size``
+  (environment-specific file-system metadata), ``next_cursor``
+  (encodes archive identity which can vary between tmp paths), and
+  ``zim_file`` (absolute filesystem path in find_entry_by_title results).
+  ZIM entry ``path`` values (e.g. ``A/Einstein``) are part of the contract
+  and are intentionally retained.
   Stripping these keeps the diff focused on structural contract shape.
 * ``list_zim_files_summary_data`` is intentionally excluded — its output
   contains absolute paths and file-system timestamps that are
@@ -53,7 +56,6 @@ _VOLATILE_KEYS = frozenset(
         "tokens_est",
         "chars",
         # file-system metadata — environment-specific
-        "path",
         "directory",
         "size_bytes",
         "modified",
@@ -70,9 +72,10 @@ def _strip_volatile(d: Any) -> Any:
     """Recursively remove volatile keys from a nested dict/list structure.
 
     Keys removed: ``tokens_est``, ``chars`` (content-length-dependent),
-    ``path``, ``directory``, ``size_bytes``, ``modified``, ``size``
-    (environment-specific fs metadata), and ``next_cursor`` (encodes archive
-    identity derived from tmp paths).
+    ``directory``, ``size_bytes``, ``modified``, ``size``
+    (environment-specific fs metadata), ``next_cursor`` (encodes archive
+    identity derived from tmp paths), and ``zim_file`` (absolute filesystem
+    path embedded in find_entry_by_title results).
     """
     if isinstance(d, dict):
         return {
@@ -102,7 +105,8 @@ def _capture_or_compare(name: str, payload: dict, *, capture_mode: bool) -> None
     path = GOLDENS_DIR / f"{name}.json"
     if capture_mode or not path.exists():
         path.write_text(
-            json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True)
+            json.dumps(_strip_volatile(payload), indent=2, ensure_ascii=False, sort_keys=True),
+            newline="\n",
         )
         return
     expected = json.loads(path.read_text())
@@ -134,13 +138,13 @@ def zim_ops(v2_phase_a_zim: Path) -> ZimOperations:
     return ZimOperations(config, path_validator, cache, content_processor)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def zim_path(v2_phase_a_zim: Path) -> str:
     """Return the string path to the fixture ZIM file."""
     return str(v2_phase_a_zim)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def capture_mode() -> bool:
     """Return True when the OPENZIM_MCP_CAPTURE_GOLDENS env var is set to '1'."""
     return os.environ.get("OPENZIM_MCP_CAPTURE_GOLDENS") == "1"

--- a/tests/test_golden_v2_phase_b.py
+++ b/tests/test_golden_v2_phase_b.py
@@ -1,0 +1,217 @@
+"""Phase B golden-file regression tests anchoring the v2 response-contract shape.
+
+Captures the structured output of the major ``_data`` methods so future changes
+that unintentionally alter the wire format show up as golden diffs.
+
+Usage
+-----
+Capture (or refresh) goldens::
+
+    OPENZIM_MCP_CAPTURE_GOLDENS=1 uv run pytest tests/test_golden_v2_phase_b.py -v
+
+Compare against saved goldens (default)::
+
+    uv run pytest tests/test_golden_v2_phase_b.py -v
+
+Notes
+-----
+* ``_strip_volatile`` removes keys whose values change across runs or environments:
+  ``tokens_est``, ``chars`` (depend on rendered content length),
+  ``path``, ``directory``, ``size_bytes``, ``modified``, ``size``
+  (environment-specific file-system metadata), and ``next_cursor``
+  (encodes archive identity which can vary between tmp paths).
+  Stripping these keeps the diff focused on structural contract shape.
+* ``list_zim_files_summary_data`` is intentionally excluded — its output
+  contains absolute paths and file-system timestamps that are
+  environment-specific; five solid stable snapshots beat eight flaky ones.
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from openzim_mcp.cache import OpenZimMcpCache
+from openzim_mcp.config import (
+    CacheConfig,
+    ContentConfig,
+    LoggingConfig,
+    OpenZimMcpConfig,
+)
+from openzim_mcp.content_processor import ContentProcessor
+from openzim_mcp.security import PathValidator
+from openzim_mcp.zim_operations import ZimOperations
+
+GOLDENS_DIR = Path(__file__).parent / "data" / "goldens" / "v2_phase_b"
+
+# Keys to strip from snapshots — volatile or environment-specific.
+_VOLATILE_KEYS = frozenset(
+    {
+        # token/char counts depend on rendered snippet text
+        "tokens_est",
+        "chars",
+        # file-system metadata — environment-specific
+        "path",
+        "directory",
+        "size_bytes",
+        "modified",
+        "size",
+        # opaque cursor encodes archive identity (tmp path digest)
+        "next_cursor",
+        # find_entry_by_title_data embeds the absolute zim file path in results
+        "zim_file",
+    }
+)
+
+
+def _strip_volatile(d: Any) -> Any:
+    """Recursively remove volatile keys from a nested dict/list structure.
+
+    Keys removed: ``tokens_est``, ``chars`` (content-length-dependent),
+    ``path``, ``directory``, ``size_bytes``, ``modified``, ``size``
+    (environment-specific fs metadata), and ``next_cursor`` (encodes archive
+    identity derived from tmp paths).
+    """
+    if isinstance(d, dict):
+        return {
+            k: _strip_volatile(v) for k, v in d.items() if k not in _VOLATILE_KEYS
+        }
+    if isinstance(d, list):
+        return [_strip_volatile(x) for x in d]
+    return d
+
+
+def _capture_or_compare(name: str, payload: dict, *, capture_mode: bool) -> None:
+    """Write golden snapshot or assert equality against saved snapshot.
+
+    When ``capture_mode=True`` or the file is absent, the payload is
+    serialised to JSON and written.  Otherwise the saved golden is loaded and
+    ``_strip_volatile(payload)`` must equal ``_strip_volatile(expected)``.
+
+    Args:
+        name: Basename (without extension) of the golden file.
+        payload: The dict returned by the ``_data`` method under test.
+        capture_mode: When ``True``, always overwrite the file.
+
+    Raises:
+        AssertionError: When the stripped payloads differ in compare mode.
+    """
+    GOLDENS_DIR.mkdir(parents=True, exist_ok=True)
+    path = GOLDENS_DIR / f"{name}.json"
+    if capture_mode or not path.exists():
+        path.write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True)
+        )
+        return
+    expected = json.loads(path.read_text())
+    assert _strip_volatile(payload) == _strip_volatile(expected), (
+        f"Golden mismatch for {name}. "
+        "Set OPENZIM_MCP_CAPTURE_GOLDENS=1 to refresh after intentional changes."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def zim_ops(v2_phase_a_zim: Path) -> ZimOperations:
+    """Construct a ZimOperations instance pointing at the fixture archive."""
+    zim_dir = str(v2_phase_a_zim.parent)
+    config = OpenZimMcpConfig(
+        allowed_directories=[zim_dir],
+        tool_mode="advanced",
+        cache=CacheConfig(enabled=True, max_size=20, ttl_seconds=300),
+        content=ContentConfig(max_content_length=10000, snippet_length=200),
+        logging=LoggingConfig(level="WARNING"),
+    )
+    path_validator = PathValidator(config.allowed_directories)
+    cache = OpenZimMcpCache(config.cache)
+    content_processor = ContentProcessor(snippet_length=config.content.snippet_length)
+    return ZimOperations(config, path_validator, cache, content_processor)
+
+
+@pytest.fixture
+def zim_path(v2_phase_a_zim: Path) -> str:
+    """Return the string path to the fixture ZIM file."""
+    return str(v2_phase_a_zim)
+
+
+@pytest.fixture
+def capture_mode() -> bool:
+    """Return True when the OPENZIM_MCP_CAPTURE_GOLDENS env var is set to '1'."""
+    return os.environ.get("OPENZIM_MCP_CAPTURE_GOLDENS") == "1"
+
+
+# ---------------------------------------------------------------------------
+# Snapshot tests
+# ---------------------------------------------------------------------------
+
+
+def test_golden_search_einstein(
+    zim_ops: ZimOperations, zim_path: str, capture_mode: bool
+) -> None:
+    """search_zim_file_data — top-2 results for 'Einstein'."""
+    payload = zim_ops.search_zim_file_data(zim_path, query="Einstein", limit=2)
+    _capture_or_compare("search_einstein_2", dict(payload), capture_mode=capture_mode)
+
+
+def test_golden_find_einstein(
+    zim_ops: ZimOperations, zim_path: str, capture_mode: bool
+) -> None:
+    """find_entry_by_title_data — exact title lookup for 'Einstein'."""
+    payload = zim_ops.find_entry_by_title_data(zim_path, title="Einstein")
+    _capture_or_compare("find_einstein", dict(payload), capture_mode=capture_mode)
+
+
+def test_golden_browse_a_namespace(
+    zim_ops: ZimOperations, zim_path: str, capture_mode: bool
+) -> None:
+    """browse_namespace_data — first 10 entries in namespace A."""
+    payload = zim_ops.browse_namespace_data(
+        zim_path, namespace="A", limit=10, offset=0
+    )
+    _capture_or_compare("browse_A_10", dict(payload), capture_mode=capture_mode)
+
+
+def test_golden_walk_a_namespace(
+    zim_ops: ZimOperations, zim_path: str, capture_mode: bool
+) -> None:
+    """walk_namespace_data — initial page walk through namespace A."""
+    payload = zim_ops.walk_namespace_data(
+        zim_path, namespace="A", cursor_state=None, limit=10
+    )
+    _capture_or_compare("walk_A_10", dict(payload), capture_mode=capture_mode)
+
+
+def test_golden_links_einstein_internal(
+    zim_ops: ZimOperations, zim_path: str, capture_mode: bool
+) -> None:
+    """extract_article_links_data — internal links from A/Einstein."""
+    payload = zim_ops.extract_article_links_data(
+        zim_path, entry_path="A/Einstein", kind="internal"
+    )
+    _capture_or_compare(
+        "links_einstein_internal", dict(payload), capture_mode=capture_mode
+    )
+
+
+def test_golden_list_namespaces(
+    zim_ops: ZimOperations, zim_path: str, capture_mode: bool
+) -> None:
+    """list_namespaces_data — namespace summary for the fixture archive."""
+    payload = zim_ops.list_namespaces_data(zim_path)
+    _capture_or_compare("list_namespaces", dict(payload), capture_mode=capture_mode)
+
+
+def test_golden_suggest_ein(
+    zim_ops: ZimOperations, zim_path: str, capture_mode: bool
+) -> None:
+    """get_search_suggestions_data — title suggestions for partial query 'Ein'."""
+    payload = zim_ops.get_search_suggestions_data(
+        zim_path, partial_query="Ein", limit=5
+    )
+    _capture_or_compare("suggest_ein", dict(payload), capture_mode=capture_mode)

--- a/tests/test_golden_v2_phase_b.py
+++ b/tests/test_golden_v2_phase_b.py
@@ -78,9 +78,7 @@ def _strip_volatile(d: Any) -> Any:
     path embedded in find_entry_by_title results).
     """
     if isinstance(d, dict):
-        return {
-            k: _strip_volatile(v) for k, v in d.items() if k not in _VOLATILE_KEYS
-        }
+        return {k: _strip_volatile(v) for k, v in d.items() if k not in _VOLATILE_KEYS}
     if isinstance(d, list):
         return [_strip_volatile(x) for x in d]
     return d
@@ -105,7 +103,9 @@ def _capture_or_compare(name: str, payload: dict, *, capture_mode: bool) -> None
     path = GOLDENS_DIR / f"{name}.json"
     if capture_mode or not path.exists():
         path.write_text(
-            json.dumps(_strip_volatile(payload), indent=2, ensure_ascii=False, sort_keys=True),
+            json.dumps(
+                _strip_volatile(payload), indent=2, ensure_ascii=False, sort_keys=True
+            ),
             newline="\n",
         )
         return
@@ -175,9 +175,7 @@ def test_golden_browse_a_namespace(
     zim_ops: ZimOperations, zim_path: str, capture_mode: bool
 ) -> None:
     """browse_namespace_data — first 10 entries in namespace A."""
-    payload = zim_ops.browse_namespace_data(
-        zim_path, namespace="A", limit=10, offset=0
-    )
+    payload = zim_ops.browse_namespace_data(zim_path, namespace="A", limit=10, offset=0)
     _capture_or_compare("browse_A_10", dict(payload), capture_mode=capture_mode)
 
 

--- a/tests/test_metadata_tools_extended.py
+++ b/tests/test_metadata_tools_extended.py
@@ -92,15 +92,22 @@ class TestGetMainPageToolInvocation:
     @pytest.mark.asyncio
     async def test_get_main_page_success(self, server, temp_dir):
         """Test successful main page retrieval through tool handler."""
-        server.async_zim_operations.get_main_page = AsyncMock(
-            return_value="Main page content here"
+        server.async_zim_operations.get_main_page_data = AsyncMock(
+            return_value={
+                "path": "A/Main_Page",
+                "title": "Main Page",
+                "content": "Main page content here",
+                "_meta": {"tokens_est": 5, "chars": 22, "truncated": False},
+            }
         )
 
         tools = server.mcp._tool_manager._tools
         if "get_main_page" in tools:
             tool_handler = tools["get_main_page"].fn
             result = await tool_handler(zim_file_path=str(temp_dir / "test.zim"))
-            assert "Main page content" in result
+            assert isinstance(result, dict)
+            assert result.get("title") == "Main Page"
+            assert "Main page content" in result.get("content", "")
 
     @pytest.mark.asyncio
     async def test_get_main_page_rate_limit_error(self, server, temp_dir):
@@ -113,13 +120,15 @@ class TestGetMainPageToolInvocation:
         if "get_main_page" in tools:
             tool_handler = tools["get_main_page"].fn
             result = await tool_handler(zim_file_path=str(temp_dir / "test.zim"))
-            # Should return error message, not raise
-            assert "Error" in result or "Rate" in result
+            # Should return a structured error envelope, not raise
+            assert isinstance(result, dict)
+            assert result.get("error") is True
+            assert result.get("operation") == "get main page"
 
     @pytest.mark.asyncio
     async def test_get_main_page_generic_exception(self, server, temp_dir):
         """Test generic exception handling in get_main_page."""
-        server.async_zim_operations.get_main_page = AsyncMock(
+        server.async_zim_operations.get_main_page_data = AsyncMock(
             side_effect=RuntimeError("Main page retrieval failed")
         )
 
@@ -127,8 +136,10 @@ class TestGetMainPageToolInvocation:
         if "get_main_page" in tools:
             tool_handler = tools["get_main_page"].fn
             result = await tool_handler(zim_file_path=str(temp_dir / "test.zim"))
-            # Should return error message, not raise
-            assert "Error" in result or "error" in result.lower()
+            # Should return a structured error envelope, not raise
+            assert isinstance(result, dict)
+            assert result.get("error") is True
+            assert "message" in result
 
 
 class TestListNamespacesToolInvocation:
@@ -222,8 +233,13 @@ class TestMetadataToolsInputSanitization:
     @pytest.mark.asyncio
     async def test_get_main_page_input_sanitization(self, server, temp_dir):
         """Test that get_main_page sanitizes file path input."""
-        server.async_zim_operations.get_main_page = AsyncMock(
-            return_value="Main page content"
+        server.async_zim_operations.get_main_page_data = AsyncMock(
+            return_value={
+                "path": "A/Main_Page",
+                "title": "Main Page",
+                "content": "Main page content",
+                "_meta": {"tokens_est": 5, "chars": 18, "truncated": False},
+            }
         )
 
         tools = server.mcp._tool_manager._tools
@@ -231,7 +247,8 @@ class TestMetadataToolsInputSanitization:
             tool_handler = tools["get_main_page"].fn
             # Normal path should work
             result = await tool_handler(zim_file_path=str(temp_dir / "test.zim"))
-            assert "Main page" in result
+            assert isinstance(result, dict)
+            assert "Main page" in result.get("content", "")
 
     @pytest.mark.asyncio
     async def test_list_namespaces_input_sanitization(self, server, temp_dir):

--- a/tests/test_namespace_scheme_aware.py
+++ b/tests/test_namespace_scheme_aware.py
@@ -203,7 +203,7 @@ class TestWalkNamespaceNewScheme:
         """walk_namespace('C') must surface every iterable entry."""
         zim = _require(basic_test_zim_files["nons"])
         result = json.loads(ops_for_zim_data.walk_namespace(str(zim), "C", limit=500))
-        paths = {e["path"] for e in result["entries"]}
+        paths = {e["path"] for e in result["results"]}
         assert {"favicon.png", "main.html"} <= paths
 
     def test_walk_F_empty(
@@ -214,92 +214,78 @@ class TestWalkNamespaceNewScheme:
         """First-letter bucket 'F' must walk to zero results, done=True."""
         zim = _require(basic_test_zim_files["nons"])
         result = json.loads(ops_for_zim_data.walk_namespace(str(zim), "F", limit=500))
-        assert result["entries"] == []
+        assert result["results"] == []
         assert result["done"] is True
 
 
 class TestWalkNamespaceTotalInNamespace:
-    """walk_namespace must report a namespace-specific count, not the file total.
+    """walk_namespace v2 contract: ``total`` is always None mid-scan.
 
-    Beta-test feedback: walking an empty namespace returned ``total_entries``
-    equal to the whole archive's entry count, which is misleading. The fix
-    introduces ``total_in_namespace`` (matching browse_namespace) and renames
-    the file-total field to the unambiguous ``archive_entry_count``. The old
-    ``total_entries`` is kept as a deprecated alias of ``archive_entry_count``.
+    Pre-v2 carried a ``total_in_namespace`` field plus a deprecated
+    ``total_entries`` alias. v2 Phase B unifies on the contract's single
+    ``total`` slot and consistently reports None — walk doesn't know the
+    per-namespace total without first finishing the scan, and the file
+    total is exposed separately as ``archive_entry_count``.
     """
 
-    def test_new_scheme_C_total_matches_entry_count(
+    def test_new_scheme_C_total_is_null(
         self,
         ops_for_zim_data: ZimOperations,
         basic_test_zim_files: Dict[str, Optional[Path]],
     ):
-        """New-scheme C: iterator emits only C, so total_in_namespace == entry_count.
+        """walk_namespace must not report a ``total`` — it cannot know it mid-scan.
 
-        The count is authoritative because libzim tells us exactly.
+        ``archive_entry_count`` is still surfaced for the file-level total.
         """
         zim = _require(basic_test_zim_files["nons"])
         result = ops_for_zim_data.walk_namespace_data(str(zim), "C", limit=500)
         # nons/small.zim has entry_count=2 (favicon.png, main.html)
         assert result["archive_entry_count"] == 2
-        assert result["total_in_namespace"] == 2
-        assert result["total_in_namespace_is_lower_bound"] is False
-        # Deprecated alias kept for backward compatibility
-        assert result["total_entries"] == 2
+        assert result["total"] is None
 
-    def test_new_scheme_M_total_matches_metadata_keys(
+    def test_new_scheme_M_archive_entry_count_unchanged(
         self,
         ops_for_zim_data: ZimOperations,
         basic_test_zim_files: Dict[str, Optional[Path]],
     ):
-        """New-scheme M count is len(metadata_keys), not archive.entry_count."""
+        """``archive_entry_count`` mirrors archive.entry_count regardless of namespace."""
         zim = _require(basic_test_zim_files["nons"])
         result = ops_for_zim_data.walk_namespace_data(str(zim), "M", limit=500)
-        # nons/small.zim has 10 metadata_keys, entry_count=2
+        # nons/small.zim has entry_count=2; metadata_keys=10 has nothing to do
+        # with the file's entry_count (and v2 no longer surfaces it as total).
         assert result["archive_entry_count"] == 2
-        assert result["total_in_namespace"] == 10
-        assert result["total_in_namespace_is_lower_bound"] is False
-        # Deprecated alias mirrors archive_entry_count, NOT the namespace count
-        assert result["total_entries"] == 2
+        assert result["total"] is None
 
-    def test_new_scheme_empty_namespace_reports_zero(
+    def test_new_scheme_empty_namespace_reports_no_total(
         self,
         ops_for_zim_data: ZimOperations,
         basic_test_zim_files: Dict[str, Optional[Path]],
     ):
-        """An empty namespace must report 0, not the file total.
+        """An empty namespace must report empty results plus total=None.
 
-        This was the headline beta-test issue: walking namespace ``Z``
-        returned ``total_entries: 5175`` (the whole archive size).
+        Pre-v2 surfaced ``total_in_namespace=0`` here. v2 unifies on a
+        single ``total`` slot that walk always reports as None — empty
+        results plus ``done=True`` already convey the same information.
         """
         zim = _require(basic_test_zim_files["nons"])
         result = ops_for_zim_data.walk_namespace_data(str(zim), "Z", limit=500)
-        assert result["entries"] == []
-        assert result["total_in_namespace"] == 0
-        assert result["total_in_namespace_is_lower_bound"] is False
+        assert result["results"] == []
+        assert result["total"] is None
         # archive_entry_count is still the file total — make this explicit
         assert result["archive_entry_count"] == 2
 
-    def test_old_scheme_total_in_namespace_is_unknown(
+    def test_old_scheme_total_is_null(
         self,
         ops_for_zim_data: ZimOperations,
         basic_test_zim_files: Dict[str, Optional[Path]],
     ):
-        """Old-scheme: count is None because deriving it needs a full scan.
-
-        Reporting an inaccurate number would be misleading; None signals
-        "not derivable" so callers know to fall back to browse_namespace.
-        ``is_lower_bound`` must also be None — saying ``False`` next to a
-        null count would read as "this null is the exact count", which is
-        nonsense.
-        """
+        """Old-scheme: total is None (same as new-scheme; walk never reports total)."""
         zim = _require(basic_test_zim_files["withns"])
         result = ops_for_zim_data.walk_namespace_data(str(zim), "M", limit=10)
         # archive_entry_count is always populated
         assert result["archive_entry_count"] >= 1
-        # Old-scheme: count not derivable without full scan
-        assert result["total_in_namespace"] is None
-        # When the count is unknown, the lower-bound flag is also unknown
-        assert result["total_in_namespace_is_lower_bound"] is None
+        # Walk doesn't know the per-namespace total mid-scan; always None.
+        assert result["total"] is None
 
 
 class TestSearchWithFiltersNewScheme:

--- a/tests/test_namespace_scheme_aware.py
+++ b/tests/test_namespace_scheme_aware.py
@@ -147,7 +147,7 @@ class TestBrowseNamespaceNewScheme:
         """browse_namespace('C') in new-scheme returns every iterable entry."""
         zim = _require(basic_test_zim_files["nons"])
         result = json.loads(ops_for_zim_data.browse_namespace(str(zim), "C", limit=50))
-        paths = {e["path"] for e in result["entries"]}
+        paths = {e["path"] for e in result["results"]}
         assert {"favicon.png", "main.html"} <= paths
 
     def test_browse_F_returns_empty(
@@ -158,7 +158,7 @@ class TestBrowseNamespaceNewScheme:
         """The bogus first-letter bucket 'F' must yield zero entries."""
         zim = _require(basic_test_zim_files["nons"])
         result = json.loads(ops_for_zim_data.browse_namespace(str(zim), "F", limit=50))
-        assert result["entries"] == []
+        assert result["results"] == []
 
     def test_browse_M_returns_metadata_entries(
         self,
@@ -169,7 +169,7 @@ class TestBrowseNamespaceNewScheme:
         zim = _require(basic_test_zim_files["nons"])
         result = json.loads(ops_for_zim_data.browse_namespace(str(zim), "M", limit=50))
         # Should include metadata keys like Title, Language, etc.
-        titles = {e["title"] for e in result["entries"]}
+        titles = {e["title"] for e in result["results"]}
         assert "Title" in titles or any(
             "Title" in t for t in titles
         ), f"expected metadata keys in M, got titles: {titles}"
@@ -186,7 +186,7 @@ class TestBrowseNamespaceOldScheme:
         """Old-scheme browse_namespace('M') still finds M/* metadata entries."""
         zim = _require(basic_test_zim_files["withns"])
         result = json.loads(ops_for_zim_data.browse_namespace(str(zim), "M", limit=50))
-        paths = {e["path"] for e in result["entries"]}
+        paths = {e["path"] for e in result["results"]}
         # withns/small.zim has 12 M/* entries
         assert "M/Title" in paths
         assert "M/Language" in paths
@@ -341,13 +341,15 @@ class TestBrowseNamespaceTotalIsAuthoritative:
     ):
         """For new-scheme C, totals come straight from archive.entry_count.
 
-        is_total_authoritative must be True (libzim tells us exactly).
+        Phase B: ``total`` is authoritative when libzim tells us exactly,
+        signalled by the *absence* of ``page_info.total_is_lower_bound``.
         """
         zim = _require(basic_test_zim_files["nons"])
         result = json.loads(ops_for_zim_data.browse_namespace(str(zim), "C", limit=50))
         # nons/small.zim has entry_count=2 (favicon.png, main.html)
-        assert result["total_in_namespace"] == 2
-        assert result["is_total_authoritative"] is True
+        assert result["total"] == 2
+        # Authoritative: total_is_lower_bound is absent or False.
+        assert not result["page_info"].get("total_is_lower_bound", False)
 
     def test_new_scheme_M_total_matches_metadata_keys(
         self,
@@ -358,8 +360,8 @@ class TestBrowseNamespaceTotalIsAuthoritative:
         zim = _require(basic_test_zim_files["nons"])
         result = json.loads(ops_for_zim_data.browse_namespace(str(zim), "M", limit=50))
         # nons/small.zim has 10 metadata_keys
-        assert result["total_in_namespace"] == 10
-        assert result["is_total_authoritative"] is True
+        assert result["total"] == 10
+        assert not result["page_info"].get("total_is_lower_bound", False)
 
 
 class TestExtractNamespaceFromPathSchemeAware:

--- a/tests/test_namespace_scheme_aware.py
+++ b/tests/test_namespace_scheme_aware.py
@@ -83,11 +83,11 @@ class TestListNamespacesNewScheme:
             "F" not in result["namespaces"]
         ), "first-letter bucket 'F' must not appear for new-scheme archives"
         # 'M' may legitimately exist via metadata_keys, but its source must be
-        # metadata not first-letter parsing of main.html — count must be > 1
+        # metadata not first-letter parsing of main.html — total must be > 1
         # because metadata_keys yields several entries.
         if "M" in result["namespaces"]:
             assert (
-                result["namespaces"]["M"]["count"] > 1
+                result["namespaces"]["M"]["total"] > 1
             ), "'M' must come from metadata_keys, not first-letter of main.html"
 
     def test_content_namespace_present(
@@ -100,7 +100,7 @@ class TestListNamespacesNewScheme:
         result = json.loads(ops_for_zim_data.list_namespaces(str(zim)))
         assert "C" in result["namespaces"], "C namespace must exist for new-scheme"
         assert (
-            result["namespaces"]["C"]["count"] >= 2
+            result["namespaces"]["C"]["total"] >= 2
         ), "C must contain favicon.png and main.html"
 
     def test_metadata_namespace_from_metadata_keys(
@@ -117,7 +117,7 @@ class TestListNamespacesNewScheme:
         assert (
             "M" in result["namespaces"]
         ), "M must be discovered via metadata_keys for new-scheme"
-        assert result["namespaces"]["M"]["count"] >= 10
+        assert result["namespaces"]["M"]["total"] >= 10
 
 
 class TestListNamespacesOldScheme:
@@ -132,8 +132,8 @@ class TestListNamespacesOldScheme:
         zim = _require(basic_test_zim_files["withns"])
         result = json.loads(ops_for_zim_data.list_namespaces(str(zim)))
         assert {"-", "A", "I", "M", "X"} <= set(result["namespaces"].keys())
-        assert result["namespaces"]["M"]["count"] == 12
-        assert result["namespaces"]["A"]["count"] == 1
+        assert result["namespaces"]["M"]["total"] == 12
+        assert result["namespaces"]["A"]["total"] == 1
 
 
 class TestBrowseNamespaceNewScheme:

--- a/tests/test_navigation_tools.py
+++ b/tests/test_navigation_tools.py
@@ -1006,8 +1006,6 @@ class TestNamespaceDataMethodsMeta:
             "offset": 0,
             "limit": 50,
             "returned_count": 0,
-            "has_more": False,
-            "next_cursor": None,
             "sampling_based": False,
             "discovery_method": "full_iteration",
             "is_total_authoritative": True,

--- a/tests/test_navigation_tools.py
+++ b/tests/test_navigation_tools.py
@@ -981,8 +981,8 @@ class TestNamespaceDataMethodsMeta:
         zim_file = self._zim_file(temp_dir)
         validated = zim_ops.path_validator.validate_path(str(zim_file))
         validated = zim_ops.path_validator.validate_zim_file(validated)
-        # Phase B v2 cache key (count -> total rename).
-        cache_key = f"namespaces_data:v2:{validated}"
+        # Phase B v2b cache key (entry_count -> total rename).
+        cache_key = f"namespaces_data:v2b:{validated}"
         old = {"total_entries": 5, "namespaces": {}}
         zim_ops.cache.set(cache_key, old)
 

--- a/tests/test_navigation_tools.py
+++ b/tests/test_navigation_tools.py
@@ -258,7 +258,15 @@ class TestNavigationToolsDirectInvocation:
     async def test_browse_namespace_tool_invocation(self, advanced_server, temp_dir):
         """Test invoking browse_namespace tool handler directly."""
         advanced_server.async_zim_operations.browse_namespace_data = AsyncMock(
-            return_value={"entries": [{"path": "C/Article", "title": "Article"}]}
+            return_value={
+                "namespace": "C",
+                "results": [{"path": "C/Article", "title": "Article"}],
+                "next_cursor": None,
+                "total": 1,
+                "done": True,
+                "page_info": {"offset": 0, "limit": 50, "returned_count": 1},
+                "_meta": {},
+            }
         )
 
         tools = advanced_server.mcp._tool_manager._tools
@@ -271,7 +279,7 @@ class TestNavigationToolsDirectInvocation:
                 offset=0,
             )
             assert isinstance(result, dict)
-            assert "entries" in result
+            assert "results" in result
 
     @pytest.mark.asyncio
     async def test_browse_namespace_with_invalid_limit(self, advanced_server, temp_dir):
@@ -890,7 +898,24 @@ class TestNamespaceDataMethodsMeta:
     ):
         """browse_namespace_data fresh path attaches _meta."""
         zim_file = self._zim_file(temp_dir)
-        fake_result = {"entries": [], "namespace": "C", "total": 0}
+        # _browse_namespace_entries still returns the inner shape with
+        # legacy keys (entries/total_in_namespace/...); the contract
+        # rename is performed in browse_namespace_data after this call.
+        fake_result = {
+            "namespace": "C",
+            "entries": [],
+            "total_in_namespace": 0,
+            "total_in_namespace_is_lower_bound": False,
+            "offset": 0,
+            "limit": 50,
+            "returned_count": 0,
+            "has_more": False,
+            "next_cursor": None,
+            "sampling_based": False,
+            "discovery_method": "full_iteration",
+            "is_total_authoritative": True,
+            "results_may_be_incomplete": False,
+        }
         monkeypatch.setattr(
             zim_ops,
             "_browse_namespace_entries",
@@ -910,8 +935,17 @@ class TestNamespaceDataMethodsMeta:
         zim_file = self._zim_file(temp_dir)
         validated = zim_ops.path_validator.validate_path(str(zim_file))
         validated = zim_ops.path_validator.validate_zim_file(validated)
-        cache_key = f"browse_ns_data:{validated}:C:50:0"
-        old = {"entries": [], "namespace": "C"}
+        cache_key = f"browse_ns_data:v2b:{validated}:C:50:0"
+        # Cache the *post-rename* contract shape — browse_namespace_data
+        # now caches the structured payload, not the inner legacy dict.
+        old = {
+            "namespace": "C",
+            "results": [],
+            "next_cursor": None,
+            "total": 0,
+            "done": True,
+            "page_info": {"offset": 0, "limit": 50, "returned_count": 0},
+        }
         zim_ops.cache.set(cache_key, old)
 
         result = zim_ops.browse_namespace_data(str(zim_file), "C")

--- a/tests/test_navigation_tools.py
+++ b/tests/test_navigation_tools.py
@@ -169,7 +169,7 @@ class TestGetSearchSuggestionsTool:
     async def test_get_search_suggestions_success(self, server: OpenZimMcpServer):
         """Test successful search suggestions retrieval."""
         server.async_zim_operations.get_search_suggestions = AsyncMock(
-            return_value='{"suggestions": ["Article1", "Article2"]}'
+            return_value='{"results": ["Article1", "Article2"]}'
         )
         server.rate_limiter.check_rate_limit = MagicMock()
 
@@ -177,7 +177,7 @@ class TestGetSearchSuggestionsTool:
             "/path/to/file.zim", "Art", 10
         )
 
-        assert "suggestions" in result
+        assert "results" in result
         server.async_zim_operations.get_search_suggestions.assert_called_once_with(
             "/path/to/file.zim", "Art", 10
         )
@@ -603,7 +603,21 @@ class TestNavigationToolsDirectInvocation:
     ):
         """Test invoking get_search_suggestions tool handler directly."""
         advanced_server.async_zim_operations.get_search_suggestions_data = AsyncMock(
-            return_value={"suggestions": ["Python", "Python programming"]}
+            return_value={
+                "partial_query": "Pyt",
+                "results": [
+                    {"text": "Python", "path": "C/Python", "type": "title_start_match"},
+                    {
+                        "text": "Python programming",
+                        "path": "C/Python_programming",
+                        "type": "title_start_match",
+                    },
+                ],
+                "next_cursor": None,
+                "total": 2,
+                "done": True,
+                "page_info": {"offset": 0, "limit": 10, "returned_count": 2},
+            }
         )
 
         tools = advanced_server.mcp._tool_manager._tools
@@ -615,7 +629,11 @@ class TestNavigationToolsDirectInvocation:
                 limit=10,
             )
             assert isinstance(result, dict)
-            assert "suggestions" in result
+            assert "results" in result
+            assert isinstance(result["results"], list)
+            assert result["next_cursor"] is None
+            assert result["done"] is True
+            assert result["total"] == len(result["results"])
 
     @pytest.mark.asyncio
     async def test_get_search_suggestions_invalid_limit(

--- a/tests/test_navigation_tools.py
+++ b/tests/test_navigation_tools.py
@@ -981,7 +981,8 @@ class TestNamespaceDataMethodsMeta:
         zim_file = self._zim_file(temp_dir)
         validated = zim_ops.path_validator.validate_path(str(zim_file))
         validated = zim_ops.path_validator.validate_zim_file(validated)
-        cache_key = f"namespaces_data:{validated}"
+        # Phase B v2 cache key (count -> total rename).
+        cache_key = f"namespaces_data:v2:{validated}"
         old = {"total_entries": 5, "namespaces": {}}
         zim_ops.cache.set(cache_key, old)
 

--- a/tests/test_navigation_tools.py
+++ b/tests/test_navigation_tools.py
@@ -382,9 +382,7 @@ class TestNavigationToolsDirectInvocation:
                 "query": "test query",
                 "namespace_filter": None,
                 "content_type_filter": None,
-                "results": [
-                    {"path": "C/Result1", "title": "Result 1", "snippet": ""}
-                ],
+                "results": [{"path": "C/Result1", "title": "Result 1", "snippet": ""}],
                 "next_cursor": None,
                 "total": 1,
                 "done": True,
@@ -486,9 +484,7 @@ class TestNavigationToolsDirectInvocation:
             assert isinstance(result, dict)
             assert result.get("error") is True
             message = result.get("message", "")
-            assert "**" in message and (
-                "Error" in message or "Operation" in message
-            )
+            assert "**" in message and ("Error" in message or "Operation" in message)
 
     @pytest.mark.asyncio
     async def test_search_with_filters_returns_paginated_response(
@@ -581,9 +577,7 @@ class TestNavigationToolsDirectInvocation:
         assert called_args[5] == 50  # offset
 
     @pytest.mark.asyncio
-    async def test_search_with_filters_cursor_mismatch(
-        self, advanced_server, temp_dir
-    ):
+    async def test_search_with_filters_cursor_mismatch(self, advanced_server, temp_dir):
         """A cursor issued by a different tool is rejected."""
         from openzim_mcp.pagination import Cursor
 
@@ -601,9 +595,9 @@ class TestNavigationToolsDirectInvocation:
         )
         assert isinstance(result, dict)
         assert result.get("error") is True
-        assert "search_zim_file" in result.get("message", "") or "cannot be used" in result.get(
+        assert "search_zim_file" in result.get(
             "message", ""
-        )
+        ) or "cannot be used" in result.get("message", "")
 
     @pytest.mark.asyncio
     async def test_get_search_suggestions_tool_invocation(
@@ -878,9 +872,7 @@ class TestWalkNamespaceLimitValidation:
 
         captured: dict = {}
 
-        async def _fake_walk(
-            zim_file_path, namespace, cursor_state=None, limit=200
-        ):
+        async def _fake_walk(zim_file_path, namespace, cursor_state=None, limit=200):
             captured["cursor_state"] = cursor_state
             captured["limit"] = limit
             return {

--- a/tests/test_navigation_tools.py
+++ b/tests/test_navigation_tools.py
@@ -62,7 +62,14 @@ class TestBrowseNamespaceTool:
 
 
 class TestSearchWithFiltersTool:
-    """Test search_with_filters tool functionality."""
+    """Test search_with_filters tool functionality.
+
+    Phase B: ``search_with_filters`` returns a structured
+    ``SearchWithFiltersResponse`` dict (was markdown text). Async-op
+    layer now exposes ``search_with_filters_data`` for the structured
+    path; the legacy markdown ``search_with_filters`` method is retained
+    as a compat surface.
+    """
 
     @pytest.fixture
     def server(self, test_config: OpenZimMcpConfig) -> OpenZimMcpServer:
@@ -71,45 +78,78 @@ class TestSearchWithFiltersTool:
 
     @pytest.mark.asyncio
     async def test_search_with_filters_success(self, server: OpenZimMcpServer):
-        """Test successful filtered search."""
-        server.async_zim_operations.search_with_filters = AsyncMock(
-            return_value='{"results": [{"title": "Article"}]}'
+        """Test successful filtered search returns structured payload."""
+        server.async_zim_operations.search_with_filters_data = AsyncMock(
+            return_value={
+                "query": "query",
+                "namespace_filter": None,
+                "content_type_filter": None,
+                "results": [{"path": "C/Article", "title": "Article", "snippet": ""}],
+                "next_cursor": None,
+                "total": 1,
+                "done": True,
+                "page_info": {"offset": 0, "limit": 10, "returned_count": 1},
+                "_meta": {},
+            }
         )
         server.rate_limiter.check_rate_limit = MagicMock()
 
-        result = await server.async_zim_operations.search_with_filters(
+        result = await server.async_zim_operations.search_with_filters_data(
             "/path/to/file.zim", "query", None, None, 10, 0
         )
 
         assert "results" in result
+        assert result["results"][0]["title"] == "Article"
 
     @pytest.mark.asyncio
     async def test_search_with_filters_with_namespace(self, server: OpenZimMcpServer):
         """Test filtered search with namespace filter."""
-        server.async_zim_operations.search_with_filters = AsyncMock(
-            return_value='{"results": []}'
+        server.async_zim_operations.search_with_filters_data = AsyncMock(
+            return_value={
+                "query": "query",
+                "namespace_filter": "A",
+                "content_type_filter": None,
+                "results": [],
+                "next_cursor": None,
+                "total": 0,
+                "done": True,
+                "page_info": {"offset": 0, "limit": 10, "returned_count": 0},
+                "_meta": {},
+            }
         )
 
-        result = await server.async_zim_operations.search_with_filters(
+        result = await server.async_zim_operations.search_with_filters_data(
             "/path/to/file.zim", "query", "A", None, 10, 0
         )
 
         assert "results" in result
+        assert result["namespace_filter"] == "A"
 
     @pytest.mark.asyncio
     async def test_search_with_filters_with_content_type(
         self, server: OpenZimMcpServer
     ):
         """Test filtered search with content type filter."""
-        server.async_zim_operations.search_with_filters = AsyncMock(
-            return_value='{"results": []}'
+        server.async_zim_operations.search_with_filters_data = AsyncMock(
+            return_value={
+                "query": "query",
+                "namespace_filter": None,
+                "content_type_filter": "text/html",
+                "results": [],
+                "next_cursor": None,
+                "total": 0,
+                "done": True,
+                "page_info": {"offset": 0, "limit": 10, "returned_count": 0},
+                "_meta": {},
+            }
         )
 
-        result = await server.async_zim_operations.search_with_filters(
+        result = await server.async_zim_operations.search_with_filters_data(
             "/path/to/file.zim", "query", None, "text/html", 10, 0
         )
 
         assert "results" in result
+        assert result["content_type_filter"] == "text/html"
 
     # NOTE: search_with_filters validation (limit out of range, negative
     # offset) is exercised end-to-end via the registered MCP tool handler
@@ -329,8 +369,20 @@ class TestNavigationToolsDirectInvocation:
     @pytest.mark.asyncio
     async def test_search_with_filters_tool_invocation(self, advanced_server, temp_dir):
         """Test invoking search_with_filters tool handler directly."""
-        advanced_server.async_zim_operations.search_with_filters = AsyncMock(
-            return_value='{"results": [{"title": "Result 1", "path": "C/Result1"}]}'
+        advanced_server.async_zim_operations.search_with_filters_data = AsyncMock(
+            return_value={
+                "query": "test query",
+                "namespace_filter": None,
+                "content_type_filter": None,
+                "results": [
+                    {"path": "C/Result1", "title": "Result 1", "snippet": ""}
+                ],
+                "next_cursor": None,
+                "total": 1,
+                "done": True,
+                "page_info": {"offset": 0, "limit": 10, "returned_count": 1},
+                "_meta": {},
+            }
         )
 
         tools = advanced_server.mcp._tool_manager._tools
@@ -340,13 +392,25 @@ class TestNavigationToolsDirectInvocation:
                 zim_file_path=str(temp_dir / "test.zim"),
                 query="test query",
             )
+            assert isinstance(result, dict)
             assert "results" in result
+            assert result["results"][0]["path"] == "C/Result1"
 
     @pytest.mark.asyncio
     async def test_search_with_filters_all_params(self, advanced_server, temp_dir):
         """Test search_with_filters with all parameters."""
-        advanced_server.async_zim_operations.search_with_filters = AsyncMock(
-            return_value='{"results": []}'
+        advanced_server.async_zim_operations.search_with_filters_data = AsyncMock(
+            return_value={
+                "query": "test",
+                "namespace_filter": "C",
+                "content_type_filter": "text/html",
+                "results": [],
+                "next_cursor": None,
+                "total": 0,
+                "done": True,
+                "page_info": {"offset": 10, "limit": 20, "returned_count": 0},
+                "_meta": {},
+            }
         )
 
         tools = advanced_server.mcp._tool_manager._tools
@@ -360,11 +424,14 @@ class TestNavigationToolsDirectInvocation:
                 limit=20,
                 offset=10,
             )
+            assert isinstance(result, dict)
             assert "results" in result
+            assert result["namespace_filter"] == "C"
+            assert result["content_type_filter"] == "text/html"
 
     @pytest.mark.asyncio
     async def test_search_with_filters_invalid_limit(self, advanced_server, temp_dir):
-        """Test search_with_filters with invalid limit."""
+        """Test search_with_filters with invalid limit returns error envelope."""
         tools = advanced_server.mcp._tool_manager._tools
         if "search_with_filters" in tools:
             tool_handler = tools["search_with_filters"].fn
@@ -375,11 +442,13 @@ class TestNavigationToolsDirectInvocation:
                 query="test",
                 limit=150,
             )
-            assert "must be between 1 and 100" in result
+            assert isinstance(result, dict)
+            assert result.get("error") is True
+            assert "must be between 1 and 100" in result.get("message", "")
 
     @pytest.mark.asyncio
     async def test_search_with_filters_negative_offset(self, advanced_server, temp_dir):
-        """Test search_with_filters with negative offset."""
+        """Test search_with_filters with negative offset returns error envelope."""
         tools = advanced_server.mcp._tool_manager._tools
         if "search_with_filters" in tools:
             tool_handler = tools["search_with_filters"].fn
@@ -388,12 +457,14 @@ class TestNavigationToolsDirectInvocation:
                 query="test",
                 offset=-5,
             )
-            assert "must be non-negative" in result
+            assert isinstance(result, dict)
+            assert result.get("error") is True
+            assert "must be non-negative" in result.get("message", "")
 
     @pytest.mark.asyncio
     async def test_search_with_filters_with_exception(self, advanced_server, temp_dir):
         """Test search_with_filters when an exception occurs."""
-        advanced_server.async_zim_operations.search_with_filters = AsyncMock(
+        advanced_server.async_zim_operations.search_with_filters_data = AsyncMock(
             side_effect=RuntimeError("Search failed")
         )
 
@@ -404,7 +475,127 @@ class TestNavigationToolsDirectInvocation:
                 zim_file_path=str(temp_dir / "test.zim"),
                 query="test",
             )
-            assert "Error" in result or "error" in result.lower()
+            assert isinstance(result, dict)
+            assert result.get("error") is True
+            message = result.get("message", "")
+            assert "**" in message and (
+                "Error" in message or "Operation" in message
+            )
+
+    @pytest.mark.asyncio
+    async def test_search_with_filters_returns_paginated_response(
+        self, advanced_server, temp_dir
+    ):
+        """Smoke test: top-level Phase B contract keys are present."""
+        advanced_server.async_zim_operations.search_with_filters_data = AsyncMock(
+            return_value={
+                "query": "evolution",
+                "namespace_filter": "C",
+                "content_type_filter": None,
+                "results": [],
+                "next_cursor": None,
+                "total": 0,
+                "done": True,
+                "page_info": {"offset": 0, "limit": 10, "returned_count": 0},
+                "_meta": {},
+            }
+        )
+        tools = advanced_server.mcp._tool_manager._tools
+        if "search_with_filters" not in tools:
+            pytest.skip("search_with_filters tool not registered")
+        tool_handler = tools["search_with_filters"].fn
+        result = await tool_handler(
+            zim_file_path=str(temp_dir / "test.zim"),
+            query="evolution",
+            namespace="C",
+        )
+        assert isinstance(result, dict)
+        for key in ("results", "next_cursor", "total", "done", "page_info"):
+            assert key in result
+        assert result["query"] == "evolution"
+        assert result["namespace_filter"] == "C"
+        assert result["content_type_filter"] is None
+
+    @pytest.mark.asyncio
+    async def test_search_with_filters_cursor_round_trip(
+        self, advanced_server, temp_dir
+    ):
+        """Cursor decoding overrides offset/limit/query/namespace/content_type."""
+        from openzim_mcp.pagination import Cursor
+
+        captured: dict = {}
+
+        async def _capture(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return {
+                "query": "evolution",
+                "namespace_filter": "C",
+                "content_type_filter": "text/html",
+                "results": [],
+                "next_cursor": None,
+                "total": 0,
+                "done": True,
+                "page_info": {"offset": 50, "limit": 25, "returned_count": 0},
+                "_meta": {},
+            }
+
+        advanced_server.async_zim_operations.search_with_filters_data = AsyncMock(
+            side_effect=_capture
+        )
+        tools = advanced_server.mcp._tool_manager._tools
+        if "search_with_filters" not in tools:
+            pytest.skip("search_with_filters tool not registered")
+        cursor = Cursor.encode(
+            tool="search_with_filters",
+            state={
+                "o": 50,
+                "l": 25,
+                "q": "evolution",
+                "ns": "C",
+                "ct": "text/html",
+            },
+        )
+        tool_handler = tools["search_with_filters"].fn
+        result = await tool_handler(
+            zim_file_path=str(temp_dir / "test.zim"),
+            cursor=cursor,
+        )
+        assert isinstance(result, dict)
+        assert result.get("error") is not True
+        # _data should have been called with the cursor-decoded values.
+        # signature: (zim_file_path, query, namespace, content_type, limit, offset)
+        called_args = captured["args"]
+        assert called_args[1] == "evolution"  # query
+        assert called_args[2] == "C"  # namespace
+        assert called_args[3] == "text/html"  # content_type
+        assert called_args[4] == 25  # limit
+        assert called_args[5] == 50  # offset
+
+    @pytest.mark.asyncio
+    async def test_search_with_filters_cursor_mismatch(
+        self, advanced_server, temp_dir
+    ):
+        """A cursor issued by a different tool is rejected."""
+        from openzim_mcp.pagination import Cursor
+
+        wrong_cursor = Cursor.encode(
+            tool="search_zim_file",
+            state={"o": 0, "l": 10, "q": "test"},
+        )
+        tools = advanced_server.mcp._tool_manager._tools
+        if "search_with_filters" not in tools:
+            pytest.skip("search_with_filters tool not registered")
+        tool_handler = tools["search_with_filters"].fn
+        result = await tool_handler(
+            zim_file_path=str(temp_dir / "test.zim"),
+            cursor=wrong_cursor,
+        )
+        assert isinstance(result, dict)
+        assert result.get("error") is True
+        assert "search_zim_file" in result.get("message", "") or "cannot be used" in result.get(
+            "message", ""
+        )
 
     @pytest.mark.asyncio
     async def test_get_search_suggestions_tool_invocation(

--- a/tests/test_navigation_tools.py
+++ b/tests/test_navigation_tools.py
@@ -746,7 +746,7 @@ class TestWalkNamespaceLimitValidation:
         result = await tool_handler(
             zim_file_path=str(temp_dir / "test.zim"),
             namespace="C",
-            cursor=0,
+            cursor=None,
             limit=100000,
         )
         assert isinstance(result, dict)
@@ -769,7 +769,7 @@ class TestWalkNamespaceLimitValidation:
         result = await tool_handler(
             zim_file_path=str(temp_dir / "test.zim"),
             namespace="C",
-            cursor=0,
+            cursor=None,
             limit=0,
         )
         assert isinstance(result, dict)
@@ -778,35 +778,77 @@ class TestWalkNamespaceLimitValidation:
         advanced_server.async_zim_operations.walk_namespace_data.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_walk_namespace_rejects_negative_cursor(
+    async def test_walk_namespace_rejects_cross_tool_cursor(
         self, advanced_server, temp_dir
     ):
-        """Negative cursor must produce a validation error."""
+        """A cursor issued by another tool must be rejected before backend access.
+
+        v2 Phase B: cursors are tool-bound. A cursor encoded with
+        ``tool="browse_namespace"`` cannot be used by ``walk_namespace``.
+        """
+        from openzim_mcp.pagination import Cursor
+
         advanced_server.async_zim_operations.walk_namespace_data = AsyncMock(
             side_effect=AssertionError(
-                "backend should not be called for invalid cursor"
+                "backend should not be called for cross-tool cursor"
             )
         )
 
         tools = advanced_server.mcp._tool_manager._tools
         assert "walk_namespace" in tools
         tool_handler = tools["walk_namespace"].fn
+        wrong_cursor = Cursor.encode(
+            tool="browse_namespace", state={"o": 0, "l": 50, "ns": "C"}
+        )
         result = await tool_handler(
             zim_file_path=str(temp_dir / "test.zim"),
             namespace="C",
-            cursor=-1,
+            cursor=wrong_cursor,
             limit=200,
         )
         assert isinstance(result, dict)
         assert result.get("error") is True
-        assert "must be non-negative" in result.get("message", "")
+        advanced_server.async_zim_operations.walk_namespace_data.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_walk_namespace_rejects_malformed_cursor(
+        self, advanced_server, temp_dir
+    ):
+        """A non-base64 / non-JSON cursor must surface a validation error."""
+        advanced_server.async_zim_operations.walk_namespace_data = AsyncMock(
+            side_effect=AssertionError(
+                "backend should not be called for malformed cursor"
+            )
+        )
+
+        tools = advanced_server.mcp._tool_manager._tools
+        tool_handler = tools["walk_namespace"].fn
+        result = await tool_handler(
+            zim_file_path=str(temp_dir / "test.zim"),
+            namespace="C",
+            cursor="!!!not-base64!!!",
+            limit=200,
+        )
+        assert isinstance(result, dict)
+        assert result.get("error") is True
         advanced_server.async_zim_operations.walk_namespace_data.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_walk_namespace_accepts_valid_bounds(self, advanced_server, temp_dir):
         """Valid limit/cursor must reach the backend."""
         advanced_server.async_zim_operations.walk_namespace_data = AsyncMock(
-            return_value={"entries": [], "next_cursor": 200, "done": False}
+            return_value={
+                "namespace": "C",
+                "results": [],
+                "next_cursor": None,
+                "total": None,
+                "done": True,
+                "page_info": {"offset": 0, "limit": 200, "returned_count": 0},
+                "scanned_count": 0,
+                "scanned_through_id": None,
+                "archive_entry_count": 0,
+                "_meta": {},
+            }
         )
 
         tools = advanced_server.mcp._tool_manager._tools
@@ -815,12 +857,66 @@ class TestWalkNamespaceLimitValidation:
         result = await tool_handler(
             zim_file_path=str(temp_dir / "test.zim"),
             namespace="C",
-            cursor=0,
+            cursor=None,
             limit=200,
         )
         assert isinstance(result, dict)
-        assert "entries" in result
+        assert "results" in result
         advanced_server.async_zim_operations.walk_namespace_data.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_walk_namespace_decodes_opaque_cursor(
+        self, advanced_server, temp_dir
+    ):
+        """An opaque cursor encoded with t='walk_namespace' decodes to scan_at/limit.
+
+        The decoded ``s.l`` overrides the function-arg ``limit`` (cursor wins
+        on conflict per response-contract spec) and ``s.scan_at`` becomes
+        the starting point for the backend scan.
+        """
+        from openzim_mcp.pagination import Cursor
+
+        captured: dict = {}
+
+        async def _fake_walk(
+            zim_file_path, namespace, cursor_state=None, limit=200
+        ):
+            captured["cursor_state"] = cursor_state
+            captured["limit"] = limit
+            return {
+                "namespace": "C",
+                "results": [],
+                "next_cursor": None,
+                "total": None,
+                "done": True,
+                "page_info": {"offset": 42, "limit": 50, "returned_count": 0},
+                "scanned_count": 0,
+                "scanned_through_id": None,
+                "archive_entry_count": 0,
+                "_meta": {},
+            }
+
+        advanced_server.async_zim_operations.walk_namespace_data = AsyncMock(
+            side_effect=_fake_walk
+        )
+
+        tools = advanced_server.mcp._tool_manager._tools
+        tool_handler = tools["walk_namespace"].fn
+        good_cursor = Cursor.encode(
+            tool="walk_namespace", state={"scan_at": 42, "l": 50}
+        )
+        result = await tool_handler(
+            zim_file_path=str(temp_dir / "test.zim"),
+            namespace="C",
+            cursor=good_cursor,
+            # Function-arg limit must be overridden by the cursor's "l".
+            limit=200,
+        )
+        assert isinstance(result, dict)
+        assert "results" in result
+        # cursor's "l" wins over function-arg limit.
+        assert captured["limit"] == 50
+        assert captured["cursor_state"] == {"scan_at": 42, "l": 50}
 
 
 # ---------------------------------------------------------------------------
@@ -964,7 +1060,9 @@ class TestNamespaceDataMethodsMeta:
 
         with patch("openzim_mcp.zim_operations.zim_archive") as mock_archive:
             mock_archive.return_value.__enter__.return_value = mock_archive_obj
-            result = zim_ops.walk_namespace_data(str(zim_file), "C", cursor=0, limit=10)
+            result = zim_ops.walk_namespace_data(
+                str(zim_file), "C", cursor_state=None, limit=10
+            )
 
         assert "_meta" in result
         assert result["_meta"]["tokens_est"] >= 1

--- a/tests/test_pagination_cursor.py
+++ b/tests/test_pagination_cursor.py
@@ -88,8 +88,8 @@ class TestCursorMalformed:
         assert decoded["s"]["ns"] == "C"
 
 
-class TestCursorEmptyState:
-    def test_empty_state_dict_allowed(self) -> None:
+class TestCursorWalkNamespaceState:
+    def test_walk_namespace_state_roundtrip(self) -> None:
         token = Cursor.encode(tool="walk_namespace", state={"scan_at": 0, "l": 200})
         decoded = Cursor.decode(token, expected_tool="walk_namespace")
         assert decoded["s"]["scan_at"] == 0

--- a/tests/test_pagination_cursor.py
+++ b/tests/test_pagination_cursor.py
@@ -1,0 +1,95 @@
+"""Tests for openzim_mcp.pagination.Cursor — encode/decode, tool binding, versioning."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+
+from openzim_mcp.pagination import Cursor, CursorMismatchError
+
+
+class TestCursorRoundTrip:
+    def test_encode_decode_roundtrip_minimal(self) -> None:
+        token = Cursor.encode(tool="browse_namespace", state={"o": 50, "l": 50, "ns": "C"})
+        assert isinstance(token, str)
+        decoded = Cursor.decode(token, expected_tool="browse_namespace")
+        assert decoded["v"] == 1
+        assert decoded["t"] == "browse_namespace"
+        assert decoded["s"] == {"o": 50, "l": 50, "ns": "C"}
+
+    def test_encode_produces_urlsafe_base64(self) -> None:
+        token = Cursor.encode(tool="search_zim_file", state={"o": 0, "l": 20, "q": "berlin"})
+        assert "+" not in token
+        assert "/" not in token
+
+    def test_encode_unicode_state(self) -> None:
+        token = Cursor.encode(tool="search_zim_file", state={"o": 0, "l": 20, "q": "café"})
+        decoded = Cursor.decode(token, expected_tool="search_zim_file")
+        assert decoded["s"]["q"] == "café"
+
+
+class TestCursorVersioning:
+    def test_default_version_is_one(self) -> None:
+        token = Cursor.encode(tool="browse_namespace", state={"o": 0, "l": 50, "ns": "C"})
+        decoded = Cursor.decode(token, expected_tool="browse_namespace")
+        assert decoded["v"] == 1
+
+    def test_explicit_version_passes_through(self) -> None:
+        token = Cursor.encode(tool="browse_namespace", state={"o": 0, "l": 50, "ns": "C"}, version=1)
+        decoded = Cursor.decode(token, expected_tool="browse_namespace")
+        assert decoded["v"] == 1
+
+    def test_unknown_version_rejected(self) -> None:
+        raw = json.dumps({"v": 2, "t": "browse_namespace", "s": {"o": 0, "l": 50, "ns": "C"}})
+        token = base64.urlsafe_b64encode(raw.encode()).decode()
+        with pytest.raises(ValueError, match="Unsupported cursor version"):
+            Cursor.decode(token, expected_tool="browse_namespace")
+
+
+class TestCursorToolBinding:
+    def test_decode_with_matching_tool_succeeds(self) -> None:
+        token = Cursor.encode(tool="search_zim_file", state={"o": 0, "l": 20, "q": "x"})
+        decoded = Cursor.decode(token, expected_tool="search_zim_file")
+        assert decoded["t"] == "search_zim_file"
+
+    def test_decode_with_mismatched_tool_raises(self) -> None:
+        token = Cursor.encode(tool="search_zim_file", state={"o": 0, "l": 20, "q": "x"})
+        with pytest.raises(CursorMismatchError) as exc_info:
+            Cursor.decode(token, expected_tool="browse_namespace")
+        assert "search_zim_file" in str(exc_info.value)
+        assert "browse_namespace" in str(exc_info.value)
+
+    def test_mismatch_error_is_value_error_subclass(self) -> None:
+        assert issubclass(CursorMismatchError, ValueError)
+
+
+class TestCursorMalformed:
+    def test_decode_garbage_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Invalid pagination cursor"):
+            Cursor.decode("not-base64!@#$", expected_tool="browse_namespace")
+
+    def test_decode_valid_base64_invalid_json_raises(self) -> None:
+        token = base64.urlsafe_b64encode(b"this is not json").decode()
+        with pytest.raises(ValueError, match="Invalid pagination cursor"):
+            Cursor.decode(token, expected_tool="browse_namespace")
+
+    def test_decode_missing_required_fields_raises(self) -> None:
+        raw = json.dumps({"v": 1, "s": {"o": 0, "l": 20}})
+        token = base64.urlsafe_b64encode(raw.encode()).decode()
+        with pytest.raises(ValueError, match="missing"):
+            Cursor.decode(token, expected_tool="browse_namespace")
+
+    def test_decode_tolerates_missing_padding(self) -> None:
+        token = Cursor.encode(tool="browse_namespace", state={"o": 0, "l": 50, "ns": "C"})
+        stripped = token.rstrip("=")
+        decoded = Cursor.decode(stripped, expected_tool="browse_namespace")
+        assert decoded["s"]["ns"] == "C"
+
+
+class TestCursorEmptyState:
+    def test_empty_state_dict_allowed(self) -> None:
+        token = Cursor.encode(tool="walk_namespace", state={"scan_at": 0, "l": 200})
+        decoded = Cursor.decode(token, expected_tool="walk_namespace")
+        assert decoded["s"]["scan_at"] == 0

--- a/tests/test_pagination_cursor.py
+++ b/tests/test_pagination_cursor.py
@@ -12,7 +12,9 @@ from openzim_mcp.pagination import Cursor, CursorMismatchError
 
 class TestCursorRoundTrip:
     def test_encode_decode_roundtrip_minimal(self) -> None:
-        token = Cursor.encode(tool="browse_namespace", state={"o": 50, "l": 50, "ns": "C"})
+        token = Cursor.encode(
+            tool="browse_namespace", state={"o": 50, "l": 50, "ns": "C"}
+        )
         assert isinstance(token, str)
         decoded = Cursor.decode(token, expected_tool="browse_namespace")
         assert decoded["v"] == 1
@@ -20,29 +22,39 @@ class TestCursorRoundTrip:
         assert decoded["s"] == {"o": 50, "l": 50, "ns": "C"}
 
     def test_encode_produces_urlsafe_base64(self) -> None:
-        token = Cursor.encode(tool="search_zim_file", state={"o": 0, "l": 20, "q": "berlin"})
+        token = Cursor.encode(
+            tool="search_zim_file", state={"o": 0, "l": 20, "q": "berlin"}
+        )
         assert "+" not in token
         assert "/" not in token
 
     def test_encode_unicode_state(self) -> None:
-        token = Cursor.encode(tool="search_zim_file", state={"o": 0, "l": 20, "q": "café"})
+        token = Cursor.encode(
+            tool="search_zim_file", state={"o": 0, "l": 20, "q": "café"}
+        )
         decoded = Cursor.decode(token, expected_tool="search_zim_file")
         assert decoded["s"]["q"] == "café"
 
 
 class TestCursorVersioning:
     def test_default_version_is_one(self) -> None:
-        token = Cursor.encode(tool="browse_namespace", state={"o": 0, "l": 50, "ns": "C"})
+        token = Cursor.encode(
+            tool="browse_namespace", state={"o": 0, "l": 50, "ns": "C"}
+        )
         decoded = Cursor.decode(token, expected_tool="browse_namespace")
         assert decoded["v"] == 1
 
     def test_explicit_version_passes_through(self) -> None:
-        token = Cursor.encode(tool="browse_namespace", state={"o": 0, "l": 50, "ns": "C"}, version=1)
+        token = Cursor.encode(
+            tool="browse_namespace", state={"o": 0, "l": 50, "ns": "C"}, version=1
+        )
         decoded = Cursor.decode(token, expected_tool="browse_namespace")
         assert decoded["v"] == 1
 
     def test_unknown_version_rejected(self) -> None:
-        raw = json.dumps({"v": 2, "t": "browse_namespace", "s": {"o": 0, "l": 50, "ns": "C"}})
+        raw = json.dumps(
+            {"v": 2, "t": "browse_namespace", "s": {"o": 0, "l": 50, "ns": "C"}}
+        )
         token = base64.urlsafe_b64encode(raw.encode()).decode()
         with pytest.raises(ValueError, match="Unsupported cursor version"):
             Cursor.decode(token, expected_tool="browse_namespace")
@@ -82,7 +94,9 @@ class TestCursorMalformed:
             Cursor.decode(token, expected_tool="browse_namespace")
 
     def test_decode_tolerates_missing_padding(self) -> None:
-        token = Cursor.encode(tool="browse_namespace", state={"o": 0, "l": 50, "ns": "C"})
+        token = Cursor.encode(
+            tool="browse_namespace", state={"o": 0, "l": 50, "ns": "C"}
+        )
         stripped = token.rstrip("=")
         decoded = Cursor.decode(stripped, expected_tool="browse_namespace")
         assert decoded["s"]["ns"] == "C"

--- a/tests/test_response_contract.py
+++ b/tests/test_response_contract.py
@@ -28,6 +28,9 @@ def _assert_contract(payload: dict) -> None:
     pi = payload["page_info"]
     for key in PAGE_INFO_KEYS:
         assert key in pi, f"page_info missing key: {key}"
+    assert pi["returned_count"] == len(payload["results"]), (
+        f"page_info.returned_count={pi['returned_count']} != len(results)={len(payload['results'])}"
+    )
     # done <-> next_cursor co-vary (redundant by design)
     if payload["done"]:
         assert payload["next_cursor"] is None, "done=True must imply next_cursor=None"
@@ -53,6 +56,8 @@ class TestContractShape:
         )
         _, structured = result
         payload = structured["result"] if "result" in structured else structured
+        if payload.get("error") is True:
+            pytest.skip(f"search_zim_file returned error envelope: {payload.get('details') or payload.get('operation')}")
         _assert_contract(payload)
 
     @pytest.mark.asyncio
@@ -62,12 +67,16 @@ class TestContractShape:
         )
         _, structured = result
         payload = structured["result"] if "result" in structured else structured
+        if payload.get("error") is True:
+            pytest.skip(f"search_all returned error envelope: {payload.get('details') or payload.get('operation')}")
         _assert_contract(payload)
         # search_all top-level is always done=True
         assert payload["done"] is True
         # And each per-archive result inside also conforms.
         for entry in payload["results"]:
             inner = entry["result"]
+            if inner.get("error") is True:
+                continue  # inner ZIM lacked Xapian index — skip that entry
             _assert_contract(inner)
 
     @pytest.mark.asyncio
@@ -97,6 +106,8 @@ class TestContractShape:
         )
         _, structured = result
         payload = structured["result"] if "result" in structured else structured
+        if payload.get("error") is True:
+            pytest.skip(f"get_search_suggestions returned error envelope: {payload.get('details') or payload.get('operation')}")
         _assert_contract(payload)
         assert payload["done"] is True
 

--- a/tests/test_response_contract.py
+++ b/tests/test_response_contract.py
@@ -197,7 +197,7 @@ class TestContractShape:
             pytest.skip("ZIM testing-suite small.zim not available")
         result = await server.mcp._tool_manager.call_tool(
             "get_zim_entries",
-            {"zim_file_path": str(zim_path), "entry_paths": ["C/Berlin", "C/Paris"]},
+            {"zim_file_path": str(zim_path), "entries": ["C/Berlin", "C/Paris"]},
             convert_result=True,
         )
         _, structured = result

--- a/tests/test_response_contract.py
+++ b/tests/test_response_contract.py
@@ -12,7 +12,6 @@ import pytest
 from openzim_mcp.config import OpenZimMcpConfig
 from openzim_mcp.server import OpenZimMcpServer
 
-
 CONTRACT_KEYS = ("results", "next_cursor", "total", "done", "page_info", "_meta")
 PAGE_INFO_KEYS = ("offset", "limit", "returned_count")
 
@@ -21,21 +20,25 @@ def _assert_contract(payload: dict) -> None:
     """Assert payload carries the five contract keys + _meta + page_info subkeys."""
     for key in CONTRACT_KEYS:
         assert key in payload, f"contract key missing: {key}"
-    assert isinstance(payload["results"], list), f"results must be list, got {type(payload['results'])}"
+    assert isinstance(
+        payload["results"], list
+    ), f"results must be list, got {type(payload['results'])}"
     assert isinstance(payload["done"], bool)
     assert payload["next_cursor"] is None or isinstance(payload["next_cursor"], str)
     assert payload["total"] is None or isinstance(payload["total"], int)
     pi = payload["page_info"]
     for key in PAGE_INFO_KEYS:
         assert key in pi, f"page_info missing key: {key}"
-    assert pi["returned_count"] == len(payload["results"]), (
-        f"page_info.returned_count={pi['returned_count']} != len(results)={len(payload['results'])}"
-    )
+    assert pi["returned_count"] == len(
+        payload["results"]
+    ), f"page_info.returned_count={pi['returned_count']} != len(results)={len(payload['results'])}"
     # done <-> next_cursor co-vary (redundant by design)
     if payload["done"]:
         assert payload["next_cursor"] is None, "done=True must imply next_cursor=None"
     else:
-        assert payload["next_cursor"] is not None, "done=False must imply next_cursor!=None"
+        assert (
+            payload["next_cursor"] is not None
+        ), "done=False must imply next_cursor!=None"
 
 
 @pytest.fixture
@@ -46,7 +49,9 @@ def server(test_config_with_zim_data: OpenZimMcpConfig) -> OpenZimMcpServer:
 class TestContractShape:
     @pytest.mark.asyncio
     async def test_search_zim_file_contract(self, server, basic_test_zim_files):
-        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get(
+            "withns"
+        )
         if zim_path is None:
             pytest.skip("ZIM testing-suite small.zim not available")
         result = await server.mcp._tool_manager.call_tool(
@@ -57,18 +62,24 @@ class TestContractShape:
         _, structured = result
         payload = structured["result"] if "result" in structured else structured
         if payload.get("error") is True:
-            pytest.skip(f"search_zim_file returned error envelope: {payload.get('details') or payload.get('operation')}")
+            pytest.skip(
+                f"search_zim_file returned error envelope: {payload.get('details') or payload.get('operation')}"
+            )
         _assert_contract(payload)
 
     @pytest.mark.asyncio
     async def test_search_all_contract_top_level(self, server):
         result = await server.mcp._tool_manager.call_tool(
-            "search_all", {"query": "evolution"}, convert_result=True,
+            "search_all",
+            {"query": "evolution"},
+            convert_result=True,
         )
         _, structured = result
         payload = structured["result"] if "result" in structured else structured
         if payload.get("error") is True:
-            pytest.skip(f"search_all returned error envelope: {payload.get('details') or payload.get('operation')}")
+            pytest.skip(
+                f"search_all returned error envelope: {payload.get('details') or payload.get('operation')}"
+            )
         _assert_contract(payload)
         # search_all top-level is always done=True
         assert payload["done"] is True
@@ -81,7 +92,9 @@ class TestContractShape:
 
     @pytest.mark.asyncio
     async def test_find_entry_by_title_contract(self, server, basic_test_zim_files):
-        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get(
+            "withns"
+        )
         if zim_path is None:
             pytest.skip("ZIM testing-suite small.zim not available")
         result = await server.mcp._tool_manager.call_tool(
@@ -96,7 +109,9 @@ class TestContractShape:
 
     @pytest.mark.asyncio
     async def test_get_search_suggestions_contract(self, server, basic_test_zim_files):
-        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get(
+            "withns"
+        )
         if zim_path is None:
             pytest.skip("ZIM testing-suite small.zim not available")
         result = await server.mcp._tool_manager.call_tool(
@@ -107,13 +122,17 @@ class TestContractShape:
         _, structured = result
         payload = structured["result"] if "result" in structured else structured
         if payload.get("error") is True:
-            pytest.skip(f"get_search_suggestions returned error envelope: {payload.get('details') or payload.get('operation')}")
+            pytest.skip(
+                f"get_search_suggestions returned error envelope: {payload.get('details') or payload.get('operation')}"
+            )
         _assert_contract(payload)
         assert payload["done"] is True
 
     @pytest.mark.asyncio
     async def test_browse_namespace_contract(self, server, basic_test_zim_files):
-        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get(
+            "withns"
+        )
         if zim_path is None:
             pytest.skip("ZIM testing-suite small.zim not available")
         result = await server.mcp._tool_manager.call_tool(
@@ -127,7 +146,9 @@ class TestContractShape:
 
     @pytest.mark.asyncio
     async def test_walk_namespace_contract(self, server, basic_test_zim_files):
-        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get(
+            "withns"
+        )
         if zim_path is None:
             pytest.skip("ZIM testing-suite small.zim not available")
         result = await server.mcp._tool_manager.call_tool(
@@ -142,22 +163,33 @@ class TestContractShape:
 
     @pytest.mark.asyncio
     async def test_extract_article_links_contract(self, server, basic_test_zim_files):
-        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get(
+            "withns"
+        )
         if zim_path is None:
             pytest.skip("ZIM testing-suite small.zim not available")
         # Find any article and extract links from it.
         find = await server.mcp._tool_manager.call_tool(
-            "find_entry_by_title", {"zim_file_path": str(zim_path), "title": "Berlin"},
+            "find_entry_by_title",
+            {"zim_file_path": str(zim_path), "title": "Berlin"},
             convert_result=True,
         )
         _, find_structured = find
-        find_payload = find_structured["result"] if "result" in find_structured else find_structured
+        find_payload = (
+            find_structured["result"]
+            if "result" in find_structured
+            else find_structured
+        )
         if not find_payload["results"]:
             pytest.skip("No fixture article to test against")
         entry_path = find_payload["results"][0]["path"]
         result = await server.mcp._tool_manager.call_tool(
             "extract_article_links",
-            {"zim_file_path": str(zim_path), "entry_path": entry_path, "kind": "internal"},
+            {
+                "zim_file_path": str(zim_path),
+                "entry_path": entry_path,
+                "kind": "internal",
+            },
             convert_result=True,
         )
         _, structured = result
@@ -170,7 +202,9 @@ class TestContractShape:
     @pytest.mark.asyncio
     async def test_list_zim_files_contract(self, server):
         result = await server.mcp._tool_manager.call_tool(
-            "list_zim_files", {}, convert_result=True,
+            "list_zim_files",
+            {},
+            convert_result=True,
         )
         _, structured = result
         payload = structured["result"] if "result" in structured else structured
@@ -179,15 +213,22 @@ class TestContractShape:
 
     @pytest.mark.asyncio
     async def test_get_related_articles_contract(self, server, basic_test_zim_files):
-        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get(
+            "withns"
+        )
         if zim_path is None:
             pytest.skip("ZIM testing-suite small.zim not available")
         find = await server.mcp._tool_manager.call_tool(
-            "find_entry_by_title", {"zim_file_path": str(zim_path), "title": "Berlin"},
+            "find_entry_by_title",
+            {"zim_file_path": str(zim_path), "title": "Berlin"},
             convert_result=True,
         )
         _, find_structured = find
-        find_payload = find_structured["result"] if "result" in find_structured else find_structured
+        find_payload = (
+            find_structured["result"]
+            if "result" in find_structured
+            else find_structured
+        )
         if not find_payload["results"]:
             pytest.skip("No fixture article to test against")
         entry_path = find_payload["results"][0]["path"]
@@ -203,7 +244,9 @@ class TestContractShape:
 
     @pytest.mark.asyncio
     async def test_get_zim_entries_contract(self, server, basic_test_zim_files):
-        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get(
+            "withns"
+        )
         if zim_path is None:
             pytest.skip("ZIM testing-suite small.zim not available")
         result = await server.mcp._tool_manager.call_tool(

--- a/tests/test_response_contract.py
+++ b/tests/test_response_contract.py
@@ -1,0 +1,206 @@
+"""Contract-shape regression: every list-returning tool emits the five contract keys.
+
+Phase B (#3) standardizes pagination across all list-returning tools. This
+file is the single source of truth for "did we keep the contract?" Each
+test calls a real tool against the bundled fixtures and asserts the shape.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openzim_mcp.config import OpenZimMcpConfig
+from openzim_mcp.server import OpenZimMcpServer
+
+
+CONTRACT_KEYS = ("results", "next_cursor", "total", "done", "page_info", "_meta")
+PAGE_INFO_KEYS = ("offset", "limit", "returned_count")
+
+
+def _assert_contract(payload: dict) -> None:
+    """Assert payload carries the five contract keys + _meta + page_info subkeys."""
+    for key in CONTRACT_KEYS:
+        assert key in payload, f"contract key missing: {key}"
+    assert isinstance(payload["results"], list), f"results must be list, got {type(payload['results'])}"
+    assert isinstance(payload["done"], bool)
+    assert payload["next_cursor"] is None or isinstance(payload["next_cursor"], str)
+    assert payload["total"] is None or isinstance(payload["total"], int)
+    pi = payload["page_info"]
+    for key in PAGE_INFO_KEYS:
+        assert key in pi, f"page_info missing key: {key}"
+    # done <-> next_cursor co-vary (redundant by design)
+    if payload["done"]:
+        assert payload["next_cursor"] is None, "done=True must imply next_cursor=None"
+    else:
+        assert payload["next_cursor"] is not None, "done=False must imply next_cursor!=None"
+
+
+@pytest.fixture
+def server(test_config_with_zim_data: OpenZimMcpConfig) -> OpenZimMcpServer:
+    return OpenZimMcpServer(test_config_with_zim_data)
+
+
+class TestContractShape:
+    @pytest.mark.asyncio
+    async def test_search_zim_file_contract(self, server, basic_test_zim_files):
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+        result = await server.mcp._tool_manager.call_tool(
+            "search_zim_file",
+            {"zim_file_path": str(zim_path), "query": "evolution", "limit": 5},
+            convert_result=True,
+        )
+        _, structured = result
+        payload = structured["result"] if "result" in structured else structured
+        _assert_contract(payload)
+
+    @pytest.mark.asyncio
+    async def test_search_all_contract_top_level(self, server):
+        result = await server.mcp._tool_manager.call_tool(
+            "search_all", {"query": "evolution"}, convert_result=True,
+        )
+        _, structured = result
+        payload = structured["result"] if "result" in structured else structured
+        _assert_contract(payload)
+        # search_all top-level is always done=True
+        assert payload["done"] is True
+        # And each per-archive result inside also conforms.
+        for entry in payload["results"]:
+            inner = entry["result"]
+            _assert_contract(inner)
+
+    @pytest.mark.asyncio
+    async def test_find_entry_by_title_contract(self, server, basic_test_zim_files):
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+        result = await server.mcp._tool_manager.call_tool(
+            "find_entry_by_title",
+            {"zim_file_path": str(zim_path), "title": "anything"},
+            convert_result=True,
+        )
+        _, structured = result
+        payload = structured["result"] if "result" in structured else structured
+        _assert_contract(payload)
+        assert payload["done"] is True  # non-paginated tool
+
+    @pytest.mark.asyncio
+    async def test_get_search_suggestions_contract(self, server, basic_test_zim_files):
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+        result = await server.mcp._tool_manager.call_tool(
+            "get_search_suggestions",
+            {"zim_file_path": str(zim_path), "partial_query": "ev"},
+            convert_result=True,
+        )
+        _, structured = result
+        payload = structured["result"] if "result" in structured else structured
+        _assert_contract(payload)
+        assert payload["done"] is True
+
+    @pytest.mark.asyncio
+    async def test_browse_namespace_contract(self, server, basic_test_zim_files):
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+        result = await server.mcp._tool_manager.call_tool(
+            "browse_namespace",
+            {"zim_file_path": str(zim_path), "namespace": "C", "limit": 5},
+            convert_result=True,
+        )
+        _, structured = result
+        payload = structured["result"] if "result" in structured else structured
+        _assert_contract(payload)
+
+    @pytest.mark.asyncio
+    async def test_walk_namespace_contract(self, server, basic_test_zim_files):
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+        result = await server.mcp._tool_manager.call_tool(
+            "walk_namespace",
+            {"zim_file_path": str(zim_path), "namespace": "C", "limit": 50},
+            convert_result=True,
+        )
+        _, structured = result
+        payload = structured["result"] if "result" in structured else structured
+        _assert_contract(payload)
+        assert payload["total"] is None  # walk doesn't know total
+
+    @pytest.mark.asyncio
+    async def test_extract_article_links_contract(self, server, basic_test_zim_files):
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+        # Find any article and extract links from it.
+        find = await server.mcp._tool_manager.call_tool(
+            "find_entry_by_title", {"zim_file_path": str(zim_path), "title": "Berlin"},
+            convert_result=True,
+        )
+        _, find_structured = find
+        find_payload = find_structured["result"] if "result" in find_structured else find_structured
+        if not find_payload["results"]:
+            pytest.skip("No fixture article to test against")
+        entry_path = find_payload["results"][0]["path"]
+        result = await server.mcp._tool_manager.call_tool(
+            "extract_article_links",
+            {"zim_file_path": str(zim_path), "entry_path": entry_path, "kind": "internal"},
+            convert_result=True,
+        )
+        _, structured = result
+        payload = structured["result"] if "result" in structured else structured
+        _assert_contract(payload)
+        assert "category_totals" in payload
+        for k in ("internal", "external", "media"):
+            assert k in payload["category_totals"]
+
+    @pytest.mark.asyncio
+    async def test_list_zim_files_contract(self, server):
+        result = await server.mcp._tool_manager.call_tool(
+            "list_zim_files", {}, convert_result=True,
+        )
+        _, structured = result
+        payload = structured["result"] if "result" in structured else structured
+        _assert_contract(payload)
+        assert payload["done"] is True
+
+    @pytest.mark.asyncio
+    async def test_get_related_articles_contract(self, server, basic_test_zim_files):
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+        find = await server.mcp._tool_manager.call_tool(
+            "find_entry_by_title", {"zim_file_path": str(zim_path), "title": "Berlin"},
+            convert_result=True,
+        )
+        _, find_structured = find
+        find_payload = find_structured["result"] if "result" in find_structured else find_structured
+        if not find_payload["results"]:
+            pytest.skip("No fixture article to test against")
+        entry_path = find_payload["results"][0]["path"]
+        result = await server.mcp._tool_manager.call_tool(
+            "get_related_articles",
+            {"zim_file_path": str(zim_path), "entry_path": entry_path},
+            convert_result=True,
+        )
+        _, structured = result
+        payload = structured["result"] if "result" in structured else structured
+        _assert_contract(payload)
+        assert payload["done"] is True
+
+    @pytest.mark.asyncio
+    async def test_get_zim_entries_contract(self, server, basic_test_zim_files):
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get("withns")
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+        result = await server.mcp._tool_manager.call_tool(
+            "get_zim_entries",
+            {"zim_file_path": str(zim_path), "entry_paths": ["C/Berlin", "C/Paris"]},
+            convert_result=True,
+        )
+        _, structured = result
+        payload = structured["result"] if "result" in structured else structured
+        _assert_contract(payload)
+        assert payload["done"] is True

--- a/tests/test_search_all.py
+++ b/tests/test_search_all.py
@@ -44,22 +44,18 @@ class TestSearchAll:
             ]
         )
 
-        # First call returns a structured hit; second raises
+        # First call returns a Phase B SearchResponse; second raises
         def fake(path, q, lim, off):
             if "good" in path:
                 return {
                     "query": q,
-                    "total_results": 1,
-                    "offset": 0,
-                    "limit": lim,
                     "results": [
                         {"path": "A/Python", "title": "Python", "snippet": "..."}
                     ],
-                    "pagination": {
-                        "has_more": False,
-                        "showing_start": 1,
-                        "showing_end": 1,
-                    },
+                    "next_cursor": None,
+                    "total": 1,
+                    "done": True,
+                    "page_info": {"offset": 0, "limit": lim, "returned_count": 1},
                 }
             raise RuntimeError("corrupt index")
 
@@ -69,7 +65,16 @@ class TestSearchAll:
         assert result["files_searched"] == 2
         assert result["files_with_hits"] == 1
         assert result["files_failed"] == 1
-        assert any("error" in entry for entry in result["per_file"])
+        assert any("error" in entry for entry in result["results"])
+        # Phase B contract-shape assertions
+        assert result["done"] is True
+        assert result["next_cursor"] is None
+        assert result["total"] == result["files_searched"]
+        assert result["page_info"] == {
+            "offset": 0,
+            "limit": result["files_searched"],
+            "returned_count": len(result["results"]),
+        }
 
     def test_no_hits_anywhere(self, server: OpenZimMcpServer):
         """Test that result aggregates files_with_hits=0 when nothing matches."""
@@ -79,20 +84,29 @@ class TestSearchAll:
         server.zim_operations.search_zim_file_data = MagicMock(
             return_value={
                 "query": "xyzzy",
-                "total_results": 0,
-                "offset": 0,
-                "limit": 5,
                 "results": [],
-                "pagination": {"has_more": False},
+                "next_cursor": None,
+                "total": 0,
+                "done": True,
+                "page_info": {"offset": 0, "limit": 5, "returned_count": 0},
             }
         )
 
         result = server.zim_operations.search_all_data("xyzzy", limit_per_file=5)
         assert result["files_with_hits"] == 0
-        assert result["per_file"][0]["has_hits"] is False
+        assert result["results"][0]["has_hits"] is False
+        # Phase B contract-shape assertions
+        assert result["done"] is True
+        assert result["next_cursor"] is None
+        assert result["total"] == result["files_searched"]
+        assert result["page_info"] == {
+            "offset": 0,
+            "limit": result["files_searched"],
+            "returned_count": len(result["results"]),
+        }
 
     def test_search_all_data_per_file_payload_is_dict(self, server: OpenZimMcpServer):
-        """``search_all_data['per_file'][i]['result']`` is a dict, not a string.
+        """``search_all_data['results'][i]['result']`` is a dict, not a string.
 
         Catches the triple-encoding regression: previously per_file.result
         was a markdown blob (string) and the outer json.dumps escaped its
@@ -105,23 +119,30 @@ class TestSearchAll:
         server.zim_operations.search_zim_file_data = MagicMock(
             return_value={
                 "query": "python",
-                "total_results": 1,
-                "offset": 0,
-                "limit": 5,
                 "results": [{"path": "C/Python", "title": "Python", "snippet": "..."}],
-                "pagination": {
-                    "has_more": False,
-                    "showing_start": 1,
-                    "showing_end": 1,
-                },
+                "next_cursor": None,
+                "total": 1,
+                "done": True,
+                "page_info": {"offset": 0, "limit": 5, "returned_count": 1},
             }
         )
 
         result = server.zim_operations.search_all_data("python", limit_per_file=5)
         assert isinstance(result, dict)
-        per_file = result["per_file"][0]
+        per_file = result["results"][0]
         # The fix: ``result`` is a dict, not a stringified markdown blob.
         assert isinstance(per_file["result"], dict)
         assert per_file["result"]["query"] == "python"
-        assert per_file["result"]["total_results"] == 1
+        # Phase B: per-file SearchResponse uses ``total`` (not legacy
+        # ``total_results``).
+        assert per_file["result"]["total"] == 1
         assert per_file["has_hits"] is True
+        # Phase B contract-shape assertions on the top level
+        assert result["done"] is True
+        assert result["next_cursor"] is None
+        assert result["total"] == result["files_searched"]
+        assert result["page_info"] == {
+            "offset": 0,
+            "limit": result["files_searched"],
+            "returned_count": len(result["results"]),
+        }

--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -7,8 +7,8 @@ import pytest
 
 from openzim_mcp.config import OpenZimMcpConfig
 from openzim_mcp.exceptions import OpenZimMcpRateLimitError
+from openzim_mcp.pagination import Cursor
 from openzim_mcp.server import OpenZimMcpServer
-from openzim_mcp.zim_operations import PaginationCursor
 
 
 def _get_tool_fn(server: OpenZimMcpServer, name: str):
@@ -74,13 +74,19 @@ class TestSearchZimFileTool:
     async def test_search_limit_out_of_range_returns_error(
         self, server: OpenZimMcpServer, bad_limit: int
     ):
-        """Out-of-range limits hit the registered tool's validator."""
+        """Out-of-range limits hit the registered tool's validator.
+
+        Phase B: tool returns a ``ToolErrorPayload`` envelope rather than a
+        markdown string.
+        """
         server.rate_limiter.check_rate_limit = MagicMock()
         search_zim_file = _get_tool_fn(server, "search_zim_file")
         result = await search_zim_file(
             zim_file_path="/path/to/file.zim", query="x", limit=bad_limit, offset=0
         )
-        assert "must be between 1 and 100" in result
+        assert isinstance(result, dict)
+        assert result.get("error") is True
+        assert "must be between 1 and 100" in result.get("message", "")
 
     def test_search_offset_validation_negative(self):
         """Test that negative offset returns validation error."""
@@ -118,44 +124,62 @@ class TestSearchZimFileTool:
 
 
 class TestSearchCursor:
-    """The opaque cursor token round-trips through search_zim_file."""
+    """The opaque cursor token round-trips through search_zim_file.
+
+    Phase B: cursors are tool-bound (``t="search_zim_file"``) and decoded via
+    ``openzim_mcp.pagination.Cursor``. The tool now hits ``search_zim_file_data``
+    (structured) rather than the legacy text path; on cursor errors the tool
+    returns a ``ToolErrorPayload`` envelope (``{"error": True, ...}``) instead
+    of a markdown string.
+    """
 
     @pytest.fixture
     def server(self, test_config: OpenZimMcpConfig) -> OpenZimMcpServer:
-        """Create a server with search_zim_file stubbed to a passthrough."""
+        """Create a server with search_zim_file_data stubbed to a passthrough."""
         srv = OpenZimMcpServer(test_config)
-        srv.async_zim_operations.search_zim_file = AsyncMock(return_value="ok")
+        srv.async_zim_operations.search_zim_file_data = AsyncMock(
+            return_value={
+                "query": "diabetes",
+                "results": [],
+                "next_cursor": None,
+                "total": 0,
+                "done": True,
+                "page_info": {"offset": 0, "limit": 0, "returned_count": 0},
+            }
+        )
         srv.rate_limiter.check_rate_limit = MagicMock()
         return srv
 
-    def test_pagination_cursor_round_trip(self):
+    def test_cursor_round_trip(self):
         """Encode -> decode preserves offset, limit, and query."""
-        token = PaginationCursor.create_next_cursor(
-            current_offset=0, limit=5, total=100, query="diabetes"
+        token = Cursor.encode(
+            tool="search_zim_file", state={"o": 5, "l": 5, "q": "diabetes"}
         )
-        assert token is not None
-        decoded = PaginationCursor.decode(token)
-        assert decoded == {"o": 5, "l": 5, "q": "diabetes"}
+        decoded = Cursor.decode(token, expected_tool="search_zim_file")
+        assert decoded["s"]["o"] == 5
+        assert decoded["s"]["l"] == 5
+        assert decoded["s"]["q"] == "diabetes"
+        assert decoded["t"] == "search_zim_file"
 
-    def test_pagination_cursor_decode_rejects_garbage(self):
+    def test_cursor_decode_rejects_garbage(self):
         """Malformed base64 surfaces as ValueError."""
         with pytest.raises(ValueError):
-            PaginationCursor.decode("not-base64-!!!")
+            Cursor.decode("not-base64-!!!", expected_tool="search_zim_file")
 
-    def test_pagination_cursor_decode_rejects_missing_fields(self):
-        """A token decoding to a dict without offset/limit is rejected."""
+    def test_cursor_decode_rejects_missing_fields(self):
+        """A token decoding to a dict without v/t/s is rejected."""
         import base64
         import json
 
         bad = base64.urlsafe_b64encode(json.dumps({"only": 1}).encode()).decode()
         with pytest.raises(ValueError, match="missing required fields"):
-            PaginationCursor.decode(bad)
+            Cursor.decode(bad, expected_tool="search_zim_file")
 
     @pytest.mark.asyncio
     async def test_cursor_overrides_offset_and_limit(self, server: OpenZimMcpServer):
         """`cursor` overrides explicit offset/limit when both are present."""
-        token = PaginationCursor.create_next_cursor(
-            current_offset=10, limit=7, total=100, query="diabetes"
+        token = Cursor.encode(
+            tool="search_zim_file", state={"o": 17, "l": 7, "q": "diabetes"}
         )
 
         fn = _get_tool_fn(server, "search_zim_file")
@@ -167,7 +191,7 @@ class TestSearchCursor:
             cursor=token,
         )
 
-        call = server.async_zim_operations.search_zim_file.await_args
+        call = server.async_zim_operations.search_zim_file_data.await_args
         # signature: (zim_file_path, query, limit, offset)
         assert call.args[2] == 7  # limit from cursor
         assert call.args[3] == 17  # next-page offset from cursor
@@ -176,29 +200,30 @@ class TestSearchCursor:
     async def test_invalid_cursor_returns_validation_error(
         self, server: OpenZimMcpServer
     ):
-        """Malformed cursor surfaces as a parameter-validation message."""
+        """Malformed cursor surfaces as a structured error envelope."""
         fn = _get_tool_fn(server, "search_zim_file")
         result = await fn(
             zim_file_path="/path/to/file.zim",
             query="diabetes",
             cursor="!!!not-a-cursor!!!",
         )
-        assert "Parameter Validation Error" in result
-        assert "cursor" in result.lower()
+        assert isinstance(result, dict)
+        assert result.get("error") is True
+        assert "cursor" in result.get("message", "").lower()
         # The operations layer should not have been called.
-        server.async_zim_operations.search_zim_file.assert_not_awaited()
+        server.async_zim_operations.search_zim_file_data.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_cursor_alone_supplies_query(self, server: OpenZimMcpServer):
         """A cursor alone is sufficient — the encoded query is reused."""
-        token = PaginationCursor.create_next_cursor(
-            current_offset=0, limit=2, total=100, query="diabetes"
+        token = Cursor.encode(
+            tool="search_zim_file", state={"o": 2, "l": 2, "q": "diabetes"}
         )
 
         fn = _get_tool_fn(server, "search_zim_file")
         await fn(zim_file_path="/path/to/file.zim", cursor=token)
 
-        call = server.async_zim_operations.search_zim_file.await_args
+        call = server.async_zim_operations.search_zim_file_data.await_args
         # signature: (zim_file_path, query, limit, offset)
         assert call.args[1] == "diabetes"
         assert call.args[2] == 2
@@ -211,19 +236,21 @@ class TestSearchCursor:
         """Without a cursor, an explicit query is still required."""
         fn = _get_tool_fn(server, "search_zim_file")
         result = await fn(zim_file_path="/path/to/file.zim")
-        assert "Parameter Validation Error" in result
-        assert "query" in result.lower()
-        server.async_zim_operations.search_zim_file.assert_not_awaited()
+        assert isinstance(result, dict)
+        assert result.get("error") is True
+        assert "query" in result.get("message", "").lower()
+        server.async_zim_operations.search_zim_file_data.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_matching_cursor_query_proceeds(self, server: OpenZimMcpServer):
         """When `query` matches the cursor's encoded query, the call proceeds.
 
-        The mismatch rejection must not fire on equal queries — pagination
-        with an explicit (matching) `query` is a normal pattern.
+        Phase B: cursor's ``q`` always wins, so even a "matching" explicit
+        query just gets overridden silently. The flow proceeds without
+        error.
         """
-        token = PaginationCursor.create_next_cursor(
-            current_offset=0, limit=5, total=100, query="diabetes"
+        token = Cursor.encode(
+            tool="search_zim_file", state={"o": 5, "l": 5, "q": "diabetes"}
         )
 
         fn = _get_tool_fn(server, "search_zim_file")
@@ -233,39 +260,64 @@ class TestSearchCursor:
             cursor=token,
         )
 
-        call = server.async_zim_operations.search_zim_file.await_args
+        call = server.async_zim_operations.search_zim_file_data.await_args
         # signature: (zim_file_path, query, limit, offset)
         assert call.args[1] == "diabetes"
         assert call.args[2] == 5
         assert call.args[3] == 5
 
     @pytest.mark.asyncio
-    async def test_mismatched_cursor_query_returns_validation_error(
+    async def test_cursor_q_wins_over_explicit_query(
         self, server: OpenZimMcpServer
     ):
-        """Reject when the cursor's embedded query differs from `query`.
+        """When cursor encodes q='diabetes', an explicit query='insulin' is
+        silently overridden.
 
-        Cursors encode the query they were paired with; mixing them with a
-        different ``query`` argument is almost always an LLM cycling cursors
-        across turns, and would otherwise return the wrong page of the wrong
-        query — silent data corruption. Reject loudly instead.
+        Phase B: cursor wins on conflict per response-contract spec, so a
+        caller that supplies a *different* explicit query alongside a cursor
+        sees the cursor's ``q`` field reach the operations layer — not their
+        own argument. Pinning this here so a future refactor that flips the
+        precedence is caught by the regression suite.
         """
-        token = PaginationCursor.create_next_cursor(
-            current_offset=0, limit=5, total=100, query="cursor-query"
+        token = Cursor.encode(
+            tool="search_zim_file", state={"o": 5, "l": 5, "q": "diabetes"}
+        )
+
+        fn = _get_tool_fn(server, "search_zim_file")
+        await fn(
+            zim_file_path="/path/to/file.zim",
+            query="insulin",  # different from cursor's q
+            cursor=token,
+        )
+
+        call = server.async_zim_operations.search_zim_file_data.await_args
+        # signature: (zim_file_path, query, limit, offset). Cursor's q
+        # ("diabetes") must override the caller's explicit query ("insulin").
+        assert call.args[1] == "diabetes"
+
+    @pytest.mark.asyncio
+    async def test_cross_tool_cursor_returns_error(self, server: OpenZimMcpServer):
+        """A cursor issued by another tool returns CursorMismatchError envelope.
+
+        Phase B replaces the v1 query-mismatch rejection with a tool-binding
+        check (``t`` field). A cursor minted for ``browse_namespace`` cannot
+        be redeemed against ``search_zim_file``.
+        """
+        token = Cursor.encode(
+            tool="browse_namespace", state={"o": 0, "l": 5, "ns": "C"}
         )
 
         fn = _get_tool_fn(server, "search_zim_file")
         result = await fn(
             zim_file_path="/path/to/file.zim",
-            query="explicit-query",
+            query="diabetes",
             cursor=token,
         )
 
-        assert "Parameter Validation Error" in result
-        assert "cursor" in result.lower()
-        assert "query" in result.lower()
-        # The operations layer must not be called when the inputs conflict.
-        server.async_zim_operations.search_zim_file.assert_not_awaited()
+        assert isinstance(result, dict)
+        assert result.get("error") is True
+        # The operations layer must not be called on cross-tool cursor reuse.
+        server.async_zim_operations.search_zim_file_data.assert_not_awaited()
 
 
 class TestSearchPaginationFooterFormat:
@@ -423,11 +475,11 @@ class TestSearchZimFileDataMeta:
 
         fresh_payload = {
             "query": "climate",
-            "total_results": 3,
-            "offset": 0,
-            "limit": 10,
             "results": [{"path": "A/Foo", "title": "Foo", "snippet": "snippet text"}],
-            "pagination": {"has_more": False},
+            "next_cursor": None,
+            "total": 3,
+            "done": True,
+            "page_info": {"offset": 0, "limit": 10, "returned_count": 1},
         }
 
         monkeypatch.setattr(
@@ -446,6 +498,8 @@ class TestSearchZimFileDataMeta:
         assert result["_meta"]["tokens_est"] > 0
         assert result["_meta"]["chars"] > 0
         assert result["_meta"]["truncated"] is False
+        # Guard-rail: page_info.returned_count tracks len(results).
+        assert result["page_info"]["returned_count"] == len(result["results"])
 
     def test_search_zim_file_data_meta_on_zero_results(
         self, zim_ops, temp_dir, monkeypatch
@@ -455,11 +509,11 @@ class TestSearchZimFileDataMeta:
 
         zero_payload = {
             "query": "xyzzy_no_match",
-            "total_results": 0,
-            "offset": 0,
-            "limit": 10,
             "results": [],
-            "pagination": {"has_more": False},
+            "next_cursor": None,
+            "total": 0,
+            "done": True,
+            "page_info": {"offset": 0, "limit": 10, "returned_count": 0},
         }
 
         monkeypatch.setattr(
@@ -479,16 +533,21 @@ class TestSearchZimFileDataMeta:
     def test_search_zim_file_data_meta_on_offset_exceeds_total(
         self, zim_ops, temp_dir, monkeypatch
     ):
-        """Offset-exceeds-total path carries _meta."""
+        """Offset-exceeds-total path carries _meta.
+
+        Phase B: ``offset_exceeds_total`` is no longer surfaced as a flag —
+        callers detect it from ``total < offset`` and an empty ``results``
+        list.
+        """
         zim_file = self._zim_file(temp_dir)
 
         exceed_payload = {
             "query": "climate",
-            "total_results": 5,
-            "offset": 100,
-            "limit": 10,
             "results": [],
-            "pagination": {"has_more": False, "offset_exceeds_total": True},
+            "next_cursor": None,
+            "total": 5,
+            "done": True,
+            "page_info": {"offset": 100, "limit": 10, "returned_count": 0},
         }
 
         monkeypatch.setattr(
@@ -504,22 +563,26 @@ class TestSearchZimFileDataMeta:
             )
 
         assert "_meta" in result, "offset-exceeds-total path must attach _meta"
+        # offset_exceeds_total is replaced by total < offset + empty results.
+        assert result["total"] < result["page_info"]["offset"]
+        assert result["results"] == []
 
     def test_search_zim_file_data_meta_on_cached_return(self, zim_ops, temp_dir):
         """Cached return path backfills _meta if missing, and always returns _meta."""
         zim_file = self._zim_file(temp_dir)
         validated = zim_ops.path_validator.validate_path(str(zim_file))
         validated = zim_ops.path_validator.validate_zim_file(validated)
-        cache_key = f"search_data:{validated}:climate:10:0"
+        # Phase B: cache key bumped to ``search_v2b:`` to avoid old-shape leakthrough.
+        cache_key = f"search_v2b:{validated}:climate:10:0"
 
-        # Seed cache with an old-format entry (no _meta)
+        # Seed cache with a Phase B-shape entry without _meta to verify backfill.
         old_payload = {
             "query": "climate",
-            "total_results": 2,
-            "offset": 0,
-            "limit": 10,
             "results": [{"path": "A/Bar", "title": "Bar", "snippet": "bar"}],
-            "pagination": {"has_more": False},
+            "next_cursor": None,
+            "total": 2,
+            "done": True,
+            "page_info": {"offset": 0, "limit": 10, "returned_count": 1},
         }
         zim_ops.cache.set(cache_key, old_payload)
 
@@ -713,7 +776,7 @@ class TestSearchMethodsMeta:
                         str(zim_file), "zzzimpossiblequery"
                     )
 
-        assert result["total_results"] == 0
+        assert result["total"] == 0
         assert result["_meta"].get("reason") == "0_hits"
 
     def test_non_empty_search_meta_no_reason(self, zim_ops, temp_dir, monkeypatch):
@@ -748,7 +811,7 @@ class TestSearchMethodsMeta:
                     mock_archive.return_value.__enter__.return_value = mock_archive_obj
                     result = zim_ops.search_zim_file_data(str(zim_file), "climate")
 
-        assert result["total_results"] > 0
+        assert result["total"] > 0
         assert "reason" not in result["_meta"]
 
     def test_empty_search_suggests_other_archives_with_query_match(
@@ -762,11 +825,11 @@ class TestSearchMethodsMeta:
         # Mock _perform_search to return zero results
         zero_payload = {
             "query": "wikipedia",
-            "total_results": 0,
-            "offset": 0,
-            "limit": 10,
             "results": [],
-            "pagination": {"has_more": False},
+            "next_cursor": None,
+            "total": 0,
+            "done": True,
+            "page_info": {"offset": 0, "limit": 10, "returned_count": 0},
         }
         monkeypatch.setattr(
             zim_ops, "_perform_search", lambda *a, **kw: (zero_payload, 0)
@@ -789,7 +852,7 @@ class TestSearchMethodsMeta:
                 str(zim_file), "wikipedia", limit=10, offset=0
             )
 
-        assert result["total_results"] == 0
+        assert result["total"] == 0
         assert "_meta" in result
         assert "suggestions" in result["_meta"]
         assert len(result["_meta"]["suggestions"]) > 0
@@ -811,11 +874,11 @@ class TestSearchMethodsMeta:
         # Mock _perform_search to return zero results
         zero_payload = {
             "query": "photosynthesis process biology",
-            "total_results": 0,
-            "offset": 0,
-            "limit": 10,
             "results": [],
-            "pagination": {"has_more": False},
+            "next_cursor": None,
+            "total": 0,
+            "done": True,
+            "page_info": {"offset": 0, "limit": 10, "returned_count": 0},
         }
         monkeypatch.setattr(
             zim_ops, "_perform_search", lambda *a, **kw: (zero_payload, 0)
@@ -838,7 +901,7 @@ class TestSearchMethodsMeta:
                 str(zim_file), "photosynthesis process biology", limit=10, offset=0
             )
 
-        assert result["total_results"] == 0
+        assert result["total"] == 0
         assert "_meta" in result
         assert "suggestions" in result["_meta"]
         # Should match because "biology" token (>= 4 chars) is in "biology_reference"
@@ -859,11 +922,11 @@ class TestSearchMethodsMeta:
         # Mock _perform_search to return zero results
         zero_payload = {
             "query": "zzzimpossiblequery",
-            "total_results": 0,
-            "offset": 0,
-            "limit": 10,
             "results": [],
-            "pagination": {"has_more": False},
+            "next_cursor": None,
+            "total": 0,
+            "done": True,
+            "page_info": {"offset": 0, "limit": 10, "returned_count": 0},
         }
         monkeypatch.setattr(
             zim_ops, "_perform_search", lambda *a, **kw: (zero_payload, 0)
@@ -886,7 +949,7 @@ class TestSearchMethodsMeta:
                 str(zim_file), "zzzimpossiblequery", limit=10, offset=0
             )
 
-        assert result["total_results"] == 0
+        assert result["total"] == 0
         assert "_meta" in result
         # Should have no alt_archive suggestions because query doesn't match any archive name
         suggestions = result["_meta"].get("suggestions", [])
@@ -906,11 +969,11 @@ class TestSearchMethodsMeta:
         # Mock _perform_search to return zero results
         zero_payload = {
             "query": "the in it",  # All tokens < 4 chars
-            "total_results": 0,
-            "offset": 0,
-            "limit": 10,
             "results": [],
-            "pagination": {"has_more": False},
+            "next_cursor": None,
+            "total": 0,
+            "done": True,
+            "page_info": {"offset": 0, "limit": 10, "returned_count": 0},
         }
         monkeypatch.setattr(
             zim_ops, "_perform_search", lambda *a, **kw: (zero_payload, 0)
@@ -933,7 +996,7 @@ class TestSearchMethodsMeta:
                 str(zim_file), "the in it", limit=10, offset=0
             )
 
-        assert result["total_results"] == 0
+        assert result["total"] == 0
         assert "_meta" in result
         # Should have no alt_archive suggestions because all tokens are < 4 chars
         suggestions = result["_meta"].get("suggestions", [])
@@ -953,11 +1016,11 @@ class TestSearchMethodsMeta:
         # Mock _perform_search to return zero results
         zero_payload = {
             "query": "wiki",
-            "total_results": 0,
-            "offset": 0,
-            "limit": 10,
             "results": [],
-            "pagination": {"has_more": False},
+            "next_cursor": None,
+            "total": 0,
+            "done": True,
+            "page_info": {"offset": 0, "limit": 10, "returned_count": 0},
         }
         monkeypatch.setattr(
             zim_ops, "_perform_search", lambda *a, **kw: (zero_payload, 0)
@@ -985,7 +1048,7 @@ class TestSearchMethodsMeta:
                 str(zim_file), "wiki", limit=10, offset=0
             )
 
-        assert result["total_results"] == 0
+        assert result["total"] == 0
         assert "_meta" in result
         # Check that suggestions are capped at the configured limit
         limit_n = zim_ops.config.search.structured_suggestions_limit
@@ -1005,11 +1068,11 @@ class TestSearchMethodsMeta:
         # Mock _perform_search to return zero results
         zero_payload = {
             "query": "wikipedia",
-            "total_results": 0,
-            "offset": 0,
-            "limit": 10,
             "results": [],
-            "pagination": {"has_more": False},
+            "next_cursor": None,
+            "total": 0,
+            "done": True,
+            "page_info": {"offset": 0, "limit": 10, "returned_count": 0},
         }
         monkeypatch.setattr(
             zim_ops, "_perform_search", lambda *a, **kw: (zero_payload, 0)
@@ -1035,7 +1098,7 @@ class TestSearchMethodsMeta:
                 str(zim_file), "wikipedia", limit=10, offset=0
             )
 
-        assert result["total_results"] == 0
+        assert result["total"] == 0
         assert "_meta" in result
         alt_archive_suggestions = [
             s for s in result["_meta"]["suggestions"] if s.get("type") == "alt_archive"

--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -697,7 +697,7 @@ class TestSearchMethodsMeta:
         zim_file = self._zim_file(temp_dir)
         validated = zim_ops.path_validator.validate_path(str(zim_file))
         validated = zim_ops.path_validator.validate_zim_file(validated)
-        cache_key = f"suggestions_data:{validated}:climate:10"
+        cache_key = f"suggestions_data:v2b:{validated}:climate:10"
         old = {
             "partial_query": "climate",
             "suggestions": [{"title": "Climate"}],

--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -267,9 +267,7 @@ class TestSearchCursor:
         assert call.args[3] == 5
 
     @pytest.mark.asyncio
-    async def test_cursor_q_wins_over_explicit_query(
-        self, server: OpenZimMcpServer
-    ):
+    async def test_cursor_q_wins_over_explicit_query(self, server: OpenZimMcpServer):
         """When cursor encodes q='diabetes', an explicit query='insulin' is
         silently overridden.
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -226,6 +226,7 @@ class TestOpenZimMcpServerMCPToolsErrorHandling:
         original_list_summary_method = server.zim_operations.list_zim_files_summary_data
         original_search_method = server.zim_operations.search_zim_file
         original_entry_method = server.zim_operations.get_zim_entry
+        original_entry_data_method = server.zim_operations.get_zim_entry_data
 
         try:
             # Set up mocks that will cause exceptions
@@ -242,6 +243,11 @@ class TestOpenZimMcpServerMCPToolsErrorHandling:
                 side_effect=Exception("Search error")
             )
             server.zim_operations.get_zim_entry = MagicMock(
+                side_effect=Exception("Entry error")
+            )
+            # The migrated MCP tool routes through ``get_zim_entry_data``,
+            # so mock it too to keep this test provider-agnostic.
+            server.zim_operations.get_zim_entry_data = MagicMock(
                 side_effect=Exception("Entry error")
             )
 
@@ -268,16 +274,18 @@ class TestOpenZimMcpServerMCPToolsErrorHandling:
             assert "Search error" in result_str or "search ZIM file" in result_str
             assert "'error': True" in result_str or "**Operation Failed**" in result_str
 
-            # Test get_zim_entry exception handling
+            # Test get_zim_entry exception handling. Phase B: returns a
+            # structured error envelope ({"error": True, ...}); error text
+            # and envelope shape are surfaced in the result.
             result = asyncio.run(
                 server.mcp.call_tool(
                     "get_zim_entry",
                     {"zim_file_path": "test.zim", "entry_path": "A/Test"},
                 )
             )
-            assert "**Operation Failed**" in str(result) and "Entry error" in str(
-                result
-            )
+            result_str = str(result)
+            assert "Entry error" in result_str or "get ZIM entry" in result_str
+            assert "'error': True" in result_str or "**Operation Failed**" in result_str
 
         finally:
             # Restore original methods
@@ -288,6 +296,7 @@ class TestOpenZimMcpServerMCPToolsErrorHandling:
             )
             server.zim_operations.search_zim_file = original_search_method
             server.zim_operations.get_zim_entry = original_entry_method
+            server.zim_operations.get_zim_entry_data = original_entry_data_method
 
     def test_mcp_tool_validation_paths(self, server: OpenZimMcpServer):
         """Test MCP tool validation paths using call_tool."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -256,15 +256,17 @@ class TestOpenZimMcpServerMCPToolsErrorHandling:
             assert "List error" in result_str
             assert "**Operation Failed**" in result_str or "'error': True" in result_str
 
-            # Test search_zim_file exception handling
+            # Test search_zim_file exception handling. Phase B: tool returns
+            # a structured error envelope ({"error": True, ...}) — exception
+            # text and error envelope shape are surfaced in the result.
             result = asyncio.run(
                 server.mcp.call_tool(
                     "search_zim_file", {"zim_file_path": "test.zim", "query": "test"}
                 )
             )
-            assert "**Operation Failed**" in str(result) and "Search error" in str(
-                result
-            )
+            result_str = str(result)
+            assert "Search error" in result_str or "search ZIM file" in result_str
+            assert "'error': True" in result_str or "**Operation Failed**" in result_str
 
             # Test get_zim_entry exception handling
             result = asyncio.run(
@@ -289,6 +291,11 @@ class TestOpenZimMcpServerMCPToolsErrorHandling:
 
     def test_mcp_tool_validation_paths(self, server: OpenZimMcpServer):
         """Test MCP tool validation paths using call_tool."""
+        # Phase B: search_zim_file returns a ToolErrorPayload envelope on
+        # validation failure. The error text is in the ``message`` field;
+        # str(result) renders the structuredContent dict alongside the
+        # TextContent JSON, so substring assertions still work.
+
         # Test search_zim_file validation - invalid limit
         result = asyncio.run(
             server.mcp.call_tool(
@@ -300,9 +307,8 @@ class TestOpenZimMcpServerMCPToolsErrorHandling:
                 },
             )
         )
-        assert "**Parameter Validation Error**" in str(
-            result
-        ) and "limit must be between 1 and" in str(result)
+        assert "limit must be between 1 and" in str(result)
+        assert "'error': True" in str(result) or "error" in str(result).lower()
 
         # Test search_zim_file validation - invalid limit (too high)
         result = asyncio.run(
@@ -315,9 +321,8 @@ class TestOpenZimMcpServerMCPToolsErrorHandling:
                 },
             )
         )
-        assert "**Parameter Validation Error**" in str(
-            result
-        ) and "limit must be between 1 and" in str(result)
+        assert "limit must be between 1 and" in str(result)
+        assert "'error': True" in str(result) or "error" in str(result).lower()
 
         # Test search_zim_file validation - invalid offset
         result = asyncio.run(
@@ -330,9 +335,8 @@ class TestOpenZimMcpServerMCPToolsErrorHandling:
                 },
             )
         )
-        assert "**Parameter Validation Error**" in str(
-            result
-        ) and "Offset must be non-negative" in str(result)
+        assert "Offset must be non-negative" in str(result)
+        assert "'error': True" in str(result) or "error" in str(result).lower()
 
         # Test get_zim_entry validation - invalid max_content_length
         result = asyncio.run(

--- a/tests/test_simple_tools.py
+++ b/tests/test_simple_tools.py
@@ -698,7 +698,7 @@ class TestSimpleToolsOptionsPassthrough:
         from openzim_mcp.simple_tools import SimpleToolsHandler
 
         zim_ops = MagicMock()
-        zim_ops.get_related_articles.return_value = '{"outbound_results": []}'
+        zim_ops.get_related_articles.return_value = '{"results": []}'
         zim_ops.list_zim_files_data.return_value = [{"path": "/x.zim"}]
         handler = SimpleToolsHandler(zim_ops)
 
@@ -1536,7 +1536,7 @@ class TestCompactMarkdownRenderingForJsonIntents:
         h, mock = self._handler_with_data(
             get_related_articles_data={
                 "entry_path": "Photosynthesis",
-                "outbound_results": [
+                "results": [
                     {
                         "path": "Carbohydrate",
                         "title": "Carbohydrate",
@@ -1563,7 +1563,7 @@ class TestCompactMarkdownRenderingForJsonIntents:
         h, _ = self._handler_with_data(
             get_related_articles_data={
                 "entry_path": "Bad_Article",
-                "outbound_results": [],
+                "results": [],
                 "outbound_error": "Failed to extract: Entry not found",
             }
         )
@@ -1641,7 +1641,7 @@ class TestCompactMarkdownRenderingForJsonIntents:
         mock = MagicMock()
         mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
         mock.find_entry_by_title.return_value = '{"results": []}'
-        mock.get_related_articles.return_value = '{"outbound_results": []}'
+        mock.get_related_articles.return_value = '{"results": []}'
         mock.walk_namespace.return_value = '{"entries": []}'
         mock.list_namespaces.return_value = '{"namespaces": {}}'
         h = SimpleToolsHandler(mock)

--- a/tests/test_simple_tools.py
+++ b/tests/test_simple_tools.py
@@ -649,13 +649,19 @@ class TestSimpleToolsOptionsPassthrough:
         assert kwargs.get("limit_per_file") == 25
 
     def test_walk_namespace_forwards_options_limit_and_offset(self):
-        """walk_namespace must use options['offset'] as cursor and options['limit']."""
+        """walk_namespace must use options['offset'] as scan_at and options['limit'].
+
+        v2: walk_namespace's ``cursor`` parameter is now a decoded
+        cursor-state dict (``{scan_at, l}``) rather than a raw int.
+        simple_tools maps the legacy ``options['offset']`` passthrough
+        channel to ``scan_at``.
+        """
         from unittest.mock import MagicMock
 
         from openzim_mcp.simple_tools import SimpleToolsHandler
 
         zim_ops = MagicMock()
-        zim_ops.walk_namespace.return_value = '{"entries": []}'
+        zim_ops.walk_namespace.return_value = '{"results": []}'
         zim_ops.list_zim_files_data.return_value = [{"path": "/x.zim"}]
         handler = SimpleToolsHandler(zim_ops)
 
@@ -664,7 +670,8 @@ class TestSimpleToolsOptionsPassthrough:
             options={"limit": 50, "offset": 1234},
         )
         _args, kwargs = zim_ops.walk_namespace.call_args
-        assert kwargs.get("cursor") == 1234
+        # v2: cursor is now the decoded state dict, not a raw int.
+        assert kwargs.get("cursor") == {"scan_at": 1234, "l": 50}
         assert kwargs.get("limit") == 50
 
     def test_find_by_title_forwards_options_limit(self):
@@ -1567,29 +1574,37 @@ class TestCompactMarkdownRenderingForJsonIntents:
         assert "Entry not found" in out
 
     def test_walk_namespace_compact_renders_entry_list(self):
+        # v2 Phase B contract: top-level results / next_cursor (opaque str) /
+        # total / done / page_info (offset/limit/returned_count). The compact
+        # renderer reads these directly.
+        from openzim_mcp.pagination import Cursor
+
+        next_cursor = Cursor.encode(
+            tool="walk_namespace", state={"scan_at": 3, "l": 3}
+        )
         h, mock = self._handler_with_data(
             walk_namespace_data={
                 "namespace": "C",
-                "cursor": 0,
-                "limit": 3,
-                "returned_count": 3,
-                "next_cursor": 3,
-                "done": False,
-                "total_in_namespace": 27199904,
-                "total_in_namespace_is_lower_bound": False,
-                "entries": [
+                "results": [
                     {"path": "!", "title": "!"},
                     {"path": "Photosynthesis", "title": "Photosynthesis"},
                     {"path": "Cell_(biology)", "title": "Cell (biology)"},
                 ],
+                "next_cursor": next_cursor,
+                "total": None,
+                "done": False,
+                "page_info": {"offset": 0, "limit": 3, "returned_count": 3},
+                "scanned_count": 3,
+                "scanned_through_id": 2,
+                "archive_entry_count": 27199904,
             }
         )
         out = h.handle_zim_query("walk namespace C", options={"compact": True})
         mock.walk_namespace_data.assert_called_once()
         assert "Namespace `C`" in out
-        assert "27,199,904" in out  # total formatted with commas
         assert "Photosynthesis" in out
-        assert "offset=3" in out  # next-cursor pagination hint
+        # Resume hint surfaces the opaque cursor (not a raw int).
+        assert next_cursor in out
         # JSON shape NOT in output.
         assert "{" not in out
 
@@ -2377,24 +2392,32 @@ class TestCompactRenderersModule:
 
     def test_render_walk_namespace_smoke(self):
         from openzim_mcp import compact_renderers
+        from openzim_mcp.pagination import Cursor
 
+        next_cursor = Cursor.encode(
+            tool="walk_namespace", state={"scan_at": 100, "l": 2}
+        )
         out = compact_renderers.render_walk_namespace(
             {
                 "namespace": "C",
-                "cursor": 0,
-                "next_cursor": 100,
-                "returned_count": 2,
-                "total_in_namespace": 1234,
-                "entries": [
+                "results": [
                     {"title": "A", "path": "C/A"},
                     {"title": "B", "path": "C/B"},
                 ],
+                "next_cursor": next_cursor,
+                "total": None,
                 "done": False,
+                "page_info": {"offset": 0, "limit": 2, "returned_count": 2},
+                "scanned_count": 2,
+                "scanned_through_id": 1,
+                "archive_entry_count": 1234,
             }
         )
         assert "Namespace `C`" in out
-        assert "1-2 of 1,234" in out
-        assert "offset=100" in out
+        # Header shows "1-2 of <archive_total>" since walk doesn't know per-ns total.
+        assert "1-2" in out
+        # Resume hint surfaces the opaque cursor.
+        assert next_cursor in out
 
     def test_render_namespaces_smoke(self):
         from openzim_mcp import compact_renderers

--- a/tests/test_simple_tools.py
+++ b/tests/test_simple_tools.py
@@ -1674,35 +1674,58 @@ class TestCompactLinksResponse:
     def mock_zim_operations(self):
         mock = Mock()
         mock.list_zim_files_data.return_value = [{"path": "/zim/test.zim"}]
-        mock.extract_article_links_data.return_value = {
-            "title": "Photosynthesis",
-            "path": "Photosynthesis",
-            "internal_links": [
-                {"url": "Carbohydrate", "text": "carbohydrates", "type": "internal"},
-                {"url": "Phytoplankton", "text": "phytoplankton", "type": "internal"},
-            ],
-            "external_links": [
-                {"url": "https://example.com/x", "text": "example", "type": "external"},
-            ],
-            "media_links": [
-                {
-                    "url": "./_assets_/img.png",
-                    "type": "image",
-                    "alt": "",
-                    "title": "",
+
+        # v2 Phase B: extract_article_links_data returns ONE category
+        # per call. The compact path issues two calls (internal +
+        # external); return different payloads based on the ``kind``.
+        def _per_kind(*args, **kwargs):
+            kind = kwargs.get("kind") or (args[4] if len(args) > 4 else "internal")
+            base = {
+                "title": "Photosynthesis",
+                "path": "Photosynthesis",
+                "content_type": "text/html",
+                "next_cursor": "OPAQUE",
+                "done": False,
+                "category_totals": {
+                    "internal": 1988,
+                    "external": 401,
+                    "media": 25,
                 },
-            ],
-            "total_internal_links": 1988,
-            "total_external_links": 401,
-            "total_media_links": 25,
-            "total_links": 2414,
-            "pagination": {
-                "offset": 0,
-                "limit": 20,
-                "kind": None,
-                "has_more": True,
-            },
-        }
+            }
+            if kind == "external":
+                return {
+                    **base,
+                    "kind": "external",
+                    "results": [
+                        {
+                            "url": "https://example.com/x",
+                            "text": "example",
+                            "type": "external",
+                        },
+                    ],
+                    "total": 401,
+                    "page_info": {"offset": 0, "limit": 20, "returned_count": 1},
+                }
+            return {
+                **base,
+                "kind": "internal",
+                "results": [
+                    {
+                        "url": "Carbohydrate",
+                        "text": "carbohydrates",
+                        "type": "internal",
+                    },
+                    {
+                        "url": "Phytoplankton",
+                        "text": "phytoplankton",
+                        "type": "internal",
+                    },
+                ],
+                "total": 1988,
+                "page_info": {"offset": 0, "limit": 20, "returned_count": 2},
+            }
+
+        mock.extract_article_links_data.side_effect = _per_kind
         mock.extract_article_links.return_value = (
             '{"title":"Photosynthesis","internal_links":[...legacy verbose...]}'
         )
@@ -1715,15 +1738,26 @@ class TestCompactLinksResponse:
     def test_compact_renders_flat_markdown_list(self, handler, mock_zim_operations):
         """Compact mode hits the structured-data path with a tight
         default limit (20) and renders a flat ``- text -> path`` list.
+
+        v2 Phase B: ``extract_article_links_data`` returns ONE kind
+        per call, so the compact path issues two calls (internal +
+        external).
         """
         result = handler.handle_zim_query(
             "links in Photosynthesis",
             zim_file_path="/zim/test.zim",
             options={"compact": True, "limit": 20},
         )
-        mock_zim_operations.extract_article_links_data.assert_called_once()
-        args, kwargs = mock_zim_operations.extract_article_links_data.call_args
-        assert kwargs.get("limit") == 20
+        # Two calls — one per category.
+        assert mock_zim_operations.extract_article_links_data.call_count == 2
+        kinds_called = {
+            call.kwargs.get("kind")
+            for call in mock_zim_operations.extract_article_links_data.call_args_list
+        }
+        assert kinds_called == {"internal", "external"}
+        # All calls used the requested limit.
+        for call in mock_zim_operations.extract_article_links_data.call_args_list:
+            assert call.kwargs.get("limit") == 20
 
         # Header names the article and the per-category counts include
         # the full totals so the LLM knows what's been paged in.

--- a/tests/test_simple_tools.py
+++ b/tests/test_simple_tools.py
@@ -1616,16 +1616,16 @@ class TestCompactMarkdownRenderingForJsonIntents:
                 "discovery_method": "sampling",
                 "namespaces": {
                     "C": {
-                        "count": 27199903,
+                        "total": 27199903,
                         "description": "User content entries",
                     },
-                    "M": {"count": 13, "description": "ZIM metadata"},
+                    "M": {"total": 13, "description": "ZIM metadata"},
                 },
             }
         )
         out = h.handle_zim_query("list namespaces", options={"compact": True})
         mock.list_namespaces_data.assert_called_once()
-        # Sorted by count descending; C comes first.
+        # Sorted by total descending; C comes first.
         c_idx = out.find("**`C`**")
         m_idx = out.find("**`M`**")
         assert c_idx >= 0 and m_idx >= 0 and c_idx < m_idx
@@ -2428,12 +2428,12 @@ class TestCompactRenderersModule:
                 "is_total_authoritative": False,
                 "discovery_method": "scan",
                 "namespaces": {
-                    "C": {"count": 26_000_000, "description": "Content"},
-                    "M": {"count": 100, "description": "Metadata"},
+                    "C": {"total": 26_000_000, "description": "Content"},
+                    "M": {"total": 100, "description": "Metadata"},
                 },
             }
         )
-        # Sorted by count: C should come before M.
+        # Sorted by total: C should come before M.
         c_idx = out.find("**`C`**")
         m_idx = out.find("**`M`**")
         assert c_idx >= 0 and m_idx >= 0 and c_idx < m_idx

--- a/tests/test_simple_tools.py
+++ b/tests/test_simple_tools.py
@@ -1579,9 +1579,7 @@ class TestCompactMarkdownRenderingForJsonIntents:
         # renderer reads these directly.
         from openzim_mcp.pagination import Cursor
 
-        next_cursor = Cursor.encode(
-            tool="walk_namespace", state={"scan_at": 3, "l": 3}
-        )
+        next_cursor = Cursor.encode(tool="walk_namespace", state={"scan_at": 3, "l": 3})
         h, mock = self._handler_with_data(
             walk_namespace_data={
                 "namespace": "C",

--- a/tests/test_simple_tools.py
+++ b/tests/test_simple_tools.py
@@ -1284,15 +1284,16 @@ class TestCompactSearchSnippetTruncation:
             "Showing 1-1 of 1 (end of results)\n"
         )
         # In compact mode _handle_search calls search_zim_file_data + _format_search_text
+        # Phase B shape: top-level total/done/page_info, no nested pagination block.
         mock.search_zim_file_data.return_value = {
             "query": "biology",
-            "total_results": 1,
-            "offset": 0,
-            "limit": 5,
             "results": [
                 {"path": "Biology", "title": "Biology article", "snippet": "x"}
             ],
-            "pagination": {"has_more": False},
+            "next_cursor": None,
+            "total": 1,
+            "done": True,
+            "page_info": {"offset": 0, "limit": 5, "returned_count": 1},
             "_meta": {"tokens_est": 10, "chars": 100, "truncated": False},
         }
         mock._format_search_text.return_value = rendered
@@ -3037,11 +3038,11 @@ class TestCompactFooter:
         # search_zim_file_data returns zero results with suggestions in _meta
         mock.search_zim_file_data.return_value = {
             "query": "xyzzy",
-            "total_results": 0,
-            "offset": 0,
-            "limit": 5,
             "results": [],
-            "pagination": {"has_more": False},
+            "next_cursor": None,
+            "total": 0,
+            "done": True,
+            "page_info": {"offset": 0, "limit": 5, "returned_count": 0},
             "_meta": {
                 "tokens_est": 5,
                 "chars": 20,

--- a/tests/test_structure_tools.py
+++ b/tests/test_structure_tools.py
@@ -343,7 +343,18 @@ class TestStructureToolsDirectInvocation:
     ):
         """Test invoking extract_article_links tool handler directly."""
         advanced_server.async_zim_operations.extract_article_links_data = AsyncMock(
-            return_value={"internal_links": [], "external_links": []}
+            return_value={
+                "title": "Article",
+                "path": "C/Article",
+                "content_type": "text/html",
+                "kind": "internal",
+                "results": [],
+                "next_cursor": None,
+                "total": 0,
+                "done": True,
+                "page_info": {"offset": 0, "limit": 100, "returned_count": 0},
+                "category_totals": {"internal": 0, "external": 0, "media": 0},
+            }
         )
 
         tools = advanced_server.mcp._tool_manager._tools
@@ -354,7 +365,9 @@ class TestStructureToolsDirectInvocation:
                 entry_path="C/Article",
             )
             assert isinstance(result, dict)
-            assert "internal_links" in result
+            assert "results" in result
+            assert result["kind"] == "internal"
+            assert "category_totals" in result
 
     @pytest.mark.asyncio
     async def test_extract_article_links_with_exception(
@@ -591,21 +604,6 @@ class TestStructureDataMethodsMeta:
             "_get_or_load_link_extraction",
             lambda *a, **kw: fake_extraction,
         )
-        monkeypatch.setattr(
-            zim_ops,
-            "_render_paged_links",
-            lambda *a, **kw: {
-                "title": "Foo",
-                "path": "C/Foo",
-                "internal_links": [],
-                "external_links": [],
-                "media_links": [],
-                "total_internal_links": 0,
-                "total_external_links": 0,
-                "total_media_links": 0,
-                "pagination": {"offset": 0, "limit": 100, "has_more": False},
-            },
-        )
 
         from unittest.mock import MagicMock, patch
 
@@ -615,6 +613,16 @@ class TestStructureDataMethodsMeta:
 
         assert "_meta" in result
         assert result["_meta"]["tokens_est"] >= 1
+        # v2 Phase B contract: single category in `results`, full
+        # category_totals echoed.
+        assert result["kind"] == "internal"
+        assert result["results"] == []
+        assert result["category_totals"] == {
+            "internal": 0,
+            "external": 0,
+            "media": 0,
+        }
+        assert result["done"] is True
 
     def test_get_table_of_contents_data_fresh_attaches_meta(
         self, zim_ops, temp_dir, monkeypatch
@@ -658,9 +666,9 @@ class TestStructureDataMethodsMeta:
             "extract_article_links_data",
             lambda *a, **kw: {
                 "path": "C/Foo",
-                "internal_links": [],
-                "external_links": [],
-                "media_links": [],
+                "kind": "internal",
+                "results": [],
+                "category_totals": {"internal": 0, "external": 0, "media": 0},
             },
         )
         result = zim_ops.get_related_articles_data(str(zim_file), "C/Foo")

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -250,6 +250,53 @@ class TestStructuredOutput:
             assert "query" in payload
 
     @pytest.mark.asyncio
+    async def test_search_with_filters_returns_paginated_response(
+        self, server: OpenZimMcpServer, basic_test_zim_files
+    ) -> None:
+        """search_with_filters (Phase B) emits a SearchWithFiltersResponse-shaped payload.
+
+        Phase B migration: the tool now declares a
+        ``Union[SearchWithFiltersResponse, ToolErrorPayload]`` return
+        annotation, so FastMCP wraps the payload in a uniform
+        ``{"result": ...}`` envelope (see spec § FastMCP wrapping). The
+        inner shape must carry the contract keys plus the tool-specific
+        ``query`` / ``namespace_filter`` / ``content_type_filter`` extras.
+        """
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get(
+            "withns"
+        )
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+        result = await server.mcp._tool_manager.call_tool(
+            "search_with_filters",
+            {
+                "zim_file_path": str(zim_path),
+                "query": "evolution",
+                "namespace": "C",
+            },
+            convert_result=True,
+        )
+        assert isinstance(result, tuple)
+        _, structured = result
+        assert isinstance(structured, dict)
+        # FastMCP wraps Union returns in {"result": ...}; accept the wrapper.
+        payload = structured["result"] if "result" in structured else structured
+        # Tool may emit an error envelope on a transient libzim failure —
+        # tolerate it; the wire format is what we're verifying.
+        if payload.get("error") is True:
+            assert "operation" in payload
+        else:
+            for key in ("results", "next_cursor", "total", "done", "page_info"):
+                assert key in payload
+            assert isinstance(payload["results"], list)
+            assert isinstance(payload["page_info"], dict)
+            # _meta envelope should also be present (sibling of contract keys).
+            assert "_meta" in payload
+            assert payload["query"] == "evolution"
+            assert payload["namespace_filter"] == "C"
+            assert payload["content_type_filter"] is None
+
+    @pytest.mark.asyncio
     async def test_search_all_returns_structured_content(
         self, server: OpenZimMcpServer
     ) -> None:

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -500,7 +500,7 @@ class TestStructuredOutput:
         # non-error response to assert the success-branch shape against.
         find_result = await server.mcp._tool_manager.call_tool(
             "find_entry_by_title",
-            {"zim_file_path": str(zim_path), "title": ""},
+            {"zim_file_path": str(zim_path), "title": "a"},
             convert_result=True,
         )
         assert isinstance(find_result, tuple)
@@ -510,6 +510,10 @@ class TestStructuredOutput:
             if "result" in find_structured
             else find_structured
         )
+        if find_payload.get("error") is True:
+            pytest.skip(
+                f"find_entry_by_title returned an error envelope: {find_payload.get('operation')}"
+            )
         entries = find_payload.get("results", [])
         if not entries:
             pytest.skip("No entries found in test ZIM to exercise get_zim_entry")

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -166,7 +166,13 @@ class TestStructuredOutput:
         assert isinstance(structured, dict)
         payload = structured["result"] if "result" in structured else structured
         assert "namespace" in payload
-        assert "entries" in payload and isinstance(payload["entries"], list)
+        # Phase B contract: results / next_cursor / total / done / page_info.
+        assert "results" in payload and isinstance(payload["results"], list)
+        assert "done" in payload
+        assert "page_info" in payload
+        assert payload["page_info"]["offset"] == 0
+        assert payload["page_info"]["limit"] == 50
+        assert payload["page_info"]["returned_count"] == len(payload["results"])
 
     @pytest.mark.asyncio
     async def test_walk_namespace_returns_structured_content(

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -131,6 +131,37 @@ class TestStructuredOutput:
         assert "entry_count" in payload
 
     @pytest.mark.asyncio
+    async def test_get_main_page_returns_structured_content(
+        self, server: OpenZimMcpServer, basic_test_zim_files
+    ) -> None:
+        """get_main_page emits a real dict at structuredContent.result (FastMCP Union wrap)."""
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get(
+            "withns"
+        )
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+
+        result = await server.mcp._tool_manager.call_tool(
+            "get_main_page",
+            {"zim_file_path": str(zim_path)},
+            convert_result=True,
+        )
+        assert isinstance(result, tuple)
+        _, structured = result
+        assert isinstance(structured, dict)
+        # FastMCP wraps Union returns in a uniform {"result": ...} envelope
+        # (see spec § FastMCP wrapping). Accept the wrapper; assert inner shape.
+        payload = structured["result"] if "result" in structured else structured
+        if payload.get("error") is True:
+            assert "operation" in payload
+        else:
+            # Tolerate both: archive with main page (non-empty path/title/content)
+            # and archive without (empty path, textual notice in content).
+            assert "path" in payload
+            assert "title" in payload
+            assert "content" in payload
+
+    @pytest.mark.asyncio
     async def test_list_zim_files_returns_structured_content(
         self, server: OpenZimMcpServer
     ) -> None:
@@ -453,6 +484,54 @@ class TestStructuredOutput:
             assert payload["done"] is True
             assert payload["total"] == len(payload["results"])
             assert "page_info" in payload
+
+    @pytest.mark.asyncio
+    async def test_get_zim_entry_returns_structured_content(
+        self, server: OpenZimMcpServer, basic_test_zim_files
+    ) -> None:
+        """get_zim_entry emits a real dict at structuredContent.result (FastMCP Union wrap)."""
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get(
+            "withns"
+        )
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+
+        # Resolve a real entry path via find_entry_by_title so we get a
+        # non-error response to assert the success-branch shape against.
+        find_result = await server.mcp._tool_manager.call_tool(
+            "find_entry_by_title",
+            {"zim_file_path": str(zim_path), "title": ""},
+            convert_result=True,
+        )
+        assert isinstance(find_result, tuple)
+        _, find_structured = find_result
+        find_payload = (
+            find_structured["result"]
+            if "result" in find_structured
+            else find_structured
+        )
+        entries = find_payload.get("results", [])
+        if not entries:
+            pytest.skip("No entries found in test ZIM to exercise get_zim_entry")
+        entry_path = entries[0]["path"]
+
+        result = await server.mcp._tool_manager.call_tool(
+            "get_zim_entry",
+            {"zim_file_path": str(zim_path), "entry_path": entry_path},
+            convert_result=True,
+        )
+        assert isinstance(result, tuple)
+        _, structured = result
+        assert isinstance(structured, dict)
+        # FastMCP wraps Union returns in a uniform {"result": ...} envelope
+        # (see spec § FastMCP wrapping). Accept the wrapper; assert inner shape.
+        payload = structured["result"] if "result" in structured else structured
+        if payload.get("error") is True:
+            assert "operation" in payload
+        else:
+            assert "path" in payload
+            assert "title" in payload
+            assert "content" in payload
 
     @pytest.mark.asyncio
     async def test_get_article_structure_returns_structured_content(

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -210,8 +210,11 @@ class TestStructuredOutput:
         _, structured = result
         assert isinstance(structured, dict)
         payload = structured["result"] if "result" in structured else structured
-        assert "suggestions" in payload
-        assert isinstance(payload["suggestions"], list)
+        assert "results" in payload
+        assert isinstance(payload["results"], list)
+        assert payload["next_cursor"] is None
+        assert payload["done"] is True
+        assert payload["total"] == len(payload["results"])
 
     @pytest.mark.asyncio
     async def test_search_zim_file_returns_structured_content(

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -95,9 +95,7 @@ class TestStructuredOutput:
         # Per-namespace summaries declare ``total`` (renamed from the
         # legacy ``count`` in v2 Phase B) and ``is_authoritative``.
         for ns_letter, summary in payload["namespaces"].items():
-            assert isinstance(
-                summary, dict
-            ), f"namespaces[{ns_letter}] should be dict"
+            assert isinstance(summary, dict), f"namespaces[{ns_letter}] should be dict"
             assert (
                 "total" in summary
             ), f"namespaces[{ns_letter}] missing renamed 'total' field"

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -483,7 +483,12 @@ class TestStructuredOutput:
         if payload.get("error") is True:
             assert "operation" in payload
         else:
-            assert "internal_links" in payload
+            # v2 Phase B contract: single category per call.
+            assert "results" in payload
+            assert "kind" in payload and payload["kind"] == "internal"
+            assert "category_totals" in payload
+            for k in ("internal", "external", "media"):
+                assert k in payload["category_totals"]
 
     @pytest.mark.asyncio
     async def test_get_entry_summary_returns_structured_content(

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -594,7 +594,15 @@ class TestStructuredOutput:
         if payload.get("error") is True:
             assert "operation" in payload
         else:
-            assert "outbound_results" in payload
+            # v2 Phase B contract: top-level results / next_cursor / total /
+            # done / page_info plus tool-specific entry_path.
+            assert "results" in payload
+            assert "outbound_results" not in payload
+            assert payload["next_cursor"] is None
+            assert payload["done"] is True
+            assert payload["total"] == len(payload["results"])
+            assert payload["page_info"]["limit"] >= 1
+            assert "entry_path" in payload
 
     @pytest.mark.asyncio
     async def test_get_server_health_returns_structured_content(

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -210,11 +210,15 @@ class TestStructuredOutput:
     async def test_search_zim_file_returns_structured_content(
         self, server: OpenZimMcpServer, basic_test_zim_files
     ) -> None:
-        """search_zim_file (Phase B) emits a top-level TypedDict payload.
+        """search_zim_file (Phase B) emits a SearchResponse-shaped payload.
 
-        Phase B migration: the tool now declares a ``SearchResponse`` return
-        annotation, so FastMCP places the dict at the top level of
-        ``structuredContent`` rather than nesting it under ``"result"``.
+        Phase B migration: the tool now declares a
+        ``Union[SearchResponse, ToolErrorPayload]`` return annotation, so
+        FastMCP wraps the payload in a single uniform ``{"result": ...}``
+        envelope (see spec § FastMCP wrapping — Union returns flow through
+        ``_try_create_model_and_schema``'s ``wrap_output=True`` path). The
+        inner shape carries a real ``anyOf`` schema and is the contract
+        we assert against.
         """
         zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get(
             "withns"
@@ -229,11 +233,10 @@ class TestStructuredOutput:
         assert isinstance(result, tuple)
         _, structured = result
         assert isinstance(structured, dict)
-        # Phase B: TypedDict return — payload is at top level, no "result" wrapper.
-        assert "result" not in structured, (
-            "TypedDict migration regression: payload still wrapped"
-        )
-        payload = structured
+        # FastMCP wraps Union returns in a uniform {"result": ...} envelope
+        # (see spec § FastMCP wrapping). Accept that wrapper; assert the
+        # inner shape.
+        payload = structured["result"] if "result" in structured else structured
         # Tool may emit an error envelope on a transient missing-index call —
         # tolerate it; the wire format is what we're verifying.
         if payload.get("error") is True:
@@ -258,12 +261,14 @@ class TestStructuredOutput:
         Phase B contract-shape).
 
         Note on the ``"result"`` wrapper: FastMCP wraps Union return
-        annotations (``Union[SearchAllResponse, ToolErrorPayload]``) under
-        a generic ``{"result": ...}`` envelope because ``Union`` falls
-        through ``_try_create_model_and_schema``'s wrap path. A
-        TypedDict-only return would land at the top level, but the spec
-        keeps the ``Union`` for the error-as-data envelope. We tolerate
-        the wrapper — what matters is the inner shape.
+        annotations (``Union[SearchAllResponse, ToolErrorPayload]``) in a
+        uniform ``{"result": ...}`` envelope because ``Union`` flows
+        through ``_try_create_model_and_schema``'s ``wrap_output=True``
+        path. Per spec § FastMCP wrapping, Phase B accepts this uniform
+        wrapper deliberately (the inner content carries a real
+        ``anyOf: [SearchAllResponse, ToolErrorPayload]`` schema). Tests
+        assert against ``structured["result"]`` (or the wrapper-tolerant
+        equivalent) — what matters is the inner shape.
         """
         result = await server.mcp._tool_manager.call_tool(
             "search_all", {"query": "evolution"}, convert_result=True

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -348,7 +348,7 @@ class TestStructuredOutput:
             assert "query" in payload
 
     @pytest.mark.asyncio
-    async def test_search_with_filters_returns_paginated_response(
+    async def test_search_with_filters_returns_structured_content(
         self, server: OpenZimMcpServer, basic_test_zim_files
     ) -> None:
         """search_with_filters (Phase B) emits a SearchWithFiltersResponse-shaped payload.

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -138,6 +138,13 @@ class TestStructuredOutput:
         assert "results" in payload and isinstance(payload["results"], list)
         assert "query" in payload
         assert "files_searched" in payload
+        # Phase B contract keys (non-paginated tool, but contract still applies).
+        assert payload["next_cursor"] is None
+        assert payload["done"] is True
+        assert payload["total"] == len(payload["results"])
+        assert payload["page_info"]["offset"] == 0
+        assert payload["page_info"]["limit"] == 10
+        assert payload["page_info"]["returned_count"] == len(payload["results"])
 
     @pytest.mark.asyncio
     async def test_browse_namespace_returns_structured_content(

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -65,15 +65,48 @@ class TestStructuredOutput:
             structured, dict
         ), f"structured payload should be dict, got {type(structured)}"
 
-        # FastMCP wraps generic ``Dict[str, Any]`` return types under a
-        # ``"result"`` key (see ``_try_create_model_and_schema`` in
-        # ``mcp.server.fastmcp.utilities.func_metadata``). TypedDict /
-        # Pydantic returns would land at the top level instead. The pilot
-        # uses ``Dict[str, Any]`` so the payload sits one level down.
+        # FastMCP wraps Union return annotations
+        # (``Union[ListNamespacesResponse, ToolErrorPayload]``) in a
+        # uniform ``{"result": ...}`` envelope (see spec § FastMCP
+        # wrapping). Tolerate the wrapper; assert the inner shape.
         payload = structured["result"] if "result" in structured else structured
         assert isinstance(payload, dict)
+        # list_namespaces is the one list-shaped result that does NOT
+        # carry the PaginatedResponse contract — it returns a
+        # dict-of-summaries instead. Top-level keys are stable.
         assert "namespaces" in payload
         assert isinstance(payload["namespaces"], dict)
+        for key in (
+            "total_entries",
+            "sampled_entries",
+            "has_new_namespace_scheme",
+            "is_total_authoritative",
+            "discovery_method",
+        ):
+            assert key in payload, f"missing top-level key: {key}"
+        # Phase B contract keys MUST NOT leak onto this non-paginated
+        # response — protect against an accidental
+        # PaginatedResponse-style migration.
+        for forbidden in ("results", "next_cursor", "done", "page_info"):
+            assert forbidden not in payload, (
+                f"non-paginated list_namespaces unexpectedly carries "
+                f"contract key: {forbidden}"
+            )
+        # Per-namespace summaries declare ``total`` (renamed from the
+        # legacy ``count`` in v2 Phase B) and ``is_authoritative``.
+        for ns_letter, summary in payload["namespaces"].items():
+            assert isinstance(
+                summary, dict
+            ), f"namespaces[{ns_letter}] should be dict"
+            assert (
+                "total" in summary
+            ), f"namespaces[{ns_letter}] missing renamed 'total' field"
+            assert (
+                "count" not in summary
+            ), f"namespaces[{ns_letter}] still carries legacy 'count' field"
+            assert (
+                "is_authoritative" in summary
+            ), f"namespaces[{ns_letter}] missing 'is_authoritative'"
 
     @pytest.mark.asyncio
     async def test_get_zim_metadata_returns_structured_content(

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -193,9 +193,15 @@ class TestStructuredOutput:
         _, structured = result
         assert isinstance(structured, dict)
         payload = structured["result"] if "result" in structured else structured
-        assert "entries" in payload and isinstance(payload["entries"], list)
+        # Phase B contract: results / next_cursor / total / done / page_info.
+        assert "results" in payload and isinstance(payload["results"], list)
         assert "done" in payload
         assert "namespace" in payload
+        # walk_namespace cannot know the per-namespace total mid-scan.
+        assert payload["total"] is None
+        assert "page_info" in payload
+        assert payload["page_info"]["limit"] == 200
+        assert payload["page_info"]["returned_count"] == len(payload["results"])
 
     @pytest.mark.asyncio
     async def test_get_search_suggestions_returns_structured_content(

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -431,9 +431,16 @@ class TestStructuredOutput:
         if payload.get("error") is True:
             assert "operation" in payload
         else:
+            # v2 Phase B contract: the success envelope carries the
+            # canonical list-shaped keys plus the tool-specific
+            # succeeded/failed counters.
             assert "results" in payload
             assert "succeeded" in payload
             assert "failed" in payload
+            assert payload["next_cursor"] is None
+            assert payload["done"] is True
+            assert payload["total"] == len(payload["results"])
+            assert "page_info" in payload
 
     @pytest.mark.asyncio
     async def test_get_article_structure_returns_structured_content(

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -253,8 +253,17 @@ class TestStructuredOutput:
         """search_all per-file results must be dicts, not stringified markdown.
 
         Catches both wire-format requirements: (a) the tool emits
-        structuredContent at all, and (b) ``per_file[].result`` is itself
-        a real dict (the triple-encoding fix).
+        structuredContent at all, and (b) ``results[].result`` is itself
+        a real ``SearchResponse`` dict (the triple-encoding fix, plus
+        Phase B contract-shape).
+
+        Note on the ``"result"`` wrapper: FastMCP wraps Union return
+        annotations (``Union[SearchAllResponse, ToolErrorPayload]``) under
+        a generic ``{"result": ...}`` envelope because ``Union`` falls
+        through ``_try_create_model_and_schema``'s wrap path. A
+        TypedDict-only return would land at the top level, but the spec
+        keeps the ``Union`` for the error-as-data envelope. We tolerate
+        the wrapper — what matters is the inner shape.
         """
         result = await server.mcp._tool_manager.call_tool(
             "search_all", {"query": "evolution"}, convert_result=True
@@ -262,16 +271,27 @@ class TestStructuredOutput:
         assert isinstance(result, tuple)
         _, structured = result
         assert isinstance(structured, dict)
-        # The previous tool migration revealed FastMCP wraps
-        # ``Dict[str, Any]`` returns under a ``"result"`` key. Tolerate that.
         payload = structured["result"] if "result" in structured else structured
-        assert "per_file" in payload
-        for entry in payload.get("per_file", []):
-            if "result" in entry:
-                assert isinstance(
-                    entry["result"], dict
-                ), f"per_file[].result should be dict, got {type(entry['result'])}"
-                assert "results" in entry["result"]
+        # Phase B: results is the renamed per-file list, no longer ``per_file``.
+        assert "per_file" not in payload, (
+            "TypedDict migration regression: top-level still uses legacy "
+            "``per_file`` key — Task 6 renamed it to ``results``."
+        )
+        assert "results" in payload
+        # Top-level Phase B contract keys (always done=True, no cursor —
+        # search_all is fan-out, not paginated at the top level).
+        assert payload["done"] is True
+        assert payload["next_cursor"] is None
+        assert "page_info" in payload
+        for entry in payload["results"]:
+            inner = entry["result"]
+            assert isinstance(
+                inner, dict
+            ), f"per_file[].result should be dict, got {type(inner)}"
+            # inner is itself a SearchResponse — it has its own results list
+            assert "results" in inner
+            assert "done" in inner
+            assert "next_cursor" in inner
 
     @pytest.mark.asyncio
     async def test_get_zim_entries_returns_structured_content(

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -146,8 +146,20 @@ class TestStructuredOutput:
         _, structured = result
         assert isinstance(structured, dict)
         payload = structured["result"] if "result" in structured else structured
-        assert "files" in payload and isinstance(payload["files"], list)
-        assert "count" in payload
+        # v2 Phase B contract keys (non-paginated, but contract still applies).
+        assert "results" in payload and isinstance(payload["results"], list)
+        assert payload["next_cursor"] is None
+        assert payload["done"] is True
+        assert payload["total"] == len(payload["results"])
+        assert payload["page_info"]["offset"] == 0
+        assert payload["page_info"]["limit"] == len(payload["results"])
+        assert payload["page_info"]["returned_count"] == len(payload["results"])
+        # Tool-specific extras.
+        assert "directories_count" in payload
+        assert "name_filter" in payload
+        # Renamed legacy keys must not leak through.
+        assert "files" not in payload
+        assert "count" not in payload
 
     @pytest.mark.asyncio
     async def test_find_entry_by_title_returns_structured_content(

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -207,6 +207,46 @@ class TestStructuredOutput:
         assert isinstance(payload["suggestions"], list)
 
     @pytest.mark.asyncio
+    async def test_search_zim_file_returns_structured_content(
+        self, server: OpenZimMcpServer, basic_test_zim_files
+    ) -> None:
+        """search_zim_file (Phase B) emits a top-level TypedDict payload.
+
+        Phase B migration: the tool now declares a ``SearchResponse`` return
+        annotation, so FastMCP places the dict at the top level of
+        ``structuredContent`` rather than nesting it under ``"result"``.
+        """
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get(
+            "withns"
+        )
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+        result = await server.mcp._tool_manager.call_tool(
+            "search_zim_file",
+            {"zim_file_path": str(zim_path), "query": "anything"},
+            convert_result=True,
+        )
+        assert isinstance(result, tuple)
+        _, structured = result
+        assert isinstance(structured, dict)
+        # Phase B: TypedDict return — payload is at top level, no "result" wrapper.
+        assert "result" not in structured, (
+            "TypedDict migration regression: payload still wrapped"
+        )
+        payload = structured
+        # Tool may emit an error envelope on a transient missing-index call —
+        # tolerate it; the wire format is what we're verifying.
+        if payload.get("error") is True:
+            assert "operation" in payload
+        else:
+            assert "results" in payload and isinstance(payload["results"], list)
+            assert "next_cursor" in payload
+            assert "total" in payload
+            assert "done" in payload
+            assert "page_info" in payload and isinstance(payload["page_info"], dict)
+            assert "query" in payload
+
+    @pytest.mark.asyncio
     async def test_search_all_returns_structured_content(
         self, server: OpenZimMcpServer
     ) -> None:

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -1,0 +1,72 @@
+"""Structural tests for openzim_mcp.tool_schemas.
+
+These tests don't assert behavior — they assert the TypedDict surface
+exists and the contract keys are present on every list-returning response.
+The dynamic per-tool wire-format checks live in test_response_contract.py.
+"""
+
+from __future__ import annotations
+
+from typing import get_type_hints
+
+from openzim_mcp import tool_schemas as ts
+
+
+# Every list-returning response TypedDict must declare these five keys
+# plus _meta. The interpretation of each is documented in the spec.
+CONTRACT_KEYS = {"results", "next_cursor", "total", "done", "page_info", "_meta"}
+
+
+def test_page_info_has_required_fields() -> None:
+    hints = get_type_hints(ts.PageInfo)
+    assert "offset" in hints
+    assert "limit" in hints
+    assert "returned_count" in hints
+    # total_is_lower_bound is NotRequired — get_type_hints still surfaces it.
+    assert "total_is_lower_bound" in hints
+
+
+def test_meta_envelope_has_phase_a_fields() -> None:
+    hints = get_type_hints(ts.MetaEnvelope)
+    for key in ("tokens_est", "chars", "truncated", "more_at_offset", "total_chars",
+                "suggestions", "reason"):
+        assert key in hints, f"MetaEnvelope missing {key}"
+
+
+def test_paginated_responses_carry_contract_keys() -> None:
+    paginated = [
+        ts.SearchResponse,
+        ts.SearchAllResponse,
+        ts.SearchWithFiltersResponse,
+        ts.FindEntryResponse,
+        ts.SearchSuggestionsResponse,
+        ts.BrowseNamespaceResponse,
+        ts.WalkNamespaceResponse,
+        ts.LinksResponse,
+        ts.ListZimFilesResponse,
+        ts.RelatedArticlesResponse,
+        ts.BatchEntryResponse,
+    ]
+    for cls in paginated:
+        hints = get_type_hints(cls)
+        missing = CONTRACT_KEYS - set(hints.keys())
+        assert not missing, f"{cls.__name__} missing contract keys: {missing}"
+
+
+def test_non_paginated_responses_do_not_carry_results() -> None:
+    """list_namespaces and the entry/metadata tools don't get the contract."""
+    non_paginated = [
+        ts.ZimMetadataResponse,
+        ts.ListNamespacesResponse,
+        ts.EntryResponse,
+        ts.EntrySummaryResponse,
+        ts.TableOfContentsResponse,
+        ts.ArticleStructureResponse,
+        ts.BinaryEntryResponse,
+    ]
+    for cls in non_paginated:
+        hints = get_type_hints(cls)
+        # _meta is universal; the rest of the contract keys must NOT be present.
+        leaked = {"results", "next_cursor", "done", "page_info"} & set(hints.keys())
+        assert not leaked, f"{cls.__name__} unexpectedly has paginated keys: {leaked}"
+        assert "_meta" in hints, f"{cls.__name__} missing _meta envelope"

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -11,7 +11,6 @@ from typing import get_type_hints
 
 from openzim_mcp import tool_schemas as ts
 
-
 # Every list-returning response TypedDict must declare these five keys
 # plus _meta. The interpretation of each is documented in the spec.
 CONTRACT_KEYS = {"results", "next_cursor", "total", "done", "page_info", "_meta"}
@@ -28,8 +27,15 @@ def test_page_info_has_required_fields() -> None:
 
 def test_meta_envelope_has_phase_a_fields() -> None:
     hints = get_type_hints(ts.MetaEnvelope)
-    for key in ("tokens_est", "chars", "truncated", "more_at_offset", "total_chars",
-                "suggestions", "reason"):
+    for key in (
+        "tokens_est",
+        "chars",
+        "truncated",
+        "more_at_offset",
+        "total_chars",
+        "suggestions",
+        "reason",
+    ):
         assert key in hints, f"MetaEnvelope missing {key}"
 
 

--- a/tests/test_walk_namespace.py
+++ b/tests/test_walk_namespace.py
@@ -23,27 +23,21 @@ class TestWalkNamespace:
         with pytest.raises(
             OpenZimMcpValidationError, match="limit must be between 1 and 500"
         ):
-            server.zim_operations.walk_namespace(
-                "/path/to/file.zim", "C", limit=0
-            )
+            server.zim_operations.walk_namespace("/path/to/file.zim", "C", limit=0)
 
     def test_walk_namespace_limit_validation_high(self, server: OpenZimMcpServer):
         """Test that limit > 500 raises OpenZimMcpValidationError."""
         with pytest.raises(
             OpenZimMcpValidationError, match="limit must be between 1 and 500"
         ):
-            server.zim_operations.walk_namespace(
-                "/path/to/file.zim", "C", limit=10000
-            )
+            server.zim_operations.walk_namespace("/path/to/file.zim", "C", limit=10000)
 
     def test_walk_namespace_raises_validation_error_for_bad_limit(
         self, server: OpenZimMcpServer
     ):
         """Mirror the explicit acceptance test from the fix plan (Task 6.4)."""
         with pytest.raises(OpenZimMcpValidationError):
-            server.zim_operations.walk_namespace(
-                "/path/to/file.zim", "A", limit=10000
-            )
+            server.zim_operations.walk_namespace("/path/to/file.zim", "A", limit=10000)
 
     def test_walk_namespace_lowercase_namespace_normalized(
         self, server: OpenZimMcpServer, monkeypatch

--- a/tests/test_walk_namespace.py
+++ b/tests/test_walk_namespace.py
@@ -24,7 +24,7 @@ class TestWalkNamespace:
             OpenZimMcpValidationError, match="limit must be between 1 and 500"
         ):
             server.zim_operations.walk_namespace(
-                "/path/to/file.zim", "C", cursor=0, limit=0
+                "/path/to/file.zim", "C", limit=0
             )
 
     def test_walk_namespace_limit_validation_high(self, server: OpenZimMcpServer):
@@ -33,7 +33,7 @@ class TestWalkNamespace:
             OpenZimMcpValidationError, match="limit must be between 1 and 500"
         ):
             server.zim_operations.walk_namespace(
-                "/path/to/file.zim", "C", cursor=0, limit=10000
+                "/path/to/file.zim", "C", limit=10000
             )
 
     def test_walk_namespace_raises_validation_error_for_bad_limit(
@@ -42,7 +42,7 @@ class TestWalkNamespace:
         """Mirror the explicit acceptance test from the fix plan (Task 6.4)."""
         with pytest.raises(OpenZimMcpValidationError):
             server.zim_operations.walk_namespace(
-                "/path/to/file.zim", "A", cursor=0, limit=10000
+                "/path/to/file.zim", "A", limit=10000
             )
 
     def test_walk_namespace_lowercase_namespace_normalized(
@@ -80,18 +80,18 @@ class TestWalkNamespace:
         )
 
         result_json = server.zim_operations.walk_namespace(
-            "/path/to/file.zim", "c", cursor=0, limit=10
+            "/path/to/file.zim", "c", limit=10
         )
         result = json.loads(result_json)
-        # Without normalisation, entries=[] silently. With normalisation,
+        # Without normalisation, results=[] silently. With normalisation,
         # the canonical "C" is matched and we surface the entry.
-        assert len(result["entries"]) == 1
-        assert result["entries"][0]["path"] == "C/Foo"
+        assert len(result["results"]) == 1
+        assert result["results"][0]["path"] == "C/Foo"
 
-    def test_walk_namespace_negative_cursor_clamped(
+    def test_walk_namespace_first_page_no_cursor(
         self, server: OpenZimMcpServer, monkeypatch
     ):
-        """Negative cursor is clamped to 0."""
+        """First page with cursor=None walks from scan_at=0 and reports done."""
         # Build a minimal mock archive that the walk loop can iterate.
         mock_archive = MagicMock()
         mock_archive.entry_count = 0
@@ -111,11 +111,14 @@ class TestWalkNamespace:
         )
 
         result_json = server.zim_operations.walk_namespace(
-            "/path/to/file.zim", "C", cursor=-5, limit=10
+            "/path/to/file.zim", "C", limit=10
         )
         result = json.loads(result_json)
-        assert result["cursor"] == 0
+        # New v2 contract: page_info.offset replaces top-level cursor (int).
+        assert result["page_info"]["offset"] == 0
         assert result["done"] is True
+        assert result["next_cursor"] is None
+        assert result["total"] is None  # walk never knows per-namespace total
 
 
 def _ctx(value):

--- a/tests/test_zim_operations.py
+++ b/tests/test_zim_operations.py
@@ -642,14 +642,20 @@ class TestZimOperations:
                 str(zim_file), "bio", limit=5
             )
 
-            assert "suggestions" in result
+            # Phase B contract: ``suggestions`` was renamed to ``results``
+            # at the top level. The legacy JSON-string variant serializes
+            # the same payload, so the contract keys appear in the string.
+            assert "results" in result
             assert "partial_query" in result
             assert "bio" in result
 
     def test_get_search_suggestions_short_query(self, zim_operations: ZimOperations):
         """Test search suggestions with too short query."""
         result = zim_operations.get_search_suggestions("test.zim", "a", limit=5)
-        assert "Query too short" in result
+        # Phase B contract: short queries return the empty contract envelope
+        # (``done=True``, ``total=0``) instead of a free-form ``message``.
+        assert '"results": []' in result
+        assert '"done": true' in result
 
     def test_get_article_structure(self, zim_operations: ZimOperations, temp_dir: Path):
         """Test article structure extraction."""
@@ -2117,7 +2123,8 @@ class TestZimOperations:
             result = zim_operations.get_search_suggestions(
                 str(zim_file), "test", limit=15
             )
-            assert "suggestions" in result
+            # Phase B contract: top-level key is ``results`` (was ``suggestions``).
+            assert "results" in result
 
     def test_additional_edge_cases_for_coverage(
         self, zim_operations: ZimOperations, temp_dir: Path
@@ -2126,9 +2133,11 @@ class TestZimOperations:
         zim_file = temp_dir / "test.zim"
         zim_file.touch()
 
-        # Test search suggestions with short query
+        # Test search suggestions with short query — Phase B drops the
+        # free-form ``message`` and returns the empty contract envelope.
         result = zim_operations.get_search_suggestions(str(zim_file), "a")
-        assert "Query too short for suggestions" in result
+        assert '"results": []' in result
+        assert '"done": true' in result
 
         # Test search suggestions with invalid limit
         with pytest.raises(

--- a/tests/test_zim_operations.py
+++ b/tests/test_zim_operations.py
@@ -2308,14 +2308,24 @@ class TestZimOperations:
             mock_archive_instance.get_entry_by_path.return_value = mock_entry
             mock_archive.return_value.__enter__.return_value = mock_archive_instance
 
-            result = zim_operations.extract_article_links(
-                str(zim_file), "C/Test_Article"
+            # v2 Phase B: each call returns a single category in `results`.
+            internal_raw = zim_operations.extract_article_links(
+                str(zim_file), "C/Test_Article", kind="internal"
+            )
+            external_raw = zim_operations.extract_article_links(
+                str(zim_file), "C/Test_Article", kind="external"
+            )
+            media_raw = zim_operations.extract_article_links(
+                str(zim_file), "C/Test_Article", kind="media"
             )
 
-            assert "internal_links" in result
-            assert "external_links" in result
-            assert "media_links" in result
-            assert "total_links" in result
+            assert '"kind": "internal"' in internal_raw
+            assert '"kind": "external"' in external_raw
+            assert '"kind": "media"' in media_raw
+            # `category_totals` echoes counts for all three categories.
+            for raw in (internal_raw, external_raw, media_raw):
+                assert '"category_totals"' in raw
+                assert '"results"' in raw
 
 
 class TestZimOperationsUtilityFunctions:

--- a/tests/test_zim_operations.py
+++ b/tests/test_zim_operations.py
@@ -1330,10 +1330,12 @@ class TestZimOperations:
 
         # Test list_namespaces_data cache hit (lines 584-585).
         # list_namespaces now delegates to list_namespaces_data, which caches
-        # dicts under a `namespaces_data:` key. Exercise the cache hit path
-        # against the dict-returning entry point directly so we test the
-        # cache layer without an extra json.dumps round trip.
-        cache_key = f"namespaces_data:{validated_path}"
+        # dicts under a `namespaces_data:v2:` key (v2 marker added with the
+        # per-namespace ``count`` -> ``total`` rename so v1.x cached responses
+        # don't leak through). Exercise the cache hit path against the
+        # dict-returning entry point directly so we test the cache layer
+        # without an extra json.dumps round trip.
+        cache_key = f"namespaces_data:v2:{validated_path}"
         zim_operations.cache.set(cache_key, {"cached": "namespaces"})
 
         result = zim_operations.list_namespaces_data(str(zim_file))

--- a/tests/test_zim_operations.py
+++ b/tests/test_zim_operations.py
@@ -1330,12 +1330,12 @@ class TestZimOperations:
 
         # Test list_namespaces_data cache hit (lines 584-585).
         # list_namespaces now delegates to list_namespaces_data, which caches
-        # dicts under a `namespaces_data:v2:` key (v2 marker added with the
-        # per-namespace ``count`` -> ``total`` rename so v1.x cached responses
+        # dicts under a `namespaces_data:v2b:` key (v2b marker added with the
+        # Phase B ``entry_count`` -> ``total`` rename so v1.x cached responses
         # don't leak through). Exercise the cache hit path against the
         # dict-returning entry point directly so we test the cache layer
         # without an extra json.dumps round trip.
-        cache_key = f"namespaces_data:v2:{validated_path}"
+        cache_key = f"namespaces_data:v2b:{validated_path}"
         zim_operations.cache.set(cache_key, {"cached": "namespaces"})
 
         result = zim_operations.list_namespaces_data(str(zim_file))
@@ -1366,11 +1366,11 @@ class TestZimOperations:
 
         # Test extract_article_links_data cache hit. extract_article_links_data
         # caches the parsed extraction (full lists) under a stable
-        # ``links_full:`` key so different paginated requests share one parse;
+        # ``links_full:v2b:`` key so different paginated requests share one parse;
         # the response is rendered fresh per call, so the hit assertion checks
         # the post-render dict carries the cached title/path metadata rather
         # than asserting raw equality.
-        cache_key = f"links_full:{validated_path}:A/Test"
+        cache_key = f"links_full:v2b:{validated_path}:A/Test"
         zim_operations.cache.set(
             cache_key,
             {

--- a/tests/test_zim_operations.py
+++ b/tests/test_zim_operations.py
@@ -522,8 +522,9 @@ class TestZimOperations:
 
             assert "namespace" in result
             assert "C" in result
-            assert "entries" in result
-            assert "total_in_namespace" in result
+            # Phase B contract keys (substring check on the JSON-string surface).
+            assert '"results"' in result
+            assert '"total"' in result
 
     def test_browse_namespace_invalid_params(self, zim_operations: ZimOperations):
         """Test namespace browsing with invalid parameters.
@@ -1241,7 +1242,7 @@ class TestZimOperations:
             mock_archive.return_value.__enter__.return_value = mock_archive_instance
 
             result = zim_operations.browse_namespace(str(zim_file), "A")
-            assert 'total_in_namespace": 0' in result
+            assert '"total": 0' in result
 
     def test_search_with_filters_comprehensive(
         self, zim_operations: ZimOperations, temp_dir: Path
@@ -1343,7 +1344,7 @@ class TestZimOperations:
         # delegates to browse_namespace_data, which caches dicts under a
         # `browse_ns_data:` key. Exercise the cache hit path against the
         # dict-returning entry point directly.
-        cache_key = f"browse_ns_data:{validated_path}:A:50:0"
+        cache_key = f"browse_ns_data:v2b:{validated_path}:A:50:0"
         zim_operations.cache.set(cache_key, {"cached": "browse"})
 
         result = zim_operations.browse_namespace_data(str(zim_file), "A")

--- a/tests/test_zim_operations.py
+++ b/tests/test_zim_operations.py
@@ -293,9 +293,12 @@ class TestZimOperations:
 
         assert isinstance(data, dict)
         assert data["query"] == "no_match"
-        assert data["total_results"] == 0
+        # Phase B: top-level total/done/page_info; pagination block removed.
+        assert data["total"] == 0
         assert data["results"] == []
-        assert data["pagination"]["has_more"] is False
+        assert data["done"] is True
+        assert data["next_cursor"] is None
+        assert data["page_info"]["returned_count"] == 0
 
     def test_get_zim_metadata(self, zim_operations: ZimOperations, temp_dir: Path):
         """Test ZIM metadata retrieval."""
@@ -902,8 +905,11 @@ class TestZimOperations:
         ):
             payload, total = zim_operations._perform_search(mock_archive, "test", 10, 0)
             assert isinstance(payload, dict)
-            assert payload["total_results"] == 0
+            # Phase B: total replaces total_results; pagination block removed.
+            assert payload["total"] == 0
             assert payload["results"] == []
+            assert payload["done"] is True
+            assert payload["next_cursor"] is None
             # The legacy markdown rendering still produces the same text,
             # plus an actionable next-step hint that names the two common
             # rescues (suggestions/autocomplete and tell_me_about).


### PR DESCRIPTION
## Phase B of the v2 effort — response contract migration

**Tag target:** v2.0.0a2 (alpha pre-release)
**Spec:** docs/superpowers/specs/2026-05-08-v2-phase-b-response-contract-design.md

### What's in scope (#3 + #13)

- **#3 Standard pagination contract.** Every list-returning tool returns the same five contract keys (`results`, `next_cursor`, `total`, `done`, `page_info`) plus `_meta`.
- **#13 TypedDict everywhere.** Every dict-returning tool migrated from `Dict[str, Any]` to a per-tool TypedDict. FastMCP continues to wrap `Union[<Response>, ToolErrorPayload]` returns in `{"result": ...}` at the wire level (its standard behaviour for multi-arm Union returns); the inner payload now carries a real schema instead of `Dict[str, Any]`.

### Wire-format breaks

This is a clean break from v1.x — no deprecation period (v2 policy). See CHANGELOG for the per-tool key renames table.

Most surgical changes:
- `extract_article_links` requires `kind` (default `"internal"`); single category per call.
- `walk_namespace` cursor type changes from `int` to opaque `str`.
- `search_with_filters` now returns structured dict (was markdown).

### Test surface

- New: `tests/test_pagination_cursor.py`, `tests/test_response_contract.py`, `tests/test_golden_v2_phase_b.py`, `tests/test_tool_schemas.py`.
- Extended: `tests/test_structured_tool_output.py` covers every migrated tool with wrapper-tolerant payload assertions.
- Updated: every per-tool test file reflects the new shape.
- 1259 tests pass, mypy clean, ruff clean.

### Release plan

- Merge this PR into `main`.
- Tag `v2.0.0a2` after merge.
- v2 final tag waits for Phases C–F.