### PR TITLE
feat(v2): Phase C part 2 — get_section + synthesize (#7 + #10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,88 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0a4] — 2026-05-10 (alpha pre-release)
+
+v2 Phase C, part 2: completes the retrieval-primitives phase. Adds the
+`get_section` tool (#7) and the `zim_query(synthesize=True)` mode (#10)
+on top of the EntryBundle infrastructure that shipped in v2.0.0a3.
+**No wire-format breaks** — both new surfaces are additive.
+
+### #7 — New tool `get_section`
+
+```
+get_section(zim_file_path, entry_path, section_id, *, max_chars=None)
+  → Union[GetSectionResponse, ToolErrorPayload]
+```
+
+Returns a single section's body (~500-1500 tokens — small-model sweet
+spot per parent-document-retrieval research) plus full metadata.
+`section_id` values come from `get_table_of_contents`
+(`TocHeading.section_id`). On miss, returns
+`tool_error("section_not_found", extras={"available_section_ids": [...]
+})` so the model can self-correct.
+
+The data layer slices `EntryBundle.rendered_markdown[char_start:char_end]`
+where the bundle's section ranges include subsections (a parent heading's
+`char_end` extends to the next heading at the same or higher level).
+Parent sections therefore return the full subtree body. `max_chars`
+truncates the body and sets `truncated=True` plus `_meta.truncated=True`
+in the envelope for budget-aware clients.
+
+### #10 — New `zim_query(synthesize=True)` mode
+
+```python
+{
+    "query": str,
+    "answer_markdown": str,        # passages + inline [cite: ...] markers
+    "passages": list[SynthesizePassage],
+    "citations": list[Citation],
+    "archives_searched": list[str],
+    "fallback_used": Literal["xapian_score", "rrf_fusion", "reranker"],
+    "total_chars": int,
+    "total_words": int,
+    "_meta": MetaEnvelope,
+}
+```
+
+Pure retrieval + concatenation; no LLM generation. The seven-stage
+pipeline (in `openzim_mcp/synthesize.py`):
+
+1. **Per-archive search** — Xapian top-K hits (`search_top_k` helper
+   on `ZimOperations`).
+2. **RRF fusion** — Reciprocal Rank Fusion (k=60) when multiple archives
+   are searched; identity passthrough for single-archive
+   (`fallback_used="xapian_score"` vs `"rrf_fusion"`).
+3. **Identity rerank** — placeholder for Phase D's cross-encoder.
+4. **Passage extraction** — libzim snippets rendered to markdown.
+5. **Section attribution** — best-effort lookup via `EntryBundle`;
+   passages get `cite_id = "{archive}/{entry_path}#{section_id}"`
+   when the snippet text is found in a section's char range. Bundle
+   build failures keep the cite_id at entry level.
+6. **Budget enforcement** — `output_char_budget` truncates the last
+   passage; subsequent passages are dropped.
+7. **Render + citations** — passages joined with `\n\n` and inline
+   `[cite: ...]` markers; structured `Citation` list deduplicated by
+   `cite_id`.
+
+Zero hits returns an empty response with `_meta.reason="0_hits"`.
+
+### Other
+
+- Extended `tool_error()` with an `extras: Optional[Dict[str, Any]]`
+  kwarg so error payloads can carry self-correction hints (e.g. the
+  `available_section_ids` list above) without `# type: ignore` at
+  call sites.
+- New tests: `tests/test_get_section.py` (4),
+  `tests/test_synthesize.py` (~20 unit + 3 end-to-end),
+  `tests/test_golden_v2_phase_c.py` (3 `get_section` + 3 `synthesize`
+  snapshots, deterministic via the new `v2_phase_c_zim` heading-rich
+  fixture). `test_response_contract` exempts both new tools from the
+  list-pagination contract while still asserting `_meta` is present.
+- The Phase A `_meta` envelope continues to attach on every response.
+  `_meta.truncated` is now correctly forwarded by `get_section_data`
+  on truncation (was a hidden gap in earlier scaffolding).
+
 ## [2.0.0a3] — 2026-05-10 (alpha pre-release)
 
 v2 Phase C, part 1: EntryBundle infrastructure and the four-tool collapse.

--- a/docs/v2/README.md
+++ b/docs/v2/README.md
@@ -29,7 +29,7 @@ These apply across all phases; per-phase specs do not re-litigate them.
 |-------|-------|-------|--------|------|
 | **A** | Quality wins, non-breaking | #1, #2, #4, #5, #14 | **Shipped (v2.0.0a1)** | [2026-05-08-v2-phase-a-quality-wins-design.md](../superpowers/specs/2026-05-08-v2-phase-a-quality-wins-design.md) |
 | **B** | Response contract | #3, #13 | **Shipped (v2.0.0a2)** | [2026-05-08-v2-phase-b-response-contract-design.md](../superpowers/specs/2026-05-08-v2-phase-b-response-contract-design.md) |
-| **C** | New retrieval primitives | #7, #10, #11 | In Progress: #11 **Shipped (v2.0.0a3)**; #7, #10 deferred to a4 | [2026-05-09-v2-phase-c-retrieval-primitives-design.md](../superpowers/specs/2026-05-09-v2-phase-c-retrieval-primitives-design.md) |
+| **C** | New retrieval primitives | #7, #10, #11 | **Shipped (v2.0.0a4)** | [2026-05-09-v2-phase-c-retrieval-primitives-design.md](../superpowers/specs/2026-05-09-v2-phase-c-retrieval-primitives-design.md) |
 | **D** | Optional ML accelerators | #6, #8, #12, #15 | Planned | _TBD_ |
 | **E** | Offline build artifacts | #16, #17 | Planned | _TBD_ |
 | **F** | Tool surface v2 | #9 | Planned | _TBD_ |

--- a/openzim_mcp/async_operations.py
+++ b/openzim_mcp/async_operations.py
@@ -8,11 +8,12 @@ the event loop during I/O-bound operations.
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from .zim_operations import ZimOperations
 
 if TYPE_CHECKING:
+    from .responses import ToolErrorPayload
     from .tool_schemas import (
         ArticleStructureResponse,
         BatchEntryResponse,
@@ -21,6 +22,7 @@ if TYPE_CHECKING:
         EntryResponse,
         EntrySummaryResponse,
         FindEntryResponse,
+        GetSectionResponse,
         LinksResponse,
         ListNamespacesResponse,
         ListZimFilesResponse,
@@ -648,4 +650,20 @@ class AsyncZimOperations:
             zim_file_path,
             entry_path,
             limit,
+        )
+
+    async def get_section_data(
+        self,
+        zim_file_path: str,
+        entry_path: str,
+        section_id: str,
+        max_chars: Optional[int] = None,
+    ) -> "Union[GetSectionResponse, ToolErrorPayload]":
+        """Structured variant of ``get_section`` (async)."""
+        return await asyncio.to_thread(
+            self._ops.get_section_data,
+            zim_file_path,
+            entry_path,
+            section_id,
+            max_chars=max_chars,
         )

--- a/openzim_mcp/responses.py
+++ b/openzim_mcp/responses.py
@@ -8,7 +8,7 @@ helpers in this module standardize the shapes used for error responses
 so every tool emits a recognisable envelope on failure.
 """
 
-from typing import NotRequired, Optional, TypedDict
+from typing import Any, Dict, NotRequired, Optional, TypedDict
 
 
 class ToolErrorPayload(TypedDict):
@@ -31,6 +31,7 @@ def tool_error(
     operation: str,
     message: str,
     context: Optional[str] = None,
+    extras: Optional[Dict[str, Any]] = None,
 ) -> ToolErrorPayload:
     """Build a structured error payload for a failed tool invocation.
 
@@ -40,6 +41,12 @@ def tool_error(
         message: The user-facing error text — typically the markdown blob
             produced by ``_create_enhanced_error_message``.
         context: Optional contextual hint (file path, query, etc.).
+        extras: Optional dict of additional keys to merge into the payload.
+            Useful for attaching self-correction hints (e.g.
+            ``available_section_ids``) without a ``# type: ignore`` at
+            every call site. The extra keys are intentional runtime
+            extensions; ``ToolErrorPayload`` stays narrow in its TypedDict
+            declaration.
 
     Returns:
         A ``ToolErrorPayload`` envelope ready to be returned from an MCP
@@ -52,4 +59,6 @@ def tool_error(
     }
     if context is not None:
         payload["context"] = context
+    if extras:
+        payload.update(extras)  # type: ignore[typeddict-item]
     return payload

--- a/openzim_mcp/server.py
+++ b/openzim_mcp/server.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, Literal, Optional, Union
 
 from mcp.server.fastmcp import FastMCP
 
@@ -19,12 +19,14 @@ from .error_messages import (
 )
 from .exceptions import OpenZimMcpConfigurationError
 from .rate_limiter import RateLimiter
+from .responses import ToolErrorPayload
 from .security import (
     PathValidator,
     redact_paths_in_message,
     sanitize_context_for_error,
 )
 from .simple_tools import SimpleToolsHandler
+from .tool_schemas import SynthesizeResponse
 from .tools import register_all_tools
 from .zim_operations import ZimOperations
 
@@ -209,7 +211,8 @@ class OpenZimMcpServer:
             max_content_length: Optional[int] = None,
             compact: bool = True,
             compact_budget: Optional[Any] = None,
-        ) -> str:
+            synthesize: bool = False,
+        ) -> Union[str, SynthesizeResponse, ToolErrorPayload]:
             """Query ZIM archives using natural language.
 
             Single intelligent tool — parses your query, detects intent,
@@ -270,9 +273,17 @@ class OpenZimMcpServer:
                     window: an 8B-class model on an agentic prompt fits
                     `tiny`, a 70B-class assistant fits `large`. Has no
                     effect when `compact=False`.
+                synthesize: When True, bypass intent classification and
+                    run the synthesize pipeline — multi-archive Xapian
+                    search, RRF fusion, passage extraction, section
+                    attribution, and citation rendering. Returns a
+                    SynthesizeResponse dict instead of markdown text.
+                    Defaults to False (legacy markdown path unchanged).
 
             Returns:
-                Markdown response — article, search list, or listing.
+                Markdown string (synthesize=False) or SynthesizeResponse
+                dict (synthesize=True) with answer_markdown, passages,
+                citations, and archives_searched.
             """
             try:
                 # Build options dict from parameters. Simple mode is for
@@ -297,6 +308,7 @@ class OpenZimMcpServer:
                         max_content_length if max_content_length is not None else 4000
                     ),
                     "compact": compact,
+                    "synthesize": synthesize,
                 }
                 if offset != 0:
                     options["offset"] = offset

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -152,7 +152,16 @@ class SimpleToolsHandler:
         """
         options = options or {}
         if options.get("synthesize"):
-            return self._handle_synthesize_query(query, zim_file_path, options)
+            try:
+                return self._handle_synthesize_query(query, zim_file_path, options)
+            except Exception as e:
+                logger.error(
+                    "Unexpected error in synthesize path: %s", e, exc_info=True
+                )
+                return tool_error(
+                    operation="synthesize_pipeline_error",
+                    message=f"Synthesize pipeline failed: {e}",
+                )
         try:
             # Reject empty / whitespace-only queries upfront. The router
             # would otherwise classify the input as a low-confidence search

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -12,14 +12,20 @@ re-exported here for backward-compatibility with existing imports.
 import logging
 import re
 from collections import Counter
+from contextlib import ExitStack
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
+
+import openzim_mcp.zim_operations as _zim_ops_mod
 
 from . import compact_renderers
 from .exceptions import RegexTimeoutError
 from .intent_parser import IntentParser, safe_regex_sub
 from .meta import build_meta, format_footer
+from .responses import ToolErrorPayload, tool_error
 from .security import sanitize_context_for_error
+from .tool_schemas import SynthesizeResponse
 from .zim_operations import ZimOperations
 
 logger = logging.getLogger(__name__)
@@ -129,7 +135,7 @@ class SimpleToolsHandler:
         query: str,
         zim_file_path: Optional[str] = None,
         options: Optional[Dict[str, Any]] = None,
-    ) -> str:
+    ) -> Union[str, SynthesizeResponse, ToolErrorPayload]:
         """Handle a natural language query about ZIM file content.
 
         This is the main intelligent tool that routes queries to appropriate
@@ -141,8 +147,12 @@ class SimpleToolsHandler:
             options: Optional dict with advanced options (limit, offset, etc.)
 
         Returns:
-            Response string with results
+            Markdown string (synthesize=False) or SynthesizeResponse
+            (synthesize=True) or ToolErrorPayload on error.
         """
+        options = options or {}
+        if options.get("synthesize"):
+            return self._handle_synthesize_query(query, zim_file_path, options)
         try:
             # Reject empty / whitespace-only queries upfront. The router
             # would otherwise classify the input as a low-confidence search
@@ -174,7 +184,6 @@ class SimpleToolsHandler:
             if self._is_meta_only_query(query):
                 self._track("meta_only_guidance")
                 return self._meta_query_guidance()
-            options = options or {}
             intent, params, confidence = self.intent_parser.parse_intent(query)
             logger.info(
                 f"Parsed intent: {intent}, params: {params}, "
@@ -1542,6 +1551,91 @@ class SimpleToolsHandler:
         "get_zim_entries": _handle_get_zim_entries,
         "get_section": _handle_get_section,
     }
+
+    def _handle_synthesize_query(
+        self,
+        query: str,
+        zim_file_path: Optional[str],
+        options: Dict[str, Any],
+    ) -> Union[SynthesizeResponse, ToolErrorPayload]:
+        """Phase C: dispatch query to the synthesize pipeline.
+
+        Opens archives using ExitStack (clean lifecycle, no leaks), calls
+        synthesize_query, and returns a SynthesizeResponse or ToolErrorPayload.
+
+        Archive resolution:
+          - If zim_file_path is provided, validate and open that single archive.
+          - Otherwise, discover all ZIM files via list_zim_files_data() and
+            open all of them (multi-archive RRF fusion path).
+
+        search_handler is self.zim_operations — ZimOperations has search_top_k
+        directly, satisfying the synthesize pipeline's duck-typed interface.
+        """
+        from openzim_mcp.synthesize import synthesize_query
+
+        # Resolve the set of archive paths to open.
+        archives_to_open: list[Path] = []
+        if zim_file_path:
+            try:
+                validated = self.zim_operations.path_validator.validate_path(
+                    zim_file_path
+                )
+                validated = self.zim_operations.path_validator.validate_zim_file(
+                    validated
+                )
+                archives_to_open = [validated]
+            except Exception as e:
+                return tool_error(
+                    operation="invalid_path",
+                    message=f"Invalid ZIM file path: {e}",
+                )
+        else:
+            try:
+                file_entries = self.zim_operations.list_zim_files_data()
+                archives_to_open = [
+                    Path(str(entry["path"]))
+                    for entry in file_entries
+                    if entry.get("path")
+                ]
+            except Exception as e:
+                logger.warning("list_zim_files_data failed in synthesize: %s", e)
+                archives_to_open = []
+
+        if not archives_to_open:
+            return tool_error(
+                operation="no_archives_available",
+                message=(
+                    "No ZIM archives are available. "
+                    "Specify a zim_file_path or configure allowed_directories."
+                ),
+            )
+
+        with ExitStack() as stack:
+            archives: list = []
+            for vp in archives_to_open:
+                try:
+                    archive = stack.enter_context(_zim_ops_mod.zim_archive(vp))
+                    archives.append((archive, vp))
+                except Exception as e:
+                    logger.warning(
+                        "Could not open archive %s for synthesize: %s", vp, e
+                    )
+                    continue
+
+            if not archives:
+                return tool_error(
+                    operation="no_archives_available",
+                    message="No ZIM archives could be opened for synthesize.",
+                )
+
+            return synthesize_query(
+                query,
+                archives=archives,
+                search_handler=self.zim_operations,
+                cache=self.zim_operations.cache,
+                content_processor=self.zim_operations.content_processor,
+                config=self.zim_operations.config.synthesize,
+            )
 
     def _resolve_zim_path(self, candidate: str) -> Optional[str]:
         """Try to resolve ``candidate`` to a real ZIM file's full path.

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -153,7 +153,7 @@ class SimpleToolsHandler:
         options = options or {}
         if options.get("synthesize"):
             try:
-                return self._handle_synthesize_query(query, zim_file_path, options)
+                return self._handle_synthesize_query(query, zim_file_path)
             except Exception as e:
                 logger.error(
                     "Unexpected error in synthesize path: %s", e, exc_info=True
@@ -1565,7 +1565,6 @@ class SimpleToolsHandler:
         self,
         query: str,
         zim_file_path: Optional[str],
-        options: Dict[str, Any],
     ) -> Union[SynthesizeResponse, ToolErrorPayload]:
         """Phase C: dispatch query to the synthesize pipeline.
 

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -72,7 +72,7 @@ def _rrf_fuse(
 
 
 def _per_archive_search(
-    archive: "Archive",
+    archive: Archive,
     *,
     search_handler: Any,  # SearchToolsHandler — typed loosely to avoid circular import
     query: str,
@@ -94,7 +94,7 @@ def _extract_passages(
     hits: list[dict],
     *,
     archive_name: str,
-    content_processor: "ContentProcessor",
+    content_processor: ContentProcessor,
 ) -> list[SynthesizePassage]:
     """Convert hit dicts into SynthesizePassage entries.
 
@@ -284,17 +284,17 @@ def _build_citations(
 def synthesize_query(
     query: str,
     *,
-    archives: list[tuple["Archive", "Path"]],  # (archive, validated_path) pairs
+    archives: list[tuple[Archive, Path]],  # (archive, validated_path) pairs
     search_handler: Any,
-    cache: "OpenZimMcpCache",
-    content_processor: "ContentProcessor",
-    config: "SynthesizeConfig",
+    cache: OpenZimMcpCache,
+    content_processor: ContentProcessor,
+    config: SynthesizeConfig,
 ) -> SynthesizeResponse:
     """Run the synthesize pipeline end-to-end."""
     # Stage 1: per-archive search
     per_archive_hits: list[list[dict]] = []
     archives_searched: list[str] = []
-    archive_by_name: dict[str, tuple["Archive", "Path"]] = {}
+    archive_by_name: dict[str, tuple[Archive, Path]] = {}
     for archive, validated_path in archives:
         archive_name = validated_path.stem
         archives_searched.append(archive_name)
@@ -370,7 +370,7 @@ def synthesize_query(
         p["rank"] = i
 
     # Stage 5: section attribution
-    archive_for_path: dict[str, tuple["Archive", "Path"]] = {}
+    archive_for_path: dict[str, tuple[Archive, Path]] = {}
     for archive_name, hit in top_hits:
         archive_for_path[hit["path"]] = archive_by_name[archive_name]
 

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from openzim_mcp.config import SynthesizeConfig
     from openzim_mcp.content_processor import ContentProcessor
 
+from openzim_mcp.bundle import get_or_build_bundle
 from openzim_mcp.tool_schemas import Citation, SynthesizePassage, SynthesizeResponse
 
 logger = logging.getLogger(__name__)
@@ -276,7 +277,7 @@ def _build_citations(
 
 
 # ---------------------------------------------------------------------------
-# synthesize_query — main entry point (skeleton; stages added in Tasks 18-21)
+# synthesize_query — main entry point
 # ---------------------------------------------------------------------------
 
 
@@ -289,14 +290,16 @@ def synthesize_query(
     content_processor: "ContentProcessor",
     config: "SynthesizeConfig",
 ) -> SynthesizeResponse:
-    """Run the synthesize pipeline. Stages added incrementally in Tasks 18-21."""
+    """Run the synthesize pipeline end-to-end."""
     # Stage 1: per-archive search
-    per_archive_results: list[list[dict]] = []
+    per_archive_hits: list[list[dict]] = []
     archives_searched: list[str] = []
+    archive_by_name: dict[str, tuple["Archive", "Path"]] = {}
     for archive, validated_path in archives:
         archive_name = validated_path.stem
         archives_searched.append(archive_name)
-        per_archive_results.append(
+        archive_by_name[archive_name] = (archive, validated_path)
+        per_archive_hits.append(
             _per_archive_search(
                 archive,
                 search_handler=search_handler,
@@ -305,19 +308,127 @@ def synthesize_query(
             )
         )
 
-    # Subsequent stages added in Tasks 18-21 below this line.
-    # For now, return a minimal SynthesizeResponse so the module imports cleanly.
+    hit_to_archive: dict[tuple[str, str], dict] = {}
+    for archive_name, hits in zip(archives_searched, per_archive_hits):
+        for hit in hits:
+            hit_to_archive[(archive_name, hit["path"])] = hit
+
+    # Stage 2-3: fuse + (identity) rerank
+    is_multi = len(archives) > 1
+    top_hits: list[tuple[str, dict]] = []
+    if is_multi:
+        per_archive_rankings = [
+            [(hit["path"], hit["score"]) for hit in hits] for hits in per_archive_hits
+        ]
+        fused = _rrf_fuse(per_archive_rankings, k=60)[: config.top_n]
+        fallback_used: str = "rrf_fusion"
+        for path, fused_score in fused:
+            for archive_name in archives_searched:
+                if (archive_name, path) in hit_to_archive:
+                    h = dict(hit_to_archive[(archive_name, path)])
+                    h["score"] = fused_score
+                    top_hits.append((archive_name, h))
+                    break
+    else:
+        archive_name = archives_searched[0] if archives_searched else "unknown"
+        top_hits = (
+            [(archive_name, hit) for hit in per_archive_hits[0][: config.top_n]]
+            if per_archive_hits
+            else []
+        )
+        fallback_used = "xapian_score"
+
+    # Zero hits short-circuit
+    if not top_hits:
+        return cast(
+            "SynthesizeResponse",
+            {
+                "query": query,
+                "answer_markdown": "",
+                "passages": [],
+                "citations": [],
+                "archives_searched": archives_searched,
+                "fallback_used": fallback_used,
+                "total_chars": 0,
+                "total_words": 0,
+                "_meta": {"reason": "0_hits"},
+            },
+        )
+
+    # Stage 4: passage extraction
+    all_passages: list[SynthesizePassage] = []
+    all_paths: list[str] = []
+    for archive_name, hit in top_hits:
+        passages = _extract_passages(
+            [hit],
+            archive_name=archive_name,
+            content_processor=content_processor,
+        )
+        all_passages.extend(passages)
+        all_paths.append(hit["path"])
+    for i, p in enumerate(all_passages, start=1):
+        p["rank"] = i
+
+    # Stage 5: section attribution
+    archive_for_path: dict[str, tuple["Archive", "Path"]] = {}
+    for archive_name, hit in top_hits:
+        archive_for_path[hit["path"]] = archive_by_name[archive_name]
+
+    def bundle_lookup(entry_path: str) -> Any:
+        pair = archive_for_path.get(entry_path)
+        if pair is None:
+            return None
+        archive_val, validated_path = pair
+        return get_or_build_bundle(
+            archive_val,
+            entry_path,
+            cache=cache,
+            validated_path=validated_path,
+            content_processor=content_processor,
+        )
+
+    attributed = _attribute_sections(
+        all_passages,
+        bundle_lookup=bundle_lookup,
+        hit_paths=all_paths,
+    )
+
+    # Stage 7: budget enforcement
+    capped = _enforce_budget(attributed, char_budget=config.output_char_budget)
+
+    # Stage 6: render + build citations
+    answer_md = _render_answer(capped)
+
+    archive_titles: dict[str, str] = {}
+    section_titles: dict[tuple[str, str], str] = {}
+    for archive_name, hit in top_hits:
+        try:
+            b = bundle_lookup(hit["path"])
+        except Exception:
+            continue
+        if b is None:
+            continue
+        archive_titles[hit["path"]] = b["title"]
+        for s in b["sections"]:
+            section_titles[(hit["path"], s["id"])] = s["title"]
+
+    citations = _build_citations(
+        capped,
+        archive_titles=archive_titles,
+        section_titles=section_titles,
+    )
+
     return cast(
         "SynthesizeResponse",
         {
             "query": query,
-            "answer_markdown": "",
-            "passages": [],
-            "citations": [],
+            "answer_markdown": answer_md,
+            "passages": capped,
+            "citations": citations,
             "archives_searched": archives_searched,
-            "fallback_used": "xapian_score" if len(archives) == 1 else "rrf_fusion",
-            "total_chars": 0,
-            "total_words": 0,
+            "fallback_used": fallback_used,
+            "total_chars": len(answer_md),
+            "total_words": len(answer_md.split()),
             "_meta": {},
         },
     )

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -1,0 +1,53 @@
+"""Server-side synthesize mode for zim_query.
+
+Phase C #10: when zim_query is called with synthesize=True, this module
+runs the pipeline:
+
+    per-archive search → fuse (RRF for multi-archive) → rerank (identity
+    in Phase C; cross-encoder hook in Phase D) → passage extraction via
+    libzim.SearchIterator.getSnippet → section attribution via the
+    EntryBundle → citation rendering → budget enforcement
+
+Returns SynthesizeResponse (defined in tool_schemas.py).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# RRF helper — Reciprocal Rank Fusion
+# ---------------------------------------------------------------------------
+
+
+def _rrf_fuse(
+    rankings: list[list[tuple[str, float]]],
+    *,
+    k: int = 60,
+) -> list[tuple[str, float]]:
+    """Combine multiple per-archive rankings into a single fused ranking.
+
+    For each document, score = sum over rankings of 1 / (k + rank). k=60
+    is the standard from the Cormack et al. reference. Documents missing
+    from a ranking contribute 0 from that ranking.
+
+    Args:
+        rankings: list of per-source rankings; each ranking is a list of
+                  (entry_path, source_score) in rank order.
+        k: smoothing constant.
+
+    Returns:
+        list of (entry_path, fused_score) sorted by fused_score descending.
+    """
+    if not rankings:
+        return []
+    scores: dict[str, float] = defaultdict(float)
+    for ranking in rankings:
+        for rank, (path, _src_score) in enumerate(ranking, start=1):
+            scores[path] += 1.0 / (k + rank)
+    fused = sorted(scores.items(), key=lambda x: x[1], reverse=True)
+    return fused

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -120,6 +120,63 @@ def _extract_passages(
             )
         )
     return passages
+
+
+# ---------------------------------------------------------------------------
+# Pipeline stage 5: section attribution
+# ---------------------------------------------------------------------------
+
+
+def _attribute_sections(
+    passages: list[SynthesizePassage],
+    *,
+    bundle_lookup: Callable[[str], Any],
+    hit_paths: list[str],
+) -> list[SynthesizePassage]:
+    """For each passage, find its containing section in the bundle and append #section_id.
+
+    On bundle-build failure for an entry, leave the cite_id at entry level
+    (no #section suffix). The passage is never dropped — section attribution
+    is best-effort.
+    """
+    attributed: list[SynthesizePassage] = []
+    for passage, hit_path in zip(passages, hit_paths):
+        new_cite_id = passage["cite_id"]
+        try:
+            bundle = bundle_lookup(hit_path)
+        except Exception as e:
+            logger.info(
+                "Bundle build failed for %s during synthesize attribution: %s",
+                hit_path,
+                e,
+            )
+            attributed.append(passage)
+            continue
+
+        if bundle is None:
+            attributed.append(passage)
+            continue
+
+        md = bundle.get("rendered_markdown", "")
+        passage_text = passage["text_markdown"]
+        if not passage_text or not md:
+            attributed.append(passage)
+            continue
+
+        pos = md.find(passage_text)
+        if pos < 0:
+            attributed.append(passage)
+            continue
+
+        for section in bundle.get("sections", []):
+            if section["char_start"] <= pos < section["char_end"]:
+                new_cite_id = f"{passage['cite_id']}#{section['id']}"
+                break
+
+        new_passage = dict(passage)
+        new_passage["cite_id"] = new_cite_id
+        attributed.append(cast(SynthesizePassage, new_passage))
+    return attributed
 
 
 # ---------------------------------------------------------------------------

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from openzim_mcp.config import SynthesizeConfig
     from openzim_mcp.content_processor import ContentProcessor
 
-from openzim_mcp.tool_schemas import SynthesizeResponse
+from openzim_mcp.tool_schemas import SynthesizePassage, SynthesizeResponse
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +82,44 @@ def _per_archive_search(
     Hit shape: {"path": str, "snippet": str, "score": float}.
     """
     return cast(list[dict], search_handler.search_top_k(archive, query, k=k))
+
+
+# ---------------------------------------------------------------------------
+# Pipeline stage 4: passage extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_passages(
+    hits: list[dict],
+    *,
+    archive_name: str,
+    content_processor: "ContentProcessor",
+) -> list[SynthesizePassage]:
+    """Convert hit dicts into SynthesizePassage entries.
+
+    Each hit's snippet (potentially HTML from libzim.getSnippet) is
+    rendered to markdown. cite_id is the entry-level form
+    f"{archive_name}/{path}" — the "#section_id" suffix is added by
+    Stage 5 (_attribute_sections) once the bundle is consulted.
+    """
+    passages: list[SynthesizePassage] = []
+    for rank, hit in enumerate(hits, start=1):
+        snippet = hit.get("snippet") or ""
+        text = content_processor.html_to_plain_text(snippet) if snippet else ""
+        text = text.strip()
+        cite_id = f"{archive_name}/{hit['path']}"
+        passages.append(
+            cast(
+                SynthesizePassage,
+                {
+                    "cite_id": cite_id,
+                    "text_markdown": text,
+                    "rank": rank,
+                    "score": float(hit.get("score", 0.0)),
+                },
+            )
+        )
+    return passages
 
 
 # ---------------------------------------------------------------------------

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -281,17 +281,14 @@ def _build_citations(
 # ---------------------------------------------------------------------------
 
 
-def synthesize_query(
-    query: str,
+def _do_per_archive_search(
+    archives: list[tuple[Archive, Path]],
     *,
-    archives: list[tuple[Archive, Path]],  # (archive, validated_path) pairs
     search_handler: Any,
-    cache: OpenZimMcpCache,
-    content_processor: ContentProcessor,
-    config: SynthesizeConfig,
-) -> SynthesizeResponse:
-    """Run the synthesize pipeline end-to-end."""
-    # Stage 1: per-archive search
+    query: str,
+    k: int,
+) -> tuple[list[list[dict]], list[str], dict[str, tuple[Archive, Path]]]:
+    """Stage 1: run per-archive Xapian search for every archive in the list."""
     per_archive_hits: list[list[dict]] = []
     archives_searched: list[str] = []
     archive_by_name: dict[str, tuple[Archive, Path]] = {}
@@ -301,78 +298,73 @@ def synthesize_query(
         archive_by_name[archive_name] = (archive, validated_path)
         per_archive_hits.append(
             _per_archive_search(
-                archive,
-                search_handler=search_handler,
-                query=query,
-                k=config.per_archive_k,
+                archive, search_handler=search_handler, query=query, k=k
             )
         )
+    return per_archive_hits, archives_searched, archive_by_name
 
-    hit_to_archive: dict[tuple[str, str], dict] = {}
-    for archive_name, hits in zip(archives_searched, per_archive_hits):
-        for hit in hits:
-            hit_to_archive[(archive_name, hit["path"])] = hit
 
-    # Stage 2-3: fuse + (identity) rerank
-    is_multi = len(archives) > 1
+def _select_top_hits(
+    per_archive_hits: list[list[dict]],
+    archives_searched: list[str],
+    *,
+    top_n: int,
+) -> tuple[list[tuple[str, dict]], str]:
+    """Stages 2–3: fuse (RRF for multi-archive, identity for single) + rerank.
+
+    Returns ``(top_hits, fallback_used)`` where ``top_hits`` is a list of
+    ``(archive_name, hit)`` tuples and ``fallback_used`` is
+    ``"rrf_fusion"`` or ``"xapian_score"``.
+    """
+    if len(per_archive_hits) > 1:
+        return _select_top_hits_multi(per_archive_hits, archives_searched, top_n=top_n)
+    archive_name = archives_searched[0] if archives_searched else "unknown"
+    top_hits = (
+        [(archive_name, hit) for hit in per_archive_hits[0][:top_n]]
+        if per_archive_hits
+        else []
+    )
+    return top_hits, "xapian_score"
+
+
+def _select_top_hits_multi(
+    per_archive_hits: list[list[dict]],
+    archives_searched: list[str],
+    *,
+    top_n: int,
+) -> tuple[list[tuple[str, dict]], str]:
+    """Multi-archive RRF fusion path of :func:`_select_top_hits`."""
+    hit_to_archive: dict[tuple[str, str], dict] = {
+        (archive_name, hit["path"]): hit
+        for archive_name, hits in zip(archives_searched, per_archive_hits)
+        for hit in hits
+    }
+    rankings = [
+        [(hit["path"], hit["score"]) for hit in hits] for hits in per_archive_hits
+    ]
+    fused = _rrf_fuse(rankings, k=60)[:top_n]
     top_hits: list[tuple[str, dict]] = []
-    if is_multi:
-        per_archive_rankings = [
-            [(hit["path"], hit["score"]) for hit in hits] for hits in per_archive_hits
-        ]
-        fused = _rrf_fuse(per_archive_rankings, k=60)[: config.top_n]
-        fallback_used: str = "rrf_fusion"
-        for path, fused_score in fused:
-            for archive_name in archives_searched:
-                if (archive_name, path) in hit_to_archive:
-                    h = dict(hit_to_archive[(archive_name, path)])
-                    h["score"] = fused_score
-                    top_hits.append((archive_name, h))
-                    break
-    else:
-        archive_name = archives_searched[0] if archives_searched else "unknown"
-        top_hits = (
-            [(archive_name, hit) for hit in per_archive_hits[0][: config.top_n]]
-            if per_archive_hits
-            else []
-        )
-        fallback_used = "xapian_score"
+    for path, fused_score in fused:
+        for archive_name in archives_searched:
+            if (archive_name, path) in hit_to_archive:
+                h = dict(hit_to_archive[(archive_name, path)])
+                h["score"] = fused_score
+                top_hits.append((archive_name, h))
+                break
+    return top_hits, "rrf_fusion"
 
-    # Zero hits short-circuit
-    if not top_hits:
-        return cast(
-            "SynthesizeResponse",
-            {
-                "query": query,
-                "answer_markdown": "",
-                "passages": [],
-                "citations": [],
-                "archives_searched": archives_searched,
-                "fallback_used": fallback_used,
-                "total_chars": 0,
-                "total_words": 0,
-                "_meta": {"reason": "0_hits"},
-            },
-        )
 
-    # Stage 4: passage extraction
-    all_passages: list[SynthesizePassage] = []
-    all_paths: list[str] = []
-    for archive_name, hit in top_hits:
-        passages = _extract_passages(
-            [hit],
-            archive_name=archive_name,
-            content_processor=content_processor,
-        )
-        all_passages.extend(passages)
-        all_paths.append(hit["path"])
-    for i, p in enumerate(all_passages, start=1):
-        p["rank"] = i
-
-    # Stage 5: section attribution
-    archive_for_path: dict[str, tuple[Archive, Path]] = {}
-    for archive_name, hit in top_hits:
-        archive_for_path[hit["path"]] = archive_by_name[archive_name]
+def _make_bundle_lookup(
+    top_hits: list[tuple[str, dict]],
+    archive_by_name: dict[str, tuple[Archive, Path]],
+    *,
+    cache: OpenZimMcpCache,
+    content_processor: ContentProcessor,
+) -> Callable[[str], Any]:
+    """Build a path→bundle closure used by attribution and citation lookups."""
+    archive_for_path: dict[str, tuple[Archive, Path]] = {
+        hit["path"]: archive_by_name[archive_name] for archive_name, hit in top_hits
+    }
 
     def bundle_lookup(entry_path: str) -> Any:
         pair = archive_for_path.get(entry_path)
@@ -387,21 +379,44 @@ def synthesize_query(
             content_processor=content_processor,
         )
 
-    attributed = _attribute_sections(
-        all_passages,
-        bundle_lookup=bundle_lookup,
-        hit_paths=all_paths,
-    )
+    return bundle_lookup
 
-    # Stage 7: budget enforcement
-    capped = _enforce_budget(attributed, char_budget=config.output_char_budget)
 
-    # Stage 6: render + build citations
-    answer_md = _render_answer(capped)
+def _extract_passages_for_top_hits(
+    top_hits: list[tuple[str, dict]],
+    *,
+    content_processor: ContentProcessor,
+) -> tuple[list[SynthesizePassage], list[str]]:
+    """Stage 4: extract per-hit passages and renumber rank globally."""
+    all_passages: list[SynthesizePassage] = []
+    all_paths: list[str] = []
+    for archive_name, hit in top_hits:
+        all_passages.extend(
+            _extract_passages(
+                [hit],
+                archive_name=archive_name,
+                content_processor=content_processor,
+            )
+        )
+        all_paths.append(hit["path"])
+    for i, p in enumerate(all_passages, start=1):
+        p["rank"] = i
+    return all_passages, all_paths
 
+
+def _build_section_lookups(
+    top_hits: list[tuple[str, dict]],
+    bundle_lookup: Callable[[str], Any],
+) -> tuple[dict[str, str], dict[tuple[str, str], str]]:
+    """Per-(entry, section) title maps used by :func:`_build_citations`.
+
+    Bundle build failures are swallowed at info level by the caller pattern
+    (the bundle is best-effort); on failure the entry is skipped and its
+    citations stay at entry level.
+    """
     archive_titles: dict[str, str] = {}
     section_titles: dict[tuple[str, str], str] = {}
-    for archive_name, hit in top_hits:
+    for _, hit in top_hits:
         try:
             b = bundle_lookup(hit["path"])
         except Exception:
@@ -411,13 +426,68 @@ def synthesize_query(
         archive_titles[hit["path"]] = b["title"]
         for s in b["sections"]:
             section_titles[(hit["path"], s["id"])] = s["title"]
+    return archive_titles, section_titles
 
-    citations = _build_citations(
-        capped,
-        archive_titles=archive_titles,
-        section_titles=section_titles,
+
+def _zero_hits_response(
+    query: str, archives_searched: list[str], fallback_used: str
+) -> SynthesizeResponse:
+    return cast(
+        "SynthesizeResponse",
+        {
+            "query": query,
+            "answer_markdown": "",
+            "passages": [],
+            "citations": [],
+            "archives_searched": archives_searched,
+            "fallback_used": fallback_used,
+            "total_chars": 0,
+            "total_words": 0,
+            "_meta": {"reason": "0_hits"},
+        },
     )
 
+
+def synthesize_query(
+    query: str,
+    *,
+    archives: list[tuple[Archive, Path]],  # (archive, validated_path) pairs
+    search_handler: Any,
+    cache: OpenZimMcpCache,
+    content_processor: ContentProcessor,
+    config: SynthesizeConfig,
+) -> SynthesizeResponse:
+    """Run the synthesize pipeline end-to-end."""
+    per_archive_hits, archives_searched, archive_by_name = _do_per_archive_search(
+        archives,
+        search_handler=search_handler,
+        query=query,
+        k=config.per_archive_k,
+    )
+    top_hits, fallback_used = _select_top_hits(
+        per_archive_hits, archives_searched, top_n=config.top_n
+    )
+    if not top_hits:
+        return _zero_hits_response(query, archives_searched, fallback_used)
+
+    all_passages, all_paths = _extract_passages_for_top_hits(
+        top_hits, content_processor=content_processor
+    )
+    bundle_lookup = _make_bundle_lookup(
+        top_hits,
+        archive_by_name,
+        cache=cache,
+        content_processor=content_processor,
+    )
+    attributed = _attribute_sections(
+        all_passages, bundle_lookup=bundle_lookup, hit_paths=all_paths
+    )
+    capped = _enforce_budget(attributed, char_budget=config.output_char_budget)
+    answer_md = _render_answer(capped)
+    archive_titles, section_titles = _build_section_lookups(top_hits, bundle_lookup)
+    citations = _build_citations(
+        capped, archive_titles=archive_titles, section_titles=section_titles
+    )
     return cast(
         "SynthesizeResponse",
         {

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Callable, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from openzim_mcp.config import SynthesizeConfig
     from openzim_mcp.content_processor import ContentProcessor
 
-from openzim_mcp.tool_schemas import SynthesizePassage, SynthesizeResponse
+from openzim_mcp.tool_schemas import Citation, SynthesizePassage, SynthesizeResponse
 
 logger = logging.getLogger(__name__)
 
@@ -177,6 +177,102 @@ def _attribute_sections(
         new_passage["cite_id"] = new_cite_id
         attributed.append(cast(SynthesizePassage, new_passage))
     return attributed
+
+
+# ---------------------------------------------------------------------------
+# Pipeline stage 6: answer rendering
+# ---------------------------------------------------------------------------
+
+
+def _render_answer(passages: list[SynthesizePassage]) -> str:
+    """Concatenate passages with inline [cite: ...] markers."""
+    parts: list[str] = []
+    for p in passages:
+        parts.append(f"{p['text_markdown']}\n[cite: {p['cite_id']}]")
+    return "\n\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Pipeline stage 7: budget enforcement
+# ---------------------------------------------------------------------------
+
+
+def _enforce_budget(
+    passages: list[SynthesizePassage],
+    *,
+    char_budget: int,
+) -> list[SynthesizePassage]:
+    """Truncate passages so total text_markdown chars <= char_budget.
+
+    Iterates in rank order; the last passage that doesn't fit is truncated
+    to fit the remaining budget. Subsequent passages are dropped if budget
+    is exhausted. Citation markers are NOT counted against the budget
+    (they're small and rendering happens after this stage).
+    """
+    budget = char_budget
+    capped: list[SynthesizePassage] = []
+    for p in passages:
+        body = p["text_markdown"]
+        if len(body) <= budget:
+            capped.append(p)
+            budget -= len(body)
+            continue
+        if budget > 0:
+            new_p = dict(p)
+            new_p["text_markdown"] = body[:budget]
+            capped.append(cast("SynthesizePassage", new_p))
+        break
+    return capped
+
+
+# ---------------------------------------------------------------------------
+# Pipeline stage 8: citation building
+# ---------------------------------------------------------------------------
+
+
+def _parse_cite_id(cite_id: str) -> tuple[str, str, Optional[str]]:
+    """Decompose 'archive/entry_path#section_id' into its parts.
+
+    archive/entry_path is everything before '#'; section_id is the suffix
+    after '#' (or None if absent). The archive identifier is the FIRST
+    path segment (basename of the .zim, minus extension).
+    """
+    base, _, section_id = cite_id.partition("#")
+    archive, _, entry_path = base.partition("/")
+    return archive, entry_path, (section_id or None)
+
+
+def _build_citations(
+    passages: list[SynthesizePassage],
+    *,
+    archive_titles: dict[str, str],  # entry_path -> entry title
+    section_titles: dict[
+        tuple[str, str], str
+    ],  # (entry_path, section_id) -> section title
+) -> list[Citation]:
+    """Expand passages' cite_ids into Citation entries; dedupe by cite_id."""
+    seen: dict[str, Citation] = {}
+    for p in passages:
+        cite_id = p["cite_id"]
+        if cite_id in seen:
+            continue
+        archive, entry_path, section_id = _parse_cite_id(cite_id)
+        title = archive_titles.get(entry_path, entry_path)
+        section_title = (
+            section_titles.get((entry_path, section_id)) if section_id else None
+        )
+        seen[cite_id] = cast(
+            "Citation",
+            {
+                "cite_id": cite_id,
+                "archive": archive,
+                "entry_path": entry_path,
+                "title": title,
+                "section_id": section_id,
+                "section_title": section_title,
+            },
+        )
+    return list(seen.values())
 
 
 # ---------------------------------------------------------------------------

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -15,6 +15,18 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from libzim.reader import Archive  # type: ignore[import-untyped]
+
+    from openzim_mcp.cache import OpenZimMcpCache
+    from openzim_mcp.config import SynthesizeConfig
+    from openzim_mcp.content_processor import ContentProcessor
+
+from openzim_mcp.tool_schemas import SynthesizeResponse
 
 logger = logging.getLogger(__name__)
 
@@ -51,3 +63,70 @@ def _rrf_fuse(
             scores[path] += 1.0 / (k + rank)
     fused = sorted(scores.items(), key=lambda x: x[1], reverse=True)
     return fused
+
+
+# ---------------------------------------------------------------------------
+# Pipeline stage 1: per-archive search
+# ---------------------------------------------------------------------------
+
+
+def _per_archive_search(
+    archive: "Archive",
+    *,
+    search_handler: Any,  # SearchToolsHandler — typed loosely to avoid circular import
+    query: str,
+    k: int,
+) -> list[dict]:
+    """Run Xapian search on one archive, return top-K hits as dicts.
+
+    Hit shape: {"path": str, "snippet": str, "score": float}.
+    """
+    return cast(list[dict], search_handler.search_top_k(archive, query, k=k))
+
+
+# ---------------------------------------------------------------------------
+# synthesize_query — main entry point (skeleton; stages added in Tasks 18-21)
+# ---------------------------------------------------------------------------
+
+
+def synthesize_query(
+    query: str,
+    *,
+    archives: list[tuple["Archive", "Path"]],  # (archive, validated_path) pairs
+    search_handler: Any,
+    cache: "OpenZimMcpCache",
+    content_processor: "ContentProcessor",
+    config: "SynthesizeConfig",
+) -> SynthesizeResponse:
+    """Run the synthesize pipeline. Stages added incrementally in Tasks 18-21."""
+    # Stage 1: per-archive search
+    per_archive_results: list[list[dict]] = []
+    archives_searched: list[str] = []
+    for archive, validated_path in archives:
+        archive_name = validated_path.stem
+        archives_searched.append(archive_name)
+        per_archive_results.append(
+            _per_archive_search(
+                archive,
+                search_handler=search_handler,
+                query=query,
+                k=config.per_archive_k,
+            )
+        )
+
+    # Subsequent stages added in Tasks 18-21 below this line.
+    # For now, return a minimal SynthesizeResponse so the module imports cleanly.
+    return cast(
+        "SynthesizeResponse",
+        {
+            "query": query,
+            "answer_markdown": "",
+            "passages": [],
+            "citations": [],
+            "archives_searched": archives_searched,
+            "fallback_used": "xapian_score" if len(archives) == 1 else "rrf_fusion",
+            "total_chars": 0,
+            "total_words": 0,
+            "_meta": {},
+        },
+    )

--- a/openzim_mcp/tools/structure_tools.py
+++ b/openzim_mcp/tools/structure_tools.py
@@ -11,6 +11,7 @@ from ..tool_schemas import (
     ArticleStructureResponse,
     BinaryEntryResponse,
     EntrySummaryResponse,
+    GetSectionResponse,
     LinksResponse,
     RelatedArticlesResponse,
     TableOfContentsResponse,
@@ -35,6 +36,7 @@ def register_structure_tools(server: "OpenZimMcpServer") -> None:
     _register_get_table_of_contents(server)
     _register_get_binary_entry(server)
     _register_get_related_articles(server)
+    _register_get_section(server)
 
 
 def _register_get_article_structure(server: "OpenZimMcpServer") -> None:
@@ -515,4 +517,70 @@ def _register_get_related_articles(server: "OpenZimMcpServer") -> None:
                     context=f"File: {zim_file_path}, Entry: {entry_path}",
                 ),
                 context=f"File: {zim_file_path}, Entry: {entry_path}",
+            )
+
+
+def _register_get_section(server: "OpenZimMcpServer") -> None:
+    @server.mcp.tool()
+    async def get_section(
+        zim_file_path: str,
+        entry_path: str,
+        section_id: str,
+        max_chars: Optional[int] = None,
+    ) -> Union[GetSectionResponse, ToolErrorPayload]:
+        """Fetch a single section from an entry by its section_id.
+
+        section_id values come from get_table_of_contents (TocHeading.section_id)
+        or get_article_structure (heading[].id). Returns the section body as
+        markdown plus metadata. Sections are sized for direct consumption
+        (≈500-1500 tokens); a max_chars cap truncates the body and sets
+        truncated=True.
+
+        On a miss (no section with that id), returns a ToolErrorPayload with
+        error="section_not_found" and available_section_ids in the payload so
+        the model can self-correct.
+
+        Args:
+            zim_file_path: Path to the ZIM file.
+            entry_path: Entry path (e.g., 'A/Berlin').
+            section_id: Section identifier from TOC.
+            max_chars: Optional cap on section body chars (default uses
+                       config.content.max_content_length).
+        """
+        try:
+            try:
+                server.rate_limiter.check_rate_limit("get_structure")
+            except OpenZimMcpRateLimitError as e:
+                return tool_error(
+                    operation="get section",
+                    message=server._create_enhanced_error_message(
+                        operation="get section",
+                        error=e,
+                        context=f"Entry: {entry_path}, section_id: {section_id}",
+                    ),
+                    context=f"Entry: {entry_path}, section_id: {section_id}",
+                )
+
+            zim_file_path = sanitize_input(zim_file_path, INPUT_LIMIT_FILE_PATH)
+            entry_path = sanitize_input(entry_path, INPUT_LIMIT_ENTRY_PATH)
+
+            return await server.async_zim_operations.get_section_data(
+                zim_file_path,
+                entry_path,
+                section_id,
+                max_chars=max_chars,
+            )
+
+        except Exception as e:
+            logger.error(f"Error in get_section: {e}")
+            return tool_error(
+                operation="get section",
+                message=server._create_enhanced_error_message(
+                    operation="get section",
+                    error=e,
+                    context=f"File: {zim_file_path}, Entry: {entry_path}, "
+                    f"section_id: {section_id}",
+                ),
+                context=f"File: {zim_file_path}, Entry: {entry_path}, "
+                f"section_id: {section_id}",
             )

--- a/openzim_mcp/tools/structure_tools.py
+++ b/openzim_mcp/tools/structure_tools.py
@@ -521,6 +521,8 @@ def _register_get_related_articles(server: "OpenZimMcpServer") -> None:
 
 
 def _register_get_section(server: "OpenZimMcpServer") -> None:
+    _op = "get section"
+
     @server.mcp.tool()
     async def get_section(
         zim_file_path: str,
@@ -552,9 +554,9 @@ def _register_get_section(server: "OpenZimMcpServer") -> None:
                 server.rate_limiter.check_rate_limit("get_structure")
             except OpenZimMcpRateLimitError as e:
                 return tool_error(
-                    operation="get section",
+                    operation=_op,
                     message=server._create_enhanced_error_message(
-                        operation="get section",
+                        operation=_op,
                         error=e,
                         context=f"Entry: {entry_path}, section_id: {section_id}",
                     ),
@@ -574,9 +576,9 @@ def _register_get_section(server: "OpenZimMcpServer") -> None:
         except Exception as e:
             logger.error(f"Error in get_section: {e}")
             return tool_error(
-                operation="get section",
+                operation=_op,
                 message=server._create_enhanced_error_message(
-                    operation="get section",
+                    operation=_op,
                     error=e,
                     context=f"File: {zim_file_path}, Entry: {entry_path}, "
                     f"section_id: {section_id}",

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -1977,3 +1977,39 @@ class _SearchMixin:
             indent=2,
             ensure_ascii=False,
         )
+
+    def search_top_k(self, archive: "Archive", query: str, *, k: int) -> list[dict]:
+        """Top-K Xapian results from an open archive as a flat dict list.
+
+        Used by synthesize.py as the primary stage of the pipeline.  Each hit
+        has the shape ``{"path": str, "snippet": str, "score": float}``.
+
+        ``path`` is the entry path string returned directly by
+        ``search.getResults()`` (entry_id IS the path in libzim 9+).
+        ``snippet`` is produced by ``_get_entry_snippet`` (content-processor
+        extract, consistent with the rest of the search surface).
+        ``score`` is set to the hit's rank-based inverse (1 / rank) as a
+        lightweight proxy — libzim's Xapian binding does not expose raw BM25
+        scores through the public Python API.
+        """
+        query_obj = _zim_ops_mod.Query().set_query(query)
+        searcher = _zim_ops_mod.Searcher(archive)
+        search = searcher.search(query_obj)
+        total_results = search.getEstimatedMatches()
+        if total_results == 0:
+            return []
+        result_count = min(k, total_results)
+        entry_ids: List[str] = list(search.getResults(0, result_count))
+        hits: list[dict] = []
+        for rank, entry_id in enumerate(entry_ids, start=1):
+            try:
+                entry = archive.get_entry_by_path(entry_id)
+                snippet = self._get_entry_snippet(entry, query=query)
+            except Exception as exc:
+                logger.warning(
+                    f"search_top_k: error fetching entry {entry_id!r}: {exc}"
+                )
+                snippet = ""
+            score = 1.0 / rank  # rank-inverse proxy; no raw BM25 in libzim Python API
+            hits.append({"path": entry_id, "snippet": snippet, "score": score})
+        return hits

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -545,20 +545,14 @@ class _StructureMixin:
             None,
         )
         if section is None:
-            err = tool_error(
+            return tool_error(
                 operation="section_not_found",
                 message=(
                     f"No section with id={section_id!r} in entry {entry_path!r}. "
                     f"Use get_table_of_contents to list available section IDs."
                 ),
+                extras={"available_section_ids": [s["id"] for s in bundle["sections"]]},
             )
-            # Attach available_section_ids so the model can self-correct.
-            # ToolErrorPayload is a plain dict at runtime; the extra key is
-            # safe even though the TypedDict does not declare it.
-            err["available_section_ids"] = [  # type: ignore[typeddict-unknown-key]
-                s["id"] for s in bundle["sections"]
-            ]
-            return err
 
         body = bundle["rendered_markdown"][section["char_start"] : section["char_end"]]
         cap = (
@@ -587,7 +581,7 @@ class _StructureMixin:
         )
         return cast(
             "GetSectionResponse",
-            attach_meta(cast(Dict[str, Any], payload)),
+            attach_meta(cast(Dict[str, Any], payload), truncated=truncated),
         )
 
     def get_related_articles_data(

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -13,14 +13,19 @@ without changes.
 import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 
 from libzim.reader import Archive  # type: ignore[import-untyped]
 
 import openzim_mcp.zim_operations as _zim_ops_mod
-from openzim_mcp.exceptions import OpenZimMcpArchiveError, OpenZimMcpValidationError
+from openzim_mcp.exceptions import (
+    OpenZimMcpArchiveError,
+    OpenZimMcpFileNotFoundError,
+    OpenZimMcpValidationError,
+)
 from openzim_mcp.meta import attach_meta
 from openzim_mcp.pagination import Cursor
+from openzim_mcp.responses import ToolErrorPayload, tool_error
 
 if TYPE_CHECKING:
     from openzim_mcp.cache import OpenZimMcpCache
@@ -29,6 +34,7 @@ if TYPE_CHECKING:
     from openzim_mcp.security import PathValidator
     from openzim_mcp.tool_schemas import (
         ArticleStructureResponse,
+        GetSectionResponse,
         LinksResponse,
         RelatedArticlesResponse,
         SectionMeta,
@@ -486,6 +492,103 @@ class _StructureMixin:
             raise OpenZimMcpArchiveError(
                 f"Failed to extract table of contents: {e}"
             ) from e
+
+    def get_section_data(
+        self,
+        zim_file_path: str,
+        entry_path: str,
+        section_id: str,
+        *,
+        max_chars: "Optional[int]" = None,
+    ) -> "Union[GetSectionResponse, ToolErrorPayload]":
+        """Public entry point for the get_section tool.
+
+        Returns the typed response or a ToolErrorPayload on
+        file-not-found / entry-not-found / section-not-found.
+        """
+        try:
+            validated_path = self.path_validator.validate_path(zim_file_path)
+            validated_path = self.path_validator.validate_zim_file(validated_path)
+            with _zim_ops_mod.zim_archive(validated_path) as archive:
+                return self._get_section_data(
+                    archive, validated_path, entry_path, section_id, max_chars
+                )
+        except OpenZimMcpFileNotFoundError as e:
+            return tool_error(operation="file_not_found", message=str(e))
+        except OpenZimMcpArchiveError as e:
+            return tool_error(operation="entry_not_found", message=str(e))
+
+    def _get_section_data(
+        self,
+        archive: Archive,
+        validated_path: Path,
+        entry_path: str,
+        section_id: str,
+        max_chars: "Optional[int]",
+    ) -> "Union[GetSectionResponse, ToolErrorPayload]":
+        """Build the bundle, find the section by id, and return GetSectionResponse.
+
+        Returns a ToolErrorPayload if the section_id is not found in the bundle.
+        """
+        from openzim_mcp.bundle import get_or_build_bundle
+
+        bundle = get_or_build_bundle(
+            archive,
+            entry_path,
+            cache=self.cache,
+            validated_path=validated_path,
+            content_processor=self.content_processor,
+        )
+
+        section = next(
+            (s for s in bundle["sections"] if s["id"] == section_id),
+            None,
+        )
+        if section is None:
+            err = tool_error(
+                operation="section_not_found",
+                message=(
+                    f"No section with id={section_id!r} in entry {entry_path!r}. "
+                    f"Use get_table_of_contents to list available section IDs."
+                ),
+            )
+            # Attach available_section_ids so the model can self-correct.
+            # ToolErrorPayload is a plain dict at runtime; the extra key is
+            # safe even though the TypedDict does not declare it.
+            err["available_section_ids"] = [  # type: ignore[typeddict-unknown-key]
+                s["id"] for s in bundle["sections"]
+            ]
+            return err
+
+        body = bundle["rendered_markdown"][section["char_start"] : section["char_end"]]
+        cap = (
+            max_chars
+            if max_chars is not None
+            else self.config.content.max_content_length
+        )
+        truncated = len(body) > cap
+        if truncated:
+            body = body[:cap]
+
+        payload: "GetSectionResponse" = cast(
+            "GetSectionResponse",
+            {
+                "entry_path": bundle["entry_path"],
+                "title": bundle["title"],
+                "section_id": section["id"],
+                "section_title": section["title"],
+                "level": section["level"],
+                "parent_id": section.get("parent_id"),
+                "content_markdown": body,
+                "char_count": len(body),
+                "word_count": len(body.split()),
+                "truncated": truncated,
+            },
+        )
+        return cast(
+            "GetSectionResponse",
+            attach_meta(cast(Dict[str, Any], payload)),
+        )
 
     def get_related_articles_data(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -241,7 +241,10 @@ def test_config_with_zim_data(
     )
 
 
-from tests.conftest_v2_fixtures import v2_phase_a_zim  # noqa: F401, E402
+from tests.conftest_v2_fixtures import (  # noqa: F401, E402
+    v2_phase_a_zim,
+    v2_phase_c_zim,
+)
 
 
 def pytest_configure(config):

--- a/tests/conftest_v2_fixtures.py
+++ b/tests/conftest_v2_fixtures.py
@@ -1,8 +1,158 @@
-"""V2 golden-file fixture archive builders."""
+"""V2 golden-file fixture archive builders + shared helpers.
 
+Centralises three things used by ``test_golden_v2_phase_*`` and ``test_response_contract``:
+
+* ``_HtmlItem`` – the libzim Item subclass used to populate test ZIMs.
+* ``strip_volatile`` / ``capture_or_compare`` – the snapshot-equality helpers.
+* ``make_zim_ops`` – the canonical ``ZimOperations`` builder used by both
+  golden modules and the contract-shape test.
+"""
+
+from __future__ import annotations
+
+import json
+import os
 from pathlib import Path
+from typing import Any
 
 import pytest
+from libzim.writer import Creator, Hint, Item, StringProvider
+
+from openzim_mcp.cache import OpenZimMcpCache
+from openzim_mcp.config import (
+    CacheConfig,
+    ContentConfig,
+    LoggingConfig,
+    OpenZimMcpConfig,
+)
+from openzim_mcp.content_processor import ContentProcessor
+from openzim_mcp.security import PathValidator
+from openzim_mcp.zim_operations import ZimOperations
+
+# ---------------------------------------------------------------------------
+# Shared libzim Item used by every fixture archive in this module.
+# ---------------------------------------------------------------------------
+
+
+class _HtmlItem(Item):
+    """A minimal HTML item suitable for the libzim ``Creator`` API."""
+
+    def __init__(self, path: str, title: str, html: str) -> None:
+        super().__init__()
+        self._path = path
+        self._title = title
+        self._html = html
+
+    def get_path(self) -> str:
+        return self._path
+
+    def get_title(self) -> str:
+        return self._title
+
+    def get_mimetype(self) -> str:
+        return "text/html"
+
+    def get_contentprovider(self) -> StringProvider:
+        return StringProvider(self._html)
+
+    def get_hints(self) -> dict[Hint, int]:
+        return {Hint.FRONT_ARTICLE: 1}
+
+
+# ---------------------------------------------------------------------------
+# Snapshot helpers (used by test_golden_v2_phase_*).
+# ---------------------------------------------------------------------------
+
+# Keys to strip from snapshots — volatile or environment-specific.
+_VOLATILE_KEYS = frozenset(
+    {
+        # token/char counts depend on rendered snippet text
+        "tokens_est",
+        "chars",
+        # file-system metadata — environment-specific
+        "directory",
+        "size_bytes",
+        "modified",
+        "size",
+        # opaque cursor encodes archive identity (tmp path digest)
+        "next_cursor",
+        # find_entry_by_title_data embeds the absolute zim file path in results
+        "zim_file",
+    }
+)
+
+
+def strip_volatile(d: Any) -> Any:
+    """Recursively remove volatile keys from a nested dict/list structure."""
+    if isinstance(d, dict):
+        return {k: strip_volatile(v) for k, v in d.items() if k not in _VOLATILE_KEYS}
+    if isinstance(d, list):
+        return [strip_volatile(x) for x in d]
+    return d
+
+
+def capture_or_compare(
+    name: str,
+    payload: dict,
+    *,
+    capture_mode: bool,
+    goldens_dir: Path,
+) -> None:
+    """Write golden snapshot or assert equality against saved snapshot.
+
+    When ``capture_mode=True`` or the file is absent, the payload is
+    serialised to JSON and written. Otherwise the saved golden is loaded
+    and ``strip_volatile(payload)`` must equal ``strip_volatile(expected)``.
+    """
+    goldens_dir.mkdir(parents=True, exist_ok=True)
+    path = goldens_dir / f"{name}.json"
+    if capture_mode or not path.exists():
+        path.write_text(
+            json.dumps(
+                strip_volatile(payload), indent=2, ensure_ascii=False, sort_keys=True
+            ),
+            newline="\n",
+        )
+        return
+    expected = json.loads(path.read_text())
+    assert strip_volatile(payload) == strip_volatile(expected), (
+        f"Golden mismatch for {name}. "
+        "Set OPENZIM_MCP_CAPTURE_GOLDENS=1 to refresh after intentional changes."
+    )
+
+
+def golden_capture_mode() -> bool:
+    """Return True when the OPENZIM_MCP_CAPTURE_GOLDENS env var is set to '1'."""
+    return os.environ.get("OPENZIM_MCP_CAPTURE_GOLDENS") == "1"
+
+
+# ---------------------------------------------------------------------------
+# Shared ZimOperations builder.
+# ---------------------------------------------------------------------------
+
+
+def make_zim_ops(zim_dir: str) -> ZimOperations:
+    """Construct a ZimOperations instance pointing at ``zim_dir``.
+
+    Used by golden tests and the contract-shape test to share a uniform
+    construction recipe (cache size, content limits, snippet length, log level).
+    """
+    config = OpenZimMcpConfig(
+        allowed_directories=[zim_dir],
+        tool_mode="advanced",
+        cache=CacheConfig(enabled=True, max_size=20, ttl_seconds=300),
+        content=ContentConfig(max_content_length=10000, snippet_length=200),
+        logging=LoggingConfig(level="WARNING"),
+    )
+    path_validator = PathValidator(config.allowed_directories)
+    cache = OpenZimMcpCache(config.cache)
+    content_processor = ContentProcessor(snippet_length=config.content.snippet_length)
+    return ZimOperations(config, path_validator, cache, content_processor)
+
+
+# ---------------------------------------------------------------------------
+# Phase A archive — shipped with v2.0.0a1; used by Phase B goldens.
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture(scope="session")
@@ -15,32 +165,8 @@ def v2_phase_a_zim(tmp_path_factory) -> Path:
       - A/MultiTable: multiple oversized tables
       - A/LongArticle: longer than typical compact_budget (forces truncation)
     """
-    from libzim.writer import Creator, Hint, Item, StringProvider
-
     out_dir = tmp_path_factory.mktemp("v2-golden")
     out_path = out_dir / "v2_phase_a.zim"
-
-    class _HtmlItem(Item):
-        def __init__(self, path, title, html):
-            super().__init__()
-            self._path = path
-            self._title = title
-            self._html = html
-
-        def get_path(self):
-            return self._path
-
-        def get_title(self):
-            return self._title
-
-        def get_mimetype(self):
-            return "text/html"
-
-        def get_contentprovider(self):
-            return StringProvider(self._html)
-
-        def get_hints(self):
-            return {Hint.FRONT_ARTICLE: 1}
 
     fixtures = [
         (
@@ -93,6 +219,33 @@ def v2_phase_a_zim(tmp_path_factory) -> Path:
     return out_path
 
 
+# ---------------------------------------------------------------------------
+# Phase C archive — heading-rich content for get_section + synthesize goldens.
+# ---------------------------------------------------------------------------
+
+
+_BERLIN_HTML = (
+    "<html><body><h1>Berlin</h1>"
+    + "<p>Berlin is the capital and largest city of Germany.</p>"
+    + "<h2 id='geography'>Geography</h2>"
+    + "<p>Berlin lies in northeastern Germany on the river Spree.</p>"
+    + "<h2 id='climate'>Climate</h2>"
+    + "<p>Berlin has a temperate seasonal climate.</p>"
+    + "<h2 id='history'>History</h2>"
+    + "<p>The history of Berlin begins in the 13th century.</p>"
+    + "</body></html>"
+)
+_MUNICH_HTML = (
+    "<html><body><h1>Munich</h1>"
+    + "<p>Munich is the capital of Bavaria.</p>"
+    + "<h2 id='history'>History</h2>"
+    + "<p>Munich was founded in 1158.</p>"
+    + "<h2 id='culture'>Culture</h2>"
+    + "<p>Munich is famous for Oktoberfest.</p>"
+    + "</body></html>"
+)
+
+
 @pytest.fixture(scope="module")
 def v2_phase_c_zim(tmp_path_factory) -> Path:
     """Build a heading-rich ZIM for Phase C golden tests (get_section + synthesize).
@@ -101,56 +254,12 @@ def v2_phase_c_zim(tmp_path_factory) -> Path:
       - A/Berlin: h2 sections geography, climate, history
       - A/Munich: h2 sections history, culture
     """
-    from libzim.writer import Creator, Hint, Item, StringProvider
-
     out_dir = tmp_path_factory.mktemp("v2-phase-c-golden")
     out_path = out_dir / "v2_phase_c.zim"
 
-    class _HtmlItem(Item):
-        def __init__(self, path, title, html):
-            super().__init__()
-            self._path = path
-            self._title = title
-            self._html = html
-
-        def get_path(self):
-            return self._path
-
-        def get_title(self):
-            return self._title
-
-        def get_mimetype(self):
-            return "text/html"
-
-        def get_contentprovider(self):
-            return StringProvider(self._html)
-
-        def get_hints(self):
-            return {Hint.FRONT_ARTICLE: 1}
-
-    berlin_html = (
-        "<html><body><h1>Berlin</h1>"
-        + "<p>Berlin is the capital and largest city of Germany.</p>"
-        + "<h2 id='geography'>Geography</h2>"
-        + "<p>Berlin lies in northeastern Germany on the river Spree.</p>"
-        + "<h2 id='climate'>Climate</h2>"
-        + "<p>Berlin has a temperate seasonal climate.</p>"
-        + "<h2 id='history'>History</h2>"
-        + "<p>The history of Berlin begins in the 13th century.</p>"
-        + "</body></html>"
-    )
-    munich_html = (
-        "<html><body><h1>Munich</h1>"
-        + "<p>Munich is the capital of Bavaria.</p>"
-        + "<h2 id='history'>History</h2>"
-        + "<p>Munich was founded in 1158.</p>"
-        + "<h2 id='culture'>Culture</h2>"
-        + "<p>Munich is famous for Oktoberfest.</p>"
-        + "</body></html>"
-    )
     articles = [
-        ("A/Berlin", "Berlin", berlin_html),
-        ("A/Munich", "Munich", munich_html),
+        ("A/Berlin", "Berlin", _BERLIN_HTML),
+        ("A/Munich", "Munich", _MUNICH_HTML),
     ]
 
     with Creator(out_path).config_indexing(True, "eng") as creator:

--- a/tests/conftest_v2_fixtures.py
+++ b/tests/conftest_v2_fixtures.py
@@ -128,33 +128,29 @@ def v2_phase_c_zim(tmp_path_factory) -> Path:
         def get_hints(self):
             return {Hint.FRONT_ARTICLE: 1}
 
+    berlin_html = (
+        "<html><body><h1>Berlin</h1>"
+        + "<p>Berlin is the capital and largest city of Germany.</p>"
+        + "<h2 id='geography'>Geography</h2>"
+        + "<p>Berlin lies in northeastern Germany on the river Spree.</p>"
+        + "<h2 id='climate'>Climate</h2>"
+        + "<p>Berlin has a temperate seasonal climate.</p>"
+        + "<h2 id='history'>History</h2>"
+        + "<p>The history of Berlin begins in the 13th century.</p>"
+        + "</body></html>"
+    )
+    munich_html = (
+        "<html><body><h1>Munich</h1>"
+        + "<p>Munich is the capital of Bavaria.</p>"
+        + "<h2 id='history'>History</h2>"
+        + "<p>Munich was founded in 1158.</p>"
+        + "<h2 id='culture'>Culture</h2>"
+        + "<p>Munich is famous for Oktoberfest.</p>"
+        + "</body></html>"
+    )
     articles = [
-        (
-            "A/Berlin",
-            "Berlin",
-            "<html><body>"
-            "<h1>Berlin</h1>"
-            "<p>Berlin is the capital and largest city of Germany.</p>"
-            "<h2 id='geography'>Geography</h2>"
-            "<p>Berlin lies in northeastern Germany on the river Spree.</p>"
-            "<h2 id='climate'>Climate</h2>"
-            "<p>Berlin has a temperate seasonal climate.</p>"
-            "<h2 id='history'>History</h2>"
-            "<p>The history of Berlin begins in the 13th century.</p>"
-            "</body></html>",
-        ),
-        (
-            "A/Munich",
-            "Munich",
-            "<html><body>"
-            "<h1>Munich</h1>"
-            "<p>Munich is the capital of Bavaria.</p>"
-            "<h2 id='history'>History</h2>"
-            "<p>Munich was founded in 1158.</p>"
-            "<h2 id='culture'>Culture</h2>"
-            "<p>Munich is famous for Oktoberfest.</p>"
-            "</body></html>",
-        ),
+        ("A/Berlin", "Berlin", berlin_html),
+        ("A/Munich", "Munich", munich_html),
     ]
 
     with Creator(out_path).config_indexing(True, "eng") as creator:

--- a/tests/conftest_v2_fixtures.py
+++ b/tests/conftest_v2_fixtures.py
@@ -1,4 +1,4 @@
-"""V2 golden-file fixture archive builder."""
+"""V2 golden-file fixture archive builders."""
 
 from pathlib import Path
 
@@ -89,5 +89,77 @@ def v2_phase_a_zim(tmp_path_factory) -> Path:
         for path, title, html in fixtures:
             creator.add_item(_HtmlItem(path, title, html))
         creator.set_mainpath("A/Einstein")
+
+    return out_path
+
+
+@pytest.fixture(scope="module")
+def v2_phase_c_zim(tmp_path_factory) -> Path:
+    """Build a heading-rich ZIM for Phase C golden tests (get_section + synthesize).
+
+    Articles:
+      - A/Berlin: h2 sections geography, climate, history
+      - A/Munich: h2 sections history, culture
+    """
+    from libzim.writer import Creator, Hint, Item, StringProvider
+
+    out_dir = tmp_path_factory.mktemp("v2-phase-c-golden")
+    out_path = out_dir / "v2_phase_c.zim"
+
+    class _HtmlItem(Item):
+        def __init__(self, path, title, html):
+            super().__init__()
+            self._path = path
+            self._title = title
+            self._html = html
+
+        def get_path(self):
+            return self._path
+
+        def get_title(self):
+            return self._title
+
+        def get_mimetype(self):
+            return "text/html"
+
+        def get_contentprovider(self):
+            return StringProvider(self._html)
+
+        def get_hints(self):
+            return {Hint.FRONT_ARTICLE: 1}
+
+    articles = [
+        (
+            "A/Berlin",
+            "Berlin",
+            "<html><body>"
+            "<h1>Berlin</h1>"
+            "<p>Berlin is the capital and largest city of Germany.</p>"
+            "<h2 id='geography'>Geography</h2>"
+            "<p>Berlin lies in northeastern Germany on the river Spree.</p>"
+            "<h2 id='climate'>Climate</h2>"
+            "<p>Berlin has a temperate seasonal climate.</p>"
+            "<h2 id='history'>History</h2>"
+            "<p>The history of Berlin begins in the 13th century.</p>"
+            "</body></html>",
+        ),
+        (
+            "A/Munich",
+            "Munich",
+            "<html><body>"
+            "<h1>Munich</h1>"
+            "<p>Munich is the capital of Bavaria.</p>"
+            "<h2 id='history'>History</h2>"
+            "<p>Munich was founded in 1158.</p>"
+            "<h2 id='culture'>Culture</h2>"
+            "<p>Munich is famous for Oktoberfest.</p>"
+            "</body></html>",
+        ),
+    ]
+
+    with Creator(out_path).config_indexing(True, "eng") as creator:
+        for path, title, html in articles:
+            creator.add_item(_HtmlItem(path, title, html))
+        creator.set_mainpath("A/Berlin")
 
     return out_path

--- a/tests/data/goldens/v2_phase_c/get_section_berlin_climate.json
+++ b/tests/data/goldens/v2_phase_c/get_section_berlin_climate.json
@@ -1,0 +1,15 @@
+{
+  "_meta": {
+    "truncated": false
+  },
+  "char_count": 54,
+  "content_markdown": "## Climate\n\nBerlin has a temperate seasonal climate.\n\n",
+  "entry_path": "A/Berlin",
+  "level": 2,
+  "parent_id": "berlin",
+  "section_id": "climate",
+  "section_title": "Climate",
+  "title": "Berlin",
+  "truncated": false,
+  "word_count": 8
+}

--- a/tests/data/goldens/v2_phase_c/get_section_berlin_geography.json
+++ b/tests/data/goldens/v2_phase_c/get_section_berlin_geography.json
@@ -1,0 +1,15 @@
+{
+  "_meta": {
+    "truncated": false
+  },
+  "char_count": 71,
+  "content_markdown": "## Geography\n\nBerlin lies in northeastern Germany on the river Spree.\n\n",
+  "entry_path": "A/Berlin",
+  "level": 2,
+  "parent_id": "berlin",
+  "section_id": "geography",
+  "section_title": "Geography",
+  "title": "Berlin",
+  "truncated": false,
+  "word_count": 11
+}

--- a/tests/data/goldens/v2_phase_c/get_section_munich_history.json
+++ b/tests/data/goldens/v2_phase_c/get_section_munich_history.json
@@ -1,0 +1,15 @@
+{
+  "_meta": {
+    "truncated": false
+  },
+  "char_count": 41,
+  "content_markdown": "## History\n\nMunich was founded in 1158.\n\n",
+  "entry_path": "A/Munich",
+  "level": 2,
+  "parent_id": "munich",
+  "section_id": "history",
+  "section_title": "History",
+  "title": "Munich",
+  "truncated": false,
+  "word_count": 7
+}

--- a/tests/data/goldens/v2_phase_c/synthesize_berlin_geography.json
+++ b/tests/data/goldens/v2_phase_c/synthesize_berlin_geography.json
@@ -1,0 +1,29 @@
+{
+  "_meta": {},
+  "answer_markdown": "# **Berlin** **Berlin** is the capital and largest city of Germany.\n[cite: v2_phase_c/A/Berlin]",
+  "archives_searched": [
+    "v2_phase_c"
+  ],
+  "citations": [
+    {
+      "archive": "v2_phase_c",
+      "cite_id": "v2_phase_c/A/Berlin",
+      "entry_path": "A/Berlin",
+      "section_id": null,
+      "section_title": null,
+      "title": "Berlin"
+    }
+  ],
+  "fallback_used": "xapian_score",
+  "passages": [
+    {
+      "cite_id": "v2_phase_c/A/Berlin",
+      "rank": 1,
+      "score": 1.0,
+      "text_markdown": "# **Berlin** **Berlin** is the capital and largest city of Germany."
+    }
+  ],
+  "query": "berlin geography",
+  "total_chars": 95,
+  "total_words": 13
+}

--- a/tests/data/goldens/v2_phase_c/synthesize_capital_city.json
+++ b/tests/data/goldens/v2_phase_c/synthesize_capital_city.json
@@ -1,0 +1,29 @@
+{
+  "_meta": {},
+  "answer_markdown": "Berlin is the **capital** and largest **city** of Germany. ## Geography\n[cite: v2_phase_c/A/Berlin]",
+  "archives_searched": [
+    "v2_phase_c"
+  ],
+  "citations": [
+    {
+      "archive": "v2_phase_c",
+      "cite_id": "v2_phase_c/A/Berlin",
+      "entry_path": "A/Berlin",
+      "section_id": null,
+      "section_title": null,
+      "title": "Berlin"
+    }
+  ],
+  "fallback_used": "xapian_score",
+  "passages": [
+    {
+      "cite_id": "v2_phase_c/A/Berlin",
+      "rank": 1,
+      "score": 1.0,
+      "text_markdown": "Berlin is the **capital** and largest **city** of Germany. ## Geography"
+    }
+  ],
+  "query": "capital city",
+  "total_chars": 99,
+  "total_words": 13
+}

--- a/tests/data/goldens/v2_phase_c/synthesize_munich_history.json
+++ b/tests/data/goldens/v2_phase_c/synthesize_munich_history.json
@@ -1,0 +1,29 @@
+{
+  "_meta": {},
+  "answer_markdown": "# **Munich** **Munich** is the capital of Bavaria.\n[cite: v2_phase_c/A/Munich]",
+  "archives_searched": [
+    "v2_phase_c"
+  ],
+  "citations": [
+    {
+      "archive": "v2_phase_c",
+      "cite_id": "v2_phase_c/A/Munich",
+      "entry_path": "A/Munich",
+      "section_id": null,
+      "section_title": null,
+      "title": "Munich"
+    }
+  ],
+  "fallback_used": "xapian_score",
+  "passages": [
+    {
+      "cite_id": "v2_phase_c/A/Munich",
+      "rank": 1,
+      "score": 1.0,
+      "text_markdown": "# **Munich** **Munich** is the capital of Bavaria."
+    }
+  ],
+  "query": "munich history",
+  "total_chars": 78,
+  "total_words": 10
+}

--- a/tests/test_get_section.py
+++ b/tests/test_get_section.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_get_section.py
+++ b/tests/test_get_section.py
@@ -87,6 +87,7 @@ def test_get_section_max_chars_truncates(ops, tmp_path, patched_archive) -> None
 
     assert response["truncated"] is True
     assert len(response["content_markdown"]) <= 20
+    assert response["_meta"]["truncated"] is True
 
 
 def test_get_section_meta_envelope_present(ops, tmp_path, patched_archive) -> None:

--- a/tests/test_get_section.py
+++ b/tests/test_get_section.py
@@ -1,0 +1,99 @@
+"""Tests for openzim_mcp.zim.structure._StructureMixin.get_section_data."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openzim_mcp.cache import OpenZimMcpCache
+from openzim_mcp.config import (
+    CacheConfig,
+    ContentConfig,
+    LoggingConfig,
+    OpenZimMcpConfig,
+)
+from openzim_mcp.content_processor import ContentProcessor
+from openzim_mcp.security import PathValidator
+from openzim_mcp.zim_operations import ZimOperations
+from tests.test_bundle import SAMPLE_HTML, _make_archive_with_entry
+
+
+@pytest.fixture
+def ops(tmp_path: Path) -> ZimOperations:
+    """ZimOperations backed by a temp directory with a fake .zim file."""
+    zim = tmp_path / "test.zim"
+    zim.touch()
+    cfg = OpenZimMcpConfig(
+        allowed_directories=[str(tmp_path)],
+        cache=CacheConfig(enabled=True, max_size=50, ttl_seconds=300),
+        content=ContentConfig(max_content_length=100_000, snippet_length=200),
+        logging=LoggingConfig(level="ERROR"),
+    )
+    return ZimOperations(
+        cfg,
+        PathValidator(cfg.allowed_directories),
+        OpenZimMcpCache(cfg.cache, enable_background_cleanup=False),
+        ContentProcessor(snippet_length=200),
+    )
+
+
+@pytest.fixture
+def patched_archive():
+    """Context-manager patcher that returns a mock archive for SAMPLE_HTML."""
+    return _make_archive_with_entry(SAMPLE_HTML, title="Berlin", entry_path="A/Berlin")
+
+
+def test_get_section_returns_geography(ops, tmp_path, patched_archive) -> None:
+    zim_path = str(tmp_path / "test.zim")
+    with patch("openzim_mcp.zim_operations.zim_archive") as mock_ctx:
+        mock_ctx.return_value.__enter__.return_value = patched_archive
+        response = ops.get_section_data(zim_path, "A/Berlin", section_id="geography")
+
+    assert response["entry_path"] == "A/Berlin"
+    assert response["title"] == "Berlin"
+    assert response["section_id"] == "geography"
+    assert response["section_title"] == "Geography"
+    assert response["level"] == 2
+    assert "Spree" in response["content_markdown"]
+    assert response["truncated"] is False
+    assert response["char_count"] == len(response["content_markdown"])
+    assert response["word_count"] == len(response["content_markdown"].split())
+
+
+def test_get_section_unknown_id_returns_tool_error(
+    ops, tmp_path, patched_archive
+) -> None:
+    zim_path = str(tmp_path / "test.zim")
+    with patch("openzim_mcp.zim_operations.zim_archive") as mock_ctx:
+        mock_ctx.return_value.__enter__.return_value = patched_archive
+        response = ops.get_section_data(
+            zim_path, "A/Berlin", section_id="this-does-not-exist"
+        )
+
+    assert response.get("error") is True, f"Expected ToolErrorPayload, got: {response}"
+    assert "available_section_ids" in response
+    assert "geography" in response["available_section_ids"]
+
+
+def test_get_section_max_chars_truncates(ops, tmp_path, patched_archive) -> None:
+    zim_path = str(tmp_path / "test.zim")
+    with patch("openzim_mcp.zim_operations.zim_archive") as mock_ctx:
+        mock_ctx.return_value.__enter__.return_value = patched_archive
+        response = ops.get_section_data(
+            zim_path, "A/Berlin", section_id="geography", max_chars=20
+        )
+
+    assert response["truncated"] is True
+    assert len(response["content_markdown"]) <= 20
+
+
+def test_get_section_meta_envelope_present(ops, tmp_path, patched_archive) -> None:
+    zim_path = str(tmp_path / "test.zim")
+    with patch("openzim_mcp.zim_operations.zim_archive") as mock_ctx:
+        mock_ctx.return_value.__enter__.return_value = patched_archive
+        response = ops.get_section_data(zim_path, "A/Berlin", section_id="geography")
+
+    assert "_meta" in response
+    assert "tokens_est" in response["_meta"]

--- a/tests/test_golden_v2_phase_c.py
+++ b/tests/test_golden_v2_phase_c.py
@@ -15,7 +15,7 @@ Compare against saved goldens (default)::
 
 Notes
 -----
-* Uses the same ``_capture_or_compare`` / ``_strip_volatile`` pattern as Phase B.
+* Uses ``capture_or_compare`` / ``strip_volatile`` from ``conftest_v2_fixtures``.
 * ``v2_phase_c_zim`` is a purpose-built heading-rich fixture (A/Berlin, A/Munich)
   because Phase A's articles have no h2/h3 headings and therefore no section IDs
   for ``get_section`` to slice on.
@@ -29,87 +29,20 @@ Notes
 
 from __future__ import annotations
 
-import json
-import os
 from pathlib import Path
-from typing import Any
 
 import pytest
 
-from openzim_mcp.cache import OpenZimMcpCache
-from openzim_mcp.config import (
-    CacheConfig,
-    ContentConfig,
-    LoggingConfig,
-    OpenZimMcpConfig,
-    SynthesizeConfig,
-)
-from openzim_mcp.content_processor import ContentProcessor
-from openzim_mcp.security import PathValidator
+from openzim_mcp.config import SynthesizeConfig
 from openzim_mcp.synthesize import synthesize_query
 from openzim_mcp.zim_operations import ZimOperations, zim_archive
-
-GOLDENS_DIR = Path(__file__).parent / "data" / "goldens" / "v2_phase_c"
-
-# Keys to strip from snapshots — volatile or environment-specific.
-# Inherits Phase B's full set; no new volatile keys surfaced in Phase C output.
-_VOLATILE_KEYS = frozenset(
-    {
-        # token/char counts depend on rendered snippet text
-        "tokens_est",
-        "chars",
-        # file-system metadata — environment-specific
-        "directory",
-        "size_bytes",
-        "modified",
-        "size",
-        # opaque cursor encodes archive identity (tmp path digest)
-        "next_cursor",
-        # find_entry_by_title_data embeds the absolute zim file path in results
-        "zim_file",
-    }
+from tests.conftest_v2_fixtures import (
+    capture_or_compare,
+    golden_capture_mode,
+    make_zim_ops,
 )
 
-
-def _strip_volatile(d: Any) -> Any:
-    """Recursively remove volatile keys from a nested dict/list structure."""
-    if isinstance(d, dict):
-        return {k: _strip_volatile(v) for k, v in d.items() if k not in _VOLATILE_KEYS}
-    if isinstance(d, list):
-        return [_strip_volatile(x) for x in d]
-    return d
-
-
-def _capture_or_compare(name: str, payload: dict, *, capture_mode: bool) -> None:
-    """Write golden snapshot or assert equality against saved snapshot.
-
-    When ``capture_mode=True`` or the file is absent, the payload is
-    serialised to JSON and written.  Otherwise the saved golden is loaded and
-    ``_strip_volatile(payload)`` must equal ``_strip_volatile(expected)``.
-
-    Args:
-        name: Basename (without extension) of the golden file.
-        payload: The dict returned by the operation under test.
-        capture_mode: When ``True``, always overwrite the file.
-
-    Raises:
-        AssertionError: When the stripped payloads differ in compare mode.
-    """
-    GOLDENS_DIR.mkdir(parents=True, exist_ok=True)
-    path = GOLDENS_DIR / f"{name}.json"
-    if capture_mode or not path.exists():
-        path.write_text(
-            json.dumps(
-                _strip_volatile(payload), indent=2, ensure_ascii=False, sort_keys=True
-            ),
-            newline="\n",
-        )
-        return
-    expected = json.loads(path.read_text())
-    assert _strip_volatile(payload) == _strip_volatile(expected), (
-        f"Golden mismatch for {name}. "
-        "Set OPENZIM_MCP_CAPTURE_GOLDENS=1 to refresh after intentional changes."
-    )
+GOLDENS_DIR = Path(__file__).parent / "data" / "goldens" / "v2_phase_c"
 
 
 # ---------------------------------------------------------------------------
@@ -120,18 +53,7 @@ def _capture_or_compare(name: str, payload: dict, *, capture_mode: bool) -> None
 @pytest.fixture(scope="module")
 def zim_ops_c(v2_phase_c_zim: Path) -> ZimOperations:
     """Construct a ZimOperations instance pointing at the Phase C fixture archive."""
-    zim_dir = str(v2_phase_c_zim.parent)
-    config = OpenZimMcpConfig(
-        allowed_directories=[zim_dir],
-        tool_mode="advanced",
-        cache=CacheConfig(enabled=True, max_size=20, ttl_seconds=300),
-        content=ContentConfig(max_content_length=10000, snippet_length=200),
-        logging=LoggingConfig(level="WARNING"),
-    )
-    path_validator = PathValidator(config.allowed_directories)
-    cache = OpenZimMcpCache(config.cache)
-    content_processor = ContentProcessor(snippet_length=config.content.snippet_length)
-    return ZimOperations(config, path_validator, cache, content_processor)
+    return make_zim_ops(str(v2_phase_c_zim.parent))
 
 
 @pytest.fixture(scope="module")
@@ -143,7 +65,7 @@ def zim_path_c(v2_phase_c_zim: Path) -> str:
 @pytest.fixture(scope="session")
 def capture_mode() -> bool:
     """Return True when the OPENZIM_MCP_CAPTURE_GOLDENS env var is set to '1'."""
-    return os.environ.get("OPENZIM_MCP_CAPTURE_GOLDENS") == "1"
+    return golden_capture_mode()
 
 
 # ---------------------------------------------------------------------------
@@ -172,7 +94,9 @@ def test_golden_get_section(
     assert (
         "error" not in payload
     ), f"get_section_data returned an error for {entry_path}#{section_id}: {payload}"
-    _capture_or_compare(golden_name, dict(payload), capture_mode=capture_mode)
+    capture_or_compare(
+        golden_name, dict(payload), capture_mode=capture_mode, goldens_dir=GOLDENS_DIR
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -205,4 +129,6 @@ def test_golden_synthesize(
             content_processor=zim_ops_c.content_processor,
             config=SynthesizeConfig(),
         )
-    _capture_or_compare(golden_name, dict(response), capture_mode=capture_mode)
+    capture_or_compare(
+        golden_name, dict(response), capture_mode=capture_mode, goldens_dir=GOLDENS_DIR
+    )

--- a/tests/test_golden_v2_phase_c.py
+++ b/tests/test_golden_v2_phase_c.py
@@ -1,0 +1,208 @@
+"""Phase C golden-file regression tests for get_section and synthesize.
+
+Anchors the response-contract shape for get_section_data and synthesize_query
+so future changes that unintentionally alter the wire format show up as diffs.
+
+Usage
+-----
+Capture (or refresh) goldens::
+
+    OPENZIM_MCP_CAPTURE_GOLDENS=1 uv run pytest tests/test_golden_v2_phase_c.py -v
+
+Compare against saved goldens (default)::
+
+    uv run pytest tests/test_golden_v2_phase_c.py -v
+
+Notes
+-----
+* Uses the same ``_capture_or_compare`` / ``_strip_volatile`` pattern as Phase B.
+* ``v2_phase_c_zim`` is a purpose-built heading-rich fixture (A/Berlin, A/Munich)
+  because Phase A's articles have no h2/h3 headings and therefore no section IDs
+  for ``get_section`` to slice on.
+* ``synthesize_query`` is called directly (bypassing ``handle_zim_query`` dispatch)
+  to keep the golden independent of simple-tools wiring.
+* ``score`` values in passages use rank-inverse (1/rank) — fully deterministic for
+  a fixed ZIM, so they are kept in the snapshot.
+* ``total_chars`` / ``total_words`` in SynthesizeResponse depend on rendered text
+  length, which is deterministic for fixed content, and are also retained.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from openzim_mcp.cache import OpenZimMcpCache
+from openzim_mcp.config import (
+    CacheConfig,
+    ContentConfig,
+    LoggingConfig,
+    OpenZimMcpConfig,
+    SynthesizeConfig,
+)
+from openzim_mcp.content_processor import ContentProcessor
+from openzim_mcp.security import PathValidator
+from openzim_mcp.synthesize import synthesize_query
+from openzim_mcp.zim_operations import ZimOperations, zim_archive
+
+GOLDENS_DIR = Path(__file__).parent / "data" / "goldens" / "v2_phase_c"
+
+# Keys to strip from snapshots — volatile or environment-specific.
+# Inherits Phase B's full set; no new volatile keys surfaced in Phase C output.
+_VOLATILE_KEYS = frozenset(
+    {
+        # token/char counts depend on rendered snippet text
+        "tokens_est",
+        "chars",
+        # file-system metadata — environment-specific
+        "directory",
+        "size_bytes",
+        "modified",
+        "size",
+        # opaque cursor encodes archive identity (tmp path digest)
+        "next_cursor",
+        # find_entry_by_title_data embeds the absolute zim file path in results
+        "zim_file",
+    }
+)
+
+
+def _strip_volatile(d: Any) -> Any:
+    """Recursively remove volatile keys from a nested dict/list structure."""
+    if isinstance(d, dict):
+        return {k: _strip_volatile(v) for k, v in d.items() if k not in _VOLATILE_KEYS}
+    if isinstance(d, list):
+        return [_strip_volatile(x) for x in d]
+    return d
+
+
+def _capture_or_compare(name: str, payload: dict, *, capture_mode: bool) -> None:
+    """Write golden snapshot or assert equality against saved snapshot.
+
+    When ``capture_mode=True`` or the file is absent, the payload is
+    serialised to JSON and written.  Otherwise the saved golden is loaded and
+    ``_strip_volatile(payload)`` must equal ``_strip_volatile(expected)``.
+
+    Args:
+        name: Basename (without extension) of the golden file.
+        payload: The dict returned by the operation under test.
+        capture_mode: When ``True``, always overwrite the file.
+
+    Raises:
+        AssertionError: When the stripped payloads differ in compare mode.
+    """
+    GOLDENS_DIR.mkdir(parents=True, exist_ok=True)
+    path = GOLDENS_DIR / f"{name}.json"
+    if capture_mode or not path.exists():
+        path.write_text(
+            json.dumps(
+                _strip_volatile(payload), indent=2, ensure_ascii=False, sort_keys=True
+            ),
+            newline="\n",
+        )
+        return
+    expected = json.loads(path.read_text())
+    assert _strip_volatile(payload) == _strip_volatile(expected), (
+        f"Golden mismatch for {name}. "
+        "Set OPENZIM_MCP_CAPTURE_GOLDENS=1 to refresh after intentional changes."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def zim_ops_c(v2_phase_c_zim: Path) -> ZimOperations:
+    """Construct a ZimOperations instance pointing at the Phase C fixture archive."""
+    zim_dir = str(v2_phase_c_zim.parent)
+    config = OpenZimMcpConfig(
+        allowed_directories=[zim_dir],
+        tool_mode="advanced",
+        cache=CacheConfig(enabled=True, max_size=20, ttl_seconds=300),
+        content=ContentConfig(max_content_length=10000, snippet_length=200),
+        logging=LoggingConfig(level="WARNING"),
+    )
+    path_validator = PathValidator(config.allowed_directories)
+    cache = OpenZimMcpCache(config.cache)
+    content_processor = ContentProcessor(snippet_length=config.content.snippet_length)
+    return ZimOperations(config, path_validator, cache, content_processor)
+
+
+@pytest.fixture(scope="module")
+def zim_path_c(v2_phase_c_zim: Path) -> str:
+    """Return the string path to the Phase C fixture ZIM file."""
+    return str(v2_phase_c_zim)
+
+
+@pytest.fixture(scope="session")
+def capture_mode() -> bool:
+    """Return True when the OPENZIM_MCP_CAPTURE_GOLDENS env var is set to '1'."""
+    return os.environ.get("OPENZIM_MCP_CAPTURE_GOLDENS") == "1"
+
+
+# ---------------------------------------------------------------------------
+# get_section golden snapshots
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "entry_path,section_id,golden_name",
+    [
+        ("A/Berlin", "geography", "get_section_berlin_geography"),
+        ("A/Berlin", "climate", "get_section_berlin_climate"),
+        ("A/Munich", "history", "get_section_munich_history"),
+    ],
+)
+def test_golden_get_section(
+    zim_ops_c: ZimOperations,
+    zim_path_c: str,
+    entry_path: str,
+    section_id: str,
+    golden_name: str,
+    capture_mode: bool,
+) -> None:
+    """get_section_data — snapshot of a named section from the heading-rich fixture."""
+    payload = zim_ops_c.get_section_data(zim_path_c, entry_path, section_id=section_id)
+    assert (
+        "error" not in payload
+    ), f"get_section_data returned an error for {entry_path}#{section_id}: {payload}"
+    _capture_or_compare(golden_name, dict(payload), capture_mode=capture_mode)
+
+
+# ---------------------------------------------------------------------------
+# synthesize golden snapshots
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "query,golden_name",
+    [
+        ("berlin geography", "synthesize_berlin_geography"),
+        ("munich history", "synthesize_munich_history"),
+        ("capital city", "synthesize_capital_city"),
+    ],
+)
+def test_golden_synthesize(
+    zim_ops_c: ZimOperations,
+    v2_phase_c_zim: Path,
+    query: str,
+    golden_name: str,
+    capture_mode: bool,
+) -> None:
+    """synthesize_query — end-to-end snapshot for deterministic queries."""
+    with zim_archive(v2_phase_c_zim) as archive:
+        response = synthesize_query(
+            query,
+            archives=[(archive, v2_phase_c_zim)],
+            search_handler=zim_ops_c,
+            cache=zim_ops_c.cache,
+            content_processor=zim_ops_c.content_processor,
+            config=SynthesizeConfig(),
+        )
+    _capture_or_compare(golden_name, dict(response), capture_mode=capture_mode)

--- a/tests/test_response_contract.py
+++ b/tests/test_response_contract.py
@@ -17,16 +17,7 @@ from pathlib import Path
 
 import pytest
 
-from openzim_mcp.cache import OpenZimMcpCache
-from openzim_mcp.config import (
-    CacheConfig,
-    ContentConfig,
-    LoggingConfig,
-    OpenZimMcpConfig,
-    SynthesizeConfig,
-)
-from openzim_mcp.content_processor import ContentProcessor
-from openzim_mcp.security import PathValidator
+from openzim_mcp.config import OpenZimMcpConfig, SynthesizeConfig
 from openzim_mcp.server import OpenZimMcpServer
 from openzim_mcp.synthesize import synthesize_query
 from openzim_mcp.zim_operations import ZimOperations, zim_archive
@@ -287,18 +278,9 @@ class TestContractShape:
 
 @pytest.fixture(scope="module")
 def _phase_c_zim_ops(v2_phase_c_zim: Path) -> ZimOperations:
-    zim_dir = str(v2_phase_c_zim.parent)
-    config = OpenZimMcpConfig(
-        allowed_directories=[zim_dir],
-        tool_mode="advanced",
-        cache=CacheConfig(enabled=True, max_size=20, ttl_seconds=300),
-        content=ContentConfig(max_content_length=10000, snippet_length=200),
-        logging=LoggingConfig(level="WARNING"),
-    )
-    path_validator = PathValidator(config.allowed_directories)
-    cache = OpenZimMcpCache(config.cache)
-    content_processor = ContentProcessor(snippet_length=config.content.snippet_length)
-    return ZimOperations(config, path_validator, cache, content_processor)
+    from tests.conftest_v2_fixtures import make_zim_ops
+
+    return make_zim_ops(str(v2_phase_c_zim.parent))
 
 
 class TestPhaseCMetaEnvelope:

--- a/tests/test_response_contract.py
+++ b/tests/test_response_contract.py
@@ -3,14 +3,33 @@
 Phase B (#3) standardizes pagination across all list-returning tools. This
 file is the single source of truth for "did we keep the contract?" Each
 test calls a real tool against the bundled fixtures and asserts the shape.
+
+Phase C note
+------------
+``get_section`` and ``synthesize`` are NOT list-paginated tools and are
+therefore exempt from ``_assert_contract``.  They still carry ``_meta`` —
+see ``TestPhaseCMetaEnvelope`` below.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
-from openzim_mcp.config import OpenZimMcpConfig
+from openzim_mcp.cache import OpenZimMcpCache
+from openzim_mcp.config import (
+    CacheConfig,
+    ContentConfig,
+    LoggingConfig,
+    OpenZimMcpConfig,
+    SynthesizeConfig,
+)
+from openzim_mcp.content_processor import ContentProcessor
+from openzim_mcp.security import PathValidator
 from openzim_mcp.server import OpenZimMcpServer
+from openzim_mcp.synthesize import synthesize_query
+from openzim_mcp.zim_operations import ZimOperations, zim_archive
 
 CONTRACT_KEYS = ("results", "next_cursor", "total", "done", "page_info", "_meta")
 PAGE_INFO_KEYS = ("offset", "limit", "returned_count")
@@ -258,3 +277,54 @@ class TestContractShape:
         payload = structured["result"] if "result" in structured else structured
         _assert_contract(payload)
         assert payload["done"] is True
+
+
+# ---------------------------------------------------------------------------
+# Phase C: non-paginated tools are exempt from _assert_contract but must
+# still carry _meta.  Tests use the heading-rich v2_phase_c_zim fixture.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def _phase_c_zim_ops(v2_phase_c_zim: Path) -> ZimOperations:
+    zim_dir = str(v2_phase_c_zim.parent)
+    config = OpenZimMcpConfig(
+        allowed_directories=[zim_dir],
+        tool_mode="advanced",
+        cache=CacheConfig(enabled=True, max_size=20, ttl_seconds=300),
+        content=ContentConfig(max_content_length=10000, snippet_length=200),
+        logging=LoggingConfig(level="WARNING"),
+    )
+    path_validator = PathValidator(config.allowed_directories)
+    cache = OpenZimMcpCache(config.cache)
+    content_processor = ContentProcessor(snippet_length=config.content.snippet_length)
+    return ZimOperations(config, path_validator, cache, content_processor)
+
+
+class TestPhaseCMetaEnvelope:
+    """get_section and synthesize are exempt from the list-pagination contract
+    but must still carry a _meta dict."""
+
+    def test_get_section_response_carries_meta_envelope(
+        self, _phase_c_zim_ops: ZimOperations, v2_phase_c_zim: Path
+    ) -> None:
+        response = _phase_c_zim_ops.get_section_data(
+            str(v2_phase_c_zim), "A/Berlin", section_id="geography"
+        )
+        assert "_meta" in response, "get_section response missing _meta"
+        assert isinstance(response["_meta"], dict)
+
+    def test_synthesize_response_carries_meta_envelope(
+        self, _phase_c_zim_ops: ZimOperations, v2_phase_c_zim: Path
+    ) -> None:
+        with zim_archive(v2_phase_c_zim) as archive:
+            response = synthesize_query(
+                "berlin geography",
+                archives=[(archive, v2_phase_c_zim)],
+                search_handler=_phase_c_zim_ops,
+                cache=_phase_c_zim_ops.cache,
+                content_processor=_phase_c_zim_ops.content_processor,
+                config=SynthesizeConfig(),
+            )
+        assert "_meta" in response, "synthesize response missing _meta"
+        assert isinstance(response["_meta"], dict)

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -39,3 +39,25 @@ class TestToolError:
         """
         payload: ToolErrorPayload = tool_error(operation="x", message="y")
         assert isinstance(payload, dict)
+
+    def test_extras_merged_into_payload(self) -> None:
+        """extras dict keys are merged into the returned payload."""
+        payload = tool_error(
+            operation="section_not_found",
+            message="Not found",
+            extras={"available_section_ids": ["intro", "history"]},
+        )
+        assert payload["error"] is True
+        assert "available_section_ids" in payload
+        assert payload["available_section_ids"] == ["intro", "history"]  # type: ignore[typeddict-item]
+
+    def test_extras_none_does_not_add_keys(self) -> None:
+        """Omitting extras (default None) leaves the payload unaffected."""
+        payload = tool_error(operation="x", message="y")
+        # Only the three base keys (and no extras) should be present.
+        assert set(payload.keys()) == {"error", "operation", "message"}
+
+    def test_extras_empty_dict_does_not_add_keys(self) -> None:
+        """An empty extras dict does not add any keys to the payload."""
+        payload = tool_error(operation="x", message="y", extras={})
+        assert set(payload.keys()) == {"error", "operation", "message"}

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -867,13 +867,10 @@ class TestZimQuerySynthesize:
         # A plain str return does NOT produce a tuple — FastMCP returns the
         # bare list of TextContent blocks. This verifies the legacy path is intact.
         # When the Union return annotation is active, FastMCP may wrap even
-        # strings — accept both: a tuple whose text element is non-empty, or
+        # strings — accept both: a tuple whose first element is non-empty, or
         # a list with at least one text item.
         if isinstance(result, tuple):
-            _, structured = result
-            # structured may be None or a dict wrapping the string
-            # The unstructured part must contain text.
-            unstructured, _ = result
+            unstructured = result[0]
             assert (
                 unstructured
             ), "zim_query markdown path should produce non-empty content"

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -751,7 +751,7 @@ class TestStructuredOutput:
     async def test_get_section_returns_structured_content(
         self, server: OpenZimMcpServer, basic_test_zim_files
     ) -> None:
-        """get_section must emit a structured dict envelope."""
+        """get_section must emit a GetSectionResponse dict for a valid section_id."""
         zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get(
             "withns"
         )
@@ -772,18 +772,19 @@ class TestStructuredOutput:
         # FastMCP wraps Union returns in a uniform {"result": ...} envelope.
         # Accept the wrapper; assert the inner shape.
         payload = structured.get("result", structured)
-        # Tool returns either a GetSectionResponse or a ToolErrorPayload
-        # (section_not_found when the archive lacks that section_id).
-        # Both paths carry the wire-format contract — the structured
-        # content must be a real dict, not a JSON string.
         assert isinstance(payload, dict)
-        if payload.get("error") is True:
-            # section_not_found or entry-missing — check ToolErrorPayload shape.
-            assert "operation" in payload
-        else:
-            assert "section_id" in payload
-            assert "section_title" in payload
-            assert "_meta" in payload
+        # A valid section_id on an existing entry MUST return GetSectionResponse,
+        # not ToolErrorPayload. A ToolErrorPayload here is a regression.
+        assert payload.get("error") is not True, (
+            f"get_section returned ToolErrorPayload for a valid section_id: "
+            f"{payload.get('operation')!r} — {payload.get('message')!r}"
+        )
+        # Exact value assertions — not just presence.
+        assert payload["section_id"] == "introduction"
+        assert payload["section_title"] and isinstance(
+            payload["section_title"], str
+        ), f"section_title should be a non-empty string, got: {payload.get('section_title')!r}"
+        assert "_meta" in payload
 
 
 def test_phase_c_bundle_shared_across_four_tools(v2_phase_a_zim) -> None:

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -787,6 +787,101 @@ class TestStructuredOutput:
         assert "_meta" in payload
 
 
+@pytest.fixture
+def simple_server(test_config_with_zim_data: OpenZimMcpConfig) -> OpenZimMcpServer:
+    """Simple-mode server bound to the ZIM testing-suite dir.
+
+    zim_query is only registered in simple mode, so synthesize integration
+    tests need a separate server fixture with tool_mode='simple'.
+    """
+    import copy
+
+    cfg = copy.copy(test_config_with_zim_data)
+    # Pydantic models are immutable; rebuild with tool_mode='simple'.
+    cfg = OpenZimMcpConfig(
+        allowed_directories=test_config_with_zim_data.allowed_directories,
+        tool_mode="simple",
+        cache=test_config_with_zim_data.cache,
+        content=test_config_with_zim_data.content,
+        logging=test_config_with_zim_data.logging,
+    )
+    return OpenZimMcpServer(cfg)
+
+
+class TestZimQuerySynthesize:
+    """Integration tests for zim_query synthesize=True wire format."""
+
+    @pytest.mark.asyncio
+    async def test_zim_query_synthesize_returns_structured_response(
+        self, simple_server: OpenZimMcpServer, basic_test_zim_files
+    ) -> None:
+        """synthesize=True returns SynthesizeResponse via structuredContent."""
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get(
+            "withns"
+        )
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+
+        result = await simple_server.mcp._tool_manager.call_tool(
+            "zim_query",
+            {
+                "query": "berlin geography",
+                "zim_file_path": str(zim_path),
+                "synthesize": True,
+            },
+            convert_result=True,
+        )
+
+        # Union return type triggers FastMCP's structured-content path.
+        assert isinstance(result, tuple), (
+            "zim_query with synthesize=True must return a tuple — "
+            "the Union return annotation has not landed."
+        )
+        _, structured = result
+        assert isinstance(structured, dict)
+        # FastMCP wraps Union returns in a {"result": ...} envelope.
+        payload = structured.get("result", structured)
+        assert isinstance(payload, dict)
+        # SynthesizeResponse or ToolErrorPayload — accept either for wire-format
+        # correctness; a ToolErrorPayload (e.g. no FT index) is still structured.
+        if payload.get("error") is True:
+            assert "operation" in payload
+        else:
+            assert "answer_markdown" in payload
+            assert "passages" in payload
+            assert "citations" in payload
+            assert "archives_searched" in payload
+            assert payload.get("fallback_used") in ("xapian_score", "rrf_fusion")
+
+    @pytest.mark.asyncio
+    async def test_zim_query_no_synthesize_returns_string(
+        self, simple_server: OpenZimMcpServer
+    ) -> None:
+        """synthesize=False (default) keeps returning the markdown string path."""
+        result = await simple_server.mcp._tool_manager.call_tool(
+            "zim_query",
+            {"query": "list available ZIM files"},
+            convert_result=True,
+        )
+        # A plain str return does NOT produce a tuple — FastMCP returns the
+        # bare list of TextContent blocks. This verifies the legacy path is intact.
+        # When the Union return annotation is active, FastMCP may wrap even
+        # strings — accept both: a tuple whose text element is non-empty, or
+        # a list with at least one text item.
+        if isinstance(result, tuple):
+            _, structured = result
+            # structured may be None or a dict wrapping the string
+            # The unstructured part must contain text.
+            unstructured, _ = result
+            assert (
+                unstructured
+            ), "zim_query markdown path should produce non-empty content"
+        else:
+            # Legacy: bare list of TextContent
+            assert result, "zim_query markdown path should produce non-empty content"
+            assert result[0].text, "first TextContent block should be non-empty"
+
+
 def test_phase_c_bundle_shared_across_four_tools(v2_phase_a_zim) -> None:
     """All four collapsed tools share one EntryBundle per entry.
 

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -851,7 +851,11 @@ class TestZimQuerySynthesize:
             assert "passages" in payload
             assert "citations" in payload
             assert "archives_searched" in payload
-            assert payload.get("fallback_used") in ("xapian_score", "rrf_fusion")
+            assert payload.get("fallback_used") in (
+                "xapian_score",
+                "rrf_fusion",
+                "reranker",
+            )
 
     @pytest.mark.asyncio
     async def test_zim_query_no_synthesize_returns_string(

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -747,6 +747,44 @@ class TestStructuredOutput:
         assert "configuration" in payload
         assert "diagnostics" in payload
 
+    @pytest.mark.asyncio
+    async def test_get_section_returns_structured_content(
+        self, server: OpenZimMcpServer, basic_test_zim_files
+    ) -> None:
+        """get_section must emit a structured dict envelope."""
+        zim_path = basic_test_zim_files.get("nons") or basic_test_zim_files.get(
+            "withns"
+        )
+        if zim_path is None:
+            pytest.skip("ZIM testing-suite small.zim not available")
+        result = await server.mcp._tool_manager.call_tool(
+            "get_section",
+            {
+                "zim_file_path": str(zim_path),
+                "entry_path": "A/Main_Page",
+                "section_id": "introduction",
+            },
+            convert_result=True,
+        )
+        assert isinstance(result, tuple)
+        _, structured = result
+        assert isinstance(structured, dict)
+        # FastMCP wraps Union returns in a uniform {"result": ...} envelope.
+        # Accept the wrapper; assert the inner shape.
+        payload = structured.get("result", structured)
+        # Tool returns either a GetSectionResponse or a ToolErrorPayload
+        # (section_not_found when the archive lacks that section_id).
+        # Both paths carry the wire-format contract — the structured
+        # content must be a real dict, not a JSON string.
+        assert isinstance(payload, dict)
+        if payload.get("error") is True:
+            # section_not_found or entry-missing — check ToolErrorPayload shape.
+            assert "operation" in payload
+        else:
+            assert "section_id" in payload
+            assert "section_title" in payload
+            assert "_meta" in payload
+
 
 def test_phase_c_bundle_shared_across_four_tools(v2_phase_a_zim) -> None:
     """All four collapsed tools share one EntryBundle per entry.

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -793,11 +793,8 @@ def simple_server(test_config_with_zim_data: OpenZimMcpConfig) -> OpenZimMcpServ
 
     zim_query is only registered in simple mode, so synthesize integration
     tests need a separate server fixture with tool_mode='simple'.
+    Pydantic models are immutable, so rebuild rather than copy-and-patch.
     """
-    import copy
-
-    cfg = copy.copy(test_config_with_zim_data)
-    # Pydantic models are immutable; rebuild with tool_mode='simple'.
     cfg = OpenZimMcpConfig(
         allowed_directories=test_config_with_zim_data.allowed_directories,
         tool_mode="simple",

--- a/tests/test_synthesize.py
+++ b/tests/test_synthesize.py
@@ -185,7 +185,9 @@ def test_attribute_sections_adds_section_id_when_match_in_first_section() -> Non
             },
         ),
     ]
-    bundle_lookup = lambda path: bundle if path == "A/Berlin" else None
+
+    def bundle_lookup(path: str) -> dict | None:
+        return bundle if path == "A/Berlin" else None
 
     attributed = _attribute_sections(
         passages, bundle_lookup=bundle_lookup, hit_paths=["A/Berlin"]
@@ -235,7 +237,10 @@ def test_attribute_sections_no_match_keeps_entry_level() -> None:
             },
         ],
     }
-    bundle_lookup = lambda path: bundle
+
+    def bundle_lookup(path: str) -> dict:
+        return bundle
+
     passages = [
         cast(
             SynthesizePassage,

--- a/tests/test_synthesize.py
+++ b/tests/test_synthesize.py
@@ -22,6 +22,19 @@ def cp() -> Any:
     return mock_cp
 
 
+def _passage(cite_id: str, text: str, rank: int, score: float) -> SynthesizePassage:
+    """Build a SynthesizePassage TypedDict for tests; keeps fixtures terse."""
+    return cast(
+        SynthesizePassage,
+        {
+            "cite_id": cite_id,
+            "text_markdown": text,
+            "rank": rank,
+            "score": score,
+        },
+    )
+
+
 def test_rrf_fuse_single_ranking_preserves_order() -> None:
     """One ranking → output is the same order, with k-decayed scores."""
     rankings = [
@@ -116,7 +129,7 @@ def test_extract_passages_renders_markdown_from_snippets() -> None:
     assert passages[0]["rank"] == 1
     assert passages[0]["text_markdown"] == "Berlin is the capital."
     assert passages[0]["cite_id"] == "wikipedia_en_simple/A/Berlin"  # no #section yet
-    assert passages[0]["score"] == 0.9
+    assert passages[0]["score"] == pytest.approx(0.9)
 
 
 def test_extract_passages_preserves_rank_order() -> None:
@@ -174,17 +187,7 @@ def test_attribute_sections_adds_section_id_when_match_in_first_section() -> Non
             },
         ],
     }
-    passages = [
-        cast(
-            SynthesizePassage,
-            {
-                "cite_id": "wiki/A/Berlin",
-                "text_markdown": "Geography text here.",
-                "rank": 1,
-                "score": 0.9,
-            },
-        ),
-    ]
+    passages = [_passage("wiki/A/Berlin", "Geography text here.", 1, 0.9)]
 
     def bundle_lookup(path: str) -> dict | None:
         return bundle if path == "A/Berlin" else None
@@ -202,17 +205,7 @@ def test_attribute_sections_drops_section_on_bundle_failure() -> None:
     def bundle_lookup(path: str) -> None:
         raise RuntimeError("simulated archive read failure")
 
-    passages = [
-        cast(
-            SynthesizePassage,
-            {
-                "cite_id": "wiki/A/Berlin",
-                "text_markdown": "Anything",
-                "rank": 1,
-                "score": 0.5,
-            },
-        ),
-    ]
+    passages = [_passage("wiki/A/Berlin", "Anything", 1, 0.5)]
     attributed = _attribute_sections(
         passages, bundle_lookup=bundle_lookup, hit_paths=["A/Berlin"]
     )
@@ -241,17 +234,7 @@ def test_attribute_sections_no_match_keeps_entry_level() -> None:
     def bundle_lookup(path: str) -> dict:
         return bundle
 
-    passages = [
-        cast(
-            SynthesizePassage,
-            {
-                "cite_id": "wiki/A/Berlin",
-                "text_markdown": "totally unrelated string",
-                "rank": 1,
-                "score": 0.1,
-            },
-        ),
-    ]
+    passages = [_passage("wiki/A/Berlin", "totally unrelated string", 1, 0.1)]
     attributed = _attribute_sections(
         passages, bundle_lookup=bundle_lookup, hit_paths=["A/Berlin"]
     )
@@ -267,24 +250,8 @@ def test_render_answer_joins_passages_with_citations() -> None:
     from openzim_mcp.synthesize import _render_answer
 
     passages = [
-        cast(
-            "SynthesizePassage",
-            {
-                "cite_id": "wiki/A/Berlin#geography",
-                "text_markdown": "Berlin is mostly flat.",
-                "rank": 1,
-                "score": 0.9,
-            },
-        ),
-        cast(
-            "SynthesizePassage",
-            {
-                "cite_id": "wiki/A/Berlin#climate",
-                "text_markdown": "Climate is humid continental.",
-                "rank": 2,
-                "score": 0.7,
-            },
-        ),
+        _passage("wiki/A/Berlin#geography", "Berlin is mostly flat.", 1, 0.9),
+        _passage("wiki/A/Berlin#climate", "Climate is humid continental.", 2, 0.7),
     ]
     md = _render_answer(passages)
     assert "Berlin is mostly flat." in md
@@ -297,14 +264,8 @@ def test_enforce_budget_truncates_last_passage() -> None:
     from openzim_mcp.synthesize import _enforce_budget
 
     passages = [
-        cast(
-            "SynthesizePassage",
-            {"cite_id": "x/y", "text_markdown": "A" * 50, "rank": 1, "score": 1.0},
-        ),
-        cast(
-            "SynthesizePassage",
-            {"cite_id": "x/y", "text_markdown": "B" * 50, "rank": 2, "score": 0.9},
-        ),
+        _passage("x/y", "A" * 50, 1, 1.0),
+        _passage("x/y", "B" * 50, 2, 0.9),
     ]
     capped = _enforce_budget(passages, char_budget=70)
     # First passage is 50 chars; budget allows 70. Second passage truncates to 20.
@@ -317,33 +278,9 @@ def test_build_citations_dedupes_by_entry() -> None:
     from openzim_mcp.synthesize import _build_citations
 
     passages = [
-        cast(
-            "SynthesizePassage",
-            {
-                "cite_id": "wiki/A/Berlin#geography",
-                "text_markdown": "",
-                "rank": 1,
-                "score": 0.9,
-            },
-        ),
-        cast(
-            "SynthesizePassage",
-            {
-                "cite_id": "wiki/A/Berlin#climate",
-                "text_markdown": "",
-                "rank": 2,
-                "score": 0.7,
-            },
-        ),
-        cast(
-            "SynthesizePassage",
-            {
-                "cite_id": "wiki/A/Munich#geography",
-                "text_markdown": "",
-                "rank": 3,
-                "score": 0.5,
-            },
-        ),
+        _passage("wiki/A/Berlin#geography", "", 1, 0.9),
+        _passage("wiki/A/Berlin#climate", "", 2, 0.7),
+        _passage("wiki/A/Munich#geography", "", 3, 0.5),
     ]
     bundle_titles = {"A/Berlin": "Berlin", "A/Munich": "Munich"}
     bundle_section_titles = {

--- a/tests/test_synthesize.py
+++ b/tests/test_synthesize.py
@@ -1,0 +1,46 @@
+"""Tests for openzim_mcp.synthesize."""
+
+from __future__ import annotations
+
+import pytest
+
+from openzim_mcp.synthesize import _rrf_fuse
+
+
+def test_rrf_fuse_single_ranking_preserves_order() -> None:
+    """One ranking → output is the same order, with k-decayed scores."""
+    rankings = [
+        [("A/Doc1", 0.9), ("A/Doc2", 0.7), ("A/Doc3", 0.5)],
+    ]
+    fused = _rrf_fuse(rankings, k=60)
+    paths = [p for p, _ in fused]
+    assert paths == ["A/Doc1", "A/Doc2", "A/Doc3"]
+
+
+def test_rrf_fuse_two_rankings_unifies() -> None:
+    """Doc that appears high in both rankings beats one that appears in just one."""
+    rankings = [
+        [("A/Doc1", 0.9), ("A/Doc2", 0.7), ("A/Doc3", 0.5)],
+        [("A/Doc1", 0.8), ("A/Doc4", 0.6), ("A/Doc2", 0.4)],
+    ]
+    fused = _rrf_fuse(rankings, k=60)
+    paths = [p for p, _ in fused]
+    # Doc1 appears at rank 1 in both → highest fused score.
+    assert paths[0] == "A/Doc1"
+    # Doc2 appears at ranks 2 + 3 → next.
+    assert paths[1] == "A/Doc2"
+
+
+def test_rrf_fuse_empty_rankings_returns_empty() -> None:
+    assert _rrf_fuse([], k=60) == []
+
+
+def test_rrf_fuse_score_formula() -> None:
+    """Score(d) = sum over rankings of 1/(k + rank(d))."""
+    rankings = [
+        [("A/Doc1", 0.9)],  # rank 1 in this ranking
+        [("A/Doc1", 0.5)],  # rank 1 in this ranking too
+    ]
+    fused = _rrf_fuse(rankings, k=60)
+    expected = 1.0 / (60 + 1) + 1.0 / (60 + 1)
+    assert fused[0][1] == pytest.approx(expected)

--- a/tests/test_synthesize.py
+++ b/tests/test_synthesize.py
@@ -44,3 +44,45 @@ def test_rrf_fuse_score_formula() -> None:
     fused = _rrf_fuse(rankings, k=60)
     expected = 1.0 / (60 + 1) + 1.0 / (60 + 1)
     assert fused[0][1] == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# Task 17: per-archive search stage
+# ---------------------------------------------------------------------------
+
+from unittest.mock import MagicMock  # noqa: E402
+
+
+def test_per_archive_search_single_archive() -> None:
+    """Single archive → list[(entry_path, snippet, score)] from Xapian."""
+    from openzim_mcp.synthesize import _per_archive_search
+
+    archive = MagicMock()
+    archive.basename = "wikipedia_en_simple"
+
+    search_handler = MagicMock()
+    search_handler.search_top_k.return_value = [
+        {"path": "A/Berlin", "snippet": "...", "score": 0.9},
+        {"path": "A/Munich", "snippet": "...", "score": 0.7},
+    ]
+
+    results = _per_archive_search(
+        archive,
+        search_handler=search_handler,
+        query="german cities",
+        k=5,
+    )
+    assert len(results) == 2
+    assert results[0]["path"] == "A/Berlin"
+
+
+def test_synthesize_query_signature_exists() -> None:
+    """synthesize_query is callable; signature stable from this task on."""
+    import inspect
+
+    from openzim_mcp.synthesize import synthesize_query
+
+    sig = inspect.signature(synthesize_query)
+    assert {"query", "archives", "cache", "content_processor", "config"} <= set(
+        sig.parameters
+    )

--- a/tests/test_synthesize.py
+++ b/tests/test_synthesize.py
@@ -239,3 +239,113 @@ def test_attribute_sections_no_match_keeps_entry_level() -> None:
         passages, bundle_lookup=bundle_lookup, hit_paths=["A/Berlin"]
     )
     assert attributed[0]["cite_id"] == "wiki/A/Berlin"
+
+
+# ---------------------------------------------------------------------------
+# Task 20: citation rendering, budget enforcement, citation building
+# ---------------------------------------------------------------------------
+
+
+def test_render_answer_joins_passages_with_citations() -> None:
+    from openzim_mcp.synthesize import _render_answer
+
+    passages = [
+        cast(
+            "SynthesizePassage",
+            {
+                "cite_id": "wiki/A/Berlin#geography",
+                "text_markdown": "Berlin is mostly flat.",
+                "rank": 1,
+                "score": 0.9,
+            },
+        ),
+        cast(
+            "SynthesizePassage",
+            {
+                "cite_id": "wiki/A/Berlin#climate",
+                "text_markdown": "Climate is humid continental.",
+                "rank": 2,
+                "score": 0.7,
+            },
+        ),
+    ]
+    md = _render_answer(passages)
+    assert "Berlin is mostly flat." in md
+    assert "[cite: wiki/A/Berlin#geography]" in md
+    assert "Climate is humid continental." in md
+    assert "[cite: wiki/A/Berlin#climate]" in md
+
+
+def test_enforce_budget_truncates_last_passage() -> None:
+    from openzim_mcp.synthesize import _enforce_budget
+
+    passages = [
+        cast(
+            "SynthesizePassage",
+            {"cite_id": "x/y", "text_markdown": "A" * 50, "rank": 1, "score": 1.0},
+        ),
+        cast(
+            "SynthesizePassage",
+            {"cite_id": "x/y", "text_markdown": "B" * 50, "rank": 2, "score": 0.9},
+        ),
+    ]
+    capped = _enforce_budget(passages, char_budget=70)
+    # First passage is 50 chars; budget allows 70. Second passage truncates to 20.
+    assert len(capped) == 2
+    assert len(capped[0]["text_markdown"]) == 50
+    assert len(capped[1]["text_markdown"]) == 20
+
+
+def test_build_citations_dedupes_by_entry() -> None:
+    from openzim_mcp.synthesize import _build_citations
+
+    passages = [
+        cast(
+            "SynthesizePassage",
+            {
+                "cite_id": "wiki/A/Berlin#geography",
+                "text_markdown": "",
+                "rank": 1,
+                "score": 0.9,
+            },
+        ),
+        cast(
+            "SynthesizePassage",
+            {
+                "cite_id": "wiki/A/Berlin#climate",
+                "text_markdown": "",
+                "rank": 2,
+                "score": 0.7,
+            },
+        ),
+        cast(
+            "SynthesizePassage",
+            {
+                "cite_id": "wiki/A/Munich#geography",
+                "text_markdown": "",
+                "rank": 3,
+                "score": 0.5,
+            },
+        ),
+    ]
+    bundle_titles = {"A/Berlin": "Berlin", "A/Munich": "Munich"}
+    bundle_section_titles = {
+        ("A/Berlin", "geography"): "Geography",
+        ("A/Berlin", "climate"): "Climate",
+        ("A/Munich", "geography"): "Geography",
+    }
+    citations = _build_citations(
+        passages,
+        archive_titles=bundle_titles,
+        section_titles=bundle_section_titles,
+    )
+    # 3 unique cite_ids → 3 citations
+    assert len(citations) == 3
+    cite_ids = [c["cite_id"] for c in citations]
+    assert "wiki/A/Berlin#geography" in cite_ids
+    berlin_geo = next(c for c in citations if c["cite_id"] == "wiki/A/Berlin#geography")
+    assert berlin_geo["title"] == "Berlin"
+    assert berlin_geo["section_title"] == "Geography"
+    assert berlin_geo["section_id"] == "geography"
+    assert berlin_geo["entry_path"] == "A/Berlin"
+    assert berlin_geo["archive"] == "wiki"

--- a/tests/test_synthesize.py
+++ b/tests/test_synthesize.py
@@ -2,12 +2,24 @@
 
 from __future__ import annotations
 
-from typing import cast
+from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
+from openzim_mcp.config import SynthesizeConfig
 from openzim_mcp.synthesize import _rrf_fuse
 from openzim_mcp.tool_schemas import SynthesizePassage
+
+
+@pytest.fixture
+def cp() -> Any:
+    """A content_processor mock that passes HTML through unchanged."""
+    from unittest.mock import MagicMock
+
+    mock_cp = MagicMock()
+    mock_cp.html_to_plain_text.side_effect = lambda html: html
+    return mock_cp
 
 
 def test_rrf_fuse_single_ranking_preserves_order() -> None:
@@ -349,3 +361,124 @@ def test_build_citations_dedupes_by_entry() -> None:
     assert berlin_geo["section_id"] == "geography"
     assert berlin_geo["entry_path"] == "A/Berlin"
     assert berlin_geo["archive"] == "wiki"
+
+
+# ---------------------------------------------------------------------------
+# Task 21: end-to-end synthesize_query tests
+# ---------------------------------------------------------------------------
+
+
+def test_synthesize_query_zero_hits_returns_empty_with_reason(
+    cp: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from unittest.mock import MagicMock
+
+    from openzim_mcp.synthesize import synthesize_query
+
+    archive = MagicMock()
+    archive.basename = "test"
+    cache = MagicMock()
+    config = SynthesizeConfig()
+
+    search_handler = MagicMock()
+    search_handler.search_top_k.return_value = []  # zero hits
+
+    response = synthesize_query(
+        "no results query",
+        archives=[(archive, Path("test.zim"))],
+        search_handler=search_handler,
+        cache=cache,
+        content_processor=cp,
+        config=config,
+    )
+    assert response["passages"] == []
+    assert response["citations"] == []
+    assert response["answer_markdown"] == ""
+    assert response["_meta"].get("reason") == "0_hits"
+
+
+def test_synthesize_query_single_archive_uses_xapian_score_fallback(
+    cp: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from unittest.mock import MagicMock
+
+    from openzim_mcp.synthesize import synthesize_query
+
+    archive = MagicMock()
+    cache = MagicMock()
+    config = SynthesizeConfig()
+
+    search_handler = MagicMock()
+    search_handler.search_top_k.return_value = [
+        {"path": "A/Berlin", "snippet": "<p>Berlin info</p>", "score": 0.9},
+    ]
+
+    monkey_bundle = {
+        "entry_path": "A/Berlin",
+        "title": "Berlin",
+        "content_type": "text/html",
+        "word_count": 1,
+        "char_count": 100,
+        "rendered_markdown": "Berlin info\n",
+        "sections": [
+            {
+                "id": "berlin",
+                "title": "Berlin",
+                "level": 1,
+                "char_start": 0,
+                "char_end": 12,
+                "parent_id": None,
+            }
+        ],
+        "links": {"internal": [], "external": [], "media": []},
+        "infobox": None,
+    }
+
+    monkeypatch.setattr(
+        "openzim_mcp.synthesize.get_or_build_bundle",
+        lambda archive, path, **kwargs: monkey_bundle,
+    )
+
+    response = synthesize_query(
+        "berlin",
+        archives=[(archive, Path("test.zim"))],
+        search_handler=search_handler,
+        cache=cache,
+        content_processor=cp,
+        config=config,
+    )
+    assert response["fallback_used"] == "xapian_score"
+    assert response["archives_searched"] == ["test"]
+
+
+def test_synthesize_query_multi_archive_uses_rrf_fusion(
+    cp: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from unittest.mock import MagicMock
+
+    from openzim_mcp.synthesize import synthesize_query
+
+    a1 = MagicMock()
+    a2 = MagicMock()
+    search_handler = MagicMock()
+    search_handler.search_top_k.side_effect = [
+        [{"path": "A/Berlin", "snippet": "", "score": 0.9}],
+        [{"path": "A/Berlin", "snippet": "", "score": 0.5}],  # both archives have it
+    ]
+    cache = MagicMock()
+
+    monkeypatch.setattr(
+        "openzim_mcp.synthesize.get_or_build_bundle",
+        lambda archive, path, **kwargs: None,
+    )
+
+    response = synthesize_query(
+        "berlin",
+        archives=[(a1, Path("wiki1.zim")), (a2, Path("wiki2.zim"))],
+        search_handler=search_handler,
+        cache=cache,
+        content_processor=cp,
+        config=SynthesizeConfig(),
+    )
+    assert response["fallback_used"] == "rrf_fusion"
+    assert sorted(response["archives_searched"]) == ["wiki1", "wiki2"]

--- a/tests/test_synthesize.py
+++ b/tests/test_synthesize.py
@@ -76,6 +76,47 @@ def test_per_archive_search_single_archive() -> None:
     assert results[0]["path"] == "A/Berlin"
 
 
+# ---------------------------------------------------------------------------
+# Task 18: passage extraction stage
+# ---------------------------------------------------------------------------
+
+
+def test_extract_passages_renders_markdown_from_snippets() -> None:
+    """libzim snippets may come back as HTML; passages contain markdown."""
+    from openzim_mcp.synthesize import _extract_passages
+
+    hits = [
+        {"path": "A/Berlin", "snippet": "<p>Berlin is the capital.</p>", "score": 0.9},
+        {"path": "A/Munich", "snippet": "<p>Munich is in Bavaria.</p>", "score": 0.7},
+    ]
+    cp = MagicMock()
+    cp.html_to_plain_text.side_effect = lambda html: html.replace("<p>", "").replace(
+        "</p>", ""
+    )
+
+    passages = _extract_passages(
+        hits, archive_name="wikipedia_en_simple", content_processor=cp
+    )
+    assert len(passages) == 2
+    assert passages[0]["rank"] == 1
+    assert passages[0]["text_markdown"] == "Berlin is the capital."
+    assert passages[0]["cite_id"] == "wikipedia_en_simple/A/Berlin"  # no #section yet
+    assert passages[0]["score"] == 0.9
+
+
+def test_extract_passages_preserves_rank_order() -> None:
+    from openzim_mcp.synthesize import _extract_passages
+
+    hits = [
+        {"path": f"A/Doc{i}", "snippet": f"<p>doc {i}</p>", "score": 1.0 - 0.1 * i}
+        for i in range(5)
+    ]
+    cp = MagicMock()
+    cp.html_to_plain_text.side_effect = lambda html: html
+    passages = _extract_passages(hits, archive_name="test", content_processor=cp)
+    assert [p["rank"] for p in passages] == [1, 2, 3, 4, 5]
+
+
 def test_synthesize_query_signature_exists() -> None:
     """synthesize_query is callable; signature stable from this task on."""
     import inspect

--- a/tests/test_synthesize.py
+++ b/tests/test_synthesize.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 
 from openzim_mcp.synthesize import _rrf_fuse
+from openzim_mcp.tool_schemas import SynthesizePassage
 
 
 def test_rrf_fuse_single_ranking_preserves_order() -> None:
@@ -127,3 +130,112 @@ def test_synthesize_query_signature_exists() -> None:
     assert {"query", "archives", "cache", "content_processor", "config"} <= set(
         sig.parameters
     )
+
+
+# ---------------------------------------------------------------------------
+# Task 19: section attribution stage
+# ---------------------------------------------------------------------------
+
+
+def test_attribute_sections_adds_section_id_when_match_in_first_section() -> None:
+    """Passage text found in section 0 → cite_id gets #<section_id>."""
+    from openzim_mcp.synthesize import _attribute_sections
+
+    bundle = {
+        "rendered_markdown": "# Berlin\n\nIntro paragraph.\n\n## Geography\n\nGeography text here.\n",
+        "sections": [
+            {
+                "id": "berlin",
+                "title": "Berlin",
+                "level": 1,
+                "char_start": 0,
+                "char_end": 38,
+                "parent_id": None,
+            },
+            {
+                "id": "geography",
+                "title": "Geography",
+                "level": 2,
+                "char_start": 38,
+                "char_end": 75,
+                "parent_id": "berlin",
+            },
+        ],
+    }
+    passages = [
+        cast(
+            SynthesizePassage,
+            {
+                "cite_id": "wiki/A/Berlin",
+                "text_markdown": "Geography text here.",
+                "rank": 1,
+                "score": 0.9,
+            },
+        ),
+    ]
+    bundle_lookup = lambda path: bundle if path == "A/Berlin" else None
+
+    attributed = _attribute_sections(
+        passages, bundle_lookup=bundle_lookup, hit_paths=["A/Berlin"]
+    )
+    assert attributed[0]["cite_id"] == "wiki/A/Berlin#geography"
+
+
+def test_attribute_sections_drops_section_on_bundle_failure() -> None:
+    """Bundle build fails → cite_id stays at entry level; passage not dropped."""
+    from openzim_mcp.synthesize import _attribute_sections
+
+    def bundle_lookup(path: str) -> None:
+        raise RuntimeError("simulated archive read failure")
+
+    passages = [
+        cast(
+            SynthesizePassage,
+            {
+                "cite_id": "wiki/A/Berlin",
+                "text_markdown": "Anything",
+                "rank": 1,
+                "score": 0.5,
+            },
+        ),
+    ]
+    attributed = _attribute_sections(
+        passages, bundle_lookup=bundle_lookup, hit_paths=["A/Berlin"]
+    )
+    assert len(attributed) == 1
+    assert attributed[0]["cite_id"] == "wiki/A/Berlin"  # unchanged
+
+
+def test_attribute_sections_no_match_keeps_entry_level() -> None:
+    """Passage text not located in any section → cite_id stays at entry level."""
+    from openzim_mcp.synthesize import _attribute_sections
+
+    bundle = {
+        "rendered_markdown": "Whole article body here.",
+        "sections": [
+            {
+                "id": "intro",
+                "title": "Intro",
+                "level": 1,
+                "char_start": 0,
+                "char_end": 24,
+                "parent_id": None,
+            },
+        ],
+    }
+    bundle_lookup = lambda path: bundle
+    passages = [
+        cast(
+            SynthesizePassage,
+            {
+                "cite_id": "wiki/A/Berlin",
+                "text_markdown": "totally unrelated string",
+                "rank": 1,
+                "score": 0.1,
+            },
+        ),
+    ]
+    attributed = _attribute_sections(
+        passages, bundle_lookup=bundle_lookup, hit_paths=["A/Berlin"]
+    )
+    assert attributed[0]["cite_id"] == "wiki/A/Berlin"


### PR DESCRIPTION
v2 Phase C, part 2 — completes the retrieval-primitives phase. Adds `get_section` (#7) and `zim_query(synthesize=True)` (#10) on top of the EntryBundle infrastructure shipped in v2.0.0a3 (PR #117). **No wire-format breaks** — both surfaces are additive.

Closes #7 and closes #10. Final piece of #11 work landed earlier in #117.

## What ships

### `get_section` — single-section retrieval

```
get_section(zim_file_path, entry_path, section_id, *, max_chars=None)
  → Union[GetSectionResponse, ToolErrorPayload]
```

Slices `EntryBundle.rendered_markdown[char_start:char_end]` for the named section. Bundle char ranges include subsections (parent heading's `char_end` extends through the next heading at same-or-higher level), so a parent section returns the full subtree. `max_chars` truncates and forwards `truncated=True` into both the payload and `_meta.truncated`. On miss: `tool_error("section_not_found", extras={"available_section_ids": [...]})` so the model can self-correct.

### `zim_query(synthesize=True)` — server-side retrieval pipeline

```python
{
    "query": str,
    "answer_markdown": str,        # passages joined with inline [cite: ...] markers
    "passages": list[SynthesizePassage],
    "citations": list[Citation],
    "archives_searched": list[str],
    "fallback_used": Literal["xapian_score", "rrf_fusion", "reranker"],
    "total_chars": int,
    "total_words": int,
    "_meta": MetaEnvelope,
}
```

Pure retrieval + concatenation. No LLM generation. Seven-stage pipeline in `openzim_mcp/synthesize.py`:

1. Per-archive Xapian search (`ZimOperations.search_top_k`, top-K with rank-inverse score proxy since libzim has no public BM25)
2. Reciprocal Rank Fusion (k=60) for multi-archive; single-archive passes through (`fallback_used="xapian_score"` vs `"rrf_fusion"`)
3. Identity rerank — placeholder for Phase D's cross-encoder
4. Passage extraction — libzim snippets rendered to markdown
5. Section attribution — best-effort `EntryBundle` lookup; passages get `cite_id = "{archive}/{entry_path}#{section_id}"` when the snippet text is found inside a section's char range. Bundle build failures keep entry-level cite_id (passage never dropped)
6. Budget enforcement — `output_char_budget` truncates the last passage; subsequent passages dropped
7. Render + citations — passages joined with `\n\n` and `[cite: ...]` markers; structured `Citation` list deduped by cite_id

Zero hits returns an empty response with `_meta.reason="0_hits"`. Archive lifecycle is managed via `contextlib.ExitStack` so failure paths don't leak handles.

### Other surface changes

- `tool_error()` gains an `extras: Optional[Dict[str, Any]]` kwarg. Self-correction hints (e.g. `available_section_ids`) attach cleanly without `# type: ignore` at call sites; the single suppression now lives inside the helper.
- `_meta.truncated` correctly reflects truncation in `get_section_data` (forwarded via `attach_meta(truncated=...)`).
- `get_section` and `synthesize` are exempted from the Phase B list-pagination contract; both still assert `_meta` independently.

## Plan-vs-reality adjustments captured during execution

- libzim's `SearchIterator.getSnippet()` / `.getScore()` aren't part of the Python bindings. `search_top_k` mirrors the existing `_perform_search` pattern (`archive.get_entry_by_path` + `_get_entry_snippet`) and uses `1/rank` as a deterministic score proxy. RRF discards source scores anyway.
- The plan's `_handle_synthesize_query` archive cleanup pattern (calling `__exit__` on a fresh context manager instance) was a bug; replaced with `ExitStack`.
- The plan's `self.config.list_zim_files()` doesn't exist; using `self.zim_operations.list_zim_files_data()` (canonical path used by `_auto_select_zim_file`).
- `ZimOperations` mixes in `search_top_k` directly, so it serves as the `search_handler` — no extra constructor argument needed.

## Tests

`1320 passed, 51 skipped, 27 deselected.` New files:

- `tests/test_get_section.py` — 4 unit tests covering geography slice, section-not-found with `available_section_ids`, `max_chars` truncation including `_meta.truncated`, `_meta` envelope.
- `tests/test_synthesize.py` — RRF helper, per-archive search wrapper, passage extraction, section attribution, render/budget/citations, plus 3 end-to-end tests for zero-hits / xapian_score / rrf_fusion paths (uses `monkeypatch.setattr` of `get_or_build_bundle` to keep mocks deterministic).
- `tests/test_responses.py` — extras kwarg coverage on `tool_error()`.
- `tests/test_golden_v2_phase_c.py` — 3 `get_section` + 3 `synthesize` snapshots over a new heading-rich fixture (`v2_phase_c_zim` in `conftest_v2_fixtures.py`). Reuses Phase B's `_capture_or_compare`/`_strip_volatile`. Set `OPENZIM_MCP_CAPTURE_GOLDENS=1` to refresh.
- `tests/test_response_contract.py` — `TestPhaseCMetaEnvelope` class asserts `_meta` on both new tools without subjecting them to list-pagination shape.
- `tests/test_structured_tool_output.py` — strict `get_section` integration assertions (rejects error payload on valid section_id) and a `TestZimQuerySynthesize` class for the public `zim_query(synthesize=True)` path.

## Commits

16 focused commits on `v2-phase-c-2`, summarized:

- `bdc9e98` get_section data layer
- `f72fab9` `_meta.truncated` forwarding + `tool_error(extras=...)` extension
- `42ac84c` register `get_section` MCP tool
- `a5821cd` tighten `get_section` structured-output integration test
- `cf4c731` `synthesize.py` skeleton + RRF helper
- `4a49a92` per-archive search + `search_top_k`
- `c8aa06e` passage extraction
- `5684afd` section attribution
- `45aa6ac` render + budget + build_citations
- `ca6f70f` full pipeline wiring + zero-hits + fallback selection
- `6df6ec1` `zim_query(synthesize=True)` wiring
- `b1ecbbb` structured error path on synthesize exception + reranker forward-compat in test
- `641ea5d` Phase C golden snapshots
- `04e96d1` exempt new tools from list-pagination contract
- `2fb340d` lint cleanup
- `b9f6e57` CHANGELOG + Phase C status update

## Verification

- `make lint` — clean (flake8 + isort + black)
- `uv run mypy openzim_mcp` — 0 errors across 44 files
- `uv run pytest` — 1320 passed, 51 skipped, 27 deselected
- Phase C goldens present at `tests/data/goldens/v2_phase_c/`

## Release plan

After squash-merge, tag the merge commit `v2.0.0a4` (annotated, unsigned per the a1/a2/a3 precedent) and publish a GitHub prerelease whose body is the new `## [2.0.0a4]` block in `CHANGELOG.md`.
