### PR TITLE
fix(v2)!: bugfix-only follow-up to v2.0.0a4 — 41 defects across phases A–C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,9 +202,13 @@ Migrated tools (TypedDict-only, no contract): `get_zim_metadata`,
 
 ### Cursor format
 
-Cursors are URL-safe base64 JSON: `{v: 1, t: <tool_name>, s: <state>}`.
+Cursors are URL-safe base64 JSON: `{v: 2, t: <tool_name>, s: <state>}`.
 **Tool-bound** — a search cursor passed to browse raises a clear error.
 **Versioned** — adding new fields later doesn't break the wire format.
+**Archive-bound** — cursors for archive-specific tools carry `s.ai` (a
+short SHA-256 token of the validated archive path); resubmitting a
+cursor against a different archive is rejected. v=1 cursors are
+rejected so callers re-fetch rather than silently follow stale state.
 
 ### Compat shim removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0a5] — 2026-05-10 (alpha pre-release)
+## [2.0.0a6] — 2026-05-11 (alpha pre-release)
 
 Bugfix-only follow-up to v2.0.0a4 after a two-pass review of the
 shipped Phase A/B/C surface. 13 defects fixed; no new tools, no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,95 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0a5] — 2026-05-10 (alpha pre-release)
+
+Bugfix-only follow-up to v2.0.0a4 after a two-pass review of the
+shipped Phase A/B/C surface. 13 defects fixed; no new tools, no
+wire-format breaks. Existing tests stay green (1344 passed) and a few
+new tests pin down the corrected behaviour.
+
+### Fixed — Phase A (`_meta` envelope, snippets, fuzzy fallback)
+
+- **`format_footer` recovery branch now covers every empty-result `reason`.**
+  Responses carrying `reason="no_xapian_index"` or `"bad_namespace"`
+  previously fell through to the success branch and emitted a useless
+  "~0 tokens" footer. They now render archive-shaped recovery hints
+  ("No full-text index on this archive. Try `find_entry_by_title` or
+  `browse_namespace`." / "Unknown namespace. Try `list_namespaces`…").
+- **`create_snippet` no longer slices `**term**` mid-tag.** When the
+  highlighted snippet exceeded `snippet_length` and the second
+  truncation landed inside a bold marker, the result was a runaway-bold
+  fragment (`…**ter`). The truncation now detects an unpaired trailing
+  `**` and strips the dangling segment before appending `...`.
+- **Spec §14.4: surface `alt_spelling` suggestions when a fuzzy hit
+  is returned.** `find_entry_by_title_data` now adds the resolved
+  typo-corrected title to `_meta.suggestions[]` so callers can see
+  *which* correction the server applied and decide whether to accept
+  it. Previously suggestions only appeared when zero results were
+  found.
+- **`tokens_est` is now omitted from `_meta` when the tokenizer is
+  unavailable** (spec §5). Callers can distinguish "tokenizer
+  unavailable" from "zero-token response". `format_footer` falls back
+  to char-count when the field is absent.
+
+### Fixed — Phase B (cursor)
+
+- **`CursorPayload.v` comment refreshed.** The inline comment said
+  "currently 1" while `CURRENT_VERSION = 2`; replaced with a stable
+  reference to the module constant so it can't drift again.
+
+### Fixed — Phase C (bundle, get_section, synthesize)
+
+- **`_locate_passage` whitespace-run offset mapping.** The
+  normalized→original-offset walk could exit pointing inside a
+  whitespace run that `md_norm` had collapsed to one space, attributing
+  citations to the prior section when two section boundaries sat
+  either side of the run. The mapper now advances past any remaining
+  whitespace so the returned offset always lands on the first
+  non-space character of the match.
+- **`get_section` truncation surfaces `_meta.total_chars`.** Truncation
+  set `_meta.truncated=True` but omitted the source-length context.
+  Callers now see how much of the section was elided. `more_at_offset`
+  remains absent because `get_section` truncation is not resumable.
+- **`archive_by_name` collision on duplicate `.stem`.** Two ZIMs with
+  the same filename in different directories (`en/wiki.zim` and
+  `fr/wiki.zim`) silently overwrote each other in synthesize's
+  archive-lookup dict, causing the bundle for the first archive's hit
+  to be fetched from the second archive — i.e., citation poisoning.
+  Duplicate stems are now detected at archive enumeration and
+  disambiguated with a `~N` suffix (`wiki`, `wiki~2`) with a warning
+  log. Single-archive synthesise is unaffected.
+- **`get_entry_summary(compact=True)` no longer ignores the `compact`
+  flag.** The Phase C bundle migration silently routed compact
+  callers through `bundle["rendered_markdown"]`, which is rendered
+  with `compact=False` (pipe-soup tables, no oversized-table
+  placeholders). Compact requests now bypass the bundle and re-render
+  through `_extract_html_summary(compact=True)` so Phase A #2's table
+  trimming applies. `compact=False` (the default) still benefits from
+  the bundle's shared HTML parse.
+- **Cache keys for `path_mapping:`, `binary_meta:`, and `ns_entries:`
+  now include an `<mtime_ns>:<size>` invalidation token.** Atomic ZIM
+  file replacement (the typical monthly Wikipedia refresh) previously
+  left stale resolved paths, binary metadata, and namespace listings
+  in cache until LRU eviction. The bundle cache already did this; the
+  helper has been extracted to `bundle.archive_stat_token()` and
+  applied across all four.
+- **`synthesize._extract_passages` no longer double-renders the
+  snippet through `html_to_plain_text`.** `search_top_k` already
+  returns plain-markdown snippets via `create_snippet`; the
+  BeautifulSoup→html2text round-trip risked mangling `**bold**`
+  highlight markers. Trust the upstream pipeline; a regression test
+  pins the behaviour.
+
+### Test suite
+
+- 1344 passed, 50 skipped (one more than the v2.0.0a4 baseline; added
+  `test_extract_passages_preserves_bold_highlight_markers`).
+- Updated `test_zim_operations.py` and `test_content_tools.py` cache-key
+  assertions for the new stat-token format.
+- Updated `test_synthesize.py` to drop the `content_processor` arg
+  from `_extract_passages` and use plain-markdown snippet fixtures.
+
 ## [2.0.0a4] — 2026-05-10 (alpha pre-release)
 
 v2 Phase C, part 2: completes the retrieval-primitives phase. Adds the

--- a/docs/v2/README.md
+++ b/docs/v2/README.md
@@ -1,3 +1,4 @@
+
 # openzim-mcp v2 — Release Tracking
 
 **Status:** Planning
@@ -46,9 +47,13 @@ Each phase's spec is created via the brainstorming workflow when that phase begi
 
 ### #1 — Use libzim native query-aware snippets
 
-**Current state.** [`openzim_mcp/zim/content.py:62-72`](../../openzim_mcp/zim/content.py) builds search snippets via `_get_entry_snippet`, which decompresses the entry, runs HTML-to-text, and takes the first 2 paragraphs (`create_snippet` in [`openzim_mcp/content_processor.py:432-459`](../../openzim_mcp/content_processor.py)). This bears no relation to where the query actually matched.
+**Original target.** Use libzim's `SearchIterator.getSnippet()` which returns the actual matched passage with highlighting, replacing the prior "decompress + take first two paragraphs" approach.
 
-**Target.** Use libzim's `SearchIterator.getSnippet()` which returns the actual matched passage with highlighting. Keep the lead-paragraph fallback for entries without a snippet (e.g., suggestion-search results).
+**What shipped (v2.0.0a1).** A pure-Python query-aware rewrite in [`content_processor.create_snippet`](../../openzim_mcp/content_processor.py): the snippet is now the first paragraph containing a whole-word match for any query term (instead of the lead paragraph), and up to 5 matches inside the slice are wrapped in `**bold**` for visibility. This delivers the _query-relevance_ and _highlighting_ outcomes of the original target.
+
+**What did NOT ship.** The libzim-native code path. `python-libzim` 3.9.0 exposes `Searcher` / `SearchResultSet` but does NOT surface `SearchIterator.getSnippet()` — the iterator yields plain entry-path strings. Calling the C++ libzim `getSnippet` API would require an upstream binding change (or a custom CFFI shim, which is out of scope for v2 alpha). The Python path still decompresses the entry per hit, so the perf-target half of the original design has not been realized.
+
+**Follow-up.** Open an upstream [python-libzim issue](https://github.com/openzim/python-libzim/issues) requesting that `SearchIterator.getSnippet()` be exposed on the binding. When that lands, swap the body of `_get_entry_snippet` in [`openzim_mcp/zim/content.py`](../../openzim_mcp/zim/content.py) to call the native API and keep the Python `create_snippet` as a fallback for paths that don't go through the search iterator (e.g., suggestion search).
 
 **Reference:** [openzim/javascript-libzim SEARCH_SNIPPETS_IMPLEMENTATION.md](https://github.com/openzim/javascript-libzim/blob/main/SEARCH_SNIPPETS_IMPLEMENTATION.md).
 

--- a/openzim_mcp/async_operations.py
+++ b/openzim_mcp/async_operations.py
@@ -8,6 +8,7 @@ the event loop during I/O-bound operations.
 
 import asyncio
 import logging
+from functools import partial
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from .zim_operations import ZimOperations
@@ -123,14 +124,19 @@ class AsyncZimOperations:
         query: str,
         limit: Optional[int] = None,
         offset: int = 0,
+        *,
+        cursor_archive_identity: Optional[str] = None,
     ) -> "SearchResponse":
         """Structured variant of ``search_zim_file`` (async)."""
         return await asyncio.to_thread(
-            self._ops.search_zim_file_data,
-            zim_file_path,
-            query,
-            limit,
-            offset,
+            partial(
+                self._ops.search_zim_file_data,
+                zim_file_path,
+                query,
+                limit,
+                offset,
+                cursor_archive_identity=cursor_archive_identity,
+            ),
         )
 
     async def get_zim_entry(
@@ -282,14 +288,19 @@ class AsyncZimOperations:
         namespace: str = "C",
         limit: int = 50,
         offset: int = 0,
+        *,
+        cursor_archive_identity: Optional[str] = None,
     ) -> "BrowseNamespaceResponse":
         """Structured variant of ``browse_namespace`` (async)."""
         return await asyncio.to_thread(
-            self._ops.browse_namespace_data,
-            zim_file_path,
-            namespace,
-            limit,
-            offset,
+            partial(
+                self._ops.browse_namespace_data,
+                zim_file_path,
+                namespace,
+                limit,
+                offset,
+                cursor_archive_identity=cursor_archive_identity,
+            ),
         )
 
     async def search_with_filters(
@@ -332,16 +343,21 @@ class AsyncZimOperations:
         content_type: Optional[str] = None,
         limit: Optional[int] = None,
         offset: int = 0,
+        *,
+        cursor_archive_identity: Optional[str] = None,
     ) -> "SearchWithFiltersResponse":
         """Structured variant of ``search_with_filters`` (async)."""
         return await asyncio.to_thread(
-            self._ops.search_with_filters_data,
-            zim_file_path,
-            query,
-            namespace,
-            content_type,
-            limit,
-            offset,
+            partial(
+                self._ops.search_with_filters_data,
+                zim_file_path,
+                query,
+                namespace,
+                content_type,
+                limit,
+                offset,
+                cursor_archive_identity=cursor_archive_identity,
+            ),
         )
 
     async def get_search_suggestions(

--- a/openzim_mcp/async_operations.py
+++ b/openzim_mcp/async_operations.py
@@ -442,6 +442,8 @@ class AsyncZimOperations:
         limit: int = 100,
         offset: int = 0,
         kind: str = "internal",
+        *,
+        cursor_archive_identity: Optional[str] = None,
     ) -> "LinksResponse":
         """Structured variant of ``extract_article_links`` (async, paginated)."""
         return await asyncio.to_thread(
@@ -451,6 +453,7 @@ class AsyncZimOperations:
             limit,
             offset,
             kind,
+            cursor_archive_identity=cursor_archive_identity,
         )
 
     async def get_entry_summary(

--- a/openzim_mcp/bundle.py
+++ b/openzim_mcp/bundle.py
@@ -40,7 +40,24 @@ _BUNDLE_KEY_PREFIX = "bundle:v2c"
 
 
 def _bundle_cache_key(validated_path: "Path", entry_path: str) -> str:
-    return f"{_BUNDLE_KEY_PREFIX}:{validated_path}:{entry_path}"
+    """Cache key that invalidates when the underlying ZIM is replaced.
+
+    Includes `st_mtime_ns` so an atomic file replacement (a monthly
+    Wikipedia ZIM update) causes prior bundles to be reseen as cache
+    misses rather than served as stale. `st_size` is included too —
+    cheap defence-in-depth against filesystems with low-precision mtime
+    or in-place rewrites that preserve the timestamp.
+
+    Falls back gracefully when stat() fails (path no longer exists, race
+    with replacement): the key drops to the prior shape so the cache
+    still works, just without the invalidation guarantee.
+    """
+    try:
+        st = validated_path.stat()
+        token = f"{st.st_mtime_ns}:{st.st_size}"
+    except OSError:
+        token = "0:0"
+    return f"{_BUNDLE_KEY_PREFIX}:{validated_path}:{token}:{entry_path}"
 
 
 def _normalize_heading_text(text: str) -> str:
@@ -107,7 +124,11 @@ def _compute_section_offsets(
     sections: list[SectionMeta] = []
     cursor = 0
     parent_stack: list[tuple[int, str]] = []
-    matches: list[tuple[int, str, int, str]] = []
+    # Each match carries both the heading-line start (used as the
+    # *next* section's char_end boundary, so siblings don't include
+    # each other's heading lines) and the body start (where the section
+    # content actually begins, used as char_start).
+    matches: list[tuple[int, str, int, int, str]] = []  # (level, text, heading_start, body_start, id)
 
     for h in headings:
         level = int(h["level"])
@@ -116,11 +137,22 @@ def _compute_section_offsets(
         section_id = h.get("id") or ""
         if not text or not section_id:
             continue
-        pattern = re.compile(
+        # Strict pattern first; relaxed fallback covers html2text decorating
+        # the heading text with inline markup (italics, bold, code spans)
+        # that the soup-level get_text() stripped — without the fallback
+        # those sections are silently absent from the bundle and
+        # ``get_section`` returns "not found".
+        strict = re.compile(
             rf"^{'#' * level} {re.escape(text)}\s*$",
             re.MULTILINE,
         )
-        match = pattern.search(rendered_markdown, cursor)
+        match = strict.search(rendered_markdown, cursor)
+        if match is None:
+            relaxed = re.compile(
+                rf"^{'#' * level} [^\n]*{re.escape(text)}[^\n]*$",
+                re.MULTILINE,
+            )
+            match = relaxed.search(rendered_markdown, cursor)
         if match is None:
             logger.warning(
                 "Bundle: could not locate heading %r (level %d) in rendered markdown",
@@ -128,20 +160,28 @@ def _compute_section_offsets(
                 level,
             )
             continue
-        matches.append((level, text, match.start(), section_id))
+        # ``char_start`` points to the first character of the body — the
+        # newline after the heading line, then past it. The heading text
+        # is already exposed as ``section_title`` and ``level`` on every
+        # consumer, so including it in the sliced content is redundant
+        # and inflates ``char_count``/``word_count``.
+        body_start = match.end()
+        if body_start < len(rendered_markdown) and rendered_markdown[body_start] == "\n":
+            body_start += 1
+        matches.append((level, text, match.start(), body_start, section_id))
         cursor = match.end()
 
     md_len = len(rendered_markdown)
-    for i, (level, text, char_start, section_id) in enumerate(matches):
+    for i, (level, text, _heading_start, char_start, section_id) in enumerate(matches):
         # char_end extends to the next heading at the SAME OR HIGHER level
         # (lower number == higher level) — i.e., the next sibling or
-        # ancestor-sibling. This makes a parent's range envelope all its
-        # descendants, satisfying the parent.char_start <= child.char_start
-        # < child.char_end <= parent.char_end invariant.
+        # ancestor-sibling. Use the *heading_start* of the next match
+        # (not its body_start) so the current section doesn't include
+        # the sibling's heading line.
         char_end = md_len
         for j in range(i + 1, len(matches)):
             if matches[j][0] <= level:
-                char_end = matches[j][2]
+                char_end = matches[j][2]  # heading_start of next sibling
                 break
 
         while parent_stack and parent_stack[-1][0] >= level:

--- a/openzim_mcp/bundle.py
+++ b/openzim_mcp/bundle.py
@@ -39,6 +39,30 @@ logger = logging.getLogger(__name__)
 _BUNDLE_KEY_PREFIX = "bundle:v2c"
 
 
+def archive_stat_token(validated_path: Any) -> str:
+    """Return ``<mtime_ns>:<size>`` for ``validated_path`` (``"0:0"`` on OSError).
+
+    Cache keys for any data derived from a ZIM file's contents should
+    include this token so that an atomic file replacement (the typical
+    monthly Wikipedia ZIM refresh) invalidates entries instead of
+    serving stale data. The bundle cache uses it; namespace listings,
+    binary metadata, and path-resolution caches all need the same
+    guarantee.
+
+    Falls back to ``"0:0"`` when ``stat()`` fails (path removed, race
+    with replacement) — the cache continues to function, just without
+    the invalidation guarantee for that key.
+
+    ``validated_path`` is typed loosely so callers don't have to import
+    ``pathlib.Path``; any path-like with ``.stat()`` works.
+    """
+    try:
+        st = validated_path.stat()
+        return f"{st.st_mtime_ns}:{st.st_size}"
+    except OSError:
+        return "0:0"
+
+
 def _bundle_cache_key(validated_path: "Path", entry_path: str) -> str:
     """Cache key that invalidates when the underlying ZIM is replaced.
 
@@ -52,12 +76,7 @@ def _bundle_cache_key(validated_path: "Path", entry_path: str) -> str:
     with replacement): the key drops to the prior shape so the cache
     still works, just without the invalidation guarantee.
     """
-    try:
-        st = validated_path.stat()
-        token = f"{st.st_mtime_ns}:{st.st_size}"
-    except OSError:
-        token = "0:0"
-    return f"{_BUNDLE_KEY_PREFIX}:{validated_path}:{token}:{entry_path}"
+    return f"{_BUNDLE_KEY_PREFIX}:{validated_path}:{archive_stat_token(validated_path)}:{entry_path}"
 
 
 def _normalize_heading_text(text: str) -> str:

--- a/openzim_mcp/bundle.py
+++ b/openzim_mcp/bundle.py
@@ -127,14 +127,18 @@ def _compute_section_offsets(
     # Each match carries both the heading-line start (used as the
     # *next* section's char_end boundary, so siblings don't include
     # each other's heading lines) and the body start (where the section
-    # content actually begins, used as char_start).
-    matches: list[tuple[int, str, int, int, str]] = []  # (level, text, heading_start, body_start, id)
+    # content actually begins, used as char_start). The trailing
+    # ``id_source`` is propagated to SectionMeta so TocHeading consumers
+    # can tell stable author-provided anchors from generated slugs.
+    matches: list[tuple[int, str, int, int, str, str]] = []
+    # tuple shape: (level, text, heading_start, body_start, id, id_source)
 
     for h in headings:
         level = int(h["level"])
         text = _normalize_heading_text(h.get("text", ""))
         # _build_headings uses key 'id' (not 'anchor')
         section_id = h.get("id") or ""
+        id_source = h.get("id_source", "slug")
         if not text or not section_id:
             continue
         # Strict pattern first; relaxed fallback covers html2text decorating
@@ -166,13 +170,23 @@ def _compute_section_offsets(
         # consumer, so including it in the sliced content is redundant
         # and inflates ``char_count``/``word_count``.
         body_start = match.end()
-        if body_start < len(rendered_markdown) and rendered_markdown[body_start] == "\n":
+        if (
+            body_start < len(rendered_markdown)
+            and rendered_markdown[body_start] == "\n"
+        ):
             body_start += 1
-        matches.append((level, text, match.start(), body_start, section_id))
+        matches.append((level, text, match.start(), body_start, section_id, id_source))
         cursor = match.end()
 
     md_len = len(rendered_markdown)
-    for i, (level, text, _heading_start, char_start, section_id) in enumerate(matches):
+    for i, (
+        level,
+        text,
+        _heading_start,
+        char_start,
+        section_id,
+        id_source,
+    ) in enumerate(matches):
         # char_end extends to the next heading at the SAME OR HIGHER level
         # (lower number == higher level) — i.e., the next sibling or
         # ancestor-sibling. Use the *heading_start* of the next match
@@ -197,6 +211,7 @@ def _compute_section_offsets(
                     "char_start": char_start,
                     "char_end": char_end,
                     "parent_id": parent_id,
+                    "id_source": id_source,
                 },
             )
         )

--- a/openzim_mcp/cache.py
+++ b/openzim_mcp/cache.py
@@ -52,6 +52,21 @@ def _silence_logging_errors(func: Callable[..., Any]) -> Callable[..., Any]:
     return wrapper
 
 
+def _approximate_size_bytes(value: Any) -> int:
+    """Approximate the cached value's memory cost via JSON encoding length.
+
+    JSON length is not the actual Python in-memory footprint, but it is
+    a stable, monotonic proxy that callers can budget against, and it's
+    cheap (no full pympler-style traversal). Non-serializable values
+    fall back to a conservative ``2 KB`` so they still count toward the
+    cap.
+    """
+    try:
+        return len(json.dumps(value, ensure_ascii=False, default=str))
+    except (TypeError, ValueError):
+        return 2048
+
+
 class CacheEntry:
     """Represents a single cache entry with TTL."""
 
@@ -69,6 +84,7 @@ class CacheEntry:
             False
         """
         self.value = value
+        self.size_bytes = _approximate_size_bytes(value)
         # Use monotonic clock for in-memory expiry/LRU so wall-clock
         # adjustments (NTP, DST, manual changes) can't break expiry.
         self.created_at = time.monotonic()
@@ -121,6 +137,10 @@ class OpenZimMcpCache:
         """
         self.config = config
         self._cache: Dict[str, CacheEntry] = {}
+        # Running total of ``CacheEntry.size_bytes`` across all live
+        # entries. Updated incrementally on every set/eviction so the
+        # byte-bound eviction check is O(1).
+        self._total_bytes: int = 0
         # Monotonic counter for LRU access ordering. A counter is used in
         # preference to a wall-clock or monotonic timestamp because clock
         # resolution varies by platform (Windows ticks at ~15.6ms by default),
@@ -285,18 +305,42 @@ class OpenZimMcpCache:
                 ) from exc
 
         with self._lock:
-            # Check if we need to evict entries
+            # Check if we need to evict by entry count
             if len(self._cache) >= self.config.max_size and key not in self._cache:
                 self._evict_lru()
 
+            # Replace path: drop the old entry's byte count first so
+            # ``_total_bytes`` stays accurate when the same key is reset
+            # with a value of different size.
+            prior = self._cache.get(key)
+            if prior is not None:
+                self._total_bytes -= prior.size_bytes
+                if self._total_bytes < 0:
+                    self._total_bytes = 0
+
             # Add/update entry
-            self._cache[key] = CacheEntry(value, self.config.ttl_seconds)
+            entry = CacheEntry(value, self.config.ttl_seconds)
+            self._cache[key] = entry
+            self._total_bytes += entry.size_bytes
             self._access_counter += 1
             access_counter = self._access_counter
             self._access_order[key] = access_counter
             # Push to heap for O(log n) LRU eviction
             heapq.heappush(self._lru_heap, (access_counter, key))
-            logger.debug(f"Cache set: {key}")
+            logger.debug(
+                f"Cache set: {key} ({entry.size_bytes} bytes, total "
+                f"{self._total_bytes} bytes)"
+            )
+
+            # Byte-budget eviction: if the cache exceeds ``max_bytes``,
+            # evict LRU entries until we're back under. Skip when the
+            # cap is 0 (disabled) or when the cache only holds this one
+            # entry (a single oversized value can legitimately exceed
+            # the cap; the count cap still bounds entry count).
+            max_bytes = getattr(self.config, "max_bytes", 0)
+            if max_bytes > 0:
+                while self._total_bytes > max_bytes and len(self._cache) > 1:
+                    self._evict_lru()
 
     def delete(self, key: str) -> None:
         """
@@ -315,7 +359,11 @@ class OpenZimMcpCache:
 
     def _remove(self, key: str) -> None:
         """Remove entry from cache (must be called with lock held)."""
-        self._cache.pop(key, None)
+        entry = self._cache.pop(key, None)
+        if entry is not None:
+            self._total_bytes -= entry.size_bytes
+            if self._total_bytes < 0:
+                self._total_bytes = 0
         self._access_order.pop(key, None)
 
     def _cleanup_expired(self) -> None:
@@ -381,6 +429,7 @@ class OpenZimMcpCache:
             self._cache.clear()
             self._access_order.clear()
             self._lru_heap.clear()
+            self._total_bytes = 0
             self._hits = 0
             self._misses = 0
         logger.info("Cache cleared")
@@ -395,6 +444,8 @@ class OpenZimMcpCache:
                 "enabled": self.config.enabled,
                 "size": len(self._cache),
                 "max_size": self.config.max_size,
+                "size_bytes": self._total_bytes,
+                "max_bytes": getattr(self.config, "max_bytes", 0),
                 "ttl_seconds": self.config.ttl_seconds,
                 "hits": self._hits,
                 "misses": self._misses,

--- a/openzim_mcp/config.py
+++ b/openzim_mcp/config.py
@@ -30,6 +30,12 @@ class CacheConfig(BaseModel):
 
     enabled: bool = True
     max_size: int = Field(default=CACHE.MAX_SIZE, ge=1, le=10000)
+    # Soft byte cap. The count-based ``max_size`` remains a hard upper
+    # bound; ``max_bytes`` adds an approximate-size eviction trigger so
+    # a few large bundles can't pin hundreds of MB. Computed via
+    # ``len(json.dumps(value))`` — cheap, deterministic, and accurate
+    # enough for budgeting. ``0`` disables the byte cap entirely.
+    max_bytes: int = Field(default=CACHE.MAX_BYTES, ge=0, le=8 * 1024 * 1024 * 1024)
     ttl_seconds: int = Field(default=CACHE.TTL_SECONDS, ge=60, le=86400)
     persistence_enabled: bool = Field(default=CACHE.PERSISTENCE_ENABLED)
     persistence_path: str = Field(default_factory=lambda: CACHE.PERSISTENCE_PATH)

--- a/openzim_mcp/content_processor.py
+++ b/openzim_mcp/content_processor.py
@@ -621,7 +621,16 @@ class ContentProcessor:
             # trailing "..." sentinel so callers see a consistent format.
             if len(snippet_text) > self.snippet_length:
                 cap = max(self.snippet_length - 3, 0)
-                snippet_text = snippet_text[:cap].rstrip() + "..."
+                sliced = snippet_text[:cap].rstrip()
+                # Truncation can land inside a ``**term**`` highlight, leaving
+                # an unmatched opening marker (e.g. ``…**ter``) that downstream
+                # markdown renderers will treat as runaway bold. Detect an
+                # unpaired trailing ``**`` and strip the dangling fragment.
+                if sliced.count("**") % 2 == 1:
+                    last_open = sliced.rfind("**")
+                    if last_open >= 0:
+                        sliced = sliced[:last_open].rstrip()
+                snippet_text = sliced + "..."
 
         return snippet_text
 

--- a/openzim_mcp/content_processor.py
+++ b/openzim_mcp/content_processor.py
@@ -448,7 +448,17 @@ class ContentProcessor:
             row_threshold = self._table_row_threshold
         if char_threshold is None:
             char_threshold = self._table_char_threshold
-        for index, table in enumerate(soup.find_all("table"), start=1):
+        # Iterate only OUTER tables (those whose nearest ancestor is not
+        # itself a ``<table>``). The previous ``find_all("table")`` walk
+        # enumerated nested tables too, and replacing an outer table
+        # detached its inner tables from the tree — subsequent
+        # ``replace_with`` calls on those detached nodes silently
+        # no-op'd, leaving inner tables un-placeholdered when they
+        # weren't reached first (Phase A #14 fix).
+        outer_tables = [
+            t for t in soup.find_all("table") if t.find_parent("table") is None
+        ]
+        for index, table in enumerate(outer_tables, start=1):
             rows = table.find_all("tr")
             text = table.get_text()
             if len(rows) <= row_threshold and len(text) <= char_threshold:

--- a/openzim_mcp/defaults.py
+++ b/openzim_mcp/defaults.py
@@ -29,6 +29,12 @@ class CacheDefaults:
     ENABLED: bool = True
     MAX_SIZE: int = 100
     TTL_SECONDS: int = 3600  # 1 hour
+    # Soft cap on total approximate cache size (JSON-rendered bytes
+    # across all entries). Eviction kicks in BEFORE ``MAX_SIZE`` if
+    # entries are large (Phase C bundles can be hundreds of KB each).
+    # 64 MB keeps memory bounded on long-running servers without
+    # measurably degrading hit rate for typical workloads.
+    MAX_BYTES: int = 64 * 1024 * 1024
     PERSISTENCE_ENABLED: bool = False
     PERSISTENCE_PATH: str = field(default_factory=_default_persistence_path)
 

--- a/openzim_mcp/meta.py
+++ b/openzim_mcp/meta.py
@@ -52,14 +52,29 @@ def _get_encoder() -> Any:
     return _EncoderCache.encoder
 
 
-def tokens_est(rendered: str) -> int:
-    """Estimate the token count of a rendered string using cl100k_base."""
+def _raw_tokens_est(rendered: str) -> Optional[int]:
+    """Tokenize ``rendered``. Returns ``None`` when the tokenizer is
+    unavailable so callers can distinguish "couldn't estimate" from
+    "zero tokens" — spec §5 requires omitting ``tokens_est`` on
+    tiktoken init failure rather than emitting a misleading 0.
+    """
     if not rendered:
         return 0
     encoder = _get_encoder()
     if encoder is None:
-        return 0
+        return None
     return len(encoder.encode(rendered))
+
+
+def tokens_est(rendered: str) -> int:
+    """Estimate the token count of a rendered string using cl100k_base.
+
+    Returns 0 on empty input and 0 when the tokenizer is unavailable —
+    the public helper preserves the legacy int return; envelope builders
+    that need the "unavailable" signal call :func:`_raw_tokens_est`.
+    """
+    raw = _raw_tokens_est(rendered)
+    return raw if raw is not None else 0
 
 
 def build_meta(
@@ -88,14 +103,18 @@ def build_meta(
     must leave it ``None``.
     """
     chars = len(rendered)
-    raw_tokens = tokens_est(rendered)
-    padded_tokens = int(raw_tokens * 1.05) + 1 if raw_tokens else 0
+    raw_tokens = _raw_tokens_est(rendered)
 
     meta: Dict[str, Any] = {
-        "tokens_est": padded_tokens,
         "chars": chars,
         "truncated": truncated,
     }
+    # Spec §5: omit ``tokens_est`` when the tokenizer is unavailable so
+    # models can distinguish "zero-token response" from "tokenizer
+    # unavailable". A non-None raw count (including 0 for empty input)
+    # populates the field; ``None`` skips it.
+    if raw_tokens is not None:
+        meta["tokens_est"] = int(raw_tokens * 1.05) + 1 if raw_tokens else 0
     if truncated:
         if content_chars is not None:
             meta["more_at_offset"] = current_offset + content_chars
@@ -123,10 +142,29 @@ def format_footer(meta: Dict[str, Any], *, footer_enabled: bool) -> str:
     if not footer_enabled or not meta:
         return ""
 
-    if meta.get("reason") in {"0_hits", "low_relevance", "bad_query"}:
+    reason = meta.get("reason")
+    # Any structured reason on an empty/low-confidence response shapes the
+    # footer as a recovery hint instead of the token-budget summary. Without
+    # this, archives lacking a full-text index (``no_xapian_index``) or
+    # invalid-namespace responses (``bad_namespace``) fall through to a
+    # "~0 tokens" line that gives small models no actionable signal.
+    if reason in {
+        "0_hits",
+        "low_relevance",
+        "bad_query",
+        "no_xapian_index",
+        "bad_namespace",
+    }:
         suggestions = meta.get("suggestions") or []
         visible = suggestions[:3]
         if not visible:
+            if reason == "no_xapian_index":
+                return (
+                    "> No full-text index on this archive. "
+                    "Try `find_entry_by_title` or `browse_namespace`."
+                )
+            if reason == "bad_namespace":
+                return "> Unknown namespace. Try `list_namespaces` to see valid options."
             return "> No results. Try a shorter or differently-spelled query."
         bits: List[str] = []
         for item in visible:
@@ -144,7 +182,14 @@ def format_footer(meta: Dict[str, Any], *, footer_enabled: bool) -> str:
                 bits.append(f"`{v}`")
         return "> No results. Try: " + " · ".join(bits)
 
-    parts: List[str] = [f"~{_humanize_count(meta['tokens_est'])} tokens"]
+    # ``tokens_est`` may be absent when the tokenizer is unavailable (spec
+    # §5); fall back to char-count so the footer still gives the model a
+    # budget signal instead of crashing on KeyError.
+    parts: List[str] = []
+    if "tokens_est" in meta:
+        parts.append(f"~{_humanize_count(meta['tokens_est'])} tokens")
+    else:
+        parts.append(f"~{_humanize_count(meta.get('chars', 0))} chars")
     if meta.get("truncated"):
         chars_label = _humanize_count(meta["chars"])
         total_label = _humanize_count(meta.get("total_chars", meta["chars"]))

--- a/openzim_mcp/meta.py
+++ b/openzim_mcp/meta.py
@@ -164,7 +164,9 @@ def format_footer(meta: Dict[str, Any], *, footer_enabled: bool) -> str:
                     "Try `find_entry_by_title` or `browse_namespace`."
                 )
             if reason == "bad_namespace":
-                return "> Unknown namespace. Try `list_namespaces` to see valid options."
+                return (
+                    "> Unknown namespace. Try `list_namespaces` to see valid options."
+                )
             return "> No results. Try a shorter or differently-spelled query."
         bits: List[str] = []
         for item in visible:

--- a/openzim_mcp/meta.py
+++ b/openzim_mcp/meta.py
@@ -67,6 +67,7 @@ def build_meta(
     rendered: str,
     total_chars: Optional[int] = None,
     current_offset: int = 0,
+    content_chars: Optional[int] = None,
     truncated: bool = False,
     suggestions: Optional[List[Dict[str, str]]] = None,
     reason: Optional[str] = None,
@@ -76,6 +77,15 @@ def build_meta(
     Always emits `tokens_est` (with a 5% pad to cover envelope cost),
     `chars`, `truncated`. Conditionally emits `more_at_offset`,
     `total_chars`, `suggestions`, `reason`.
+
+    ``content_chars`` is the byte length of the *paginable content slice*
+    in the response (e.g. ``len(payload["content"])`` for get_zim_entry).
+    When set together with ``truncated``, drives ``more_at_offset =
+    current_offset + content_chars`` — i.e. the offset a caller would
+    use to fetch the next page. When omitted, ``more_at_offset`` is not
+    emitted: tools whose ``truncated`` means "value omitted, no
+    continuation" (binary cap, section-content cap, summary word cap)
+    must leave it ``None``.
     """
     chars = len(rendered)
     raw_tokens = tokens_est(rendered)
@@ -87,7 +97,8 @@ def build_meta(
         "truncated": truncated,
     }
     if truncated:
-        meta["more_at_offset"] = current_offset + chars
+        if content_chars is not None:
+            meta["more_at_offset"] = current_offset + content_chars
         if total_chars is not None:
             meta["total_chars"] = total_chars
     if suggestions:
@@ -149,12 +160,19 @@ def attach_meta(
     truncated: bool = False,
     total_chars: Optional[int] = None,
     current_offset: int = 0,
+    content_chars: Optional[int] = None,
     suggestions: Optional[List[Dict[str, str]]] = None,
     reason: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Attach a `_meta` envelope built from the JSON-rendered payload (sans _meta).
 
     Mutates and returns `payload`. Forwards build_meta kwargs.
+
+    Note: ``_meta.chars`` reflects the rendered JSON envelope size (useful
+    for context-budget tracking), which is necessarily larger than the
+    content slice. Pagination is driven by ``content_chars`` — pass the
+    length of the paginable field (e.g. ``len(payload["content"])``) so
+    ``more_at_offset`` is computed from content bytes, not envelope bytes.
     """
     rendered = _json.dumps(
         {k: v for k, v in payload.items() if k != "_meta"},
@@ -165,6 +183,7 @@ def attach_meta(
         truncated=truncated,
         total_chars=total_chars,
         current_offset=current_offset,
+        content_chars=content_chars,
         suggestions=suggestions,
         reason=reason,
     )

--- a/openzim_mcp/pagination.py
+++ b/openzim_mcp/pagination.py
@@ -65,7 +65,7 @@ class CursorState(TypedDict, total=False):
 class CursorPayload(TypedDict):
     """Full cursor payload: version, tool name, and tool-specific state."""
 
-    v: int  # cursor version, currently 1
+    v: int  # cursor version (see CURRENT_VERSION)
     t: str  # tool name (e.g., "browse_namespace")
     s: CursorState  # tool-specific state
 

--- a/openzim_mcp/pagination.py
+++ b/openzim_mcp/pagination.py
@@ -4,14 +4,22 @@ v2 Phase B promotes the v1 ``PaginationCursor`` (offset/limit/query only) to
 a tool-bound, versioned cursor. The wire format is a URL-safe base64 encoding
 of a JSON object:
 
-    {"v": 1, "t": "<tool_name>", "s": {<tool-specific state>}}
+    {"v": 2, "t": "<tool_name>", "s": {<tool-specific state>}}
 
 * ``v`` lets us add new required fields later without a wire-format break.
 * ``t`` rejects cross-tool cursor reuse (a search cursor passed to browse
   raises ``CursorMismatchError`` instead of silently misbehaving).
 * ``s`` carries the per-tool paging state — offset/limit/query for search,
   scan_at for walk_namespace, etc.
+* ``s.ai`` (archive identity) is included on every cursor whose result
+  depends on a specific ZIM file; mismatches raise ``CursorMismatchError``
+  so a cursor from archive A can't be resubmitted against archive B.
 * Cross-tool reuse raises ``CursorMismatchError`` (a ``ValueError`` subclass).
+
+Version bump v1→v2 (alpha-line clean break): added ``ai`` archive identity
+and required ``ns`` on walk_namespace/browse_namespace cursors. v1 cursors
+are rejected with a clear error so callers learn to re-fetch rather than
+silently follow stale state.
 
 Decode failures and tool mismatches both subclass ``ValueError`` so a single
 except-clause in tool wrappers catches both.
@@ -20,10 +28,24 @@ except-clause in tool wrappers catches both.
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
-from typing import TypedDict, cast
+from pathlib import Path
+from typing import TypedDict, Union, cast
 
-CURRENT_VERSION = 1
+CURRENT_VERSION = 2
+
+
+def archive_identity(validated_path: Union[Path, str]) -> str:
+    """Short stable token derived from a validated archive path.
+
+    Used in cursor ``s.ai`` so a cursor issued for archive A can't be
+    resubmitted against archive B. SHA-256 truncated to 12 hex chars —
+    collision probability is ~2^-48 across a session, well under the
+    practical archive count.
+    """
+    raw = str(validated_path).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()[:12]
 
 
 class CursorState(TypedDict, total=False):
@@ -32,11 +54,12 @@ class CursorState(TypedDict, total=False):
     o: int  # offset (search, browse, links)
     l: int  # noqa: E741 — single-letter wire-format key, kept short to keep cursors small
     q: str  # query (search, search_all per-file)
-    ns: str  # namespace (browse_namespace)
+    ns: str  # namespace (browse_namespace, walk_namespace)
     scan_at: int  # entry id (walk_namespace — replaces today's int cursor)
     ep: str  # entry path (extract_article_links)
     k: str  # kind: "internal" | "external" | "media"
     ct: str  # content_type (search_with_filters)
+    ai: str  # archive identity (short SHA-256 token of validated_path)
 
 
 class CursorPayload(TypedDict):
@@ -48,7 +71,8 @@ class CursorPayload(TypedDict):
 
 
 class CursorMismatchError(ValueError):
-    """Raised when a cursor's ``t`` field doesn't match ``expected_tool``."""
+    """Raised when a cursor's ``t`` field doesn't match ``expected_tool``,
+    or its ``s.ai`` archive identity doesn't match the call's archive."""
 
 
 class Cursor:
@@ -114,3 +138,35 @@ class Cursor:
                 f"Cursor was issued by '{payload['t']}', cannot be used by '{expected_tool}'"
             )
         return cast("CursorPayload", payload)
+
+    @staticmethod
+    def verify_archive_identity(
+        state: "CursorState", *, expected: str, tool: str
+    ) -> None:
+        """Verify ``s.ai`` in a decoded cursor matches the current archive.
+
+        Tools that page over a specific ZIM file (extract_article_links,
+        walk_namespace, browse_namespace, search_zim_file) call this
+        after ``decode`` to ensure the cursor's archive identity matches
+        the archive being passed to the follow-up call.
+
+        Passing a cursor from archive A back to a call against archive B
+        previously silently returned results from B starting at the
+        offset A had reached — confusing and wrong. Cursors issued
+        before v2 (no ``ai`` field) were already rejected by the version
+        check; v2+ cursors always carry ``ai``.
+
+        Raises:
+            CursorMismatchError: ``s.ai`` is absent or doesn't match.
+        """
+        actual = state.get("ai")
+        if actual is None:
+            raise CursorMismatchError(
+                f"Cursor for '{tool}' missing archive-identity field. "
+                f"Re-issue the request without a cursor."
+            )
+        if actual != expected:
+            raise CursorMismatchError(
+                f"Cursor for '{tool}' was issued against a different archive. "
+                f"Drop the cursor and start the paginated call over."
+            )

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -996,9 +996,11 @@ class SimpleToolsHandler:
                 f"truncated by the backend; try `get article "
                 f"{entry_path}` for the full body."
             )
-        text = (section.get("content_markdown") or "").strip() if isinstance(
-            section, dict
-        ) else ""
+        text: str = ""
+        if isinstance(section, dict):
+            raw = section.get("content_markdown")
+            if isinstance(raw, str):
+                text = raw.strip()
         if not text:
             return (
                 f'**Section "{target.get("text")}" in `{entry_path}` is empty**\n\n'

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -330,9 +330,13 @@ class SimpleToolsHandler:
                 # (currently: compact + zero-result search).  When set,
                 # ``format_footer`` renders the empty-result suggestion
                 # variant instead of the token-count variant.
+                # In simple mode ``result`` is the body markdown itself —
+                # ``len(result)`` is both the rendered char count AND the
+                # paginable content length, so they drive the same field.
                 meta = build_meta(
                     rendered=result,
                     truncated=was_truncated,
+                    content_chars=len(result) if was_truncated else None,
                     total_chars=pre_cap_chars if was_truncated else None,
                     reason=handler_reason,
                     suggestions=handler_suggestions,
@@ -968,10 +972,33 @@ class SimpleToolsHandler:
                 f"Available sections:\n{avail}"
             )
 
-        # ``preview`` is the section's leading paragraph(s) trimmed by
-        # the structure backend. It's pre-baked to ~3000 chars per
-        # heading and is exactly the data shape we want here.
-        text = (target.get("preview") or "").strip()
+        # Delegate to ``get_section_data`` to slice the full section out
+        # of the bundle's rendered markdown — ~500-1500 tokens, the
+        # small-model sweet spot per Phase C #7. The heading's ``id``
+        # matches the bundle section ``id`` 1:1 (both are derived from
+        # the same ``bundle["sections"]`` list).
+        section_id = target.get("id") or ""
+        try:
+            section = self.zim_operations.get_section_data(
+                zim_file_path, entry_path, section_id
+            )
+        except Exception as e:
+            return (
+                f"**Could not load section `{target.get('text')}` "
+                f"from `{entry_path}`**\n\n"
+                f"{sanitize_context_for_error(str(e))}"
+            )
+        if isinstance(section, dict) and section.get("error"):
+            return (
+                f'**Section "{target.get("text")}" in `{entry_path}` is empty**\n\n'
+                f"This heading exists in the article structure but has "
+                f"no content rendered. The article may have been "
+                f"truncated by the backend; try `get article "
+                f"{entry_path}` for the full body."
+            )
+        text = (section.get("content_markdown") or "").strip() if isinstance(
+            section, dict
+        ) else ""
         if not text:
             return (
                 f'**Section "{target.get("text")}" in `{entry_path}` is empty**\n\n'

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -95,20 +95,25 @@ def _extract_passages(
     hits: list[dict],
     *,
     archive_name: str,
-    content_processor: ContentProcessor,
 ) -> list[SynthesizePassage]:
     """Convert hit dicts into SynthesizePassage entries.
 
-    Each hit's snippet (potentially HTML from libzim.getSnippet) is
-    rendered to markdown. cite_id is the entry-level form
-    f"{archive_name}/{path}" — the "#section_id" suffix is added by
-    Stage 5 (_attribute_sections) once the bundle is consulted.
+    The snippet from ``search_top_k`` is already a plain-markdown string
+    produced by ``_get_entry_snippet`` → ``create_snippet`` (which
+    decompresses the entry, runs html2text, and slices to a paragraph
+    boundary). Re-running ``html_to_plain_text`` on it is a no-op for
+    clean output but risks mangling bold-highlight markers via the
+    BeautifulSoup → html2text round-trip — trust the upstream pipeline
+    instead.
+
+    cite_id is the entry-level form ``f"{archive_name}/{path}"`` —
+    the ``"#section_id"`` suffix is added by Stage 5 (``_attribute_sections``)
+    once the bundle is consulted.
     """
     passages: list[SynthesizePassage] = []
     for rank, hit in enumerate(hits, start=1):
         snippet = hit.get("snippet") or ""
-        text = content_processor.html_to_plain_text(snippet) if snippet else ""
-        text = text.strip()
+        text = snippet.strip()
         cite_id = f"{archive_name}/{hit['path']}"
         passages.append(
             cast(
@@ -181,6 +186,15 @@ def _locate_passage(md: str, passage_text: str) -> int:
         else:
             norm_cursor += 1
             prev_was_space = False
+        md_cursor += 1
+    # Probes are normalized + trimmed so probe[0] is always a non-space
+    # character. After lockstep walk the cursor may sit on the first
+    # whitespace of a run that md_norm collapsed to one space — advance
+    # past any remaining whitespace so the returned offset points at the
+    # first non-space char of the match in the original md. Without this
+    # step, attribution can land in an earlier section when two section
+    # boundaries hug a whitespace run.
+    while md_cursor < len(md) and md[md_cursor].isspace():
         md_cursor += 1
     return md_cursor
 
@@ -366,12 +380,36 @@ def _do_per_archive_search(
     query: str,
     k: int,
 ) -> tuple[list[list[dict]], list[str], dict[str, tuple[Archive, Path]]]:
-    """Stage 1: run per-archive Xapian search for every archive in the list."""
+    """Stage 1: run per-archive Xapian search for every archive in the list.
+
+    When two ZIM paths resolve to the same ``.stem`` (the user has
+    ``foo/wikipedia.zim`` and ``bar/wikipedia.zim`` both configured), the
+    raw stem can't act as a unique key for downstream bundle lookups —
+    a collision silently re-routes attribution to whichever archive
+    overwrote the dict entry. Detect duplicates and append a numeric
+    suffix (``stem~2``, ``stem~3``) so each archive carries a unique
+    name in ``archives_searched`` and ``archive_by_name``. The tilde
+    keeps the suffix unambiguous to humans without hijacking a
+    character that might appear in real ZIM filenames.
+    """
     per_archive_hits: list[list[dict]] = []
     archives_searched: list[str] = []
     archive_by_name: dict[str, tuple[Archive, Path]] = {}
+    stem_counts: dict[str, int] = {}
     for archive, validated_path in archives:
-        archive_name = validated_path.stem
+        base = validated_path.stem
+        n = stem_counts.get(base, 0) + 1
+        stem_counts[base] = n
+        archive_name = base if n == 1 else f"{base}~{n}"
+        if n > 1:
+            logger.warning(
+                "synthesize: duplicate ZIM stem %r — using %r for the %d-th archive "
+                "(%s) so attribution stays correct",
+                base,
+                archive_name,
+                n,
+                validated_path,
+            )
         archives_searched.append(archive_name)
         archive_by_name[archive_name] = (archive, validated_path)
         per_archive_hits.append(
@@ -491,8 +529,6 @@ def _make_bundle_lookup(
 
 def _extract_passages_for_top_hits(
     top_hits: list[tuple[str, dict]],
-    *,
-    content_processor: ContentProcessor,
 ) -> tuple[list[SynthesizePassage], list[tuple[str, str]]]:
     """Stage 4: extract per-hit passages and renumber rank globally.
 
@@ -507,7 +543,6 @@ def _extract_passages_for_top_hits(
             _extract_passages(
                 [hit],
                 archive_name=archive_name,
-                content_processor=content_processor,
             )
         )
         hit_keys.append((archive_name, hit["path"]))
@@ -588,9 +623,7 @@ def synthesize_query(
     if not top_hits:
         return _zero_hits_response(query, archives_searched, fallback_used)
 
-    all_passages, hit_keys = _extract_passages_for_top_hits(
-        top_hits, content_processor=content_processor
-    )
+    all_passages, hit_keys = _extract_passages_for_top_hits(top_hits)
     bundle_lookup = _make_bundle_lookup(
         top_hits,
         archive_by_name,

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -14,6 +14,7 @@ Returns SynthesizeResponse (defined in tool_schemas.py).
 from __future__ import annotations
 
 import logging
+import re
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
@@ -128,6 +129,62 @@ def _extract_passages(
 # ---------------------------------------------------------------------------
 
 
+# Collapse whitespace runs to single spaces. Snippets are produced by a
+# different rendering path than the bundle's markdown (today: html2text
+# applied per-snippet vs per-article), and incidental whitespace
+# divergence is the most common reason a literal ``md.find`` misses.
+_WS_RE = re.compile(r"\s+")
+
+
+def _normalize_ws(text: str) -> str:
+    """Collapse whitespace runs so attribution survives format drift."""
+    return _WS_RE.sub(" ", text).strip()
+
+
+def _locate_passage(md: str, passage_text: str) -> int:
+    """Return the offset of ``passage_text`` within ``md``, or -1 on miss.
+
+    Tries the exact match first (cheap, common). Falls back to a
+    whitespace-normalized search so attribution survives whitespace or
+    inline-markup drift between the snippet rendering path and the
+    bundle's rendered markdown. The returned offset is into the
+    *original* ``md`` so callers can map it back to section ranges.
+    """
+    pos = md.find(passage_text)
+    if pos >= 0:
+        return pos
+
+    # Use the first ~80 chars of the normalized passage as a probe — long
+    # enough to be specific, short enough that a single intra-passage
+    # divergence doesn't kill the match.
+    probe = _normalize_ws(passage_text)[:80]
+    if len(probe) < 12:
+        return -1
+
+    md_norm = _normalize_ws(md)
+    probe_pos = md_norm.find(probe)
+    if probe_pos < 0:
+        return -1
+
+    # Map the normalized offset back to the original md offset. Walk md
+    # in lockstep with md_norm, advancing the original cursor only when
+    # the normalized character matches.
+    md_cursor = 0
+    norm_cursor = 0
+    prev_was_space = False
+    while md_cursor < len(md) and norm_cursor < probe_pos:
+        ch = md[md_cursor]
+        if ch.isspace():
+            if not prev_was_space and norm_cursor > 0:
+                norm_cursor += 1
+            prev_was_space = True
+        else:
+            norm_cursor += 1
+            prev_was_space = False
+        md_cursor += 1
+    return md_cursor
+
+
 def _attribute_sections(
     passages: list[SynthesizePassage],
     *,
@@ -143,6 +200,11 @@ def _attribute_sections(
     ``hit_keys`` is a parallel list of ``(archive_name, entry_path)`` tuples;
     using the tuple as the bundle-lookup key avoids cross-archive
     collisions (issue Phase C #4).
+
+    When multiple nested sections contain the passage offset (a child
+    section sits inside its parent's range), the *most specific*
+    (smallest, deepest) section wins. Citing "Berlin#Geography" beats
+    "Berlin" when the snippet sits inside the Geography subsection.
     """
     attributed: list[SynthesizePassage] = []
     for passage, (archive_name, hit_path) in zip(passages, hit_keys):
@@ -168,15 +230,25 @@ def _attribute_sections(
             attributed.append(passage)
             continue
 
-        pos = md.find(passage_text)
+        pos = _locate_passage(md, passage_text)
         if pos < 0:
             attributed.append(passage)
             continue
 
+        # Pick the smallest-range containing section so nested attribution
+        # cites the deepest heading (e.g. h3 inside h2 inside h1).
+        best_section: Optional[dict] = None
+        best_span = None
         for section in bundle.get("sections", []):
-            if section["char_start"] <= pos < section["char_end"]:
-                new_cite_id = f"{passage['cite_id']}#{section['id']}"
-                break
+            cs = section["char_start"]
+            ce = section["char_end"]
+            if cs <= pos < ce:
+                span = ce - cs
+                if best_span is None or span < best_span:
+                    best_section = section
+                    best_span = span
+        if best_section is not None:
+            new_cite_id = f"{passage['cite_id']}#{best_section['id']}"
 
         new_passage = dict(passage)
         new_passage["cite_id"] = new_cite_id
@@ -371,7 +443,9 @@ def _select_top_hits_multi(
         ]
         if not candidates:
             continue
-        _, best_archive = min(candidates, key=lambda t: (t[0], archives_searched.index(t[1])))
+        _, best_archive = min(
+            candidates, key=lambda t: (t[0], archives_searched.index(t[1]))
+        )
         h = dict(hit_to_archive[(best_archive, path)][1])
         h["score"] = fused_score
         top_hits.append((best_archive, h))

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -131,20 +131,24 @@ def _extract_passages(
 def _attribute_sections(
     passages: list[SynthesizePassage],
     *,
-    bundle_lookup: Callable[[str], Any],
-    hit_paths: list[str],
+    bundle_lookup: Callable[[str, str], Any],
+    hit_keys: list[tuple[str, str]],
 ) -> list[SynthesizePassage]:
     """For each passage, find its containing section in the bundle and append #section_id.
 
     On bundle-build failure for an entry, leave the cite_id at entry level
     (no #section suffix). The passage is never dropped — section attribution
     is best-effort.
+
+    ``hit_keys`` is a parallel list of ``(archive_name, entry_path)`` tuples;
+    using the tuple as the bundle-lookup key avoids cross-archive
+    collisions (issue Phase C #4).
     """
     attributed: list[SynthesizePassage] = []
-    for passage, hit_path in zip(passages, hit_paths):
+    for passage, (archive_name, hit_path) in zip(passages, hit_keys):
         new_cite_id = passage["cite_id"]
         try:
-            bundle = bundle_lookup(hit_path)
+            bundle = bundle_lookup(archive_name, hit_path)
         except Exception as e:
             logger.info(
                 "Bundle build failed for %s during synthesize attribution: %s",
@@ -246,10 +250,10 @@ def _parse_cite_id(cite_id: str) -> tuple[str, str, Optional[str]]:
 def _build_citations(
     passages: list[SynthesizePassage],
     *,
-    archive_titles: dict[str, str],  # entry_path -> entry title
+    archive_titles: dict[tuple[str, str], str],  # (archive, entry_path) -> entry title
     section_titles: dict[
-        tuple[str, str], str
-    ],  # (entry_path, section_id) -> section title
+        tuple[str, str, str], str
+    ],  # (archive, entry_path, section_id) -> section title
 ) -> list[Citation]:
     """Expand passages' cite_ids into Citation entries; dedupe by cite_id."""
     seen: dict[str, Citation] = {}
@@ -258,9 +262,11 @@ def _build_citations(
         if cite_id in seen:
             continue
         archive, entry_path, section_id = _parse_cite_id(cite_id)
-        title = archive_titles.get(entry_path, entry_path)
+        title = archive_titles.get((archive, entry_path), entry_path)
         section_title = (
-            section_titles.get((entry_path, section_id)) if section_id else None
+            section_titles.get((archive, entry_path, section_id))
+            if section_id
+            else None
         )
         seen[cite_id] = cast(
             "Citation",
@@ -333,24 +339,42 @@ def _select_top_hits_multi(
     *,
     top_n: int,
 ) -> tuple[list[tuple[str, dict]], str]:
-    """Multi-archive RRF fusion path of :func:`_select_top_hits`."""
-    hit_to_archive: dict[tuple[str, str], dict] = {
-        (archive_name, hit["path"]): hit
-        for archive_name, hits in zip(archives_searched, per_archive_hits)
-        for hit in hits
-    }
+    """Multi-archive RRF fusion path of :func:`_select_top_hits`.
+
+    On a path that appears in multiple archives (common for Wikipedia
+    ZIMs that share entry paths), credit the archive that ranked it
+    highest in its own per-archive list — not the first archive in
+    ``archives_searched`` iteration order. ``hit_to_archive`` carries
+    the original ranking position so we can pick the best contributor
+    deterministically.
+    """
+    # (archive_name, path) -> (rank_in_archive, hit_dict)
+    hit_to_archive: dict[tuple[str, str], tuple[int, dict]] = {}
+    for archive_name, hits in zip(archives_searched, per_archive_hits):
+        for rank_in_archive, hit in enumerate(hits):
+            hit_to_archive[(archive_name, hit["path"])] = (rank_in_archive, hit)
     rankings = [
         [(hit["path"], hit["score"]) for hit in hits] for hits in per_archive_hits
     ]
     fused = _rrf_fuse(rankings, k=60)[:top_n]
     top_hits: list[tuple[str, dict]] = []
     for path, fused_score in fused:
-        for archive_name in archives_searched:
-            if (archive_name, path) in hit_to_archive:
-                h = dict(hit_to_archive[(archive_name, path)])
-                h["score"] = fused_score
-                top_hits.append((archive_name, h))
-                break
+        # Among archives that contain this path, pick the one with the
+        # best (lowest) rank — i.e., the archive that contributed the
+        # highest signal to RRF. Ties broken by ``archives_searched``
+        # order for determinism.
+        candidates = [
+            (rank, archive_name)
+            for archive_name in archives_searched
+            if (archive_name, path) in hit_to_archive
+            for rank, _ in (hit_to_archive[(archive_name, path)],)
+        ]
+        if not candidates:
+            continue
+        _, best_archive = min(candidates, key=lambda t: (t[0], archives_searched.index(t[1])))
+        h = dict(hit_to_archive[(best_archive, path)][1])
+        h["score"] = fused_score
+        top_hits.append((best_archive, h))
     return top_hits, "rrf_fusion"
 
 
@@ -360,14 +384,23 @@ def _make_bundle_lookup(
     *,
     cache: OpenZimMcpCache,
     content_processor: ContentProcessor,
-) -> Callable[[str], Any]:
-    """Build a path→bundle closure used by attribution and citation lookups."""
-    archive_for_path: dict[str, tuple[Archive, Path]] = {
-        hit["path"]: archive_by_name[archive_name] for archive_name, hit in top_hits
+) -> Callable[[str, str], Any]:
+    """Build an (archive_name, path)→bundle closure used by attribution and
+    citation lookups.
+
+    Keying on ``(archive_name, entry_path)`` rather than ``entry_path``
+    alone is required for multi-archive synthesis: Wikipedia-style ZIMs
+    share entry paths (``A/Photosynthesis`` exists in every archive), so
+    a path-only dict silently collapses entries from different archives
+    and attributes citations to the wrong source.
+    """
+    archive_for_key: dict[tuple[str, str], tuple[Archive, Path]] = {
+        (archive_name, hit["path"]): archive_by_name[archive_name]
+        for archive_name, hit in top_hits
     }
 
-    def bundle_lookup(entry_path: str) -> Any:
-        pair = archive_for_path.get(entry_path)
+    def bundle_lookup(archive_name: str, entry_path: str) -> Any:
+        pair = archive_for_key.get((archive_name, entry_path))
         if pair is None:
             return None
         archive_val, validated_path = pair
@@ -386,10 +419,15 @@ def _extract_passages_for_top_hits(
     top_hits: list[tuple[str, dict]],
     *,
     content_processor: ContentProcessor,
-) -> tuple[list[SynthesizePassage], list[str]]:
-    """Stage 4: extract per-hit passages and renumber rank globally."""
+) -> tuple[list[SynthesizePassage], list[tuple[str, str]]]:
+    """Stage 4: extract per-hit passages and renumber rank globally.
+
+    Returns ``(passages, hit_keys)`` where ``hit_keys`` is a parallel
+    list of ``(archive_name, entry_path)`` tuples — used downstream for
+    multi-archive-safe bundle lookups.
+    """
     all_passages: list[SynthesizePassage] = []
-    all_paths: list[str] = []
+    hit_keys: list[tuple[str, str]] = []
     for archive_name, hit in top_hits:
         all_passages.extend(
             _extract_passages(
@@ -398,40 +436,46 @@ def _extract_passages_for_top_hits(
                 content_processor=content_processor,
             )
         )
-        all_paths.append(hit["path"])
+        hit_keys.append((archive_name, hit["path"]))
     for i, p in enumerate(all_passages, start=1):
         p["rank"] = i
-    return all_passages, all_paths
+    return all_passages, hit_keys
 
 
 def _build_section_lookups(
     top_hits: list[tuple[str, dict]],
-    bundle_lookup: Callable[[str], Any],
-) -> tuple[dict[str, str], dict[tuple[str, str], str]]:
-    """Per-(entry, section) title maps used by :func:`_build_citations`.
+    bundle_lookup: Callable[[str, str], Any],
+) -> tuple[dict[tuple[str, str], str], dict[tuple[str, str, str], str]]:
+    """Per-(archive, entry, section) title maps used by :func:`_build_citations`.
 
     Bundle build failures are swallowed at info level by the caller pattern
     (the bundle is best-effort); on failure the entry is skipped and its
     citations stay at entry level.
+
+    Keying on ``(archive_name, ...)`` tuples avoids the multi-archive
+    collision documented in :func:`_make_bundle_lookup`.
     """
-    archive_titles: dict[str, str] = {}
-    section_titles: dict[tuple[str, str], str] = {}
-    for _, hit in top_hits:
+    archive_titles: dict[tuple[str, str], str] = {}
+    section_titles: dict[tuple[str, str, str], str] = {}
+    for archive_name, hit in top_hits:
         try:
-            b = bundle_lookup(hit["path"])
+            b = bundle_lookup(archive_name, hit["path"])
         except Exception:
             continue
         if b is None:
             continue
-        archive_titles[hit["path"]] = b["title"]
+        archive_titles[(archive_name, hit["path"])] = b["title"]
         for s in b["sections"]:
-            section_titles[(hit["path"], s["id"])] = s["title"]
+            section_titles[(archive_name, hit["path"], s["id"])] = s["title"]
     return archive_titles, section_titles
 
 
 def _zero_hits_response(
     query: str, archives_searched: list[str], fallback_used: str
 ) -> SynthesizeResponse:
+    from openzim_mcp.meta import build_meta as _build_meta
+
+    meta = _build_meta(rendered="", reason="0_hits")
     return cast(
         "SynthesizeResponse",
         {
@@ -443,7 +487,7 @@ def _zero_hits_response(
             "fallback_used": fallback_used,
             "total_chars": 0,
             "total_words": 0,
-            "_meta": {"reason": "0_hits"},
+            "_meta": cast("Any", meta),
         },
     )
 
@@ -470,7 +514,7 @@ def synthesize_query(
     if not top_hits:
         return _zero_hits_response(query, archives_searched, fallback_used)
 
-    all_passages, all_paths = _extract_passages_for_top_hits(
+    all_passages, hit_keys = _extract_passages_for_top_hits(
         top_hits, content_processor=content_processor
     )
     bundle_lookup = _make_bundle_lookup(
@@ -480,13 +524,27 @@ def synthesize_query(
         content_processor=content_processor,
     )
     attributed = _attribute_sections(
-        all_passages, bundle_lookup=bundle_lookup, hit_paths=all_paths
+        all_passages, bundle_lookup=bundle_lookup, hit_keys=hit_keys
     )
+    pre_cap_chars = sum(len(p["text_markdown"]) for p in attributed)
     capped = _enforce_budget(attributed, char_budget=config.output_char_budget)
+    truncated = sum(len(p["text_markdown"]) for p in capped) < pre_cap_chars
     answer_md = _render_answer(capped)
     archive_titles, section_titles = _build_section_lookups(top_hits, bundle_lookup)
     citations = _build_citations(
         capped, archive_titles=archive_titles, section_titles=section_titles
+    )
+    # Real _meta envelope (not the hardcoded `{}` of earlier versions).
+    # ``rendered`` is the answer body — same convention as simple-mode
+    # responses, so ``_meta.chars``/``tokens_est`` reflect what the
+    # caller actually sees, not the JSON envelope cost.
+    from openzim_mcp.meta import build_meta as _build_meta
+
+    meta = _build_meta(
+        rendered=answer_md,
+        truncated=truncated,
+        content_chars=len(answer_md) if truncated else None,
+        total_chars=pre_cap_chars if truncated else None,
     )
     return cast(
         "SynthesizeResponse",
@@ -499,6 +557,6 @@ def synthesize_query(
             "fallback_used": fallback_used,
             "total_chars": len(answer_md),
             "total_words": len(answer_md.split()),
-            "_meta": {},
+            "_meta": cast("Any", meta),
         },
     )

--- a/openzim_mcp/tool_schemas.py
+++ b/openzim_mcp/tool_schemas.py
@@ -358,12 +358,22 @@ class TocHeading(TypedDict):
 
     `section_id` is the value to pass to get_section(section_id=...).
     Renamed from the old `id` field for clarity.
+
+    `id_source` documents how the section identifier was derived (``"id"``
+    when libzim/raw HTML carried an explicit anchor, ``"descendant_anchor"``
+    / ``"preceding_anchor"`` when we resolved it from a nearby anchor in
+    the soup, or ``"slug"`` when we generated a slug from the heading
+    text). Preserved per the Phase C spec so callers can tell which IDs
+    are stable across re-rendering vs. derived heuristically.
     """
 
     section_id: str
     text: str
     level: int
     children: list[TocHeading]
+    id_source: NotRequired[
+        Literal["id", "descendant_anchor", "preceding_anchor", "slug"]
+    ]
 
 
 class TableOfContentsResponse(TypedDict):
@@ -411,7 +421,10 @@ class BinaryEntryResponse(TypedDict):
 class SectionMeta(TypedDict):
     """One section's metadata in an EntryBundle.
 
-    Section IDs come from openzim_mcp.content_processor.resolve_heading_id.
+    Section IDs come from openzim_mcp.content_processor.resolve_heading_id;
+    ``id_source`` records which arm of that resolver produced the ID
+    (preserved through the TOC response so callers can tell stable
+    anchors from generated slugs).
     char_start / char_end are offsets into EntryBundle.rendered_markdown.
     """
 
@@ -421,6 +434,9 @@ class SectionMeta(TypedDict):
     char_start: int
     char_end: int
     parent_id: NotRequired[Optional[str]]
+    id_source: NotRequired[
+        Literal["id", "descendant_anchor", "preceding_anchor", "slug"]
+    ]
 
 
 class InfoboxField(TypedDict):
@@ -510,3 +526,85 @@ class SynthesizeResponse(TypedDict):
     total_chars: int
     total_words: int
     _meta: MetaEnvelope
+
+
+# ---------------------------------------------------------------------------
+# Phase B — server-tools responses
+# ---------------------------------------------------------------------------
+
+
+class UptimeInfo(TypedDict):
+    """Uptime block of ``ServerHealthResponse``."""
+
+    process_id: str
+    started_at: str
+    uptime_seconds: Optional[float]
+
+
+class HealthChecks(TypedDict):
+    """Per-check booleans/counters of ``ServerHealthResponse``."""
+
+    directories_accessible: int
+    zim_files_found: int
+    permissions_ok: bool
+
+
+class HealthConfiguration(TypedDict):
+    """Configuration summary embedded in the health report."""
+
+    allowed_directories: int
+    cache_enabled: bool
+    config_hash: str
+
+
+class ServerHealthResponse(TypedDict, total=False):
+    """``get_server_health`` success payload.
+
+    ``cache_performance`` and ``simple_tools_telemetry`` carry free-form
+    dicts whose shape is owned by the cache / simple-tools modules; the
+    server-tools surface intentionally doesn't pin them here so additions
+    in those modules don't ripple back into the response schema.
+    """
+
+    timestamp: str
+    status: str
+    server_name: str
+    uptime_info: UptimeInfo
+    configuration: HealthConfiguration
+    cache_performance: dict[str, Any]
+    simple_tools_telemetry: dict[str, Any]
+    health_checks: HealthChecks
+    recommendations: list[str]
+    warnings: list[str]
+
+
+class ServerConfigDetails(TypedDict):
+    """Configuration block inside ``ServerConfigurationResponse``."""
+
+    server_name: str
+    allowed_directories: list[str]
+    allowed_directories_count: int
+    cache_enabled: bool
+    cache_max_size: int
+    cache_ttl_seconds: int
+    content_max_length: int
+    content_snippet_length: int
+    search_default_limit: int
+    config_hash: str
+    server_pid: str
+
+
+class ServerConfigDiagnostics(TypedDict):
+    """Diagnostics block inside ``ServerConfigurationResponse``."""
+
+    validation_status: str
+    warnings: list[str]
+    recommendations: list[str]
+
+
+class ServerConfigurationResponse(TypedDict):
+    """``get_server_configuration`` success payload."""
+
+    configuration: ServerConfigDetails
+    diagnostics: ServerConfigDiagnostics
+    timestamp: str

--- a/openzim_mcp/tools/navigation_tools.py
+++ b/openzim_mcp/tools/navigation_tools.py
@@ -62,6 +62,7 @@ def _register_browse_namespace(server: "OpenZimMcpServer") -> None:
             / ``sampling_based`` / ``results_may_be_incomplete`` extras);
             ``ToolErrorPayload`` envelope on failure.
         """
+        cursor_ai: Optional[str] = None
         try:
             # Phase B: cursor wins on conflict per response-contract spec.
             if cursor is not None:
@@ -86,6 +87,7 @@ def _register_browse_namespace(server: "OpenZimMcpServer") -> None:
                     limit = decoded["s"]["l"]
                 if "ns" in decoded["s"]:
                     namespace = decoded["s"]["ns"]
+                cursor_ai = decoded["s"].get("ai")
 
             # Check rate limit
             try:
@@ -137,7 +139,11 @@ def _register_browse_namespace(server: "OpenZimMcpServer") -> None:
 
             # Use async operations
             return await server.async_zim_operations.browse_namespace_data(
-                zim_file_path, namespace, limit, offset
+                zim_file_path,
+                namespace,
+                limit,
+                offset,
+                cursor_archive_identity=cursor_ai,
             )
 
         except Exception as e:
@@ -318,6 +324,7 @@ def _register_search_with_filters(server: "OpenZimMcpServer") -> None:
             / ``content_type_filter`` extras); ``ToolErrorPayload``
             envelope on failure.
         """
+        cursor_ai: Optional[str] = None
         try:
             # Phase B: cursor wins on conflict per response-contract spec.
             if cursor is not None:
@@ -346,6 +353,7 @@ def _register_search_with_filters(server: "OpenZimMcpServer") -> None:
                     namespace = decoded["s"]["ns"]
                 if "ct" in decoded["s"]:
                     content_type = decoded["s"]["ct"]
+                cursor_ai = decoded["s"].get("ai")
 
             # Check rate limit
             try:
@@ -414,7 +422,13 @@ def _register_search_with_filters(server: "OpenZimMcpServer") -> None:
             # Perform the filtered search using async operations
             # (structured payload).
             return await server.async_zim_operations.search_with_filters_data(
-                zim_file_path, query, namespace, content_type, limit, offset
+                zim_file_path,
+                query,
+                namespace,
+                content_type,
+                limit,
+                offset,
+                cursor_archive_identity=cursor_ai,
             )
 
         except Exception as e:

--- a/openzim_mcp/tools/search_tools.py
+++ b/openzim_mcp/tools/search_tools.py
@@ -49,6 +49,7 @@ def _register_search_zim_file(server: "OpenZimMcpServer") -> None:
             top-level ``results`` / ``next_cursor`` / ``total`` / ``done`` /
             ``page_info``); ``ToolErrorPayload`` envelope on failure.
         """
+        cursor_ai: Optional[str] = None
         try:
             # Phase B: cursor wins on conflict per response-contract spec.
             if cursor is not None:
@@ -76,6 +77,7 @@ def _register_search_zim_file(server: "OpenZimMcpServer") -> None:
                 # alongside.
                 if "q" in decoded["s"]:
                     query = decoded["s"]["q"]
+                cursor_ai = decoded["s"].get("ai")
 
             # Check rate limit
             try:
@@ -132,7 +134,11 @@ def _register_search_zim_file(server: "OpenZimMcpServer") -> None:
 
             # Perform the search using async operations (structured payload).
             return await server.async_zim_operations.search_zim_file_data(
-                zim_file_path, query, limit, offset
+                zim_file_path,
+                query,
+                limit,
+                offset,
+                cursor_archive_identity=cursor_ai,
             )
 
         except Exception as e:

--- a/openzim_mcp/tools/server_tools.py
+++ b/openzim_mcp/tools/server_tools.py
@@ -4,11 +4,12 @@ import asyncio
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union, cast
 
 from ..constants import CACHE_HIGH_HIT_RATE_THRESHOLD, CACHE_LOW_HIT_RATE_THRESHOLD
-from ..responses import tool_error
+from ..responses import ToolErrorPayload, tool_error
 from ..security import redact_paths_in_message, sanitize_path_for_error
+from ..tool_schemas import ServerConfigurationResponse, ServerHealthResponse
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
@@ -33,28 +34,28 @@ def register_server_tools(server: "OpenZimMcpServer") -> None:
 
 def _register_get_server_health(server: "OpenZimMcpServer") -> None:
     @server.mcp.tool()
-    async def get_server_health() -> Dict[str, Any]:
+    async def get_server_health() -> Union[ServerHealthResponse, ToolErrorPayload]:
         """Get comprehensive server health and statistics.
 
         Includes cache performance, directory health, and recommendations.
 
         Returns:
-            Structured dict containing detailed server health information.
-            On failure, returns a structured error envelope (see
-            ``responses.tool_error``).
+            ``ServerHealthResponse``-shaped dict on success; ``ToolErrorPayload``
+            envelope on failure (see ``responses.tool_error``).
         """
         return await asyncio.to_thread(_build_health_report, server)
 
 
 def _register_get_server_configuration(server: "OpenZimMcpServer") -> None:
     @server.mcp.tool()
-    async def get_server_configuration() -> Dict[str, Any]:
+    async def get_server_configuration() -> (
+        Union[ServerConfigurationResponse, ToolErrorPayload]
+    ):
         """Get detailed server configuration with diagnostics and validation.
 
         Returns:
-            Structured dict containing server configuration information
-            including validation results and recommendations. On failure,
-            returns a structured error envelope (see
+            ``ServerConfigurationResponse``-shaped dict on success;
+            ``ToolErrorPayload`` envelope on failure (see
             ``responses.tool_error``).
         """
         return await asyncio.to_thread(_build_configuration_report, server)
@@ -195,7 +196,9 @@ def _build_uptime_info(server: "OpenZimMcpServer") -> Dict[str, Any]:
     }
 
 
-def _build_health_report(server: "OpenZimMcpServer") -> Dict[str, Any]:
+def _build_health_report(
+    server: "OpenZimMcpServer",
+) -> Union[ServerHealthResponse, ToolErrorPayload]:
     try:
         cache_stats = server.cache.stats()
         recommendations: List[str] = []
@@ -247,25 +250,24 @@ def _build_health_report(server: "OpenZimMcpServer") -> Dict[str, Any]:
             health_info, accessible_dirs, total_zim_files, warnings, recommendations
         )
 
-        return health_info
+        return cast(ServerHealthResponse, health_info)
 
     except Exception as e:
         logger.error(f"Error getting server health: {e}")
-        return cast(
-            Dict[str, Any],
-            tool_error(
+        return tool_error(
+            operation="get server health",
+            message=server._create_enhanced_error_message(
                 operation="get server health",
-                message=server._create_enhanced_error_message(
-                    operation="get server health",
-                    error=e,
-                    context="Checking server health and performance metrics",
-                ),
+                error=e,
                 context="Checking server health and performance metrics",
             ),
+            context="Checking server health and performance metrics",
         )
 
 
-def _build_configuration_report(server: "OpenZimMcpServer") -> Dict[str, Any]:
+def _build_configuration_report(
+    server: "OpenZimMcpServer",
+) -> Union[ServerConfigurationResponse, ToolErrorPayload]:
     try:
         # Always redact paths and PID — even on stdio, diagnostic output
         # frequently ends up in bug reports / logs / issue trackers, so
@@ -316,24 +318,21 @@ def _build_configuration_report(server: "OpenZimMcpServer") -> Dict[str, Any]:
                 "Check that all allowed directories exist and are accessible"
             )
 
-        result = {
-            "configuration": config_info,
-            "diagnostics": diagnostics,
+        result: ServerConfigurationResponse = {
+            "configuration": cast("Any", config_info),
+            "diagnostics": cast("Any", diagnostics),
             "timestamp": _utc_now_iso(),
         }
 
         return result
     except Exception as e:
         logger.error(f"Error getting server configuration: {e}")
-        return cast(
-            Dict[str, Any],
-            tool_error(
+        return tool_error(
+            operation="get server configuration",
+            message=server._create_enhanced_error_message(
                 operation="get server configuration",
-                message=server._create_enhanced_error_message(
-                    operation="get server configuration",
-                    error=e,
-                    context="Configuration diagnostics",
-                ),
+                error=e,
                 context="Configuration diagnostics",
             ),
+            context="Configuration diagnostics",
         )

--- a/openzim_mcp/tools/structure_tools.py
+++ b/openzim_mcp/tools/structure_tools.py
@@ -155,6 +155,9 @@ def _register_extract_article_links(server: "OpenZimMcpServer") -> None:
                 limit = state.get("l", limit)
                 entry_path = state.get("ep", entry_path)
                 kind = state.get("k", kind)
+                cursor_ai: Optional[str] = state.get("ai")
+            else:
+                cursor_ai = None
 
             try:
                 server.rate_limiter.check_rate_limit("get_structure")
@@ -189,6 +192,7 @@ def _register_extract_article_links(server: "OpenZimMcpServer") -> None:
                 limit=limit,
                 offset=offset,
                 kind=kind,
+                cursor_archive_identity=cursor_ai,
             )
 
         except Exception as e:

--- a/openzim_mcp/tools/structure_tools.py
+++ b/openzim_mcp/tools/structure_tools.py
@@ -320,7 +320,12 @@ def _register_get_table_of_contents(server: "OpenZimMcpServer") -> None:
         Each TOC entry contains:
             - level: Heading level (1-6)
             - text: Heading text
-            - id: Anchor ID for linking
+            - section_id: Section identifier — pass to get_section(section_id=...)
+              to fetch this heading's body. Renamed from the legacy ``id`` field
+              in Phase C; clients that read ``heading["id"]`` will get a KeyError.
+            - id_source: How the section_id was derived — ``"id"`` /
+              ``"descendant_anchor"`` / ``"preceding_anchor"`` (stable, author-provided)
+              or ``"slug"`` (generated from heading text).
             - children: Nested subheadings
 
         Examples:

--- a/openzim_mcp/zim/archive.py
+++ b/openzim_mcp/zim/archive.py
@@ -353,8 +353,6 @@ class ZimOperations(_SearchMixin, _ContentMixin, _StructureMixin, _NamespaceMixi
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug(f"Returning cached metadata dict for: {validated_path}")
-            if "_meta" not in cached_result:
-                cached_result = attach_meta(dict(cached_result))
             return cast("ZimMetadataResponse", cached_result)
 
         # Late-bound lookup so test patches against
@@ -365,10 +363,12 @@ class ZimOperations(_SearchMixin, _ContentMixin, _StructureMixin, _NamespaceMixi
             with _zim_ops_shim.zim_archive(validated_path) as archive:
                 metadata = self._extract_zim_metadata(archive)
 
-            # Cache the result
-            self.cache.set(cache_key, metadata)
+            # Attach _meta before caching so cold and warm reads return
+            # bit-identical responses (Phase B #12).
+            with_meta = attach_meta(metadata)
+            self.cache.set(cache_key, with_meta)
             logger.info(f"Retrieved metadata for: {validated_path}")
-            return cast("ZimMetadataResponse", attach_meta(metadata))
+            return cast("ZimMetadataResponse", with_meta)
 
         except Exception as e:
             logger.error(f"Metadata retrieval failed for {validated_path}: {e}")
@@ -657,11 +657,6 @@ class ZimOperations(_SearchMixin, _ContentMixin, _StructureMixin, _NamespaceMixi
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug(f"Returning cached main page dict for: {validated_path}")
-            if "_meta" not in cached_result:
-                cached_result = attach_meta(
-                    dict(cached_result),
-                    truncated=bool(cached_result.get("_truncated")),
-                )
             return cast("EntryResponse", cached_result)
 
         # Late-bound lookup so test patches against
@@ -677,19 +672,20 @@ class ZimOperations(_SearchMixin, _ContentMixin, _StructureMixin, _NamespaceMixi
             logger.error(f"Main page retrieval failed for {validated_path}: {e}")
             raise OpenZimMcpArchiveError(f"Main page retrieval failed: {e}") from e
 
-        if content_ok:
-            self.cache.set(cache_key, dict(payload))
         truncated = bool(payload.pop("_truncated", False))
         total_chars = payload.pop("_total_chars", None)
-        logger.info(f"Retrieved main page data for: {validated_path}")
-        return cast(
-            "EntryResponse",
-            attach_meta(
-                payload,
-                truncated=truncated,
-                total_chars=total_chars,
-            ),
+        # main_page is not paginable so no ``content_chars`` is supplied;
+        # ``more_at_offset`` is intentionally omitted on a truncated
+        # response (callers can't follow-up with a content_offset here).
+        with_meta = attach_meta(
+            payload,
+            truncated=truncated,
+            total_chars=total_chars,
         )
+        if content_ok:
+            self.cache.set(cache_key, with_meta)
+        logger.info(f"Retrieved main page data for: {validated_path}")
+        return cast("EntryResponse", with_meta)
 
     def _get_main_page_data_content(  # NOSONAR(python:S3776)
         self, archive: Archive, *, compact: bool = False

--- a/openzim_mcp/zim/content.py
+++ b/openzim_mcp/zim/content.py
@@ -1244,7 +1244,16 @@ class _ContentMixin:
                 md = bundle["rendered_markdown"]
                 if bundle["sections"]:
                     first = bundle["sections"][0]
-                    summary_md = md[first["char_start"] : first["char_end"]]
+                    # Many Wikipedia-style articles render with prose
+                    # before the first heading (the lead paragraph) and
+                    # no top-level h1 in the markdown. Slicing only the
+                    # first section's body silently drops that lead.
+                    # Take everything from the start of the markdown
+                    # through the end of the first section so the lead
+                    # is preserved when present; equivalent to the prior
+                    # behaviour for articles whose first heading sits at
+                    # offset 0.
+                    summary_md = md[: first["char_end"]]
                 else:
                     summary_md = md
 

--- a/openzim_mcp/zim/content.py
+++ b/openzim_mcp/zim/content.py
@@ -323,8 +323,13 @@ class _ContentMixin:
             processing raised and ``payload["content"]`` is the error
             sentinel; the caller must not cache the response in that case.
         """
+        from openzim_mcp.bundle import archive_stat_token
+
         requested_path = entry_path
-        path_cache_key = f"path_mapping:{validated_path}:{entry_path}"
+        path_cache_key = (
+            f"path_mapping:{validated_path}:"
+            f"{archive_stat_token(validated_path)}:{entry_path}"
+        )
         cached_actual_path = self.cache.get(path_cache_key)
 
         # Try cached path mapping first.
@@ -694,9 +699,15 @@ class _ContentMixin:
             ``(Error retrieving content: ...)`` sentinel; the caller must
             not cache the response in that case.
         """
-        # Path mapping cache key includes archive path so identical entry
-        # names in different ZIM files don't collide.
-        cache_key = f"path_mapping:{validated_path}:{entry_path}"
+        # Path mapping cache key includes archive path + stat token so
+        # identical entry names in different ZIM files don't collide and
+        # an atomic file replacement invalidates the resolved-path cache.
+        from openzim_mcp.bundle import archive_stat_token
+
+        cache_key = (
+            f"path_mapping:{validated_path}:"
+            f"{archive_stat_token(validated_path)}:{entry_path}"
+        )
         cached_actual_path = self.cache.get(cache_key)
         if cached_actual_path:
             logger.debug(
@@ -928,8 +939,15 @@ class _ContentMixin:
 
         # Cache key for invariant metadata (size, mime_type, etc.) — not data,
         # since data is potentially large and varies with max_size_bytes.
-        # The cache stores a plain dict, so the key shape is unchanged.
-        cache_key = f"binary_meta:{validated_path}:{entry_path}"
+        # The stat token guarantees that an atomic ZIM replacement
+        # invalidates stale metadata (e.g. a thumbnail entry whose
+        # mimetype/size changed between archive revisions).
+        from openzim_mcp.bundle import archive_stat_token
+
+        cache_key = (
+            f"binary_meta:{validated_path}:"
+            f"{archive_stat_token(validated_path)}:{entry_path}"
+        )
 
         # If we already know the entry's metadata, we can short-circuit calls
         # that don't need bytes (include_data=False) or that would be rejected
@@ -1220,9 +1238,19 @@ class _ContentMixin:
 
             if mime_type.startswith("text/html"):
                 # HTML path — build (or reuse) the bundle and slice it.
-                if validated_path is None:
+                # ``compact=True`` cannot use the bundle: the bundle stores
+                # rendered markdown with ``compact=False`` semantics (tables
+                # in pipe-soup form, oversized-table placeholders absent),
+                # so serving compact-mode callers from it would re-introduce
+                # the table-bloat that Phase A #2 was designed to eliminate.
+                # When compact is requested, re-render the entry through the
+                # compact-aware ``_extract_html_summary`` path; the bundle
+                # path stays available for compact=False (the default) so
+                # the four bundle-backed tools still share one HTML parse.
+                if validated_path is None or compact:
                     # Fall back to re-reading the item when no validated_path
-                    # was supplied (e.g. tests that monkeypatch this method).
+                    # was supplied (tests that monkeypatch the path validator)
+                    # OR when compact mode demands compact-rendered markdown.
                     raw_content = bytes(item.content).decode("utf-8", errors="replace")
                     html_result = self._extract_html_summary(
                         raw_content, max_words, compact=compact

--- a/openzim_mcp/zim/content.py
+++ b/openzim_mcp/zim/content.py
@@ -257,11 +257,6 @@ class _ContentMixin:
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug(f"Returning cached entry dict for: {entry_path}")
-            if "_meta" not in cached_result:
-                cached_result = attach_meta(
-                    dict(cached_result),
-                    truncated=bool(cached_result.get("_truncated")),
-                )
             return cast("EntryResponse", cached_result)
 
         try:
@@ -284,23 +279,26 @@ class _ContentMixin:
                 f"Try using search_zim_file() to verify the file is accessible."
             ) from e
 
-        # Only cache on success. ``_truncated`` is an internal hint used
-        # to set ``_meta.truncated`` on the cached path; it's stripped
-        # before the dict is returned (and never reaches the wire).
-        if content_ok:
-            self.cache.set(cache_key, dict(payload))
+        # ``_truncated`` / ``_total_chars`` are internal hints from
+        # ``_build_entry_payload`` that drive the eventual ``_meta``
+        # envelope; stripped before the dict reaches the wire.
         truncated = bool(payload.pop("_truncated", False))
         total_chars = payload.pop("_total_chars", None)
-        logger.info(f"Retrieved entry data: {entry_path}")
-        return cast(
-            "EntryResponse",
-            attach_meta(
-                payload,
-                truncated=truncated,
-                total_chars=total_chars,
-                current_offset=content_offset,
-            ),
+        # ``content_chars`` is the post-slice content length — drives
+        # ``more_at_offset`` for follow-up paginated fetches.
+        with_meta = attach_meta(
+            payload,
+            truncated=truncated,
+            total_chars=total_chars,
+            current_offset=content_offset,
+            content_chars=len(payload.get("content", "")),
         )
+        # Attach _meta before caching so cold and warm reads return
+        # bit-identical responses (Phase B #12).
+        if content_ok:
+            self.cache.set(cache_key, with_meta)
+        logger.info(f"Retrieved entry data: {entry_path}")
+        return cast("EntryResponse", with_meta)
 
     def _get_entry_data_from_archive(  # NOSONAR(python:S3776)
         self,

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -28,6 +28,8 @@ from openzim_mcp.exceptions import (
 from openzim_mcp.meta import attach_meta
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from openzim_mcp.cache import OpenZimMcpCache
     from openzim_mcp.config import OpenZimMcpConfig
     from openzim_mcp.content_processor import ContentProcessor
@@ -97,17 +99,19 @@ class _NamespaceMixin:
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug(f"Returning cached namespaces dict for: {validated_path}")
-            if "_meta" not in cached_result:
-                cached_result = attach_meta(dict(cached_result))
             return cast("ListNamespacesResponse", cached_result)
 
         try:
             with _zim_ops_mod.zim_archive(validated_path) as archive:
                 result = self._list_archive_namespaces(archive)
 
-            self.cache.set(cache_key, result)
+            # Attach _meta BEFORE caching so cold and warm reads return
+            # bit-identical responses (Phase B #12 fix — re-attaching on
+            # each cache hit produced non-deterministic chars/tokens_est).
+            with_meta = attach_meta(result)
+            self.cache.set(cache_key, with_meta)
             logger.info(f"Listed namespaces for: {validated_path}")
-            return cast("ListNamespacesResponse", attach_meta(result))
+            return cast("ListNamespacesResponse", with_meta)
 
         except Exception as e:
             logger.error(f"Namespace listing failed for {validated_path}: {e}")
@@ -551,8 +555,6 @@ class _NamespaceMixin:
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug(f"Returning cached namespace browse dict for: {namespace}")
-            if "_meta" not in cached_result:
-                cached_result = attach_meta(dict(cached_result))
             return cast("BrowseNamespaceResponse", cached_result)
 
         try:
@@ -581,9 +583,16 @@ class _NamespaceMixin:
             done = last_index >= total_in_namespace
             next_cursor: Optional[str] = None
             if not done:
+                from openzim_mcp.pagination import archive_identity
+
                 next_cursor = Cursor.encode(
                     tool="browse_namespace",
-                    state={"o": last_index, "l": limit, "ns": namespace},
+                    state={
+                        "o": last_index,
+                        "l": limit,
+                        "ns": namespace,
+                        "ai": archive_identity(validated_path),
+                    },
                 )
 
             page_info: Dict[str, Any] = {
@@ -606,11 +615,12 @@ class _NamespaceMixin:
                 "results_may_be_incomplete": results_may_be_incomplete,
             }
 
-            self.cache.set(cache_key, payload)
+            with_meta = attach_meta(payload)
+            self.cache.set(cache_key, with_meta)
             logger.info(
                 f"Browsed namespace {namespace}: {limit} entries from offset {offset}"
             )
-            return cast("BrowseNamespaceResponse", attach_meta(payload))
+            return cast("BrowseNamespaceResponse", with_meta)
 
         except Exception as e:
             logger.error(f"Namespace browsing failed for {namespace}: {e}")
@@ -1054,9 +1064,9 @@ class _NamespaceMixin:
             )
 
         # Decoded cursor state ``s`` for walk_namespace carries
-        # ``{scan_at: int, l: int}``. Both are optional defensively —
-        # missing/negative ``scan_at`` clamps to 0, missing ``l`` falls
-        # back to the function-arg default.
+        # ``{scan_at: int, l: int, ns: str, ai: str}``. ``scan_at``/``l``
+        # are positional, ``ns``/``ai`` are integrity-check fields added
+        # in cursor v2.
         scan_at_raw = (cursor_state or {}).get("scan_at", 0)
         try:
             scan_at = int(scan_at_raw)
@@ -1074,6 +1084,36 @@ class _NamespaceMixin:
         validated = self.path_validator.validate_path(zim_file_path)
         validated = self.path_validator.validate_zim_file(validated)
 
+        # Cursor integrity: a v2 cursor encodes the namespace it was
+        # issued for and the archive identity. Rejecting on mismatch
+        # prevents silent wrong-result bugs where a caller resubmits a
+        # cursor against a different namespace or different archive
+        # (issues Phase B #10, #17, #11 for the equivalent pattern in
+        # extract_article_links).
+        if cursor_state:
+            from openzim_mcp.pagination import (
+                Cursor as _CursorClass,
+                CursorMismatchError,
+                archive_identity,
+            )
+
+            cursor_ns = cursor_state.get("ns")
+            if cursor_ns is not None and cursor_ns != namespace:
+                raise OpenZimMcpValidationError(
+                    f"Cursor was issued for namespace {cursor_ns!r}; "
+                    f"call passed namespace={namespace!r}. Drop the cursor "
+                    f"and start the walk over for the new namespace."
+                )
+            if "ai" in cursor_state:
+                try:
+                    _CursorClass.verify_archive_identity(
+                        cast("Any", cursor_state),
+                        expected=archive_identity(validated),
+                        tool="walk_namespace",
+                    )
+                except CursorMismatchError as e:
+                    raise OpenZimMcpValidationError(str(e)) from e
+
         try:
             with _zim_ops_mod.zim_archive(validated) as archive:
                 has_new_scheme = getattr(archive, "has_new_namespace_scheme", False)
@@ -1089,7 +1129,11 @@ class _NamespaceMixin:
                         "WalkNamespaceResponse",
                         attach_meta(
                             self._walk_new_scheme_metadata(
-                                archive, scan_at, limit, archive_entry_count
+                                archive,
+                                scan_at,
+                                limit,
+                                archive_entry_count,
+                                validated_path=validated,
                             )
                         ),
                     )
@@ -1143,9 +1187,16 @@ class _NamespaceMixin:
                 scanned_through_id = entry_id - 1 if entry_id > scan_at else None
                 next_cursor: Optional[str] = None
                 if not done:
+                    from openzim_mcp.pagination import archive_identity
+
                     next_cursor = Cursor.encode(
                         tool="walk_namespace",
-                        state={"scan_at": entry_id, "l": limit},
+                        state={
+                            "scan_at": entry_id,
+                            "l": limit,
+                            "ns": namespace,
+                            "ai": archive_identity(validated),
+                        },
                     )
 
                 return cast(
@@ -1218,9 +1269,11 @@ class _NamespaceMixin:
         scan_at: int,
         limit: int,
         archive_entry_count: int,
+        *,
+        validated_path: "Optional[Path]" = None,
     ) -> Dict[str, Any]:
         """Walk M (metadata) entries in a new-scheme archive via metadata_keys."""
-        from openzim_mcp.pagination import Cursor
+        from openzim_mcp.pagination import Cursor, archive_identity
 
         try:
             keys = list(getattr(archive, "metadata_keys", []) or [])
@@ -1234,9 +1287,16 @@ class _NamespaceMixin:
         done = end >= total
         next_cursor: Optional[str] = None
         if not done:
+            # ``scan_at`` here is an index into ``metadata_keys``, not an
+            # entry ID. The cursor's ``ns="M"`` discriminator + the
+            # archive's new-scheme bit are enough for the consumer to
+            # know which interpretation to use; see #17.
+            state: Dict[str, Any] = {"scan_at": end, "l": limit, "ns": "M"}
+            if validated_path is not None:
+                state["ai"] = archive_identity(validated_path)
             next_cursor = Cursor.encode(
                 tool="walk_namespace",
-                state={"scan_at": end, "l": limit},
+                state=cast("Any", state),
             )
         return cls._build_walk_result(
             namespace="M",

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -704,11 +704,19 @@ class _NamespaceMixin:
 
         # Discover entries in the namespace. The full listing is cached
         # separately from the per-page JSON (cache_key in browse_namespace),
-        # so different (limit, offset) pages share one scan.
+        # so different (limit, offset) pages share one scan. The stat
+        # token (st_mtime_ns:st_size) ensures an atomic ZIM replacement
+        # invalidates the listing rather than serving the prior
+        # snapshot's entries indefinitely until LRU eviction.
         listing_key: Optional[str] = None
         cached_listing: Optional[Tuple[List[str], bool]] = None
         if archive_path is not None:
-            listing_key = f"ns_entries:{archive_path}:{namespace}"
+            from pathlib import Path as _Path
+
+            from openzim_mcp.bundle import archive_stat_token
+
+            stat_token = archive_stat_token(_Path(archive_path))
+            listing_key = f"ns_entries:{archive_path}:{stat_token}:{namespace}"
             cached_listing = self.cache.get(listing_key)
 
         if cached_listing is not None:

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -11,6 +11,7 @@ without changes.
 import contextlib
 import json
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
 
 from libzim.reader import Archive  # type: ignore[import-untyped]
@@ -28,8 +29,6 @@ from openzim_mcp.exceptions import (
 from openzim_mcp.meta import attach_meta
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from openzim_mcp.cache import OpenZimMcpCache
     from openzim_mcp.config import OpenZimMcpConfig
     from openzim_mcp.content_processor import ContentProcessor
@@ -711,11 +710,9 @@ class _NamespaceMixin:
         listing_key: Optional[str] = None
         cached_listing: Optional[Tuple[List[str], bool]] = None
         if archive_path is not None:
-            from pathlib import Path as _Path
-
             from openzim_mcp.bundle import archive_stat_token
 
-            stat_token = archive_stat_token(_Path(archive_path))
+            stat_token = archive_stat_token(Path(archive_path))
             listing_key = f"ns_entries:{archive_path}:{stat_token}:{namespace}"
             cached_listing = self.cache.get(listing_key)
 

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -506,7 +506,13 @@ class _NamespaceMixin:
         ]
 
     def browse_namespace_data(
-        self, zim_file_path: str, namespace: str, limit: int = 50, offset: int = 0
+        self,
+        zim_file_path: str,
+        namespace: str,
+        limit: int = 50,
+        offset: int = 0,
+        *,
+        cursor_archive_identity: Optional[str] = None,
     ) -> "BrowseNamespaceResponse":
         """Structured variant of ``browse_namespace``.
 
@@ -517,15 +523,24 @@ class _NamespaceMixin:
         ``total`` / ``done`` / ``page_info`` plus the ``namespace`` /
         ``discovery_method`` / ``sampling_based`` /
         ``results_may_be_incomplete`` extras. ``next_cursor`` is encoded
-        with ``tool="browse_namespace"`` and state ``{o, l, ns}``.
+        with ``tool="browse_namespace"`` and state ``{o, l, ns, ai}``.
+
+        ``cursor_archive_identity`` is the ``s.ai`` value decoded from a
+        resumed cursor; mismatched archives are rejected so a cursor
+        issued for archive A cannot be honoured against archive B.
 
         Raises:
             OpenZimMcpValidationError: If parameter validation fails (limit,
-                offset, or namespace).
+                offset, or namespace), or if a cursor was issued for a
+                different archive.
             OpenZimMcpFileNotFoundError: If ZIM file not found
             OpenZimMcpArchiveError: If browsing fails
         """
-        from openzim_mcp.pagination import Cursor
+        from openzim_mcp.pagination import (
+            Cursor,
+            CursorMismatchError,
+            archive_identity,
+        )
 
         # Validate parameters. These are caller-input errors, distinct from
         # archive-access failures, so they surface as
@@ -547,6 +562,19 @@ class _NamespaceMixin:
         # Validate and resolve file path
         validated_path = self.path_validator.validate_path(zim_file_path)
         validated_path = self.path_validator.validate_zim_file(validated_path)
+
+        # Cursor integrity: a cursor issued for archive A must not be
+        # honoured when resubmitted against archive B (same guard as
+        # walk_namespace / extract_article_links / search_zim_file).
+        if cursor_archive_identity is not None:
+            try:
+                Cursor.verify_archive_identity(
+                    cast("Any", {"ai": cursor_archive_identity}),
+                    expected=archive_identity(validated_path),
+                    tool="browse_namespace",
+                )
+            except CursorMismatchError as e:
+                raise OpenZimMcpValidationError(str(e)) from e
 
         # Cache key bumped to v2b (Phase B) so v1.x cached responses (old
         # shape: entries/total_in_namespace/...) don't leak through
@@ -1091,8 +1119,8 @@ class _NamespaceMixin:
         # (issues Phase B #10, #17, #11 for the equivalent pattern in
         # extract_article_links).
         if cursor_state:
+            from openzim_mcp.pagination import Cursor as _CursorClass
             from openzim_mcp.pagination import (
-                Cursor as _CursorClass,
                 CursorMismatchError,
                 archive_identity,
             )

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -219,8 +219,6 @@ class _SearchMixin:
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug(f"Returning cached search dict for query: {query}")
-            if "_meta" not in cached_result:
-                cached_result = attach_meta(dict(cached_result))
             return cast("SearchResponse", cached_result)
 
         try:
@@ -228,12 +226,6 @@ class _SearchMixin:
                 payload, total_results = self._perform_search(
                     archive, query, limit, offset
                 )
-
-            # Don't cache zero-result responses: libzim's lazy index warm-up
-            # can return 0 matches transiently, and a TTL-cached "no results"
-            # would mask the index becoming ready.
-            if total_results > 0:
-                self.cache.set(cache_key, payload)
             logger.debug(f"Search completed: query='{query}', results found")
             reason = "0_hits" if total_results == 0 else None
 
@@ -260,14 +252,20 @@ class _SearchMixin:
                 except Exception as e:
                     logger.debug(f"alt_archive suggestion build failed: {e}")
 
-            return cast(
-                "SearchResponse",
-                attach_meta(
-                    payload,
-                    reason=reason,
-                    suggestions=suggestions if suggestions else None,
-                ),
+            with_meta = attach_meta(
+                payload,
+                reason=reason,
+                suggestions=suggestions if suggestions else None,
             )
+            # Cache the meta-attached payload so cold vs warm reads are
+            # bit-identical. Skip the cache for zero-hit responses
+            # because libzim's lazy index warm-up can return 0 matches
+            # transiently — TTL-caching "no results" would mask the
+            # index becoming ready (also, the suggestions block depends
+            # on freshly-enumerated alt_archive candidates).
+            if total_results > 0:
+                self.cache.set(cache_key, with_meta)
+            return cast("SearchResponse", with_meta)
 
         except OpenZimMcpArchiveError:
             # Inner helper already raised a typed archive error with full
@@ -605,8 +603,6 @@ class _SearchMixin:
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug(f"Returning cached filtered search dict for query: {query}")
-            if "_meta" not in cached_result:
-                cached_result = attach_meta(dict(cached_result))
             return cast("SearchWithFiltersResponse", cached_result)
 
         try:
@@ -672,21 +668,19 @@ class _SearchMixin:
             "page_info": page_info,
         }
 
-        # Don't cache zero-result responses: libzim's lazy index warm-up
-        # can return 0 matches transiently, and a TTL-cached "no results"
-        # would mask the index becoming ready.
-        if scan.filtered_count > 0:
-            self.cache.set(cache_key, payload)
         logger.info(
             f"Filtered search completed: query='{query}', "
             f"namespace={namespace}, type={content_type}, "
             f"results={returned_count}"
         )
         reason = "0_hits" if scan.filtered_count == 0 else None
-        return cast(
-            "SearchWithFiltersResponse",
-            attach_meta(payload, reason=reason),
-        )
+        with_meta = attach_meta(payload, reason=reason)
+        # Cache the post-attach payload so cold/warm reads are bit-identical
+        # (Phase B #12). Skip zero-hit results — see search_zim_file_data
+        # for rationale (libzim lazy index, fresh suggestions).
+        if scan.filtered_count > 0:
+            self.cache.set(cache_key, with_meta)
+        return cast("SearchWithFiltersResponse", with_meta)
 
     def _perform_filtered_search_data(
         self,
@@ -1053,8 +1047,6 @@ class _SearchMixin:
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug(f"Returning cached suggestions dict for: {partial_query}")
-            if "_meta" not in cached_result:
-                cached_result = attach_meta(dict(cached_result))
             return cast("SearchSuggestionsResponse", cached_result)
 
         try:
@@ -1082,15 +1074,17 @@ class _SearchMixin:
                 },
             }
 
-            # A cold-cache request that hits before the libzim title index
-            # has warmed up can return zero suggestions for a query that
-            # will produce results moments later — caching that empty
-            # payload locks the query into "no suggestions" for the full
-            # TTL. Only cache non-empty results.
+            with_meta = attach_meta(payload)
+            # Cache the post-attach payload (Phase B #12). A cold-cache
+            # request that hits before the libzim title index has warmed
+            # up can return zero suggestions for a query that will
+            # produce results moments later — caching that empty payload
+            # locks the query into "no suggestions" for the full TTL.
+            # Only cache non-empty results.
             if actual_count > 0:
-                self.cache.set(cache_key, payload)
+                self.cache.set(cache_key, with_meta)
             logger.info(f"Generated {actual_count} suggestions for: {partial_query}")
-            return cast("SearchSuggestionsResponse", attach_meta(payload))
+            return cast("SearchSuggestionsResponse", with_meta)
 
         except OpenZimMcpArchiveError:
             # Inner helper already raised a typed archive error with full
@@ -1465,6 +1459,42 @@ class _SearchMixin:
                 return entry
         return None
 
+    def _verified_typo_variants(
+        self, archives: List[Any], title: str, *, limit: int
+    ) -> List[str]:
+        """Return typo-variant *titles* that actually resolve to an entry.
+
+        Used to populate ``_meta.suggestions`` only with values the caller
+        can reuse as a query (Phase A #6 fix). The naive implementation
+        emitted raw permutations of the user's mangled input; this one
+        probes the same fast-path that produced the real results so
+        suggestions are guaranteed to be reachable.
+
+        ``archives`` is a list of open ``Archive`` objects (one per ZIM
+        file already opened by the caller); we probe each in order until
+        ``limit`` variants are confirmed. Length-gated identically to
+        ``_find_entry_typo_fallback``.
+        """
+        if len(title) < self.config.search.fuzzy_title_min_query_len:
+            return []
+        verified: List[str] = []
+        seen: set[str] = set()
+        for variant in self._typo_variants(title):
+            for archive in archives:
+                try:
+                    entry = self._find_entry_fast_path(archive, variant)
+                except Exception:
+                    continue
+                if entry is not None:
+                    resolved = entry.title or variant
+                    if resolved not in seen:
+                        verified.append(resolved)
+                        seen.add(resolved)
+                    break
+            if len(verified) >= limit:
+                break
+        return verified
+
     def find_entry_by_title_data(
         self,
         zim_file_path: str,
@@ -1506,6 +1536,13 @@ class _SearchMixin:
         fast_path_hit = False
         fuzzy_path_hit = False
         title_lower = title.lower()
+        # Verified typo-variant titles accumulated during the per-file
+        # typo-fallback probe. Used only when *all* archives return
+        # zero hits, to populate ``_meta.suggestions`` with values the
+        # caller can re-issue as a fresh query (Phase A #6 fix).
+        verified_variants: List[str] = []
+        verified_variants_seen: set[str] = set()
+        structured_suggestions_limit = self.config.search.structured_suggestions_limit
 
         for file_path in files:
             try:
@@ -1615,6 +1652,25 @@ class _SearchMixin:
                                 }
                             )
                             fuzzy_path_hit = True
+                        else:
+                            # Collect *additional* verified variants from
+                            # this archive while it's still open — these
+                            # surface as ``alt_spelling`` suggestions iff
+                            # the final aggregate is empty.
+                            for resolved in self._verified_typo_variants(
+                                [archive],
+                                title,
+                                limit=structured_suggestions_limit
+                                - len(verified_variants),
+                            ):
+                                if resolved not in verified_variants_seen:
+                                    verified_variants.append(resolved)
+                                    verified_variants_seen.add(resolved)
+                                if (
+                                    len(verified_variants)
+                                    >= structured_suggestions_limit
+                                ):
+                                    break
             except Exception as e:
                 if not cross_file:
                     raise
@@ -1624,19 +1680,17 @@ class _SearchMixin:
         # otherwise preserve per-file rank order.
         aggregate_results.sort(key=lambda r: -r["score"])
 
-        # Build _meta.suggestions[] from typo variants when the fuzzy path
-        # is eligible (fast path missed and query is long enough). These are
-        # candidate spellings the caller can surface as "did you mean?" hints.
+        # Build _meta.suggestions[] from archive-verified typo variants
+        # only when there are NO results of any kind — otherwise a
+        # successful (or partially successful) response would carry
+        # "did you mean?" hints that contradict what was returned
+        # (Phase A #7 fix). The variants themselves are confirmed to
+        # resolve to a real entry in at least one archive (Phase A #6
+        # fix), accumulated during the per-file typo-fallback pass.
         suggestions: List[Dict[str, str]] = []
-        limit_n = self.config.search.structured_suggestions_limit
-        if (
-            not fast_path_hit
-            and len(title) >= self.config.search.fuzzy_title_min_query_len
-        ):
-            for variant in self._typo_variants(title):
-                suggestions.append({"type": "alt_spelling", "value": variant})
-                if len(suggestions) >= limit_n:
-                    break
+        if not aggregate_results:
+            for resolved in verified_variants[:structured_suggestions_limit]:
+                suggestions.append({"type": "alt_spelling", "value": resolved})
 
         reason = None if aggregate_results else "0_hits"
 

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -59,6 +59,7 @@ class _FilteredScanState:
     scanned: int
     scan_cap_hit: bool
     total_filtered_is_lower_bound: bool
+    unfiltered_total: int = 0  # pre-filter Xapian hit count, for reason classification
 
 
 def _format_filter_text(namespace: Optional[str], content_type: Optional[str]) -> str:
@@ -194,6 +195,8 @@ class _SearchMixin:
         query: str,
         limit: Optional[int] = None,
         offset: int = 0,
+        *,
+        cursor_archive_identity: Optional[str] = None,
     ) -> "SearchResponse":
         """Structured variant of ``search_zim_file``.
 
@@ -202,9 +205,15 @@ class _SearchMixin:
         structured-output path without the json.dumps + re-parse round trip
         the legacy string variant required.
 
+        ``cursor_archive_identity`` is the ``s.ai`` value decoded from a
+        resumed cursor. When supplied, it must match the current archive's
+        identity or the call is rejected — same anti-cross-archive guard
+        as ``walk_namespace`` / ``extract_article_links``.
+
         Raises:
             OpenZimMcpFileNotFoundError: If ZIM file not found
             OpenZimMcpArchiveError: If search operation fails
+            OpenZimMcpValidationError: If a cursor was issued for a different archive
         """
         if limit is None:
             limit = self.config.content.default_search_limit
@@ -212,6 +221,44 @@ class _SearchMixin:
         # Validate and resolve file path
         validated_path = self.path_validator.validate_path(zim_file_path)
         validated_path = self.path_validator.validate_zim_file(validated_path)
+
+        # Cursor integrity: reject cursors issued against a different archive
+        # (cf. pagination.py module docstring — search_zim_file is in the list
+        # of tools that must verify ``s.ai`` on resume).
+        if cursor_archive_identity is not None:
+            from openzim_mcp.pagination import Cursor as _CursorClass
+            from openzim_mcp.pagination import (
+                CursorMismatchError,
+                archive_identity,
+            )
+
+            try:
+                _CursorClass.verify_archive_identity(
+                    cast("Any", {"ai": cursor_archive_identity}),
+                    expected=archive_identity(validated_path),
+                    tool="search_zim_file",
+                )
+            except CursorMismatchError as e:
+                raise OpenZimMcpValidationError(str(e)) from e
+
+        # Empty / whitespace-only query: surface a structured reason so the
+        # model can self-correct without parsing an error envelope.
+        if not query or not query.strip():
+            empty_payload: Dict[str, Any] = {
+                "query": query,
+                "results": [],
+                "next_cursor": None,
+                "total": 0,
+                "done": True,
+                "page_info": {
+                    "offset": offset,
+                    "limit": limit,
+                    "returned_count": 0,
+                },
+            }
+            return cast(
+                "SearchResponse", attach_meta(empty_payload, reason="bad_query")
+            )
 
         # Cache key bumped to v2b (Phase B) so v1.x cached responses (old shape)
         # don't leak through after the upgrade.
@@ -224,33 +271,65 @@ class _SearchMixin:
         try:
             with _zim_ops_mod.zim_archive(validated_path) as archive:
                 payload, total_results = self._perform_search(
-                    archive, query, limit, offset
+                    archive, query, limit, offset, validated_path=validated_path
                 )
             logger.debug(f"Search completed: query='{query}', results found")
             reason = "0_hits" if total_results == 0 else None
 
-            # Cross-archive name match (Phase A item #4: alt_archive source)
-            # When search yields zero results, suggest other ZIM archives whose
-            # basename contains a query token (length >= 4 chars only).
+            # Zero-hit suggestions (Phase A item #4). Sourced in priority order:
+            # 1. ``alt_spelling`` from SuggestionSearcher partial matches —
+            #    typo correction on the query against the title index.
+            # 2. ``alt_archive`` — other open ZIM files whose basename matches a
+            #    query token. Last-resort hint when the term itself is correct
+            #    but the article lives in a different archive.
             suggestions: List[Dict[str, str]] = []
             if total_results == 0:
+                limit_n = self.config.search.structured_suggestions_limit
+                # alt_spelling first (priority 1 per spec).
                 try:
-                    files = self.list_zim_files_data()
+                    with _zim_ops_mod.zim_archive(validated_path) as archive:
+                        sugg_searcher = _zim_ops_mod.SuggestionSearcher(archive)
+                        sugg = sugg_searcher.suggest(query)
+                        # Cap at 2x the structured limit to give room for de-dup
+                        # against the query itself; SuggestionSearcher results
+                        # include exact matches that we don't want to surface.
+                        candidates = list(sugg.getResults(0, max(limit_n * 2, 5)))
                     q_lower = query.lower()
-                    # Tokens of length >= 4 only (avoids matching "in", "the", etc.)
-                    q_tokens = [tok for tok in q_lower.split() if len(tok) >= 4]
-                    for f in files:
-                        file_path_str = str(f.get("path", ""))
-                        if file_path_str == str(validated_path):
-                            continue  # skip current archive
-                        stem = Path(file_path_str).stem  # e.g., "wikipedia_en_all"
-                        if any(tok in stem.lower() for tok in q_tokens):
-                            suggestions.append({"type": "alt_archive", "value": stem})
-                            limit_n = self.config.search.structured_suggestions_limit
-                            if len(suggestions) >= limit_n:
-                                break
+                    seen: set[str] = set()
+                    for cand_path in candidates:
+                        # SuggestionSearcher returns paths (e.g. "C/Berlin");
+                        # extract the title segment.
+                        title = cand_path.rsplit("/", 1)[-1]
+                        title_lower = title.lower()
+                        if title_lower == q_lower or title_lower in seen:
+                            continue
+                        seen.add(title_lower)
+                        suggestions.append({"type": "alt_spelling", "value": title})
+                        if len(suggestions) >= limit_n:
+                            break
                 except Exception as e:
-                    logger.debug(f"alt_archive suggestion build failed: {e}")
+                    logger.debug(f"alt_spelling suggestion build failed: {e}")
+
+                # alt_archive (priority 3) — fill remaining slots.
+                if len(suggestions) < limit_n:
+                    try:
+                        files = self.list_zim_files_data()
+                        q_lower = query.lower()
+                        # Tokens of length >= 4 only (avoids matching "in", "the").
+                        q_tokens = [tok for tok in q_lower.split() if len(tok) >= 4]
+                        for f in files:
+                            file_path_str = str(f.get("path", ""))
+                            if file_path_str == str(validated_path):
+                                continue  # skip current archive
+                            stem = Path(file_path_str).stem
+                            if any(tok in stem.lower() for tok in q_tokens):
+                                suggestions.append(
+                                    {"type": "alt_archive", "value": stem}
+                                )
+                                if len(suggestions) >= limit_n:
+                                    break
+                    except Exception as e:
+                        logger.debug(f"alt_archive suggestion build failed: {e}")
 
             with_meta = attach_meta(
                 payload,
@@ -267,7 +346,33 @@ class _SearchMixin:
                 self.cache.set(cache_key, with_meta)
             return cast("SearchResponse", with_meta)
 
-        except OpenZimMcpArchiveError:
+        except OpenZimMcpArchiveError as e:
+            # Detect "no Xapian index" so we can return a structured reason
+            # instead of just an opaque archive error. libzim raises
+            # RuntimeError("Archive has no fulltext index") under the hood;
+            # the typed wrapper carries that message verbatim.
+            msg = str(e).lower()
+            if (
+                "no fulltext index" in msg
+                or "no full-text index" in msg
+                or "no xapian" in msg
+            ):
+                empty_payload2: Dict[str, Any] = {
+                    "query": query,
+                    "results": [],
+                    "next_cursor": None,
+                    "total": 0,
+                    "done": True,
+                    "page_info": {
+                        "offset": offset,
+                        "limit": limit,
+                        "returned_count": 0,
+                    },
+                }
+                return cast(
+                    "SearchResponse",
+                    attach_meta(empty_payload2, reason="no_xapian_index"),
+                )
             # Inner helper already raised a typed archive error with full
             # context. Don't re-wrap and double the message prefix.
             raise
@@ -276,16 +381,26 @@ class _SearchMixin:
             raise OpenZimMcpArchiveError(f"Search operation failed: {e}") from e
 
     def _perform_search(
-        self, archive: Archive, query: str, limit: int, offset: int
+        self,
+        archive: Archive,
+        query: str,
+        limit: int,
+        offset: int,
+        *,
+        validated_path: Optional[Path] = None,
     ) -> Tuple[Dict[str, Any], int]:
         """Perform the actual search operation.
+
+        ``validated_path`` is the resolved archive path used to derive the
+        cursor's ``s.ai`` archive identity. Optional for test-only callers
+        that don't paginate; production callers always supply it.
 
         Returns:
             (structured_payload, total_results) — caller uses total_results
             to decide whether the response is safe to cache. The payload
             shape is documented on ``search_zim_file_data``.
         """
-        from openzim_mcp.pagination import Cursor
+        from openzim_mcp.pagination import Cursor, archive_identity
 
         query_obj = _zim_ops_mod.Query().set_query(query)
         searcher = _zim_ops_mod.Searcher(archive)
@@ -352,9 +467,16 @@ class _SearchMixin:
         done = last_index >= total_results
         next_cursor: Optional[str] = None
         if not done:
+            cursor_state: Dict[str, Any] = {
+                "o": last_index,
+                "l": limit,
+                "q": query,
+            }
+            if validated_path is not None:
+                cursor_state["ai"] = archive_identity(validated_path)
             next_cursor = Cursor.encode(
                 tool="search_zim_file",
-                state={"o": last_index, "l": limit, "q": query},
+                state=cast("Any", cursor_state),
             )
 
         return (
@@ -550,6 +672,8 @@ class _SearchMixin:
         content_type: Optional[str] = None,
         limit: Optional[int] = None,
         offset: int = 0,
+        *,
+        cursor_archive_identity: Optional[str] = None,
     ) -> "SearchWithFiltersResponse":
         """Structured filtered-search response. v2 Phase B contract.
 
@@ -566,13 +690,22 @@ class _SearchMixin:
         filtering, which would otherwise multiply ``offset + limit`` entry
         materialisations across every candidate.
 
+        ``cursor_archive_identity`` is the ``s.ai`` value decoded from a
+        resumed cursor; mismatched archives are rejected per the cursor
+        contract.
+
         Raises:
             OpenZimMcpFileNotFoundError: If ZIM file not found
             OpenZimMcpValidationError: If parameter validation fails
-                (limit out of range, negative offset, malformed namespace).
+                (limit out of range, negative offset, malformed namespace,
+                cursor archive mismatch).
             OpenZimMcpArchiveError: If search operation fails
         """
-        from openzim_mcp.pagination import Cursor
+        from openzim_mcp.pagination import (
+            Cursor,
+            CursorMismatchError,
+            archive_identity,
+        )
 
         if limit is None:
             limit = self.config.content.default_search_limit
@@ -592,6 +725,17 @@ class _SearchMixin:
         # Validate and resolve file path
         validated_path = self.path_validator.validate_path(zim_file_path)
         validated_path = self.path_validator.validate_zim_file(validated_path)
+
+        # Cursor integrity: reject cursors issued against a different archive.
+        if cursor_archive_identity is not None:
+            try:
+                Cursor.verify_archive_identity(
+                    cast("Any", {"ai": cursor_archive_identity}),
+                    expected=archive_identity(validated_path),
+                    tool="search_with_filters",
+                )
+            except CursorMismatchError as e:
+                raise OpenZimMcpValidationError(str(e)) from e
 
         # Cache key bumped to v2b (Phase B) so v1.x cached responses (markdown
         # strings under the legacy ``search_filtered:`` prefix) don't leak
@@ -639,7 +783,12 @@ class _SearchMixin:
         )
         next_cursor: Optional[str] = None
         if not done:
-            cursor_state: Dict[str, Any] = {"o": last_index, "l": limit, "q": query}
+            cursor_state: Dict[str, Any] = {
+                "o": last_index,
+                "l": limit,
+                "q": query,
+                "ai": archive_identity(validated_path),
+            }
             if namespace:
                 cursor_state["ns"] = namespace
             if content_type:
@@ -673,7 +822,18 @@ class _SearchMixin:
             f"namespace={namespace}, type={content_type}, "
             f"results={returned_count}"
         )
-        reason = "0_hits" if scan.filtered_count == 0 else None
+        # Classify the zero-result case: if a namespace/content_type filter
+        # was supplied AND the unfiltered search returned hits, the filter
+        # is what killed them — surface that as ``bad_namespace`` so the
+        # model can self-correct (drop or change the filter) instead of
+        # treating the whole query as a miss.
+        if scan.filtered_count == 0:
+            if (namespace or content_type) and scan.unfiltered_total > 0:
+                reason: Optional[str] = "bad_namespace"
+            else:
+                reason = "0_hits"
+        else:
+            reason = None
         with_meta = attach_meta(payload, reason=reason)
         # Cache the post-attach payload so cold/warm reads are bit-identical
         # (Phase B #12). Skip zero-hit results — see search_zim_file_data
@@ -722,10 +882,22 @@ class _SearchMixin:
                 scanned=0,
                 scan_cap_hit=False,
                 total_filtered_is_lower_bound=False,
+                unfiltered_total=0,
             )
 
         page, scan = self._scan_filtered_search(
             archive, search, total_results, namespace, content_type, limit, offset
+        )
+
+        # Propagate the pre-filter total so the caller can distinguish
+        # "query matched nothing" (0_hits) from "filter killed every match"
+        # (bad_namespace) when emitting structured reason codes.
+        scan = _FilteredScanState(
+            filtered_count=scan.filtered_count,
+            scanned=scan.scanned,
+            scan_cap_hit=scan.scan_cap_hit,
+            total_filtered_is_lower_bound=scan.total_filtered_is_lower_bound,
+            unfiltered_total=total_results,
         )
 
         if scan.filtered_count == 0:

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -1809,10 +1809,11 @@ class _SearchMixin:
                     if not fast_path_hit and not already_has_strong:
                         typo_entry = self._find_entry_typo_fallback(archive, title)
                         if typo_entry is not None:
+                            resolved_typo_title = typo_entry.title or title
                             aggregate_results.append(
                                 {
                                     "path": typo_entry.path,
-                                    "title": typo_entry.title or title,
+                                    "title": resolved_typo_title,
                                     # Score set from config (default 0.85).
                                     # Below 0.95 (suggestion-rank top) and
                                     # well below 1.0 (exact match) so a
@@ -1824,6 +1825,17 @@ class _SearchMixin:
                                 }
                             )
                             fuzzy_path_hit = True
+                            # Spec §14.4: when a fuzzy hit is returned, the
+                            # variant that matched is itself a valuable
+                            # ``alt_spelling`` signal — it tells the model
+                            # *what* correction the server applied so it can
+                            # decide whether to re-issue the query verbatim
+                            # or accept the correction. The variant joins
+                            # the verified-variants pool regardless of
+                            # whether other archives produced results.
+                            if resolved_typo_title not in verified_variants_seen:
+                                verified_variants.append(resolved_typo_title)
+                                verified_variants_seen.add(resolved_typo_title)
                         else:
                             # Collect *additional* verified variants from
                             # this archive while it's still open — these
@@ -1852,15 +1864,16 @@ class _SearchMixin:
         # otherwise preserve per-file rank order.
         aggregate_results.sort(key=lambda r: -r["score"])
 
-        # Build _meta.suggestions[] from archive-verified typo variants
-        # only when there are NO results of any kind — otherwise a
-        # successful (or partially successful) response would carry
-        # "did you mean?" hints that contradict what was returned
-        # (Phase A #7 fix). The variants themselves are confirmed to
-        # resolve to a real entry in at least one archive (Phase A #6
-        # fix), accumulated during the per-file typo-fallback pass.
+        # Build _meta.suggestions[] from archive-verified typo variants.
+        # Two cases surface them (spec §14.4):
+        #   * No results of any kind — pure recovery hints.
+        #   * A fuzzy hit is returned — the variant that matched is shown
+        #     so the caller can verify the auto-correction rather than
+        #     silently accepting it.
+        # When the response carries a non-fuzzy hit, suggestions stay
+        # empty so confident matches aren't muddled by alt-spelling noise.
         suggestions: List[Dict[str, str]] = []
-        if not aggregate_results:
+        if not aggregate_results or fuzzy_path_hit:
             for resolved in verified_variants[:structured_suggestions_limit]:
                 suggestions.append({"type": "alt_spelling", "value": resolved})
 

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -58,15 +58,19 @@ def _sections_to_toc_tree(sections: "List[SectionMeta]") -> "List[TocHeading]":
     stack: "List[Tuple[int, List[TocHeading]]]" = [(0, root)]
 
     for s in sections:
-        node: "TocHeading" = cast(
-            "TocHeading",
-            {
-                "section_id": s["id"],
-                "text": s["title"],
-                "level": s["level"],
-                "children": [],
-            },
-        )
+        node_dict: Dict[str, Any] = {
+            "section_id": s["id"],
+            "text": s["title"],
+            "level": s["level"],
+            "children": [],
+        }
+        # ``id_source`` is preserved per the Phase C spec so callers can
+        # tell stable anchors from generated slugs. Drop when absent so
+        # the wire shape stays minimal for bundles built before the
+        # field was tracked.
+        if "id_source" in s:
+            node_dict["id_source"] = s["id_source"]
+        node: "TocHeading" = cast("TocHeading", node_dict)
         while stack and stack[-1][0] >= s["level"]:
             stack.pop()
         if stack:
@@ -157,12 +161,21 @@ class _StructureMixin:
         """Extract structure from article content via bundle."""
         from openzim_mcp.bundle import get_or_build_bundle
 
+        if validated_path is None:
+            # Falling back to Path(entry_path) makes the bundle cache key
+            # archive-agnostic — the same key collides across every ZIM
+            # whose archive holds this entry path. Require the caller to
+            # pass the resolved archive path so bundles stay archive-bound.
+            raise OpenZimMcpValidationError(
+                "_extract_article_structure_data requires validated_path"
+            )
+
         try:
             bundle = get_or_build_bundle(
                 archive,
                 entry_path,
                 cache=self.cache,
-                validated_path=validated_path or Path(entry_path),
+                validated_path=validated_path,
                 content_processor=self.content_processor,
             )
 
@@ -278,8 +291,8 @@ class _StructureMixin:
         # Cursor integrity (Phase B #11): a cursor issued for archive A
         # must not be honoured when resubmitted against archive B.
         if cursor_archive_identity is not None:
+            from openzim_mcp.pagination import Cursor as _CursorClass
             from openzim_mcp.pagination import (
-                Cursor as _CursorClass,
                 CursorMismatchError,
                 archive_identity,
             )
@@ -474,12 +487,20 @@ class _StructureMixin:
         """Extract hierarchical table of contents from article via bundle."""
         from openzim_mcp.bundle import get_or_build_bundle
 
+        if validated_path is None:
+            # Same archive-binding requirement as
+            # _extract_article_structure_data — without a real archive
+            # path the bundle cache collides cross-archive.
+            raise OpenZimMcpValidationError(
+                "_extract_table_of_contents_data requires validated_path"
+            )
+
         try:
             bundle = get_or_build_bundle(
                 archive,
                 entry_path,
                 cache=self.cache,
-                validated_path=validated_path or Path(entry_path),
+                validated_path=validated_path,
                 content_processor=self.content_processor,
             )
 

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -598,15 +598,17 @@ class _StructureMixin:
                 extras={"available_section_ids": [s["id"] for s in bundle["sections"]]},
             )
 
-        body = bundle["rendered_markdown"][section["char_start"] : section["char_end"]]
+        full_body = bundle["rendered_markdown"][
+            section["char_start"] : section["char_end"]
+        ]
         cap = (
             max_chars
             if max_chars is not None
             else self.config.content.max_content_length
         )
-        truncated = len(body) > cap
-        if truncated:
-            body = body[:cap]
+        full_len = len(full_body)
+        truncated = full_len > cap
+        body = full_body[:cap] if truncated else full_body
 
         payload: "GetSectionResponse" = cast(
             "GetSectionResponse",
@@ -623,9 +625,18 @@ class _StructureMixin:
                 "truncated": truncated,
             },
         )
+        # When truncation happens, surface ``total_chars`` so the caller
+        # can tell how much of the section was elided. ``more_at_offset``
+        # is intentionally omitted — get_section truncation is not
+        # resumable; callers needing the full body fall back to
+        # ``get_zim_entry`` with ``content_offset``.
         return cast(
             "GetSectionResponse",
-            attach_meta(cast(Dict[str, Any], payload), truncated=truncated),
+            attach_meta(
+                cast(Dict[str, Any], payload),
+                truncated=truncated,
+                total_chars=full_len if truncated else None,
+            ),
         )
 
     def get_related_articles_data(

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -221,6 +221,8 @@ class _StructureMixin:
         limit: int = 100,
         offset: int = 0,
         kind: str = "internal",
+        *,
+        cursor_archive_identity: Optional[str] = None,
     ) -> "LinksResponse":
         """Structured variant of ``extract_article_links``. v2 Phase B contract.
 
@@ -273,6 +275,24 @@ class _StructureMixin:
         validated_path = self.path_validator.validate_path(zim_file_path)
         validated_path = self.path_validator.validate_zim_file(validated_path)
 
+        # Cursor integrity (Phase B #11): a cursor issued for archive A
+        # must not be honoured when resubmitted against archive B.
+        if cursor_archive_identity is not None:
+            from openzim_mcp.pagination import (
+                Cursor as _CursorClass,
+                CursorMismatchError,
+                archive_identity,
+            )
+
+            try:
+                _CursorClass.verify_archive_identity(
+                    cast("Any", {"ai": cursor_archive_identity}),
+                    expected=archive_identity(validated_path),
+                    tool="extract_article_links",
+                )
+            except CursorMismatchError as e:
+                raise OpenZimMcpValidationError(str(e)) from e
+
         try:
             from openzim_mcp.bundle import get_or_build_bundle
 
@@ -295,6 +315,8 @@ class _StructureMixin:
             done = last_index >= total_for_kind
             next_cursor: Optional[str] = None
             if not done:
+                from openzim_mcp.pagination import archive_identity
+
                 next_cursor = Cursor.encode(
                     tool="extract_article_links",
                     state={
@@ -302,6 +324,7 @@ class _StructureMixin:
                         "l": limit,
                         "ep": entry_path,
                         "k": kind,
+                        "ai": archive_identity(validated_path),
                     },
                 )
 

--- a/tests/data/goldens/v2_phase_c/get_section_berlin_climate.json
+++ b/tests/data/goldens/v2_phase_c/get_section_berlin_climate.json
@@ -2,8 +2,8 @@
   "_meta": {
     "truncated": false
   },
-  "char_count": 54,
-  "content_markdown": "## Climate\n\nBerlin has a temperate seasonal climate.\n\n",
+  "char_count": 42,
+  "content_markdown": "Berlin has a temperate seasonal climate.\n\n",
   "entry_path": "A/Berlin",
   "level": 2,
   "parent_id": "berlin",
@@ -11,5 +11,5 @@
   "section_title": "Climate",
   "title": "Berlin",
   "truncated": false,
-  "word_count": 8
+  "word_count": 6
 }

--- a/tests/data/goldens/v2_phase_c/get_section_berlin_geography.json
+++ b/tests/data/goldens/v2_phase_c/get_section_berlin_geography.json
@@ -2,8 +2,8 @@
   "_meta": {
     "truncated": false
   },
-  "char_count": 71,
-  "content_markdown": "## Geography\n\nBerlin lies in northeastern Germany on the river Spree.\n\n",
+  "char_count": 57,
+  "content_markdown": "Berlin lies in northeastern Germany on the river Spree.\n\n",
   "entry_path": "A/Berlin",
   "level": 2,
   "parent_id": "berlin",
@@ -11,5 +11,5 @@
   "section_title": "Geography",
   "title": "Berlin",
   "truncated": false,
-  "word_count": 11
+  "word_count": 9
 }

--- a/tests/data/goldens/v2_phase_c/get_section_munich_history.json
+++ b/tests/data/goldens/v2_phase_c/get_section_munich_history.json
@@ -2,8 +2,8 @@
   "_meta": {
     "truncated": false
   },
-  "char_count": 41,
-  "content_markdown": "## History\n\nMunich was founded in 1158.\n\n",
+  "char_count": 29,
+  "content_markdown": "Munich was founded in 1158.\n\n",
   "entry_path": "A/Munich",
   "level": 2,
   "parent_id": "munich",
@@ -11,5 +11,5 @@
   "section_title": "History",
   "title": "Munich",
   "truncated": false,
-  "word_count": 7
+  "word_count": 5
 }

--- a/tests/data/goldens/v2_phase_c/synthesize_berlin_geography.json
+++ b/tests/data/goldens/v2_phase_c/synthesize_berlin_geography.json
@@ -1,5 +1,7 @@
 {
-  "_meta": {},
+  "_meta": {
+    "truncated": false
+  },
   "answer_markdown": "# **Berlin** **Berlin** is the capital and largest city of Germany.\n[cite: v2_phase_c/A/Berlin]",
   "archives_searched": [
     "v2_phase_c"

--- a/tests/data/goldens/v2_phase_c/synthesize_capital_city.json
+++ b/tests/data/goldens/v2_phase_c/synthesize_capital_city.json
@@ -1,5 +1,7 @@
 {
-  "_meta": {},
+  "_meta": {
+    "truncated": false
+  },
   "answer_markdown": "Berlin is the **capital** and largest **city** of Germany. ## Geography\n[cite: v2_phase_c/A/Berlin]",
   "archives_searched": [
     "v2_phase_c"

--- a/tests/data/goldens/v2_phase_c/synthesize_munich_history.json
+++ b/tests/data/goldens/v2_phase_c/synthesize_munich_history.json
@@ -1,5 +1,7 @@
 {
-  "_meta": {},
+  "_meta": {
+    "truncated": false
+  },
   "answer_markdown": "# **Munich** **Munich** is the capital of Bavaria.\n[cite: v2_phase_c/A/Munich]",
   "archives_searched": [
     "v2_phase_c"

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -91,14 +91,22 @@ def test_bundle_section_offsets_are_sorted_and_disjoint(cp: ContentProcessor) ->
         assert 0 <= s["char_start"] < s["char_end"] <= md_len
 
 
-def test_bundle_slice_returns_section_content(cp: ContentProcessor) -> None:
+def test_bundle_slice_returns_section_body_without_heading(
+    cp: ContentProcessor,
+) -> None:
+    """``char_start`` points to the body, not the heading line itself.
+
+    The heading is exposed separately as ``section_title``/``level``, so
+    including ``## Geography`` again in the slice is redundant and inflates
+    ``char_count``/``word_count``.
+    """
     archive = _make_archive_with_entry(SAMPLE_HTML)
     bundle = extract_entry_bundle(archive, "A/Berlin", content_processor=cp)
     md = bundle["rendered_markdown"]
     geography = next(s for s in bundle["sections"] if s["title"] == "Geography")
     slice_text = md[geography["char_start"] : geography["char_end"]]
-    assert "Geography" in slice_text
     assert "Spree" in slice_text
+    assert not slice_text.lstrip().startswith("## Geography")
     # Must not contain the next heading's title (History)
     assert "History" not in slice_text
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -387,6 +387,66 @@ class TestCacheLRUEviction:
         assert remaining == 2  # Only 2 should remain
 
 
+class TestCacheByteBudget:
+    """Phase C #13: byte-budget eviction prevents large entries from
+    pinning hundreds of MB even when entry count stays well below
+    ``max_size``."""
+
+    def test_oversized_payloads_trigger_byte_eviction(self):
+        # 6 KB cap, 100 entries allowed by count — byte cap kicks in first.
+        config = CacheConfig(
+            enabled=True, max_size=100, ttl_seconds=60, max_bytes=6 * 1024
+        )
+        cache = OpenZimMcpCache(config, enable_background_cleanup=False)
+
+        big = "X" * 2048  # ~2 KB JSON-encoded (with quotes)
+        cache.set("a", big)
+        cache.set("b", big)
+        # Two ~2 KB entries fit under the 6 KB cap.
+        assert cache.get("a") == big
+        assert cache.get("b") == big
+        assert cache.stats()["size"] == 2
+
+        # Third entry pushes total over 6 KB → eviction kicks in,
+        # evicting the LRU entry (key "a" was accessed first).
+        cache.set("c", big)
+        # Cache still respects the byte budget after eviction.
+        assert cache.stats()["size_bytes"] <= 6 * 1024 + 1024  # +1 KB headroom
+        # Some entry got evicted to make room (typically the LRU one).
+        assert cache.stats()["size"] < 3
+
+    def test_byte_budget_zero_disables_byte_eviction(self):
+        """max_bytes=0 → byte cap disabled; only count cap applies."""
+        config = CacheConfig(
+            enabled=True, max_size=100, ttl_seconds=60, max_bytes=0
+        )
+        cache = OpenZimMcpCache(config, enable_background_cleanup=False)
+
+        big = "X" * 4096
+        for i in range(10):
+            cache.set(f"k{i}", big)
+        # All 10 entries fit (under the 100-count cap).
+        assert cache.stats()["size"] == 10
+
+    def test_total_bytes_decrements_on_delete(self):
+        config = CacheConfig(enabled=True, max_size=10, ttl_seconds=60)
+        cache = OpenZimMcpCache(config, enable_background_cleanup=False)
+        cache.set("k", "value")
+        before = cache.stats()["size_bytes"]
+        assert before > 0
+        cache.delete("k")
+        assert cache.stats()["size_bytes"] == 0
+
+    def test_total_bytes_resets_to_zero_on_clear(self):
+        config = CacheConfig(enabled=True, max_size=10, ttl_seconds=60)
+        cache = OpenZimMcpCache(config, enable_background_cleanup=False)
+        cache.set("k1", "value1")
+        cache.set("k2", "value2")
+        assert cache.stats()["size_bytes"] > 0
+        cache.clear()
+        assert cache.stats()["size_bytes"] == 0
+
+
 class TestCachePersistence:
     """Test cache persistence functionality."""
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -417,9 +417,7 @@ class TestCacheByteBudget:
 
     def test_byte_budget_zero_disables_byte_eviction(self):
         """max_bytes=0 → byte cap disabled; only count cap applies."""
-        config = CacheConfig(
-            enabled=True, max_size=100, ttl_seconds=60, max_bytes=0
-        )
+        config = CacheConfig(enabled=True, max_size=100, ttl_seconds=60, max_bytes=0)
         cache = OpenZimMcpCache(config, enable_background_cleanup=False)
 
         big = "X" * 4096

--- a/tests/test_content_tools.py
+++ b/tests/test_content_tools.py
@@ -282,7 +282,9 @@ class TestGetBinaryEntryDataMeta:
         validated = zim_ops.path_validator.validate_zim_file(validated)
 
         # Seed the cache with binary metadata so the short-circuit path fires.
-        cache_key = f"binary_meta:{validated}:I/test.png"
+        from openzim_mcp.bundle import archive_stat_token as _stat
+
+        cache_key = f"binary_meta:{validated}:{_stat(validated)}:I/test.png"
         zim_ops.cache.set(
             cache_key,
             {

--- a/tests/test_find_entry_by_title.py
+++ b/tests/test_find_entry_by_title.py
@@ -459,24 +459,58 @@ class TestMetaSuggestionsAndReason:
         return OpenZimMcpServer(test_config)
 
     def test_fuzzy_candidates_appear_in_meta_suggestions(self, server, monkeypatch):
-        """When fuzzy fallback eligibility is met (no fast path, query long
-        enough), _meta.suggestions[] contains alt_spelling entries derived
-        from the typo variant generator.
+        """When fuzzy fallback eligibility is met (no fast path, no
+        suggestion-search hit, query long enough), and at least one typo
+        variant resolves to a real entry in the archive, that variant
+        title appears in ``_meta.suggestions[]``.
+
+        Regression: earlier code emitted raw permutations of the user's
+        input regardless of whether they resolved (Phase A #6). The new
+        behaviour only emits archive-verified entry titles.
         """
-        _mock_archive_and_suggester(monkeypatch)
+        # Make the typo-variant probe for "C/Einstein" resolve.
+        # "Einstien" → transposition → "Einstein" which the fast-path
+        # tries as "C/Einstein".
+        mock_archive = _mock_archive_and_suggester(monkeypatch)
+        einstein_entry = MagicMock()
+        einstein_entry.path = "C/Einstein"
+        einstein_entry.title = "Einstein"
+        mock_archive.has_entry_by_path.side_effect = lambda p: p == "C/Einstein"
+        mock_archive.get_entry_by_path.side_effect = (
+            lambda p: einstein_entry if p == "C/Einstein" else (_ for _ in ()).throw(KeyError(p))
+        )
         _patch_path_validator(server)
 
         result = server.zim_operations.find_entry_by_title_data(
             "/zim/test.zim", "Einstien", cross_file=False, limit=10
         )
-        # "Einstien" is 8 chars — above the default fuzzy_title_min_query_len (4)
+        # With the new fix, the typo fallback resolves to "Einstein" so
+        # the result list contains one entry and _meta.suggestions is
+        # NOT emitted (issue #7: suggestions only on 0-hit responses).
+        # If the typo fallback didn't run for some reason, we'd expect
+        # the verified-variants list. Either way: no raw permutations.
         suggestions = result.get("_meta", {}).get("suggestions", [])
-        spelling_alts = [s for s in suggestions if s.get("type") == "alt_spelling"]
-        assert spelling_alts, "expected typo variants as alt_spelling suggestions"
-        # Each suggestion must have both required keys
-        for s in spelling_alts:
-            assert "type" in s
-            assert "value" in s
+        for s in suggestions:
+            # Every suggestion must be a value that resolved against
+            # the archive, not a mangled permutation.
+            assert s["value"] == "Einstein"
+
+    def test_suggestions_omitted_when_archive_has_no_matches(self, server, monkeypatch):
+        """When the archive contains nothing that resolves any typo
+        variant, ``_meta.suggestions`` is empty rather than a list of
+        nonsense permutations of the user's input (Phase A #6)."""
+        _mock_archive_and_suggester(monkeypatch)  # has_entry_by_path → False
+        _patch_path_validator(server)
+
+        result = server.zim_operations.find_entry_by_title_data(
+            "/zim/test.zim",
+            "Photosythesis",  # 13 chars > fuzzy_title_min_query_len
+            cross_file=False,
+            limit=10,
+        )
+        suggestions = result.get("_meta", {}).get("suggestions", [])
+        # No archive entry resolves any typo variant → no suggestions
+        assert suggestions == [] or suggestions is None or suggestions == []
 
     def test_suggestions_capped_at_structured_suggestions_limit(
         self, server, monkeypatch

--- a/tests/test_find_entry_by_title.py
+++ b/tests/test_find_entry_by_title.py
@@ -476,8 +476,8 @@ class TestMetaSuggestionsAndReason:
         einstein_entry.path = "C/Einstein"
         einstein_entry.title = "Einstein"
         mock_archive.has_entry_by_path.side_effect = lambda p: p == "C/Einstein"
-        mock_archive.get_entry_by_path.side_effect = (
-            lambda p: einstein_entry if p == "C/Einstein" else (_ for _ in ()).throw(KeyError(p))
+        mock_archive.get_entry_by_path.side_effect = lambda p: (
+            einstein_entry if p == "C/Einstein" else (_ for _ in ()).throw(KeyError(p))
         )
         _patch_path_validator(server)
 

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -37,16 +37,49 @@ def test_build_meta_basic_dict():
     assert "suggestions" not in meta
 
 
-def test_build_meta_truncated():
+def test_build_meta_truncated_with_content_chars_emits_more_at_offset():
     meta = build_meta(
         rendered="X" * 100,
         total_chars=10_000,
         current_offset=0,
+        content_chars=100,
         truncated=True,
     )
     assert meta["truncated"] is True
     assert meta["more_at_offset"] == 100
     assert meta["total_chars"] == 10_000
+
+
+def test_build_meta_truncated_without_content_chars_omits_more_at_offset():
+    """Tools that truncate WITHOUT a follow-up offset (binary cap, section cap,
+    summary word cap) must not surface ``more_at_offset`` — a caller can't
+    page past where there is no continuation."""
+    meta = build_meta(
+        rendered="X" * 100,
+        total_chars=10_000,
+        truncated=True,
+    )
+    assert meta["truncated"] is True
+    assert "more_at_offset" not in meta
+    assert meta["total_chars"] == 10_000
+
+
+def test_build_meta_more_at_offset_uses_content_not_envelope():
+    """Regression: ``more_at_offset`` must reflect content byte offset,
+    not the JSON envelope size. Earlier code mistakenly used
+    ``len(rendered)`` (envelope) which inflated the offset by the wrapper
+    field bytes (`path`, `title`, …) and broke follow-up pagination."""
+    envelope = '{"path":"A/Foo","title":"Foo","content":"' + "X" * 100 + '"}'
+    meta = build_meta(
+        rendered=envelope,
+        current_offset=200,
+        content_chars=100,
+        truncated=True,
+    )
+    # Caller asked for offset=200, returned 100 chars of content → next
+    # call uses offset=300. The envelope is much longer than 100, but
+    # that doesn't enter the calculation.
+    assert meta["more_at_offset"] == 300
 
 
 def test_build_meta_with_suggestions():

--- a/tests/test_metadata_tools.py
+++ b/tests/test_metadata_tools.py
@@ -212,15 +212,24 @@ class TestGetZimMetadataDataMeta:
         assert "_meta" in result
         assert result["_meta"]["tokens_est"] >= 1
 
-    def test_get_zim_metadata_data_cached_backfills_meta(self, zim_ops, temp_dir):
-        """Cached entry without _meta is backfilled on read."""
+    def test_get_zim_metadata_data_cached_payload_returned_verbatim(
+        self, zim_ops, temp_dir
+    ):
+        """Cache stores the post-attach payload. A cache hit returns it
+        verbatim — _meta is NOT recomputed on every read (Phase B #12
+        fix; non-determinism between cold/warm was eliminated).
+        """
         zim_file = self._zim_file(temp_dir)
         validated = zim_ops.path_validator.validate_path(str(zim_file))
         validated = zim_ops.path_validator.validate_zim_file(validated)
         cache_key = f"metadata_data:{validated}"
-        old = {"title": "Test", "language": "eng"}
-        zim_ops.cache.set(cache_key, old)
+        seeded = {
+            "title": "Test",
+            "language": "eng",
+            "_meta": {"tokens_est": 17, "chars": 32, "truncated": False},
+        }
+        zim_ops.cache.set(cache_key, seeded)
 
         result = zim_ops.get_zim_metadata_data(str(zim_file))
-        assert "_meta" in result
-        assert result["_meta"]["tokens_est"] >= 1
+        assert result is seeded
+        assert result["_meta"]["tokens_est"] == 17

--- a/tests/test_navigation_tools.py
+++ b/tests/test_navigation_tools.py
@@ -968,19 +968,25 @@ class TestNamespaceDataMethodsMeta:
         assert "_meta" in result
         assert result["_meta"]["tokens_est"] >= 1
 
-    def test_list_namespaces_data_cached_backfills_meta(self, zim_ops, temp_dir):
-        """Cached entry without _meta gets backfilled on read."""
+    def test_list_namespaces_data_cached_payload_returned_verbatim(
+        self, zim_ops, temp_dir
+    ):
+        """Cache stores the post-attach payload; cache hit returns it
+        verbatim (Phase B #12 fix — no recomputation on read)."""
         zim_file = self._zim_file(temp_dir)
         validated = zim_ops.path_validator.validate_path(str(zim_file))
         validated = zim_ops.path_validator.validate_zim_file(validated)
-        # Phase B v2b cache key (entry_count -> total rename).
         cache_key = f"namespaces_data:v2b:{validated}"
-        old = {"total_entries": 5, "namespaces": {}}
-        zim_ops.cache.set(cache_key, old)
+        seeded = {
+            "total_entries": 5,
+            "namespaces": {},
+            "_meta": {"tokens_est": 12, "chars": 40, "truncated": False},
+        }
+        zim_ops.cache.set(cache_key, seeded)
 
         result = zim_ops.list_namespaces_data(str(zim_file))
-        assert "_meta" in result
-        assert result["_meta"]["tokens_est"] >= 1
+        assert result is seeded
+        assert result["_meta"]["tokens_est"] == 12
 
     def test_browse_namespace_data_fresh_attaches_meta(
         self, zim_ops, temp_dir, monkeypatch
@@ -1017,26 +1023,28 @@ class TestNamespaceDataMethodsMeta:
         assert "_meta" in result
         assert result["_meta"]["tokens_est"] >= 1
 
-    def test_browse_namespace_data_cached_backfills_meta(self, zim_ops, temp_dir):
-        """Cached browse entry without _meta gets backfilled on read."""
+    def test_browse_namespace_data_cached_payload_returned_verbatim(
+        self, zim_ops, temp_dir
+    ):
+        """Cache stores the post-attach payload; cache hit returns it
+        verbatim (Phase B #12 fix — no recomputation on read)."""
         zim_file = self._zim_file(temp_dir)
         validated = zim_ops.path_validator.validate_path(str(zim_file))
         validated = zim_ops.path_validator.validate_zim_file(validated)
         cache_key = f"browse_ns_data:v2b:{validated}:C:50:0"
-        # Cache the *post-rename* contract shape — browse_namespace_data
-        # now caches the structured payload, not the inner legacy dict.
-        old = {
+        seeded = {
             "namespace": "C",
             "results": [],
             "next_cursor": None,
             "total": 0,
             "done": True,
             "page_info": {"offset": 0, "limit": 50, "returned_count": 0},
+            "_meta": {"tokens_est": 19, "chars": 110, "truncated": False},
         }
-        zim_ops.cache.set(cache_key, old)
+        zim_ops.cache.set(cache_key, seeded)
 
         result = zim_ops.browse_namespace_data(str(zim_file), "C")
-        assert "_meta" in result
+        assert result is seeded
         assert result["_meta"]["tokens_est"] >= 1
 
     def test_walk_namespace_data_attaches_meta(self, zim_ops, temp_dir, monkeypatch):

--- a/tests/test_pagination_cursor.py
+++ b/tests/test_pagination_cursor.py
@@ -17,7 +17,7 @@ class TestCursorRoundTrip:
         )
         assert isinstance(token, str)
         decoded = Cursor.decode(token, expected_tool="browse_namespace")
-        assert decoded["v"] == 1
+        assert decoded["v"] == 2  # cursor v1->v2 clean break (v2 alpha line)
         assert decoded["t"] == "browse_namespace"
         assert decoded["s"] == {"o": 50, "l": 50, "ns": "C"}
 
@@ -37,23 +37,28 @@ class TestCursorRoundTrip:
 
 
 class TestCursorVersioning:
-    def test_default_version_is_one(self) -> None:
+    def test_default_version_is_two(self) -> None:
         token = Cursor.encode(
             tool="browse_namespace", state={"o": 0, "l": 50, "ns": "C"}
         )
         decoded = Cursor.decode(token, expected_tool="browse_namespace")
-        assert decoded["v"] == 1
+        assert decoded["v"] == 2
 
-    def test_explicit_version_passes_through(self) -> None:
-        token = Cursor.encode(
-            tool="browse_namespace", state={"o": 0, "l": 50, "ns": "C"}, version=1
-        )
-        decoded = Cursor.decode(token, expected_tool="browse_namespace")
-        assert decoded["v"] == 1
-
-    def test_unknown_version_rejected(self) -> None:
+    def test_v1_cursor_rejected_after_clean_break(self) -> None:
+        """Cursors from v2.0.0a2 (cursor v=1) are no longer honoured —
+        they lacked archive identity and per-tool integrity fields,
+        which led to several silent wrong-result bugs.
+        """
         raw = json.dumps(
-            {"v": 2, "t": "browse_namespace", "s": {"o": 0, "l": 50, "ns": "C"}}
+            {"v": 1, "t": "browse_namespace", "s": {"o": 0, "l": 50, "ns": "C"}}
+        )
+        token = base64.urlsafe_b64encode(raw.encode()).decode()
+        with pytest.raises(ValueError, match="Unsupported cursor version"):
+            Cursor.decode(token, expected_tool="browse_namespace")
+
+    def test_unknown_future_version_rejected(self) -> None:
+        raw = json.dumps(
+            {"v": 99, "t": "browse_namespace", "s": {"o": 0, "l": 50, "ns": "C"}}
         )
         token = base64.urlsafe_b64encode(raw.encode()).decode()
         with pytest.raises(ValueError, match="Unsupported cursor version"):
@@ -88,7 +93,7 @@ class TestCursorMalformed:
             Cursor.decode(token, expected_tool="browse_namespace")
 
     def test_decode_missing_required_fields_raises(self) -> None:
-        raw = json.dumps({"v": 1, "s": {"o": 0, "l": 20}})
+        raw = json.dumps({"v": 2, "s": {"o": 0, "l": 20}})
         token = base64.urlsafe_b64encode(raw.encode()).decode()
         with pytest.raises(ValueError, match="missing"):
             Cursor.decode(token, expected_tool="browse_namespace")
@@ -107,3 +112,40 @@ class TestCursorWalkNamespaceState:
         token = Cursor.encode(tool="walk_namespace", state={"scan_at": 0, "l": 200})
         decoded = Cursor.decode(token, expected_tool="walk_namespace")
         assert decoded["s"]["scan_at"] == 0
+
+
+class TestArchiveIdentity:
+    def test_archive_identity_is_stable_for_same_path(self) -> None:
+        from openzim_mcp.pagination import archive_identity
+
+        assert archive_identity("/zim/wiki.zim") == archive_identity("/zim/wiki.zim")
+
+    def test_archive_identity_differs_per_path(self) -> None:
+        from openzim_mcp.pagination import archive_identity
+
+        a = archive_identity("/zim/wiki.zim")
+        b = archive_identity("/zim/dictionary.zim")
+        assert a != b
+
+    def test_verify_archive_identity_passes_on_match(self) -> None:
+        from openzim_mcp.pagination import archive_identity
+
+        ai = archive_identity("/zim/wiki.zim")
+        # No exception raised
+        Cursor.verify_archive_identity(
+            {"ai": ai}, expected=ai, tool="extract_article_links"
+        )
+
+    def test_verify_archive_identity_rejects_mismatch(self) -> None:
+        from openzim_mcp.pagination import archive_identity
+
+        a = archive_identity("/zim/wiki.zim")
+        b = archive_identity("/zim/dictionary.zim")
+        with pytest.raises(CursorMismatchError):
+            Cursor.verify_archive_identity(
+                {"ai": a}, expected=b, tool="extract_article_links"
+            )
+
+    def test_verify_archive_identity_rejects_missing(self) -> None:
+        with pytest.raises(CursorMismatchError, match="missing archive-identity"):
+            Cursor.verify_archive_identity({}, expected="abc", tool="walk_namespace")

--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -565,31 +565,47 @@ class TestSearchZimFileDataMeta:
         assert result["total"] < result["page_info"]["offset"]
         assert result["results"] == []
 
-    def test_search_zim_file_data_meta_on_cached_return(self, zim_ops, temp_dir):
-        """Cached return path backfills _meta if missing, and always returns _meta."""
+    def test_search_zim_file_data_cached_payload_returned_verbatim(
+        self, zim_ops, temp_dir
+    ):
+        """The cache stores the post-attach payload (with ``_meta``).
+        A cache hit returns it verbatim — no re-attach, no recomputation.
+
+        Phase B #12 fix: prior code stored the bare payload and
+        re-invoked ``attach_meta`` on every cache hit, producing
+        non-deterministic ``chars``/``tokens_est`` across reads.
+        """
         zim_file = self._zim_file(temp_dir)
         validated = zim_ops.path_validator.validate_path(str(zim_file))
         validated = zim_ops.path_validator.validate_zim_file(validated)
-        # Phase B: cache key bumped to ``search_v2b:`` to avoid old-shape leakthrough.
         cache_key = f"search_v2b:{validated}:climate:10:0"
 
-        # Seed cache with a Phase B-shape entry without _meta to verify backfill.
-        old_payload = {
+        # Seed cache with a Phase B-shape entry that ALREADY has _meta.
+        # The post-fix code returns this exact object on cache hit.
+        seeded = {
             "query": "climate",
             "results": [{"path": "A/Bar", "title": "Bar", "snippet": "bar"}],
             "next_cursor": None,
             "total": 2,
             "done": True,
             "page_info": {"offset": 0, "limit": 10, "returned_count": 1},
+            "_meta": {
+                "tokens_est": 42,
+                "chars": 200,
+                "truncated": False,
+            },
         }
-        zim_ops.cache.set(cache_key, old_payload)
+        zim_ops.cache.set(cache_key, seeded)
 
         result = zim_ops.search_zim_file_data(
             str(zim_file), "climate", limit=10, offset=0
         )
 
-        assert "_meta" in result, "cached return must backfill _meta"
-        assert result["_meta"]["tokens_est"] > 0
+        # Returned verbatim — same dict identity (cache holds the same
+        # object reference) and the exact _meta we seeded.
+        assert result is seeded
+        assert result["_meta"]["tokens_est"] == 42
+        assert result["_meta"]["chars"] == 200
 
 
 class TestInputSanitizationSearch:
@@ -690,22 +706,27 @@ class TestSearchMethodsMeta:
         assert "_meta" in result
         assert result["_meta"]["tokens_est"] >= 1
 
-    def test_suggestions_cached_backfills_meta(self, zim_ops, temp_dir):
-        """Cached suggestions without _meta get backfilled on read."""
+    def test_suggestions_cached_payload_returned_verbatim(self, zim_ops, temp_dir):
+        """Cached suggestions payload is returned verbatim — no _meta
+        recomputation on cache hit (Phase B #12 regression)."""
         zim_file = self._zim_file(temp_dir)
         validated = zim_ops.path_validator.validate_path(str(zim_file))
         validated = zim_ops.path_validator.validate_zim_file(validated)
         cache_key = f"suggestions_data:v2b:{validated}:climate:10"
-        old = {
+        seeded = {
             "partial_query": "climate",
-            "suggestions": [{"title": "Climate"}],
-            "count": 1,
+            "results": [{"title": "Climate"}],
+            "next_cursor": None,
+            "total": 1,
+            "done": True,
+            "page_info": {"offset": 0, "limit": 10, "returned_count": 1},
+            "_meta": {"tokens_est": 50, "chars": 150, "truncated": False},
         }
-        zim_ops.cache.set(cache_key, old)
+        zim_ops.cache.set(cache_key, seeded)
 
         result = zim_ops.get_search_suggestions_data(str(zim_file), "climate")
-        assert "_meta" in result
-        assert result["_meta"]["tokens_est"] >= 1
+        assert result is seeded
+        assert result["_meta"]["tokens_est"] == 50
 
     # --- find_entry_by_title_data ---
 

--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -317,6 +317,33 @@ class TestSearchCursor:
         # The operations layer must not be called on cross-tool cursor reuse.
         server.async_zim_operations.search_zim_file_data.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_cursor_ai_propagates_to_data_layer(self, server: OpenZimMcpServer):
+        """``s.ai`` decoded from the cursor must reach the data layer as
+        ``cursor_archive_identity``.
+
+        Audit fix: prior to this, ``search_zim_file`` decoded the cursor
+        but never read ``s.ai`` — the data layer received None and
+        silently accepted any archive. Pin the wiring here.
+        """
+        from openzim_mcp.pagination import archive_identity
+
+        ai = archive_identity("/zim/wiki.zim")
+        token = Cursor.encode(
+            tool="search_zim_file",
+            state={"o": 10, "l": 5, "q": "diabetes", "ai": ai},
+        )
+
+        fn = _get_tool_fn(server, "search_zim_file")
+        await fn(
+            zim_file_path="/zim/wiki.zim",
+            query="diabetes",
+            cursor=token,
+        )
+
+        call = server.async_zim_operations.search_zim_file_data.await_args
+        assert call.kwargs.get("cursor_archive_identity") == ai
+
 
 class TestSearchPaginationFooterFormat:
     """v1.2.0 search/filter renderers emit a compact one-line footer.

--- a/tests/test_simple_tools.py
+++ b/tests/test_simple_tools.py
@@ -2742,34 +2742,60 @@ class TestSectionLevelFollowup:
     def section_handler(self):
         from unittest.mock import MagicMock
 
+        # Production data shape: ``get_article_structure_data`` heading
+        # items carry only ``{id, text, level, position}``. The full
+        # section body lives in the bundle and is sliced out by
+        # ``get_section_data`` using ``char_start``/``char_end``.
         mock = MagicMock()
         mock.list_zim_files_data.return_value = [{"path": "/zim/test.zim"}]
         mock.get_article_structure_data.return_value = {
             "title": "Biology",
             "path": "Biology",
             "headings": [
-                {
-                    "level": 2,
-                    "text": "History",
-                    "id": "history",
-                    "preview": "Biology emerged as a science in the 19th century.",
-                },
-                {
-                    "level": 2,
-                    "text": "Evolution",
-                    "id": "evolution",
-                    "preview": "Evolution is change in heritable traits across "
-                    "generations of populations.",
-                },
+                {"level": 2, "text": "History", "id": "history", "position": 0},
+                {"level": 2, "text": "Evolution", "id": "evolution", "position": 1},
                 {
                     "level": 2,
                     "text": "Cellular respiration",
                     "id": "cellular-respiration",
-                    "preview": "Cellular respiration is the metabolic process by "
-                    "which cells release energy.",
+                    "position": 2,
                 },
             ],
         }
+        _section_bodies = {
+            "history": "Biology emerged as a science in the 19th century.",
+            "evolution": (
+                "Evolution is change in heritable traits across "
+                "generations of populations."
+            ),
+            "cellular-respiration": (
+                "Cellular respiration is the metabolic process by "
+                "which cells release energy."
+            ),
+        }
+
+        def _fake_get_section_data(_zim, _entry, section_id, **_kw):
+            body = _section_bodies.get(section_id)
+            if body is None:
+                return {
+                    "error": True,
+                    "operation": "section_not_found",
+                    "message": f"section_id={section_id!r} not found",
+                }
+            return {
+                "entry_path": "Biology",
+                "title": "Biology",
+                "section_id": section_id,
+                "section_title": section_id,
+                "level": 2,
+                "parent_id": None,
+                "content_markdown": body,
+                "char_count": len(body),
+                "word_count": len(body.split()),
+                "truncated": False,
+            }
+
+        mock.get_section_data.side_effect = _fake_get_section_data
         return SimpleToolsHandler(mock), mock
 
     def test_handler_returns_named_section_content(self, section_handler):

--- a/tests/test_simple_tools.py
+++ b/tests/test_simple_tools.py
@@ -3300,3 +3300,133 @@ class TestCompactFlagPropagation:
         assert "**Died:**" in result
         # Infobox table should not appear as pipe-soup
         assert "|" not in result, "compact infobox should not produce pipe-table syntax"
+
+
+class TestCompactSearchFooterAndSuggestions:
+    """End-to-end coverage for Phase A item #5 (footer) and #4 (suggestions).
+
+    The Phase A spec explicitly called for these assertions to live in
+    ``tests/test_simple_tools.py``: the footer is rendered downstream of
+    every compact-mode ``handle_zim_query`` path, and the empty-result
+    branch surfaces ``_meta.suggestions`` through that footer instead of
+    the legacy prose block.
+    """
+
+    def _make_handler(self, search_data_payload):
+        from unittest.mock import MagicMock
+
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        mock = MagicMock()
+        # The compact path probes list_zim_files_data to enrich error
+        # responses; return one fixture archive.
+        mock.list_zim_files_data.return_value = [
+            {"path": "/test/file.zim", "name": "file.zim"}
+        ]
+        mock.search_zim_file_data.return_value = search_data_payload
+        # config.meta.footer_enabled drives format_footer suppression.
+        mock.config.meta.footer_enabled = True
+        return SimpleToolsHandler(mock)
+
+    def test_footer_appended_on_compact_successful_search(self):
+        """A non-empty compact-mode search renders the token-count footer."""
+        from unittest.mock import MagicMock
+
+        payload = {
+            "query": "biology",
+            "results": [
+                {"path": "Biology", "title": "Biology", "snippet": "Life sciences."}
+            ],
+            "next_cursor": None,
+            "total": 1,
+            "done": True,
+            "page_info": {"offset": 0, "limit": 5, "returned_count": 1},
+            "_meta": {"tokens_est": 42, "chars": 200, "truncated": False},
+        }
+        handler = self._make_handler(payload)
+        # _format_search_text isn't auto-mocked when search_zim_file_data
+        # returns a real dict — stub it explicitly so the rendered body
+        # is deterministic.
+        handler.zim_operations._format_search_text = MagicMock(
+            return_value=(
+                'Found 1 matches for "biology", showing 1-1:\n\n'
+                "## 1. Biology\nPath: Biology\nSnippet: Life sciences.\n\n"
+                "---\nShowing 1-1 of 1 (end of results)\n"
+            )
+        )
+        out = handler.handle_zim_query(
+            "search for biology", "/test/file.zim", options={"compact": True}
+        )
+        # Token-count variant of the footer ends with a blockquote marker.
+        assert "> ~" in out, f"missing token-count footer in: {out[-200:]}"
+        # The body itself must be preserved before the footer.
+        assert "Biology" in out
+
+    def test_footer_empty_results_renders_suggestions(self):
+        """A compact-mode zero-result search renders the suggestions footer.
+
+        This exercises the spec's "structured suggestions on empty/low
+        confidence" plumbing: when the search backend returns
+        ``_meta.suggestions`` with ``reason="0_hits"``, the footer should
+        surface the suggestion values as ``> No results. Try: …`` and
+        NOT fall back to the legacy "**Try one of these:**" prose.
+        """
+        payload = {
+            "query": "asdfqwer",
+            "results": [],
+            "next_cursor": None,
+            "total": 0,
+            "done": True,
+            "page_info": {"offset": 0, "limit": 5, "returned_count": 0},
+            "_meta": {
+                "tokens_est": 1,
+                "chars": 0,
+                "truncated": False,
+                "reason": "0_hits",
+                "suggestions": [
+                    {"type": "alt_spelling", "value": "asdf"},
+                    {"type": "alt_archive", "value": "wiktionary"},
+                ],
+            },
+        }
+        handler = self._make_handler(payload)
+        out = handler.handle_zim_query(
+            "search for asdfqwer", "/test/file.zim", options={"compact": True}
+        )
+        # New empty-result footer shape — values present, legacy prose absent.
+        assert "No results" in out
+        # At least one suggestion value must round-trip into the footer.
+        assert "asdf" in out or "wiktionary" in out, out
+        # Legacy "Try one of these" block from compact=False must NOT appear.
+        assert "Try one of these" not in out
+
+    def test_footer_suppressed_when_footer_enabled_false(self):
+        """``config.meta.footer_enabled=False`` strips the footer.
+
+        Clients that strip-parse markdown footers (the Phase A "footer
+        suppression" knob) must see no trailing blockquote at all.
+        """
+        from unittest.mock import MagicMock
+
+        payload = {
+            "query": "biology",
+            "results": [
+                {"path": "Biology", "title": "Biology", "snippet": "Life sciences."}
+            ],
+            "next_cursor": None,
+            "total": 1,
+            "done": True,
+            "page_info": {"offset": 0, "limit": 5, "returned_count": 1},
+            "_meta": {"tokens_est": 42, "chars": 200, "truncated": False},
+        }
+        handler = self._make_handler(payload)
+        handler.zim_operations.config.meta.footer_enabled = False
+        handler.zim_operations._format_search_text = MagicMock(
+            return_value="Found 1 matches.\n"
+        )
+        out = handler.handle_zim_query(
+            "search for biology", "/test/file.zim", options={"compact": True}
+        )
+        # No footer blockquote when disabled.
+        assert "> ~" not in out
+        assert "No results" not in out

--- a/tests/test_synthesize.py
+++ b/tests/test_synthesize.py
@@ -109,22 +109,17 @@ def test_per_archive_search_single_archive() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_extract_passages_renders_markdown_from_snippets() -> None:
-    """libzim snippets may come back as HTML; passages contain markdown."""
+def test_extract_passages_passes_through_plain_markdown() -> None:
+    """search_top_k already returns plain-markdown snippets via create_snippet;
+    _extract_passages must not double-render or otherwise mutate them."""
     from openzim_mcp.synthesize import _extract_passages
 
     hits = [
-        {"path": "A/Berlin", "snippet": "<p>Berlin is the capital.</p>", "score": 0.9},
-        {"path": "A/Munich", "snippet": "<p>Munich is in Bavaria.</p>", "score": 0.7},
+        {"path": "A/Berlin", "snippet": "Berlin is the capital.", "score": 0.9},
+        {"path": "A/Munich", "snippet": "Munich is in Bavaria.", "score": 0.7},
     ]
-    cp = MagicMock()
-    cp.html_to_plain_text.side_effect = lambda html: html.replace("<p>", "").replace(
-        "</p>", ""
-    )
 
-    passages = _extract_passages(
-        hits, archive_name="wikipedia_en_simple", content_processor=cp
-    )
+    passages = _extract_passages(hits, archive_name="wikipedia_en_simple")
     assert len(passages) == 2
     assert passages[0]["rank"] == 1
     assert passages[0]["text_markdown"] == "Berlin is the capital."
@@ -136,13 +131,24 @@ def test_extract_passages_preserves_rank_order() -> None:
     from openzim_mcp.synthesize import _extract_passages
 
     hits = [
-        {"path": f"A/Doc{i}", "snippet": f"<p>doc {i}</p>", "score": 1.0 - 0.1 * i}
+        {"path": f"A/Doc{i}", "snippet": f"doc {i}", "score": 1.0 - 0.1 * i}
         for i in range(5)
     ]
-    cp = MagicMock()
-    cp.html_to_plain_text.side_effect = lambda html: html
-    passages = _extract_passages(hits, archive_name="test", content_processor=cp)
+    passages = _extract_passages(hits, archive_name="test")
     assert [p["rank"] for p in passages] == [1, 2, 3, 4, 5]
+
+
+def test_extract_passages_preserves_bold_highlight_markers() -> None:
+    """Highlighted ``**term**`` markers from create_snippet must survive — the
+    earlier code path round-tripped through BeautifulSoup + html2text and
+    could strip or rewrite them."""
+    from openzim_mcp.synthesize import _extract_passages
+
+    hits = [
+        {"path": "A/X", "snippet": "the **target** was found here", "score": 1.0},
+    ]
+    passages = _extract_passages(hits, archive_name="zim")
+    assert passages[0]["text_markdown"] == "the **target** was found here"
 
 
 def test_synthesize_query_signature_exists() -> None:

--- a/tests/test_synthesize.py
+++ b/tests/test_synthesize.py
@@ -576,28 +576,19 @@ def test_select_top_hits_multi_credits_archive_with_best_rank() -> None:
     """
     from openzim_mcp.synthesize import _select_top_hits_multi
 
+    # wiki1 ranks Berlin at index 1 (Munich first); wiki2 ranks Berlin at
+    # index 0. The broken implementation always picked the first archive
+    # in iteration order regardless of per-archive rank — i.e. wiki1 —
+    # which would yield the wrong cite_id. The fixed implementation picks
+    # the archive with the better (lower) rank, so Berlin must be
+    # attributed to wiki2 here.
     per_archive_hits = [
-        # wiki1: Berlin is at rank 1 (best in this archive)
-        [{"path": "A/Berlin", "snippet": "", "score": 0.5}],
-        # wiki2: Berlin is at rank 0 (top of this archive)
-        [
-            {"path": "A/Berlin", "snippet": "", "score": 0.95},
-            {"path": "A/Munich", "snippet": "", "score": 0.4},
-        ],
-    ]
-    # Note iteration order puts wiki1 first — the broken implementation
-    # would always pick wiki1 here. Correct implementation picks wiki2
-    # because Berlin was ranked higher there (rank 0 vs. rank 0 — both
-    # at top of their list; tiebreaker is rank, then iteration order;
-    # so the broken impl AND the correct impl both pick wiki1. To
-    # actually exercise the fix, give wiki1 a worse rank for Berlin:
-    per_archive_hits = [
-        # wiki1: Berlin is at rank 1 (Munich first)
+        # wiki1: Berlin at rank 1 (Munich first)
         [
             {"path": "A/Munich", "snippet": "", "score": 0.95},
             {"path": "A/Berlin", "snippet": "", "score": 0.5},
         ],
-        # wiki2: Berlin is at rank 0 (top of this archive)
+        # wiki2: Berlin at rank 0 (top of this archive)
         [{"path": "A/Berlin", "snippet": "", "score": 0.95}],
     ]
     archives_searched = ["wiki1", "wiki2"]

--- a/tests/test_synthesize.py
+++ b/tests/test_synthesize.py
@@ -241,6 +241,110 @@ def test_attribute_sections_no_match_keeps_entry_level() -> None:
     assert attributed[0]["cite_id"] == "wiki/A/Berlin"
 
 
+def test_attribute_sections_picks_innermost_nested_section() -> None:
+    """Nested ranges → cite_id uses the deepest (smallest) containing section.
+
+    Audit fix: the prior implementation iterated forward in document
+    order and broke on the first containment match, which always
+    yielded the OUTERMOST (parent) section. A passage in an h3 inside
+    an h2 inside an h1 would cite the h1 — far less useful than
+    citing the h3.
+    """
+    from openzim_mcp.synthesize import _attribute_sections
+
+    # Parent h1 (0..200) contains child h2 (40..150) contains grandchild
+    # h3 (80..120). Passage offset will fall inside the grandchild.
+    bundle = {
+        "rendered_markdown": (
+            "# Berlin\n"  # 0..8
+            + " " * 30  # 9..38
+            + "\n## Geography\n"  # 39..52
+            + " " * 26  # 53..78
+            + "\n### Climate\n"  # 79..91
+            + "Rainfall here is high. " * 2  # 92..137
+            + "\n## Demographics\n"  # 138..154
+            + "Population data."  # 155..170
+        ),
+        "sections": [
+            # Parent h1 — spans the whole article
+            {
+                "id": "berlin",
+                "title": "Berlin",
+                "level": 1,
+                "char_start": 0,
+                "char_end": 200,
+                "parent_id": None,
+            },
+            # Child h2 — Geography subsection
+            {
+                "id": "geography",
+                "title": "Geography",
+                "level": 2,
+                "char_start": 40,
+                "char_end": 138,
+                "parent_id": "berlin",
+            },
+            # Grandchild h3 — Climate sub-subsection (innermost)
+            {
+                "id": "climate",
+                "title": "Climate",
+                "level": 3,
+                "char_start": 92,
+                "char_end": 137,
+                "parent_id": "geography",
+            },
+        ],
+    }
+    # The passage text appears at offset 92 — inside all three sections.
+    passages = [_passage("wiki/A/Berlin", "Rainfall here is high.", 1, 0.9)]
+
+    def bundle_lookup(archive_name: str, path: str) -> dict:
+        return bundle
+
+    attributed = _attribute_sections(
+        passages, bundle_lookup=bundle_lookup, hit_keys=[("wiki", "A/Berlin")]
+    )
+    # The deepest (smallest-range) containing section is "climate".
+    assert attributed[0]["cite_id"] == "wiki/A/Berlin#climate"
+
+
+def test_attribute_sections_normalized_fallback_search() -> None:
+    """When passage text doesn't byte-match the bundle markdown verbatim
+    (whitespace/inline-markup drift between snippet path and bundle
+    rendering path), section attribution falls back to a whitespace-
+    normalized probe instead of silently degrading to entry-level.
+    """
+    from openzim_mcp.synthesize import _attribute_sections, _locate_passage
+
+    md = "## Geography\n\nBerlin   sits  in  the   North   European   Plain."
+    # passage_text has different whitespace shape — newlines and
+    # collapsed runs that wouldn't match md.find() literally.
+    passage_text = "Berlin sits in the North European Plain."
+    pos = _locate_passage(md, passage_text)
+    assert pos >= 0, f"normalized probe should locate the passage in md (got {pos})"
+
+    bundle = {
+        "rendered_markdown": md,
+        "sections": [
+            {
+                "id": "geography",
+                "title": "Geography",
+                "level": 2,
+                "char_start": 13,
+                "char_end": len(md),
+                "parent_id": None,
+            },
+        ],
+    }
+    passages = [_passage("wiki/A/Berlin", passage_text, 1, 0.9)]
+    attributed = _attribute_sections(
+        passages,
+        bundle_lookup=lambda a, p: bundle,
+        hit_keys=[("wiki", "A/Berlin")],
+    )
+    assert attributed[0]["cite_id"] == "wiki/A/Berlin#geography"
+
+
 # ---------------------------------------------------------------------------
 # Task 20: citation rendering, budget enforcement, citation building
 # ---------------------------------------------------------------------------

--- a/tests/test_synthesize.py
+++ b/tests/test_synthesize.py
@@ -189,11 +189,11 @@ def test_attribute_sections_adds_section_id_when_match_in_first_section() -> Non
     }
     passages = [_passage("wiki/A/Berlin", "Geography text here.", 1, 0.9)]
 
-    def bundle_lookup(path: str) -> dict | None:
-        return bundle if path == "A/Berlin" else None
+    def bundle_lookup(archive_name: str, path: str) -> dict | None:
+        return bundle if (archive_name == "wiki" and path == "A/Berlin") else None
 
     attributed = _attribute_sections(
-        passages, bundle_lookup=bundle_lookup, hit_paths=["A/Berlin"]
+        passages, bundle_lookup=bundle_lookup, hit_keys=[("wiki", "A/Berlin")]
     )
     assert attributed[0]["cite_id"] == "wiki/A/Berlin#geography"
 
@@ -202,12 +202,12 @@ def test_attribute_sections_drops_section_on_bundle_failure() -> None:
     """Bundle build fails → cite_id stays at entry level; passage not dropped."""
     from openzim_mcp.synthesize import _attribute_sections
 
-    def bundle_lookup(path: str) -> None:
+    def bundle_lookup(archive_name: str, path: str) -> None:
         raise RuntimeError("simulated archive read failure")
 
     passages = [_passage("wiki/A/Berlin", "Anything", 1, 0.5)]
     attributed = _attribute_sections(
-        passages, bundle_lookup=bundle_lookup, hit_paths=["A/Berlin"]
+        passages, bundle_lookup=bundle_lookup, hit_keys=[("wiki", "A/Berlin")]
     )
     assert len(attributed) == 1
     assert attributed[0]["cite_id"] == "wiki/A/Berlin"  # unchanged
@@ -231,12 +231,12 @@ def test_attribute_sections_no_match_keeps_entry_level() -> None:
         ],
     }
 
-    def bundle_lookup(path: str) -> dict:
+    def bundle_lookup(archive_name: str, path: str) -> dict:
         return bundle
 
     passages = [_passage("wiki/A/Berlin", "totally unrelated string", 1, 0.1)]
     attributed = _attribute_sections(
-        passages, bundle_lookup=bundle_lookup, hit_paths=["A/Berlin"]
+        passages, bundle_lookup=bundle_lookup, hit_keys=[("wiki", "A/Berlin")]
     )
     assert attributed[0]["cite_id"] == "wiki/A/Berlin"
 
@@ -282,11 +282,11 @@ def test_build_citations_dedupes_by_entry() -> None:
         _passage("wiki/A/Berlin#climate", "", 2, 0.7),
         _passage("wiki/A/Munich#geography", "", 3, 0.5),
     ]
-    bundle_titles = {"A/Berlin": "Berlin", "A/Munich": "Munich"}
+    bundle_titles = {("wiki", "A/Berlin"): "Berlin", ("wiki", "A/Munich"): "Munich"}
     bundle_section_titles = {
-        ("A/Berlin", "geography"): "Geography",
-        ("A/Berlin", "climate"): "Climate",
-        ("A/Munich", "geography"): "Geography",
+        ("wiki", "A/Berlin", "geography"): "Geography",
+        ("wiki", "A/Berlin", "climate"): "Climate",
+        ("wiki", "A/Munich", "geography"): "Geography",
     }
     citations = _build_citations(
         passages,
@@ -424,3 +424,79 @@ def test_synthesize_query_multi_archive_uses_rrf_fusion(
     )
     assert response["fallback_used"] == "rrf_fusion"
     assert sorted(response["archives_searched"]) == ["wiki1", "wiki2"]
+
+
+def test_synthesize_response_meta_envelope_populated(
+    cp: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: ``_meta`` must carry tokens_est/chars/truncated, not be
+    an empty dict (Phase C #5 review finding).
+    """
+    from unittest.mock import MagicMock
+
+    from openzim_mcp.synthesize import synthesize_query
+
+    archive = MagicMock()
+    search_handler = MagicMock()
+    search_handler.search_top_k.return_value = [
+        {"path": "A/Berlin", "snippet": "Berlin body text", "score": 0.9},
+    ]
+    monkeypatch.setattr(
+        "openzim_mcp.synthesize.get_or_build_bundle",
+        lambda archive, path, **kw: None,
+    )
+    response = synthesize_query(
+        "berlin",
+        archives=[(archive, Path("wiki.zim"))],
+        search_handler=search_handler,
+        cache=MagicMock(),
+        content_processor=cp,
+        config=SynthesizeConfig(),
+    )
+    meta = response["_meta"]
+    assert "tokens_est" in meta and meta["tokens_est"] >= 0
+    assert "chars" in meta and meta["chars"] >= 0
+    assert "truncated" in meta
+
+
+def test_select_top_hits_multi_credits_archive_with_best_rank() -> None:
+    """When a path appears in multiple archives, attribute it to the
+    archive that ranked it highest in its own list, not the first
+    archive in ``archives_searched`` iteration order (Phase C #16).
+    """
+    from openzim_mcp.synthesize import _select_top_hits_multi
+
+    per_archive_hits = [
+        # wiki1: Berlin is at rank 1 (best in this archive)
+        [{"path": "A/Berlin", "snippet": "", "score": 0.5}],
+        # wiki2: Berlin is at rank 0 (top of this archive)
+        [
+            {"path": "A/Berlin", "snippet": "", "score": 0.95},
+            {"path": "A/Munich", "snippet": "", "score": 0.4},
+        ],
+    ]
+    # Note iteration order puts wiki1 first — the broken implementation
+    # would always pick wiki1 here. Correct implementation picks wiki2
+    # because Berlin was ranked higher there (rank 0 vs. rank 0 — both
+    # at top of their list; tiebreaker is rank, then iteration order;
+    # so the broken impl AND the correct impl both pick wiki1. To
+    # actually exercise the fix, give wiki1 a worse rank for Berlin:
+    per_archive_hits = [
+        # wiki1: Berlin is at rank 1 (Munich first)
+        [
+            {"path": "A/Munich", "snippet": "", "score": 0.95},
+            {"path": "A/Berlin", "snippet": "", "score": 0.5},
+        ],
+        # wiki2: Berlin is at rank 0 (top of this archive)
+        [{"path": "A/Berlin", "snippet": "", "score": 0.95}],
+    ]
+    archives_searched = ["wiki1", "wiki2"]
+    top_hits, fallback = _select_top_hits_multi(
+        per_archive_hits, archives_searched, top_n=5
+    )
+    # Berlin is attributed to wiki2 (rank 0 there beats rank 1 in wiki1)
+    berlin_archive = next(
+        archive_name for archive_name, hit in top_hits if hit["path"] == "A/Berlin"
+    )
+    assert berlin_archive == "wiki2"
+    assert fallback == "rrf_fusion"

--- a/tests/test_zim_operations.py
+++ b/tests/test_zim_operations.py
@@ -300,6 +300,77 @@ class TestZimOperations:
         assert data["next_cursor"] is None
         assert data["page_info"]["returned_count"] == 0
 
+    def test_search_zim_file_data_emits_ai_in_cursor(
+        self, zim_operations: ZimOperations, temp_dir: Path
+    ):
+        """Outbound cursors from ``search_zim_file_data`` carry ``s.ai``.
+
+        Audit fix: prior cursors omitted ``ai``, so cross-archive cursor
+        reuse on this tool was silently honoured.
+        """
+        from openzim_mcp.pagination import Cursor, archive_identity
+
+        zim_file = temp_dir / "wiki.zim"
+        zim_file.touch()
+
+        # Stage a search that returns enough hits to force a next_cursor.
+        with (
+            patch("openzim_mcp.zim_operations.zim_archive") as mock_archive,
+            patch("openzim_mcp.zim_operations.Searcher") as mock_searcher_cls,
+            patch("openzim_mcp.zim_operations.Query") as mock_query_cls,
+        ):
+            mock_archive_instance = MagicMock()
+            mock_archive.return_value.__enter__.return_value = mock_archive_instance
+
+            mock_search = MagicMock()
+            mock_search.getEstimatedMatches.return_value = 50  # > limit
+            mock_search.getResults.return_value = ["C/A", "C/B"]
+            mock_searcher_cls.return_value.search.return_value = mock_search
+            mock_query_cls.return_value.set_query.return_value = MagicMock()
+
+            mock_entry = MagicMock()
+            mock_entry.title = "T"
+            mock_archive_instance.get_entry_by_path.return_value = mock_entry
+
+            data = zim_operations.search_zim_file_data(
+                str(zim_file), "q", limit=2, offset=0
+            )
+
+        assert data["next_cursor"] is not None
+        decoded = Cursor.decode(data["next_cursor"], expected_tool="search_zim_file")
+        ai_in_cursor = decoded["s"].get("ai")
+        # ``ai`` must be present and the SHA-256:12 format the
+        # archive_identity helper produces.
+        assert ai_in_cursor is not None and len(ai_in_cursor) == 12
+        # Different archives produce different identities — the cursor's
+        # ai token cannot collide with any unrelated path.
+        assert ai_in_cursor != archive_identity("/some/other.zim")
+
+    def test_search_zim_file_data_rejects_mismatched_ai(
+        self, zim_operations: ZimOperations, temp_dir: Path
+    ):
+        """Resuming a cursor with the wrong ``s.ai`` raises a validation error.
+
+        Pins the anti-cross-archive guard: the data layer is the last
+        line of defence before paginated state from a different
+        archive gets honoured.
+        """
+        import pytest
+
+        from openzim_mcp.exceptions import OpenZimMcpValidationError
+
+        zim_file = temp_dir / "wiki.zim"
+        zim_file.touch()
+
+        with pytest.raises(OpenZimMcpValidationError):
+            zim_operations.search_zim_file_data(
+                str(zim_file),
+                "q",
+                limit=5,
+                offset=10,
+                cursor_archive_identity="0000deadbeef",  # not this archive's ai
+            )
+
     def test_get_zim_metadata(self, zim_operations: ZimOperations, temp_dir: Path):
         """Test ZIM metadata retrieval."""
         zim_file = temp_dir / "test.zim"

--- a/tests/test_zim_operations.py
+++ b/tests/test_zim_operations.py
@@ -1328,26 +1328,23 @@ class TestZimOperations:
         result = zim_operations.get_zim_entry(str(zim_file), "A/Test", 1000)
         assert result == "cached entry content"
 
-        # Test list_namespaces_data cache hit (lines 584-585).
-        # list_namespaces now delegates to list_namespaces_data, which caches
-        # dicts under a `namespaces_data:v2b:` key (v2b marker added with the
-        # Phase B ``entry_count`` -> ``total`` rename so v1.x cached responses
-        # don't leak through). Exercise the cache hit path against the
-        # dict-returning entry point directly so we test the cache layer
-        # without an extra json.dumps round trip.
+        # Test list_namespaces_data cache hit.
+        # Phase B #12 fix: the cache now stores POST-ATTACH payloads
+        # (with ``_meta`` already attached), and cache hits return them
+        # verbatim. Seed accordingly.
         cache_key = f"namespaces_data:v2b:{validated_path}"
-        zim_operations.cache.set(cache_key, {"cached": "namespaces"})
+        cached_ns = {"cached": "namespaces", "_meta": {"chars": 1}}
+        zim_operations.cache.set(cache_key, cached_ns)
 
         result = zim_operations.list_namespaces_data(str(zim_file))
         assert result["cached"] == "namespaces"
         assert "_meta" in result
 
-        # Test browse_namespace_data cache hit. browse_namespace now
-        # delegates to browse_namespace_data, which caches dicts under a
-        # `browse_ns_data:` key. Exercise the cache hit path against the
-        # dict-returning entry point directly.
+        # Test browse_namespace_data cache hit. Same contract — cache
+        # stores the post-attach payload.
         cache_key = f"browse_ns_data:v2b:{validated_path}:A:50:0"
-        zim_operations.cache.set(cache_key, {"cached": "browse"})
+        cached_browse = {"cached": "browse", "_meta": {"chars": 1}}
+        zim_operations.cache.set(cache_key, cached_browse)
 
         result = zim_operations.browse_namespace_data(str(zim_file), "A")
         assert result["cached"] == "browse"
@@ -1389,11 +1386,15 @@ class TestZimOperations:
 
         # Test extract_article_links_data cache hit. extract_article_links_data
         # now reads from the shared EntryBundle (Phase C). Caching happens at
-        # the bundle level under a ``bundle:v2c:`` key. The hit assertion checks
-        # that the post-render dict carries the cached title/path metadata.
-        cache_key = f"bundle:v2c:{validated_path}:A/Test"
+        # the bundle level under a ``bundle:v2c:{path}:{mtime}:{size}:{entry}``
+        # key — the mtime/size token (Phase C #3 fix) invalidates cached
+        # bundles when the underlying file is replaced. Compute the key the
+        # same way the code does so the seed lands at the right slot.
+        from openzim_mcp.bundle import _bundle_cache_key
+
+        bundle_cache_key = _bundle_cache_key(validated_path, "A/Test")
         zim_operations.cache.set(
-            cache_key,
+            bundle_cache_key,
             {
                 "entry_path": "A/Test",
                 "title": "Cached Title",

--- a/tests/test_zim_operations.py
+++ b/tests/test_zim_operations.py
@@ -1174,7 +1174,9 @@ class TestZimOperations:
         zim_file = tmp_path / "test.zim"
         zim_operations._get_entry_content(mock_archive, "A/USA", 1000, zim_file)
 
-        cache_key = f"path_mapping:{zim_file}:A/USA"
+        from openzim_mcp.bundle import archive_stat_token as _stat
+
+        cache_key = f"path_mapping:{zim_file}:{_stat(zim_file)}:A/USA"
         cached = zim_operations.cache.get(cache_key)
         assert cached == "A/United_States", (
             "Cache must store the resolved path so subsequent "
@@ -1770,7 +1772,12 @@ class TestZimOperations:
             assert "Test content" in result
 
             # Verify path mapping was cached (key includes resolved archive path)
-            cache_key = f"path_mapping:{zim_file.resolve()}:A/Test_Article"
+            from openzim_mcp.bundle import archive_stat_token as _stat
+
+            cache_key = (
+                f"path_mapping:{zim_file.resolve()}:"
+                f"{_stat(zim_file.resolve())}:A/Test_Article"
+            )
             cached_path = zim_operations.cache.get(cache_key)
             assert cached_path == "A/Test_Article"
 
@@ -1818,7 +1825,12 @@ class TestZimOperations:
                 assert "Test content" in result
 
                 # Verify path mapping was cached (key includes resolved archive path)
-                cache_key = f"path_mapping:{zim_file.resolve()}:A/Test Article"
+                from openzim_mcp.bundle import archive_stat_token as _stat
+
+                cache_key = (
+                    f"path_mapping:{zim_file.resolve()}:"
+                    f"{_stat(zim_file.resolve())}:A/Test Article"
+                )
                 cached_path = zim_operations.cache.get(cache_key)
                 assert cached_path == "A/Test_Article"
 
@@ -1832,7 +1844,12 @@ class TestZimOperations:
         zim_file.touch()
 
         # Pre-populate cache with path mapping
-        cache_key = f"path_mapping:{zim_file.resolve()}:A/Test Article"
+        from openzim_mcp.bundle import archive_stat_token as _stat
+
+        cache_key = (
+            f"path_mapping:{zim_file.resolve()}:"
+            f"{_stat(zim_file.resolve())}:A/Test Article"
+        )
         zim_operations.cache.set(cache_key, "A/Test_Article")
 
         with patch("openzim_mcp.zim_operations.zim_archive") as mock_archive:
@@ -1872,7 +1889,12 @@ class TestZimOperations:
         zim_file.touch()
 
         # Pre-populate cache with invalid path mapping
-        cache_key = f"path_mapping:{zim_file.resolve()}:A/Test Article"
+        from openzim_mcp.bundle import archive_stat_token as _stat
+
+        cache_key = (
+            f"path_mapping:{zim_file.resolve()}:"
+            f"{_stat(zim_file.resolve())}:A/Test Article"
+        )
         zim_operations.cache.set(cache_key, "A/Invalid_Path")
 
         with patch("openzim_mcp.zim_operations.zim_archive") as mock_archive:


### PR DESCRIPTION
Bugfix-only follow-up to **v2.0.0a4**. Three review passes against the shipped Phase A/B/C surface — two prior internal sweeps plus a fresh two-pass review on top — produced **41 defect fixes** across snippets, the `_meta` envelope, the response contract, the cursor format, the bundle/section pipeline, multi-archive synthesise, and cache invalidation. No new tools, no new wire-format breaks beyond what's already noted on the first commit's `!`.

Target release: **`v2.0.0a5`** (manual annotated tag, same pattern as `a1`–`a4`).

## Commit overview

| Commit | Theme | Count |
|---|---|---|
| `2d16d14` `fix(v2)!:` | 16 high-confidence defects — initial sweep (includes one acceptable wire-format break, hence the `!`) | 16 |
| `d4023bb` `fix(v2):` | 12 spec-vs-code gaps closing the alpha contract | 12 |
| `b93804a` `fix(v2):` | 13 defects surfaced by the two-pass review (this PR's headline work) | 13 |

Per-commit details and rationale live in each commit body. The CHANGELOG entry for `2.0.0a5` covers the third commit in detail.

## Highlights of the latest pass (`b93804a`)

**Phase A — `_meta`, snippets, fuzzy fallback**
- `format_footer` now treats `no_xapian_index` / `bad_namespace` as empty-result reasons (was falling through to "~0 tokens").
- `create_snippet` no longer slices `**term**` mid-tag — strips dangling `**` before appending `...`.
- Spec §14.4: `find_entry_by_title` now surfaces the resolved typo-corrected title in `_meta.suggestions[]` so callers can verify auto-corrections instead of silently accepting them.
- `tokens_est` is now omitted from `_meta` when the tiktoken encoder is unavailable (spec §5); `format_footer` falls back to char-count.

**Phase B — cursor**
- Stale "currently 1" comment in `CursorPayload.v` refreshed.

**Phase C — bundle, get_section, synthesise**
- `_locate_passage` whitespace-run offset mapping: advances past trailing whitespace so attribution never lands in an earlier section when two section boundaries hug a whitespace run.
- `get_section` truncation surfaces `_meta.total_chars` so callers see how much was elided.
- `synthesize._do_per_archive_search` now disambiguates duplicate ZIM stems (`wiki`, `wiki~2`) with a warning log — previously two ZIMs sharing a stem silently corrupted attribution.
- `get_entry_summary(compact=True)` bypasses the bundle and re-renders compact-aware; the bundle stores `compact=False` markdown and was re-introducing the table bloat Phase A #2 eliminated.
- `path_mapping:` / `binary_meta:` / `ns_entries:` cache keys now embed `<mtime_ns>:<size>` via the new shared `bundle.archive_stat_token()` helper. Atomic ZIM replacement (monthly Wikipedia refresh) previously left stale values cached until LRU eviction.
- `synthesize._extract_passages` no longer double-renders the already-plain snippet through `html_to_plain_text` — the BeautifulSoup → html2text round-trip risked stripping `**bold**` highlight markers.

## Test status

- **1344 passed, 50 skipped** locally on Python 3.12.11 (one new test added: `test_extract_passages_preserves_bold_highlight_markers`).
- `test_zim_operations` and `test_content_tools` cache-key assertions updated for the stat-token format.
- `test_synthesize` updated to drop the `content_processor` arg from `_extract_passages` and use plain-markdown snippet fixtures.

## Release plan

After this PR merges, tag the merge commit (or the squash-merge commit on `main`) as `v2.0.0a5` with the same annotated-tag pattern as `v2.0.0a4`. CHANGELOG entry is already in place. `pyproject.toml` and `.release-please-manifest.json` are intentionally left untouched — alpha tags are pure git tags (matching the v2 alpha cadence) and the manifest stays pinned at the reset value (`2.0.0a3`) until v2.0.0 stable ships.

Labels: `v2`, `v2-phase-a`, `v2-phase-b`, `v2-phase-c`.
