### PR TITLE
fix(v2): post-a6 defect-fix batch — 14 defects + 8 opportunities across phases A–C

### DIFF
--- a/openzim_mcp/async_operations.py
+++ b/openzim_mcp/async_operations.py
@@ -677,6 +677,8 @@ class AsyncZimOperations:
         entry_path: str,
         section_id: str,
         max_chars: Optional[int] = None,
+        *,
+        include_subsections: bool = True,
     ) -> "Union[GetSectionResponse, ToolErrorPayload]":
         """Structured variant of ``get_section`` (async)."""
         return await asyncio.to_thread(
@@ -685,4 +687,5 @@ class AsyncZimOperations:
             entry_path,
             section_id,
             max_chars=max_chars,
+            include_subsections=include_subsections,
         )

--- a/openzim_mcp/bundle.py
+++ b/openzim_mcp/bundle.py
@@ -279,7 +279,14 @@ def extract_entry_bundle(
     raw_links = content_processor.extract_html_links(html)
     link_buckets = _build_link_buckets(raw_links)
     infobox = _extract_infobox(soup, content_processor)
-    rendered = content_processor._render_soup_to_text(soup, compact=False)
+    # Render with compact=True so that the bundle's rendered_markdown
+    # carries the same table-stripping placeholders that direct
+    # ``get_zim_entry`` callers see. Without this, get_section returns
+    # raw pipe-soup tables for the climate / standings / etc. data
+    # tables embedded in Wikipedia articles — a UX regression vs. the
+    # surrounding article-fetch path. The infobox is already
+    # ``decompose()``d above, so compact rendering won't re-extract it.
+    rendered = content_processor._render_soup_to_text(soup, compact=True)
     sections = _compute_section_offsets(rendered, headings)
 
     bundle: EntryBundle = cast(

--- a/openzim_mcp/compact_renderers.py
+++ b/openzim_mcp/compact_renderers.py
@@ -20,11 +20,15 @@ from typing import Any, Dict, Mapping, Optional
 def compact_structure_payload(payload: Mapping[str, Any]) -> str:
     """Render a compact JSON view of an article-structure payload.
 
-    Drops the per-heading ``preview`` field (~3000 chars each, the
-    bulk of the response budget) and keeps only the navigation-shaped
-    fields (level, text, id) plus the article-level summary. Reduces
-    a typical structure response from ~17k chars to ~1-2k while
-    preserving everything an LLM needs to choose a next operation.
+    Drops the per-heading 300-char ``content_preview`` and substitutes
+    a tight 80-char ``summary`` derived from each section's leading
+    prose. Op2: surfacing a per-section summary closes the small-LLM
+    gap where the legacy compact form had only the heading text —
+    enough to know *that* a section exists, not enough to choose
+    which one to drill into. The 80-char cap keeps total response
+    size bounded: a typical 50-section Wikipedia article comes in
+    around 2-4 kB even with summaries, vs ~17 kB with full previews
+    or ~1 kB with bare-heading list.
 
     Returns a JSON string (matching the shape of the legacy
     ``get_article_structure`` text path) so callers can swap in
@@ -32,18 +36,43 @@ def compact_structure_payload(payload: Mapping[str, Any]) -> str:
     """
     if not isinstance(payload, dict):
         return json.dumps(payload)
+
+    # Build a quick (title → first_preview) lookup so we can pair
+    # each heading with the matching ``sections[]`` entry without
+    # an O(n²) inner loop. Sections and headings share the same
+    # document-order layout, but joining by title is more robust
+    # to future shape changes than joining by index.
+    section_summary_by_title: Dict[str, str] = {}
+    for s in payload.get("sections") or []:
+        if not isinstance(s, dict):
+            continue
+        st = s.get("title")
+        sp = s.get("content_preview") or ""
+        if isinstance(st, str) and isinstance(sp, str) and st not in section_summary_by_title:
+            # 80-char cap: short enough to keep the compact response
+            # tight, long enough to give a small model a sense of
+            # what each section covers ("Climate", "Demographics",
+            # etc. are themselves uninformative without context).
+            section_summary_by_title[st] = sp.strip()[:80]
+
+    compact_headings = []
+    for h in payload.get("headings") or []:
+        if not isinstance(h, dict):
+            continue
+        entry: Dict[str, Any] = {
+            "level": h.get("level"),
+            "text": h.get("text"),
+            "id": h.get("id"),
+        }
+        summary = section_summary_by_title.get(h.get("text") or "")
+        if summary:
+            entry["summary"] = summary
+        compact_headings.append(entry)
+
     compact: Dict[str, Any] = {
         "title": payload.get("title"),
         "path": payload.get("path"),
-        "headings": [
-            {
-                "level": h.get("level"),
-                "text": h.get("text"),
-                "id": h.get("id"),
-            }
-            for h in payload.get("headings") or []
-            if isinstance(h, dict)
-        ],
+        "headings": compact_headings,
     }
     # Preserve a couple of small article-level summary fields that
     # callers may want for context — they're a few bytes each, not a

--- a/openzim_mcp/compact_renderers.py
+++ b/openzim_mcp/compact_renderers.py
@@ -48,7 +48,11 @@ def compact_structure_payload(payload: Mapping[str, Any]) -> str:
             continue
         st = s.get("title")
         sp = s.get("content_preview") or ""
-        if isinstance(st, str) and isinstance(sp, str) and st not in section_summary_by_title:
+        if (
+            isinstance(st, str)
+            and isinstance(sp, str)
+            and st not in section_summary_by_title
+        ):
             # 80-char cap: short enough to keep the compact response
             # tight, long enough to give a small model a sense of
             # what each section covers ("Climate", "Demographics",

--- a/openzim_mcp/content_processor.py
+++ b/openzim_mcp/content_processor.py
@@ -71,19 +71,26 @@ def _word_in(folded_paragraph: str, term: str) -> bool:
 # italic disambig links, ``[**Photosynthesis**](**Photosynthesis** "…")``
 # where bolding inside the link target breaks the URL).
 #
+# - ``\[[^\]\n]+\]\([^\n)]*\)`` — full ``[text](href "title")`` link,
+#   matched as ONE unit so the URL/tooltip parenthetical only counts
+#   when it's attached to a link. An earlier shape matched any ``(...)``
+#   parenthetical — that protected ordinary prose parentheticals like
+#   ``(also called assimilation)`` from highlighting too, silently
+#   dropping query-term visibility for any term that landed inside
+#   them. (Wikipedia scientific articles are loaded with parenthetical
+#   gloss; over-protecting them cost more highlights than it saved.)
 # - ``\*\*[^*\n]+\*\*`` — existing bold runs (paired markers, single line).
 #   ``[^*\n]+`` rules out adjacent ``**`` runs and multi-paragraph spans.
 # - ``(?<!\w)_[^_\n]+_(?!\w)`` — italic runs; the lookarounds skip
 #   identifier-style underscores like ``foo_bar``.
-# - ``\[[^\]\n]+\]`` — markdown link/image link-text.
-# - ``\([^\n)]*\)`` — the URL+tooltip parenthetical of a markdown link.
-#   Combined with the link-text rule above, this covers the whole
-#   ``[text](href "title")`` construct.
+# - ``` `[^`\n]+` ``` — inline code spans (rarely emitted by html2text on
+#   Wikipedia, but cheap to skip and prevents bold-inside-code from
+#   breaking code-formatted text).
 _HIGHLIGHT_SKIP_RE = re.compile(
-    r"\*\*[^*\n]+\*\*"
+    r"\[[^\]\n]+\]\([^\n)]*\)"
+    r"|\*\*[^*\n]+\*\*"
     r"|(?<!\w)_[^_\n]+_(?!\w)"
-    r"|\[[^\]\n]+\]"
-    r"|\([^\n)]*\)",
+    r"|`[^`\n]+`",
 )
 
 
@@ -469,9 +476,43 @@ class ContentProcessor:
             rows: List[Dict[str, str]] = []
             current_section: Optional[str] = None
             title_row_consumed = False
+            # Only rows whose nearest ``<table>`` ancestor is the infobox
+            # ITSELF count — Wikipedia infoboxes frequently embed nested
+            # tables inside data cells (chronology rows, coordinates
+            # microformats, sub-component sub-tables), and a naive
+            # ``select("tr")`` would pull those nested rows into the
+            # KV list as if they were top-level infobox fields. The
+            # previous code emitted things like ``"prev|1959": "next"``
+            # rows lifted out of an album-chronology nested table.
+            #
+            # Only ``th.find("th")`` would have to look up to skip — but
+            # the cleanest filter is at the row level: keep only rows
+            # whose ``parent`` chain reaches ``node`` before reaching any
+            # other ``<table>``.
+
+            def _cell_belongs_to_infobox(cell: Optional[Tag]) -> bool:
+                """``True`` iff ``cell``'s nearest enclosing table is
+                ``node`` itself — i.e. not buried inside a nested table.
+
+                ``tr.find("th")`` searches descendants, so a top-level row
+                with an empty layout-only ``<td>`` followed by a nested
+                table could otherwise borrow the nested ``<th>`` for its
+                label. Guard at the cell level so the outer row's
+                label/value pairing only counts when both cells live in
+                this infobox directly.
+                """
+                if cell is None or not isinstance(cell, Tag):
+                    return False
+                return cell.find_parent("table") is node
+
             for tr in node.select("tr"):
-                th = tr.find("th")
-                td = tr.find("td")
+                ancestor_table = tr.find_parent("table")
+                if ancestor_table is not node:
+                    continue
+                th_candidate = tr.find("th")
+                td_candidate = tr.find("td")
+                th = th_candidate if _cell_belongs_to_infobox(th_candidate) else None
+                td = td_candidate if _cell_belongs_to_infobox(td_candidate) else None
                 if th and not td:
                     # Section-header row: a single ``<th>`` (usually with a
                     # colspan that visually spans the table). The first

--- a/openzim_mcp/content_processor.py
+++ b/openzim_mcp/content_processor.py
@@ -575,7 +575,7 @@ class ContentProcessor:
 
         Tables with more rows than ``row_threshold`` OR more text characters
         than ``char_threshold`` are replaced in document order with a
-        ``[Table N: M rows × P cols — pass compact=False to expand]`` paragraph.
+        ``[Table N: M rows x P cols - pass compact=False to expand]`` paragraph.
         """
         if row_threshold is None:
             row_threshold = self._table_row_threshold
@@ -601,8 +601,17 @@ class ContentProcessor:
                 default=0,
             )
             placeholder = soup.new_tag("p")
+            # ASCII-only placeholder: the earlier ``× ... —`` form
+            # round-tripped fine on macOS / Ubuntu CI but produced
+            # ``� ... �`` (replacement chars) on Windows runners.
+            # Snippet-level html2text rendering hits an encoding boundary
+            # somewhere — likely a sys-default-codec fallback inside
+            # html2text or BeautifulSoup. Using ASCII ``x`` / ``-``
+            # bypasses the issue entirely; the placeholder is internal
+            # diagnostic text, not user-facing prose, so the slight
+            # downgrade in glyph fidelity has no practical cost.
             placeholder.string = (
-                f"[Table {index}: {len(rows)} rows × {cols} cols — "
+                f"[Table {index}: {len(rows)} rows x {cols} cols - "
                 f"pass compact=False to expand]"
             )
             table.replace_with(placeholder)

--- a/openzim_mcp/content_processor.py
+++ b/openzim_mcp/content_processor.py
@@ -65,10 +65,36 @@ def _word_in(folded_paragraph: str, term: str) -> bool:
     return bool(re.search(rf"\b{re.escape(term)}\b", folded_paragraph))
 
 
+# Regions inside which a query-term match must NOT be wrapped in a second
+# layer of emphasis: it produces malformed markdown (e.g. ``**Artificial
+# **photosynthesis****`` from a bold heading, ``_****Berlin****_`` from
+# italic disambig links, ``[**Photosynthesis**](**Photosynthesis** "…")``
+# where bolding inside the link target breaks the URL).
+#
+# - ``\*\*[^*\n]+\*\*`` — existing bold runs (paired markers, single line).
+#   ``[^*\n]+`` rules out adjacent ``**`` runs and multi-paragraph spans.
+# - ``(?<!\w)_[^_\n]+_(?!\w)`` — italic runs; the lookarounds skip
+#   identifier-style underscores like ``foo_bar``.
+# - ``\[[^\]\n]+\]`` — markdown link/image link-text.
+# - ``\([^\n)]*\)`` — the URL+tooltip parenthetical of a markdown link.
+#   Combined with the link-text rule above, this covers the whole
+#   ``[text](href "title")`` construct.
+_HIGHLIGHT_SKIP_RE = re.compile(
+    r"\*\*[^*\n]+\*\*"
+    r"|(?<!\w)_[^_\n]+_(?!\w)"
+    r"|\[[^\]\n]+\]"
+    r"|\([^\n)]*\)",
+)
+
+
 def _highlight_terms(text: str, query: str, *, max_hits: int) -> str:
     """Wrap the first `max_hits` occurrences of any query term in **bold**.
 
     Case-insensitive, preserves original casing of the matched substring.
+    Skips matches that fall inside existing markdown emphasis (``**bold**``,
+    ``_italic_``) or markdown link constructs (``[text](url "title")``):
+    layering ``**…**`` on top of those produces malformed markdown that
+    confuses small models more than it helps them.
     """
     terms = [t for t in _split_query_terms(query) if len(t) >= 3]
     if not terms:
@@ -77,10 +103,26 @@ def _highlight_terms(text: str, query: str, *, max_hits: int) -> str:
         r"\b(" + "|".join(re.escape(t) for t in terms) + r")\b",
         flags=re.IGNORECASE,
     )
+    # Pre-compute spans where we must not wrap. Overlapping markdown
+    # constructs (a link inside a bold span, etc.) are collapsed into a
+    # single forbidden-position bitmap so the term-replacement pass can
+    # do a single membership check per match.
+    forbidden_starts: List[int] = []
+    forbidden_ends: List[int] = []
+    for m in _HIGHLIGHT_SKIP_RE.finditer(text):
+        forbidden_starts.append(m.start())
+        forbidden_ends.append(m.end())
+
+    def _is_forbidden(pos: int) -> bool:
+        for s, e in zip(forbidden_starts, forbidden_ends):
+            if s <= pos < e:
+                return True
+        return False
+
     hits = [0]
 
     def repl(m: re.Match[str]) -> str:
-        if hits[0] >= max_hits:
+        if hits[0] >= max_hits or _is_forbidden(m.start()):
             return str(m.group(0))
         hits[0] += 1
         return f"**{m.group(0)}**"
@@ -409,6 +451,14 @@ class ContentProcessor:
         Returns ``[{"label": str, "value": str}]``. Mutates ``soup`` to remove
         the extracted infobox so it doesn't get pipe-soup'd by html2text
         downstream.
+
+        Section-header rows (``<th colspan=...>`` only — no ``<td>``) act as
+        parent context for the rows that follow. Without that context, a
+        Wikipedia infobox renders three rows labelled ``City/State`` —
+        one each for Government / Area / Population — which is meaningless
+        to a small model. Carrying the section header through as
+        ``"Area — City/State"`` restores the disambiguation that the
+        original two-column rendering provided visually.
         """
         if kv_limit is None:
             kv_limit = self._infobox_kv_limit
@@ -417,16 +467,58 @@ class ContentProcessor:
             if node is None:
                 continue
             rows: List[Dict[str, str]] = []
+            current_section: Optional[str] = None
+            title_row_consumed = False
             for tr in node.select("tr"):
                 th = tr.find("th")
                 td = tr.find("td")
+                if th and not td:
+                    # Section-header row: a single ``<th>`` (usually with a
+                    # colspan that visually spans the table). The first
+                    # such row of the infobox is the title (a duplicate
+                    # of the article title at the top of the infobox);
+                    # subsequent ones act as parent context for the
+                    # rows that follow.
+                    classes_raw: Any = th.get("class") or []
+                    classes: List[str]
+                    if isinstance(classes_raw, str):
+                        classes = classes_raw.split()
+                    else:
+                        classes = [str(c) for c in classes_raw]
+                    if any("above" in c for c in classes) or not title_row_consumed:
+                        # First th-only row OR an explicitly-marked
+                        # ``infobox-above`` row: drop it. The flag stays
+                        # set so subsequent th-only rows are treated as
+                        # section dividers regardless of whether a KV
+                        # row has been seen yet.
+                        title_row_consumed = True
+                        continue
+                    candidate = " ".join(th.get_text().split())
+                    if candidate:
+                        current_section = candidate
+                    continue
                 if th and td:
-                    label = " ".join(th.get_text().split())
+                    raw_label = " ".join(th.get_text().split())
                     value = " ".join(td.get_text().split())
-                    if label and value:
-                        rows.append({"label": label, "value": value})
-                        if len(rows) >= kv_limit:
-                            break
+                    if not raw_label or not value:
+                        continue
+                    # Prefix with current section when present so labels
+                    # disambiguate across sections. Drop the prefix when
+                    # the label already starts with the section name
+                    # (e.g. some infoboxes have ``Population total`` /
+                    # ``Population density`` inside a "Population"
+                    # section — don't write ``Population — Population
+                    # total``).
+                    if current_section and not raw_label.lower().startswith(
+                        current_section.lower()
+                    ):
+                        label = f"{current_section} — {raw_label}"
+                    else:
+                        label = raw_label
+                    rows.append({"label": label, "value": value})
+                    title_row_consumed = True
+                    if len(rows) >= kv_limit:
+                        break
             node.decompose()
             return rows
         return []
@@ -575,19 +667,38 @@ class ContentProcessor:
         *,
         query: Optional[str] = None,
         max_paragraphs: int = 2,
+        title: Optional[str] = None,
     ) -> str:
         """Create a snippet from content, optionally query-aware.
 
         When `query` is supplied, locate the first paragraph that contains a
         whole-word match for any term in the query (case-insensitive,
-        diacritic-folded) and start the snippet there. Otherwise, take the
-        leading paragraphs (legacy behavior).
+        diacritic-folded) and start the snippet there. Falls back to a
+        substring (morphological) match when no whole-word paragraph hits —
+        captures stemmed forms like ``photosynthetic`` for query
+        ``photosynthesis`` instead of dropping to the lead paragraph
+        (which often carries zero query relevance for inflected matches).
+
+        ``title`` is the entry title; when supplied, a leading ``# <title>``
+        markdown H1 that duplicates the title is stripped from the snippet
+        (the title is already shown in the result header above the
+        snippet, so the H1 burns 5-15 tokens per result for no signal).
 
         Up to 5 occurrences of any matched term inside the returned slice are
         wrapped in `**bold**` for visibility.
         """
         if not content:
             return ""
+
+        # Strip a leading ``# <title>`` H1 that duplicates the entry title
+        # before any paragraph selection happens — otherwise we'd select a
+        # paragraph that contains the H1 and waste 5-15 tokens on a heading
+        # the caller already has from the result row. Done after the empty
+        # check so empty inputs short-circuit unchanged.
+        if title:
+            content = self._strip_leading_title_heading(content, title)
+            if not content:
+                return ""
 
         paragraphs = content.split("\n\n")
         start_idx = 0
@@ -596,10 +707,31 @@ class ContentProcessor:
             terms = [t for t in _split_query_terms(query) if len(t) >= 3]
             if terms:
                 folded_paragraphs = [_fold(p) for p in paragraphs]
+                # Pass 1: whole-word match (most precise — preserves the
+                # Phase A #1 spec promise).
+                whole_word_idx: Optional[int] = None
                 for i, p in enumerate(folded_paragraphs):
                     if any(_word_in(p, t) for t in terms):
-                        start_idx = i
+                        whole_word_idx = i
                         break
+                if whole_word_idx is not None:
+                    start_idx = whole_word_idx
+                else:
+                    # Pass 2: stem-prefix substring match catches
+                    # inflected/stemmed forms (``photosynthetic`` for
+                    # query ``photosynthesis``). Use the first
+                    # ``ceil(2/3 * len)`` chars of each query term as a
+                    # prefix probe — long enough to be specific to the
+                    # query stem ("photosynthe" for "photosynthesis"),
+                    # short enough to match plausible inflections
+                    # (-ic, -is, -ise, -ate). Falls through to the
+                    # legacy lead-text behavior (start_idx=0) when no
+                    # paragraph carries even a stem-prefix.
+                    stems = [t[: max(4, (len(t) * 2 + 2) // 3)] for t in terms]
+                    for i, p in enumerate(folded_paragraphs):
+                        if any(stem in p for stem in stems):
+                            start_idx = i
+                            break
 
         selected = paragraphs[start_idx : start_idx + max_paragraphs]
         snippet_text = (
@@ -633,6 +765,33 @@ class ContentProcessor:
                 snippet_text = sliced + "..."
 
         return snippet_text
+
+    @staticmethod
+    def _strip_leading_title_heading(content: str, title: str) -> str:
+        """Drop a leading ``# <title>`` line that duplicates the entry title.
+
+        Wikipedia exports prepend ``<h1>Title</h1>`` to the article body;
+        ``html2text`` renders that as ``# Title``. When the snippet/preview
+        is going to be displayed under a separate ``## N. <Title>``
+        result header, the duplicate H1 wastes 5-15 tokens per result.
+
+        Match is case-insensitive on the title and tolerant of one
+        trailing whitespace run (collapsed by html2text). Leaves
+        non-matching headings (real article subheadings) alone.
+        """
+        if not content or not title:
+            return content
+        norm_title = title.strip()
+        if not norm_title:
+            return content
+        # ``re.escape`` on the title keeps disambiguation parens / dots
+        # literal so ``# Mercury (planet)`` matches title
+        # ``Mercury (planet)``.
+        pattern = re.compile(
+            rf"^\s*#\s+{re.escape(norm_title)}\s*\n+",
+            flags=re.IGNORECASE,
+        )
+        return pattern.sub("", content, count=1)
 
     def truncate_content(self, content: str, max_length: int) -> str:
         """

--- a/openzim_mcp/defaults.py
+++ b/openzim_mcp/defaults.py
@@ -180,6 +180,25 @@ UNWANTED_HTML_SELECTORS: List[str] = [
     "footer",
     ".mw-parser-output .reflist",
     ".mw-editsection",
+    # Image captions: Wikipedia's article HTML puts a figure with a caption
+    # before the lead paragraph, so snippets start with "Schematic of …"
+    # instead of the actual lead. Stripping the figure container removes
+    # the caption text and the orphan alt-text noise. Galleries (".gallery")
+    # have the same problem at section boundaries.
+    "figure",
+    "figcaption",
+    ".thumb",
+    ".thumbcaption",
+    ".gallery",
+    # Disambiguation hatnotes ("For other uses, see X") sit between the H1
+    # and the lead paragraph. They're 99% navigation noise for a small model
+    # following a topic; keep the canonical link discovery in extract_links.
+    ".hatnote",
+    # "Part of a series on" right-rail navigation. Render as pipe-soup noise
+    # at the top of the rendered article body, displacing the actual lead.
+    ".sidebar",
+    ".navbox",
+    ".metadata.mbox-small",
 ]
 
 # Rate limiter operation costs

--- a/openzim_mcp/defaults.py
+++ b/openzim_mcp/defaults.py
@@ -199,6 +199,26 @@ UNWANTED_HTML_SELECTORS: List[str] = [
     ".sidebar",
     ".navbox",
     ".metadata.mbox-small",
+    # Inline citation superscripts (``<sup class="reference">[1]</sup>``)
+    # html2text renders as bare ``[1]``/``[a]`` text inline with prose
+    # — pure noise for a small model that won't follow them anyway and
+    # can request the reflist explicitly if needed. Stripping them
+    # noticeably tightens snippet density.
+    "sup.reference",
+    "sup.cite_ref",
+    ".reference",
+    # MediaWiki collapsed-content toggles ("show"/"hide") — render as
+    # bare ``[show]``/``[hide]`` text inline with the heading.
+    ".mw-collapsible-toggle",
+    # Coordinate displays in infoboxes: html2text mangles the
+    # microformat into pipe-soup like
+    # ``52°31′07″N 13°24′16″E / 52.518691°N 13.404183°E``. Useful for
+    # GIS, useless for a small model trying to read the article body.
+    ".geo-default",
+    ".geo-dms",
+    ".geo-dec",
+    ".geo-nondefault",
+    ".geo-multi-punct",
 ]
 
 # Rate limiter operation costs

--- a/openzim_mcp/intent_parser.py
+++ b/openzim_mcp/intent_parser.py
@@ -331,6 +331,11 @@ def _extract_get_section(query: str, params: Dict[str, Any]) -> None:
         respiration, path=Biology
       * ``"section 3 of Biology"`` -> name="3" (numeric) — handler treats
         bare integers as 1-indexed positions into the article's headings.
+      * ``"narrow section Geography of Berlin"`` (or ``"just section …"``)
+        -> name=Geography, path=Berlin, narrow=True. Tells the handler
+        to scope the slice to the heading itself (no nested
+        subsections). Op3: surfaces ``include_subsections=False`` to
+        small-model callers via a memorable verb.
 
     Two separate patterns because the section-name placement differs:
     pre-keyword (``"section X of Y"``) vs. pre-keyword-with-determiner
@@ -338,6 +343,15 @@ def _extract_get_section(query: str, params: Dict[str, Any]) -> None:
     section called ``"In the news"`` doesn't get parsed as ``"In"`` +
     `` the news`` of nothing.
     """
+    # Op3: detect a "narrow" / "just" prefix and strip it before the
+    # regular section-extraction passes run. Stays a flag in ``params``
+    # so the handler can switch ``include_subsections``.
+    narrow_match = safe_regex_search(
+        r"^\s*(?:narrow|just|only)\s+", query, re.IGNORECASE
+    )
+    if narrow_match:
+        params["narrow"] = True
+        query = query[narrow_match.end() :]
     # Form A: ``[the] section <name> of|in|from <path>``
     m = safe_regex_search(
         rf"\b(?:the\s+)?section\s+{_QUOTE_OPEN}?({_QUOTE_NOT}+?){_QUOTE_OPEN}?"

--- a/openzim_mcp/server.py
+++ b/openzim_mcp/server.py
@@ -208,6 +208,7 @@ class OpenZimMcpServer:
             zim_file_path: Optional[str] = None,
             limit: Optional[int] = None,
             offset: int = 0,
+            cursor: Optional[str] = None,
             max_content_length: Optional[int] = None,
             compact: bool = True,
             compact_budget: Optional[Any] = None,
@@ -314,6 +315,15 @@ class OpenZimMcpServer:
                     options["offset"] = offset
                 if compact_budget is not None:
                     options["compact_budget"] = compact_budget
+                # D10: ``cursor`` is the v2 Phase B pagination handle.
+                # When supplied, it's decoded and its embedded ``o``
+                # (offset) overrides any caller-supplied ``offset``.
+                # Without this, the cursors that walk/browse/search
+                # responses surface are decorative: the only paging
+                # channel reachable from zim_query was the integer
+                # ``offset`` parameter.
+                if cursor is not None and str(cursor).strip():
+                    options["cursor"] = str(cursor).strip()
 
                 # Use simple tools handler. handle_zim_query is synchronous and
                 # performs blocking ZIM I/O, so dispatch it to a worker thread

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -151,9 +151,58 @@ class SimpleToolsHandler:
             (synthesize=True) or ToolErrorPayload on error.
         """
         options = options or {}
+        # D10: decode the optional ``cursor`` and project its ``o``
+        # (offset) into ``options["offset"]`` so downstream handlers —
+        # all of which still take integer offsets — keep working
+        # unchanged. The cursor's tool name is ignored at this layer:
+        # the simple-mode router dispatches based on the parsed
+        # intent, not on which tool emitted the cursor. Mismatches
+        # surface as a no-op (the offset is still valid, just maybe
+        # smaller than the new query's hit count). Malformed cursors
+        # are surfaced as a structured error.
+        cursor_raw = options.get("cursor")
+        if cursor_raw is not None:
+            # Simple-mode dispatch routes by parsed intent, not by the
+            # tool that emitted the cursor — and ``Cursor.decode`` requires
+            # an ``expected_tool`` match. Decode the payload directly so
+            # any tool's cursor can be replayed for offset extraction.
+            # Cross-tool reuse is bounded: the only field we read is
+            # ``s.o`` (offset). Tool-specific cursor state (archive
+            # identity, query, namespace) is preserved if the caller
+            # also re-supplies the matching query terms.
+            import base64 as _b64
+            import json as _json
+
+            try:
+                token = str(cursor_raw)
+                padded = token + "=" * (-len(token) % 4)
+                decoded_payload = _json.loads(
+                    _b64.urlsafe_b64decode(padded.encode("ascii")).decode("utf-8")
+                )
+                state = (
+                    decoded_payload.get("s")
+                    if isinstance(decoded_payload, dict)
+                    else None
+                )
+                if isinstance(state, dict):
+                    decoded_offset = state.get("o")
+                    if isinstance(decoded_offset, int) and decoded_offset >= 0:
+                        options["offset"] = decoded_offset
+            except Exception as e:
+                logger.warning("Could not decode cursor %r: %s", cursor_raw, e)
+                return (
+                    "**Invalid Cursor**\n\n"
+                    "The `cursor` value could not be decoded. Drop the "
+                    "`cursor` argument and call again with an explicit "
+                    "`offset` (or no pagination arg) instead.\n"
+                )
         if options.get("synthesize"):
             try:
-                return self._handle_synthesize_query(query, zim_file_path)
+                return self._handle_synthesize_query(
+                    query,
+                    zim_file_path,
+                    compact=bool(options.get("compact", False)),
+                )
             except Exception as e:
                 logger.error(
                     "Unexpected error in synthesize path: %s", e, exc_info=True
@@ -977,10 +1026,20 @@ class SimpleToolsHandler:
         # small-model sweet spot per Phase C #7. The heading's ``id``
         # matches the bundle section ``id`` 1:1 (both are derived from
         # the same ``bundle["sections"]`` list).
+        #
+        # Op3: when the query was phrased as ``narrow section X of Y``
+        # (parser sets ``params["narrow"] = True``), scope the slice to
+        # the heading itself — no nested H3/H4 children. Lets a small
+        # model fetch just the H2 lead paragraphs without the whole
+        # sub-tree spilling into the response.
         section_id = target.get("id") or ""
+        include_subsections = not bool(params.get("narrow"))
         try:
             section = self.zim_operations.get_section_data(
-                zim_file_path, entry_path, section_id
+                zim_file_path,
+                entry_path,
+                section_id,
+                include_subsections=include_subsections,
             )
         except Exception as e:
             return (
@@ -1262,9 +1321,21 @@ class SimpleToolsHandler:
         top_path = top.get("path", "")
         top_title = top.get("title", "")
         if not self._is_strong_title_match(topic, top_path, top_title):
-            return self.zim_operations.search_zim_file(
-                zim_file_path, topic, search_limit, 0
-            )
+            # D6 fix: Xapian ranks "List of songs about Berlin" above the
+            # canonical "Berlin" article for query="Berlin" because
+            # title-match boost isn't strong enough. Before giving up
+            # and rendering search hits, ask the title index directly:
+            # is there an exact-title match for the topic? If so,
+            # promote it past the search ranking and inline the article.
+            # Saves the small-model agentic loop a turn on the most
+            # common case ("tell me about <canonical topic name>").
+            promoted = self._find_title_match_for_topic(zim_file_path, topic)
+            if promoted is None:
+                return self.zim_operations.search_zim_file(
+                    zim_file_path, topic, search_limit, 0
+                )
+            top_path = promoted["path"]
+            top_title = promoted["title"]
 
         # Disambiguation: if MULTIPLE search hits strong-match the topic,
         # there's a real ambiguity (Mercury → planet/element/mythology;
@@ -1326,6 +1397,49 @@ class SimpleToolsHandler:
             f"_Source: `{top_path}`_\n\n"
             f"{article_body}"
         )
+
+    def _find_title_match_for_topic(
+        self, zim_file_path: str, topic: str
+    ) -> Optional[Dict[str, Any]]:
+        """Ask the title index whether ``topic`` resolves to an exact entry.
+
+        Returns ``{"path": ..., "title": ...}`` when the title index
+        produces a score-1.0 match for the topic; otherwise ``None``.
+        Used as a fallback when the Xapian search ranking buries the
+        canonical article under "List of songs about X" / "Timeline of
+        X" / etc. — the title index isn't affected by BM25 noise on
+        common topic words, so an exact-title hit there is a strong
+        signal we should surface the canonical article.
+
+        Failures in the backend are logged and swallowed; the caller
+        falls through to the search-render path so a backend hiccup
+        never blanks out the response.
+        """
+        try:
+            data = self.zim_operations.find_entry_by_title_data(
+                zim_file_path, topic, cross_file=False, limit=3
+            )
+        except Exception as e:
+            logger.debug("find_entry_by_title_data failed in tell_me_about: %s", e)
+            return None
+        results = data.get("results") if isinstance(data, dict) else None
+        if not results:
+            return None
+        # Require an exact-title score of 1.0. Lower scores include
+        # SuggestionSearcher prefix matches, which can produce noise
+        # ("Java" → "Java (programming language)" with score 0.95).
+        # The disambiguation branch lower in tell_me_about handles
+        # multiple-strong-match cases; here we only promote when the
+        # title is unambiguous.
+        top = results[0]
+        if not isinstance(top, dict):
+            return None
+        if float(top.get("score", 0.0)) < 1.0:
+            return None
+        return {
+            "path": str(top.get("path", "")),
+            "title": str(top.get("title", "")),
+        }
 
     @staticmethod
     def _render_disambiguation(topic: str, candidates: list) -> str:
@@ -1594,6 +1708,8 @@ class SimpleToolsHandler:
         self,
         query: str,
         zim_file_path: Optional[str],
+        *,
+        compact: bool = False,
     ) -> Union[SynthesizeResponse, ToolErrorPayload]:
         """Phase C: dispatch query to the synthesize pipeline.
 
@@ -1607,8 +1723,40 @@ class SimpleToolsHandler:
 
         search_handler is self.zim_operations — ZimOperations has search_top_k
         directly, satisfying the synthesize pipeline's duck-typed interface.
+
+        D5 fix: strip natural-language interrogative prefixes ("tell me
+        about", "who is", "what are", …) before handing the query to
+        the search stage. Without the strip, ``synthesize=True`` with
+        query ``"tell me about Berlin"`` BM25-matched on the words
+        "tell" + "me" + "about" + "Berlin" and returned songs by Irving
+        Berlin / Nat King Cole albums / Hans Abrahamsen pieces.
+        Re-using ``IntentParser`` keeps prefix detection in one place
+        and benefits from the existing test coverage.
         """
         from openzim_mcp.synthesize import synthesize_query
+
+        # D5: distill the user's natural-language query down to the
+        # topic (or actual search terms) BEFORE handing it to BM25.
+        # The intent parser already knows how to pull "Berlin" out of
+        # "tell me about Berlin" / "who is Berlin" / "describe Berlin".
+        # Fall back to the raw query when the parser doesn't classify
+        # it as a topic ask — for plain ``search`` intents (the user
+        # typed "berlin wall" directly), the raw query IS the search
+        # query.
+        try:
+            intent, params, _confidence = self.intent_parser.parse_intent(query)
+        except Exception as e:  # pragma: no cover — defensive
+            logger.debug("intent_parser failed in synthesize prelude: %s", e)
+            intent, params = "search", {}
+        search_query = query
+        if intent == "tell_me_about" and isinstance(params, dict):
+            topic = params.get("topic")
+            if isinstance(topic, str) and topic.strip():
+                search_query = topic.strip()
+        elif intent == "search" and isinstance(params, dict):
+            extracted = params.get("query")
+            if isinstance(extracted, str) and extracted.strip():
+                search_query = extracted.strip()
 
         # Resolve the set of archive paths to open.
         archives_to_open: list[Path] = []
@@ -1666,12 +1814,25 @@ class SimpleToolsHandler:
                 )
 
             return synthesize_query(
-                query,
+                search_query,
                 archives=archives,
                 search_handler=self.zim_operations,
                 cache=self.zim_operations.cache,
                 content_processor=self.zim_operations.content_processor,
                 config=self.zim_operations.config.synthesize,
+                # The original natural-language query goes in the
+                # response so callers can correlate the synthesized
+                # answer with what they actually asked. Without this,
+                # ``query`` echoes back the BM25-stripped form which
+                # is harder to recognize.
+                original_query=query,
+                # In compact mode, suppress the answer/passage text
+                # duplication (D8) and strip Wikipedia's markdown
+                # link soup (Op4). Verbose mode keeps both for callers
+                # that want full passage shape for downstream
+                # processing.
+                omit_passage_text=compact,
+                strip_links=compact,
             )
 
     def _resolve_zim_path(self, candidate: str) -> Optional[str]:

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -170,11 +170,23 @@ class SimpleToolsHandler:
             # ``s.o`` (offset). Tool-specific cursor state (archive
             # identity, query, namespace) is preserved if the caller
             # also re-supplies the matching query terms.
+            #
+            # Defense-in-depth: cap the token length at 2 KB so an
+            # adversarially-crafted cursor can't trigger oversized
+            # base64-decode or json.loads work. Legitimate cursors
+            # issued by ``Cursor.encode`` are well under 200 chars.
             import base64 as _b64
             import json as _json
 
+            token = str(cursor_raw)
+            if len(token) > 2048:
+                return (
+                    "**Invalid Cursor**\n\n"
+                    "The `cursor` value exceeds the maximum length. Drop "
+                    "the `cursor` argument and call again with an explicit "
+                    "`offset` (or no pagination arg) instead.\n"
+                )
             try:
-                token = str(cursor_raw)
                 padded = token + "=" * (-len(token) % 4)
                 decoded_payload = _json.loads(
                     _b64.urlsafe_b64decode(padded.encode("ascii")).decode("utf-8")

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -146,6 +146,24 @@ def _normalize_ws(text: str) -> str:
     return _WS_RE.sub(" ", text).strip()
 
 
+# Strip ``**...**`` bold markers that ``create_snippet``'s
+# query-highlighting pass added. The bundle's ``rendered_markdown`` is
+# rendered WITHOUT the per-query highlight wrap, so a literal
+# ``md.find("**Photosynthesis**")`` returns -1 even though the plain
+# text matches. Stripping the bold markers before locating restores
+# section attribution (D8): every passage now carries its
+# ``#section_id`` suffix instead of dropping back to bare entry-level
+# citation.
+_BOLD_MARKER_RE = re.compile(r"\*\*")
+
+
+def _strip_bold(text: str) -> str:
+    """Remove ``**`` markers added by ``_highlight_terms`` so the
+    passage text can be located inside the bundle's plain
+    rendered_markdown."""
+    return _BOLD_MARKER_RE.sub("", text)
+
+
 def _locate_passage(md: str, passage_text: str) -> int:
     """Return the offset of ``passage_text`` within ``md``, or -1 on miss.
 
@@ -154,7 +172,15 @@ def _locate_passage(md: str, passage_text: str) -> int:
     inline-markup drift between the snippet rendering path and the
     bundle's rendered markdown. The returned offset is into the
     *original* ``md`` so callers can map it back to section ranges.
+
+    Passes the bold-stripped form to both probes — ``create_snippet``'s
+    query-highlight wrapper inserts ``**...**`` around the query term,
+    but the bundle markdown is rendered without highlighting, so a
+    literal ``md.find(passage_text)`` misses every snippet that
+    carries a highlighted term. Section attribution (D8) depends on
+    these probes hitting.
     """
+    passage_text = _strip_bold(passage_text)
     pos = md.find(passage_text)
     if pos >= 0:
         return pos
@@ -366,6 +392,43 @@ def _build_citations(
             },
         )
     return list(seen.values())
+
+
+# Markdown link/image regex shared between simple_tools._strip_markdown_links
+# and synthesize. Same disjoint-alternation shape as the simple_tools regex
+# so the pattern engine doesn't backtrack against unclosed brackets.
+_MD_LINK_RE = re.compile(r"\[([^\[\]]*?)\]\((?:[^()\n\\]|\\.)*\)")
+_MD_IMAGE_RE = re.compile(r"!\[[^\[\]]*?\]\((?:[^()\n\\]|\\.)*\)")
+
+
+def _strip_links_in_passage(p: SynthesizePassage) -> SynthesizePassage:
+    """Strip Wikipedia-style markdown link syntax from a passage's text.
+
+    Drops ``![alt](src)`` images entirely (alt-text + URL are rarely
+    informative for a small model). Replaces ``[text](href "tooltip")``
+    with ``text``. Idempotent on already-stripped text. Op4: useful
+    when ``synthesize=True`` is called with ``compact=True``, where
+    the simple-mode dispatcher otherwise applies the link strip to
+    the rendered markdown but NOT to the passages list.
+    """
+    body = p["text_markdown"]
+    if not body or "[" not in body:
+        return p
+    body = _MD_IMAGE_RE.sub("", body)
+    body = _MD_LINK_RE.sub(r"\1", body)
+    new_p = dict(p)
+    new_p["text_markdown"] = body
+    return cast("SynthesizePassage", new_p)
+
+
+def _drop_passage_text(p: SynthesizePassage) -> SynthesizePassage:
+    """Return a passage with ``text_markdown`` replaced by an empty
+    string — keeping the field present (TypedDict schema) but
+    collapsing it to one byte so it doesn't duplicate ``answer_markdown``
+    in the response."""
+    new_p = dict(p)
+    new_p["text_markdown"] = ""
+    return cast("SynthesizePassage", new_p)
 
 
 # ---------------------------------------------------------------------------
@@ -609,8 +672,30 @@ def synthesize_query(
     cache: OpenZimMcpCache,
     content_processor: ContentProcessor,
     config: SynthesizeConfig,
+    original_query: Optional[str] = None,
+    strip_links: bool = False,
+    omit_passage_text: bool = False,
 ) -> SynthesizeResponse:
-    """Run the synthesize pipeline end-to-end."""
+    """Run the synthesize pipeline end-to-end.
+
+    ``original_query`` is echoed back as ``response["query"]`` when
+    supplied — the caller is responsible for any pre-processing
+    (intent-prefix stripping for D5) and ``original_query`` lets the
+    user-facing query be preserved while ``query`` carries the
+    BM25-friendly form.
+
+    ``strip_links`` (Op4): when True, markdown-link soup
+    ``[text](href "tooltip")`` in passages is stripped to plain text
+    before rendering. Wikipedia exports are ~50% link syntax in the
+    head of a typical article; stripping doubles the useful prose
+    density for small models that can't follow inline links anyway.
+
+    ``omit_passage_text`` (D8): when True, the ``passages[]`` array
+    drops ``text_markdown`` (which is verbatim-duplicated inside
+    ``answer_markdown``) and keeps only the lightweight metadata
+    (``cite_id``, ``rank``, ``score``). Cuts the response by ~50%
+    on a typical 5-passage synthesize call.
+    """
     per_archive_hits, archives_searched, archive_by_name = _do_per_archive_search(
         archives,
         search_handler=search_handler,
@@ -620,10 +705,13 @@ def synthesize_query(
     top_hits, fallback_used = _select_top_hits(
         per_archive_hits, archives_searched, top_n=config.top_n
     )
+    response_query = original_query if original_query is not None else query
     if not top_hits:
-        return _zero_hits_response(query, archives_searched, fallback_used)
+        return _zero_hits_response(response_query, archives_searched, fallback_used)
 
     all_passages, hit_keys = _extract_passages_for_top_hits(top_hits)
+    if strip_links:
+        all_passages = [_strip_links_in_passage(p) for p in all_passages]
     bundle_lookup = _make_bundle_lookup(
         top_hits,
         archive_by_name,
@@ -653,12 +741,21 @@ def synthesize_query(
         content_chars=len(answer_md) if truncated else None,
         total_chars=pre_cap_chars if truncated else None,
     )
+    # D8: ``answer_markdown`` already carries each passage's text
+    # verbatim; ``passages[].text_markdown`` is a 100% duplicate.
+    # When ``omit_passage_text=True`` (default for compact mode in
+    # simple_tools / zim_query), drop the field so the response halves
+    # in size on a typical 5-passage call. The cite_id/rank/score
+    # remain so callers can correlate passages with citations.
+    response_passages: list[SynthesizePassage] = capped
+    if omit_passage_text:
+        response_passages = [_drop_passage_text(p) for p in capped]
     return cast(
         "SynthesizeResponse",
         {
-            "query": query,
+            "query": response_query,
             "answer_markdown": answer_md,
-            "passages": capped,
+            "passages": response_passages,
             "citations": citations,
             "archives_searched": archives_searched,
             "fallback_used": fallback_used,

--- a/openzim_mcp/tools/structure_tools.py
+++ b/openzim_mcp/tools/structure_tools.py
@@ -538,6 +538,7 @@ def _register_get_section(server: "OpenZimMcpServer") -> None:
         entry_path: str,
         section_id: str,
         max_chars: Optional[int] = None,
+        include_subsections: bool = True,
     ) -> Union[GetSectionResponse, ToolErrorPayload]:
         """Fetch a single section from an entry by its section_id.
 
@@ -557,6 +558,13 @@ def _register_get_section(server: "OpenZimMcpServer") -> None:
             section_id: Section identifier from TOC.
             max_chars: Optional cap on section body chars (default uses
                        config.content.max_content_length).
+            include_subsections: When True (default), the returned slice
+                covers the section plus its nested children (Geography
+                returns Geography + Topography + Climate). When False,
+                the slice ends at the next heading of *any* level, so
+                only the section's own body — not its sub-tree — is
+                returned. Use False when the caller already has the
+                TOC and wants to drill into one heading at a time.
         """
         try:
             try:
@@ -580,6 +588,7 @@ def _register_get_section(server: "OpenZimMcpServer") -> None:
                 entry_path,
                 section_id,
                 max_chars=max_chars,
+                include_subsections=include_subsections,
             )
 
         except Exception as e:

--- a/openzim_mcp/zim/archive.py
+++ b/openzim_mcp/zim/archive.py
@@ -78,6 +78,15 @@ ARCHIVE_OPEN_TIMEOUT = 30.0
 # ``ContentDefaults.MAX_REDIRECT_DEPTH`` in ``defaults.py``.
 MAX_REDIRECT_DEPTH = CONTENT.MAX_REDIRECT_DEPTH
 
+# Per-entry preview cap for ``_extract_zim_metadata``. Wikipedia ZIMs
+# store ``M/Title`` as a full HTML document (~1 MB) rather than the
+# archive's bare title string; without a cap, that single value dwarfs
+# every other metadata field AND blows past the per-call response
+# budget. 800 chars is enough to surface the actual title for archives
+# that store it plain, AND a clear "[truncated, …]" marker for the
+# pathological HTML-template case.
+_METADATA_PREVIEW_CAP = 800
+
 
 logger = logging.getLogger(__name__)
 
@@ -453,7 +462,24 @@ class ZimOperations(_SearchMixin, _ContentMixin, _StructureMixin, _NamespaceMixi
                             .strip()
                         )
                         if content:
-                            metadata_entries[meta_key] = content
+                            # Wikipedia ZIMs store ``M/Title`` as a full
+                            # HTML document (~1 MB) rather than the bare
+                            # archive title. Embedding that verbatim
+                            # blows the response past every per-call
+                            # budget and starves a small model of the
+                            # other metadata fields. Cap each value at
+                            # 800 chars + mark elision so the caller
+                            # can still see structure (date, language,
+                            # creator) without paying for the rare
+                            # template-bloated field.
+                            if len(content) > _METADATA_PREVIEW_CAP:
+                                preview = content[:_METADATA_PREVIEW_CAP].rstrip()
+                                metadata_entries[meta_key] = (
+                                    f"{preview}… "
+                                    f"[truncated, {len(content):,} chars total]"
+                                )
+                            else:
+                                metadata_entries[meta_key] = content
                 except Exception as e:
                     # Entry doesn't exist or can't be read - expected for optional
                     logger.debug(f"Metadata 'M/{meta_key}' not available: {e}")

--- a/openzim_mcp/zim/content.py
+++ b/openzim_mcp/zim/content.py
@@ -64,14 +64,32 @@ class _ContentMixin:
             """Resolve via ``ZimOperations`` on the concrete coordinator."""
 
     def _get_entry_snippet(self, entry: Any, query: Optional[str] = None) -> str:
-        """Get content snippet for search result, optionally query-aware."""
+        """Get content snippet for search result, optionally query-aware.
+
+        Renders the entry's HTML with ``compact=True`` so the resulting
+        markdown matches what the EntryBundle stores (the bundle is also
+        built with ``compact=True`` in :mod:`openzim_mcp.bundle`).
+        Without the same flag on both sides, search snippets carried
+        pipe-soup infoboxes and raw tables that the bundle had already
+        replaced with placeholders — section attribution in synthesize
+        couldn't find those snippets in the bundle markdown, so every
+        passage dropped back to entry-level citations.
+
+        ``title=entry.title`` is forwarded to ``create_snippet`` so the
+        leading ``# <Title>`` H1 that html2text emits (a verbatim
+        duplicate of the entry title already shown in the result row)
+        is stripped before snippet selection — Op1.
+        """
         try:
             item = entry.get_item()
             if item.mimetype.startswith("text/"):
                 content = self.content_processor.process_mime_content(
-                    bytes(item.content), item.mimetype
+                    bytes(item.content), item.mimetype, compact=True
                 )
-                return self.content_processor.create_snippet(content, query=query)
+                entry_title = getattr(entry, "title", None) or ""
+                return self.content_processor.create_snippet(
+                    content, query=query, title=entry_title
+                )
             else:
                 return f"(Unsupported content type: {item.mimetype})"
         except Exception as e:

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -701,6 +701,29 @@ class _NamespaceMixin:
         # Check if archive uses new namespace scheme
         has_new_scheme = getattr(archive, "has_new_namespace_scheme", False)
 
+        # Fast path: new-scheme + C namespace. Every iterable entry in a
+        # new-scheme archive lives under C, so we don't need to enumerate
+        # a list of "C entries" — we can pull each page directly from
+        # the entry-id range. This avoids the 27M-iteration crash that
+        # the legacy "build full list then slice" path triggered on
+        # Wikipedia (D2): walking every entry to build a list we
+        # immediately slice 50 rows out of is both pathologically slow
+        # and memory-hostile. The total is ``archive.entry_count``,
+        # which libzim returns in O(1).
+        if has_new_scheme and namespace == "C":
+            return self._browse_new_scheme_c_paginated(
+                archive, namespace, limit, offset
+            )
+        # Fast path: new-scheme + W namespace. libzim doesn't surface W
+        # through the iterable surface, but the well-known entries
+        # (mainPage, favicon) ARE reachable by ``has_entry_by_path``.
+        # Probing the known paths recovers the W namespace's actual
+        # contents (D3) instead of the legacy empty result.
+        if has_new_scheme and namespace == "W":
+            return self._browse_new_scheme_w_paginated(
+                archive, namespace, limit, offset
+            )
+
         # Discover entries in the namespace. The full listing is cached
         # separately from the per-page JSON (cache_key in browse_namespace),
         # so different (limit, offset) pages share one scan. The stat
@@ -775,6 +798,121 @@ class _NamespaceMixin:
         }
 
         return result
+
+    def _browse_new_scheme_c_paginated(
+        self,
+        archive: Archive,
+        namespace: str,
+        limit: int,
+        offset: int,
+    ) -> Dict[str, Any]:
+        """Page through new-scheme C-namespace entries by entry-id range.
+
+        New-scheme archives store every iterable entry under C, so
+        pagination is just ``[offset, offset+limit)`` against the
+        entry-id range. The legacy code built a 27M-item list first and
+        then sliced — slow, memory-hostile, and triggered "session
+        expired" errors on real Wikipedia archives (D2). ``entry_count``
+        is the authoritative total; ``done`` falls out naturally from
+        ``offset + returned_count >= total``.
+        """
+        total = int(getattr(archive, "entry_count", 0) or 0)
+        entries: List[Dict[str, Any]] = []
+        end = min(offset + limit, total)
+        for entry_id in range(offset, end):
+            try:
+                entry = archive._get_entry_by_id(entry_id)
+            except Exception as e:
+                logger.warning(f"Error reading entry id {entry_id}: {e}")
+                continue
+            try:
+                materialised = self._materialise_browse_entry(
+                    archive, entry.path, has_new_scheme=True
+                )
+                if materialised is not None:
+                    entries.append(materialised)
+            except Exception as e:
+                logger.warning(f"Error processing entry {entry.path}: {e}")
+                continue
+        return {
+            "namespace": namespace,
+            "total_in_namespace": total,
+            "total_in_namespace_is_lower_bound": False,
+            "offset": offset,
+            "limit": limit,
+            "returned_count": len(entries),
+            "entries": entries,
+            "sampling_based": False,
+            "discovery_method": "entry_id_range",
+            "is_total_authoritative": True,
+            "results_may_be_incomplete": False,
+        }
+
+    # Well-known W-namespace paths in new-scheme archives. libzim's
+    # iterable surface doesn't expose W, but ``has_entry_by_path`` does.
+    # MediaWiki-flavoured ZIMs typically populate ``W/mainPage`` and
+    # ``W/favicon``; some carry ``W/index`` and ``W/robots.txt``.
+    # Probe in priority order so the first page surfaces the most
+    # useful entries.
+    _NEW_SCHEME_W_CANDIDATES = (
+        "W/mainPage",
+        "W/favicon",
+        "W/index",
+        "W/robots.txt",
+        "W/exception.html",
+        "W/404.html",
+    )
+
+    def _browse_new_scheme_w_paginated(
+        self,
+        archive: Archive,
+        namespace: str,
+        limit: int,
+        offset: int,
+    ) -> Dict[str, Any]:
+        """Enumerate new-scheme W-namespace entries by probing known paths.
+
+        D3 fix: ``browse namespace W`` was returning 0 results despite
+        ``list_namespaces`` reporting two W entries. New-scheme archives
+        keep W off the iterable surface, but the well-known paths
+        (mainPage, favicon, …) are reachable via ``has_entry_by_path``.
+        Probing the known-candidates list recovers the actual W
+        contents so a small model navigating by namespace doesn't get a
+        false-empty page.
+        """
+        present: List[str] = []
+        for path in self._NEW_SCHEME_W_CANDIDATES:
+            try:
+                if archive.has_entry_by_path(path):
+                    present.append(path)
+            except Exception as e:
+                logger.debug(f"has_entry_by_path probe failed for {path}: {e}")
+        total = len(present)
+        page = present[offset : offset + limit]
+        entries: List[Dict[str, Any]] = []
+        for entry_path in page:
+            try:
+                materialised = self._materialise_browse_entry(
+                    archive, entry_path, has_new_scheme=True
+                )
+                if materialised is not None:
+                    entries.append(materialised)
+            except Exception as e:
+                logger.warning(f"Error processing W entry {entry_path}: {e}")
+                continue
+        return {
+            "namespace": namespace,
+            "total_in_namespace": total,
+            "total_in_namespace_is_lower_bound": False,
+            "offset": offset,
+            "limit": limit,
+            "returned_count": len(entries),
+            "entries": entries,
+            "sampling_based": False,
+            "discovery_method": "known_path_probe",
+            "is_total_authoritative": True,
+            "results_may_be_incomplete": False,
+        }
 
     def _materialise_browse_entry(
         self, archive: Archive, entry_path: str, has_new_scheme: bool

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -799,6 +799,61 @@ class _NamespaceMixin:
 
         return result
 
+    def _materialise_paths(
+        self, archive: Archive, paths: List[str], *, log_label: str
+    ) -> List[Dict[str, Any]]:
+        """Run ``_materialise_browse_entry`` for each path, swallowing errors.
+
+        Shared between the new-scheme C / W paginators — both materialise
+        an already-known list of paths into the row dicts that
+        ``browse_namespace_data`` expects. ``log_label`` lets the warning
+        path identify which caller (C-range vs W-probe) produced the
+        failure for diagnostics.
+        """
+        out: List[Dict[str, Any]] = []
+        for entry_path in paths:
+            try:
+                materialised = self._materialise_browse_entry(
+                    archive, entry_path, has_new_scheme=True
+                )
+                if materialised is not None:
+                    out.append(materialised)
+            except Exception as e:
+                logger.warning(f"Error processing {log_label} entry {entry_path}: {e}")
+                continue
+        return out
+
+    @staticmethod
+    def _new_scheme_browse_payload(
+        *,
+        namespace: str,
+        total: int,
+        offset: int,
+        limit: int,
+        entries: List[Dict[str, Any]],
+        discovery_method: str,
+    ) -> Dict[str, Any]:
+        """Build the v2 Phase B browse-namespace inner payload shape.
+
+        Both the entry-id-range fast path (C) and the known-path probe
+        (W) produce authoritative totals with no sampling — every field
+        below is the same between them except ``discovery_method``,
+        so factor the dict to one place.
+        """
+        return {
+            "namespace": namespace,
+            "total_in_namespace": total,
+            "total_in_namespace_is_lower_bound": False,
+            "offset": offset,
+            "limit": limit,
+            "returned_count": len(entries),
+            "entries": entries,
+            "sampling_based": False,
+            "discovery_method": discovery_method,
+            "is_total_authoritative": True,
+            "results_may_be_incomplete": False,
+        }
+
     def _browse_new_scheme_c_paginated(
         self,
         archive: Archive,
@@ -817,7 +872,7 @@ class _NamespaceMixin:
         ``offset + returned_count >= total``.
         """
         total = int(getattr(archive, "entry_count", 0) or 0)
-        entries: List[Dict[str, Any]] = []
+        page_paths: List[str] = []
         end = min(offset + limit, total)
         for entry_id in range(offset, end):
             try:
@@ -825,28 +880,17 @@ class _NamespaceMixin:
             except Exception as e:
                 logger.warning(f"Error reading entry id {entry_id}: {e}")
                 continue
-            try:
-                materialised = self._materialise_browse_entry(
-                    archive, entry.path, has_new_scheme=True
-                )
-                if materialised is not None:
-                    entries.append(materialised)
-            except Exception as e:
-                logger.warning(f"Error processing entry {entry.path}: {e}")
-                continue
-        return {
-            "namespace": namespace,
-            "total_in_namespace": total,
-            "total_in_namespace_is_lower_bound": False,
-            "offset": offset,
-            "limit": limit,
-            "returned_count": len(entries),
-            "entries": entries,
-            "sampling_based": False,
-            "discovery_method": "entry_id_range",
-            "is_total_authoritative": True,
-            "results_may_be_incomplete": False,
-        }
+            page_paths.append(entry.path)
+        return self._new_scheme_browse_payload(
+            namespace=namespace,
+            total=total,
+            offset=offset,
+            limit=limit,
+            entries=self._materialise_paths(
+                archive, page_paths, log_label="C-namespace"
+            ),
+            discovery_method="entry_id_range",
+        )
 
     # Well-known W-namespace paths in new-scheme archives. libzim's
     # iterable surface doesn't expose W, but ``has_entry_by_path`` does.
@@ -887,32 +931,16 @@ class _NamespaceMixin:
                     present.append(path)
             except Exception as e:
                 logger.debug(f"has_entry_by_path probe failed for {path}: {e}")
-        total = len(present)
-        page = present[offset : offset + limit]
-        entries: List[Dict[str, Any]] = []
-        for entry_path in page:
-            try:
-                materialised = self._materialise_browse_entry(
-                    archive, entry_path, has_new_scheme=True
-                )
-                if materialised is not None:
-                    entries.append(materialised)
-            except Exception as e:
-                logger.warning(f"Error processing W entry {entry_path}: {e}")
-                continue
-        return {
-            "namespace": namespace,
-            "total_in_namespace": total,
-            "total_in_namespace_is_lower_bound": False,
-            "offset": offset,
-            "limit": limit,
-            "returned_count": len(entries),
-            "entries": entries,
-            "sampling_based": False,
-            "discovery_method": "known_path_probe",
-            "is_total_authoritative": True,
-            "results_may_be_incomplete": False,
-        }
+        return self._new_scheme_browse_payload(
+            namespace=namespace,
+            total=len(present),
+            offset=offset,
+            limit=limit,
+            entries=self._materialise_paths(
+                archive, present[offset : offset + limit], log_label="W-namespace"
+            ),
+            discovery_method="known_path_probe",
+        )
 
     def _materialise_browse_entry(
         self, archive: Archive, entry_path: str, has_new_scheme: bool

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -1565,25 +1565,34 @@ class _SearchMixin:
                     logger.debug(f"_find_entry_fast_path probe {full!r} failed: {e}")
         return None
 
+    # Alphabet used for insertion + substitution edits. ASCII a-z + a few
+    # common diacritics covers ~99% of Wikipedia titles in English-class
+    # archives. Trying the full unicode letter set would inflate the
+    # variant count by ~50× without proportional recall improvement.
+    _TYPO_ALPHABET = tuple("abcdefghijklmnopqrstuvwxyz")
+
     @staticmethod
     def _typo_variants(title: str) -> List[str]:
         """Yield single-edit variants of ``title`` for typo-tolerant lookup.
 
-        Targets the two most common keystroke errors that survive the
+        Targets the four most common keystroke errors that survive the
         case-variant fast path AND produce no libzim suggestions:
 
           * Adjacent character transposition — ``"Einstien"`` →
             ``"Einstein"`` (swap of ``i``/``e`` at positions 5-6).
-          * Single character deletion — ``"Phyton"`` → ``"Python"``
-            (extra ``h`` removed).
-
-        Substitutions and insertions are deliberately NOT generated —
-        the search space explodes (26× per character) and the false-
-        match rate becomes unacceptable for short titles.
+          * Single character deletion — ``"Pythoon"`` → ``"Python"``
+            (extra ``o`` removed).
+          * Single character insertion — ``"Photosythesis"`` →
+            ``"Photosynthesis"`` (missing ``n`` between ``y`` and ``t``).
+            This was the named regression target of Phase A #14.
+          * Single character substitution — ``"Wikipidia"`` →
+            ``"Wikipedia"`` (i → e at position 5).
 
         Variants are de-duplicated. Whitespace is preserved; the caller
         (the fast path) is responsible for the space→underscore
-        normalisation.
+        normalisation. Insertion/substitution are length-gated more
+        strictly than deletion because they each multiply the search
+        space by 26.
         """
         seen: set = {title}
         variants: List[str] = []
@@ -1608,6 +1617,41 @@ class _SearchMixin:
                 if v and v not in seen:
                     seen.add(v)
                     variants.append(v)
+
+        # Single character insertion (Phase A #14 named regression
+        # target: "Photosythesis" → "Photosynthesis"). Length-gated at
+        # 5+ chars to suppress 3-char query false positives ("cat" →
+        # "cats", "cart", etc.). We try the full ASCII a-z alphabet
+        # because the most common case — a missing letter — is by
+        # definition a letter NOT in the input ("Photosythesis" is
+        # missing 'n', which doesn't appear in the user's keystrokes).
+        # Variant count is bounded at ``26 × (n+1)`` for an n-char
+        # title; each variant is a B-tree lookup against the libzim
+        # path index, so even ~400 variants finish in <100ms.
+        if len(title) >= 5:
+            for i in range(len(title) + 1):
+                for c in _SearchMixin._TYPO_ALPHABET:
+                    v = title[:i] + c + title[i:]
+                    if v not in seen:
+                        seen.add(v)
+                        variants.append(v)
+
+        # Single character substitution — handles the wrong-key case
+        # ("Wikipidia" → "Wikipedia", i → e at position 5). Same length
+        # gate as insertion; full alphabet because the substituting
+        # letter is, by definition, NOT the one typed.
+        if len(title) >= 5:
+            for i in range(len(title)):
+                if not title[i].isalpha():
+                    continue
+                original = title[i].lower()
+                for c in _SearchMixin._TYPO_ALPHABET:
+                    if c == original:
+                        continue
+                    v = title[:i] + c + title[i + 1 :]
+                    if v not in seen:
+                        seen.add(v)
+                        variants.append(v)
 
         return variants
 

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -544,8 +544,19 @@ class _StructureMixin:
         section_id: str,
         *,
         max_chars: "Optional[int]" = None,
+        include_subsections: bool = True,
     ) -> "Union[GetSectionResponse, ToolErrorPayload]":
         """Public entry point for the get_section tool.
+
+        ``include_subsections`` (Op3): when ``True`` (the default), the
+        returned slice covers the requested section plus every nested
+        descendant (Geography → Geography + Topography + Climate, the
+        legacy behavior). When ``False``, the slice ends at the next
+        heading of *any* level, so a caller can fetch just the
+        Geography lead-paragraph without the H3 subsections it
+        contains. Small models that have already seen the TOC can
+        choose the subsection IDs directly; ``False`` lets them avoid
+        re-pulling the full sub-tree just to get a narrow span.
 
         Returns the typed response or a ToolErrorPayload on
         file-not-found / entry-not-found / section-not-found.
@@ -555,7 +566,12 @@ class _StructureMixin:
             validated_path = self.path_validator.validate_zim_file(validated_path)
             with _zim_ops_mod.zim_archive(validated_path) as archive:
                 return self._get_section_data(
-                    archive, validated_path, entry_path, section_id, max_chars
+                    archive,
+                    validated_path,
+                    entry_path,
+                    section_id,
+                    max_chars,
+                    include_subsections=include_subsections,
                 )
         except OpenZimMcpFileNotFoundError as e:
             return tool_error(operation="file_not_found", message=str(e))
@@ -569,6 +585,8 @@ class _StructureMixin:
         entry_path: str,
         section_id: str,
         max_chars: "Optional[int]",
+        *,
+        include_subsections: bool = True,
     ) -> "Union[GetSectionResponse, ToolErrorPayload]":
         """Build the bundle, find the section by id, and return GetSectionResponse.
 
@@ -584,11 +602,11 @@ class _StructureMixin:
             content_processor=self.content_processor,
         )
 
-        section = next(
-            (s for s in bundle["sections"] if s["id"] == section_id),
+        section_idx = next(
+            (i for i, s in enumerate(bundle["sections"]) if s["id"] == section_id),
             None,
         )
-        if section is None:
+        if section_idx is None:
             return tool_error(
                 operation="section_not_found",
                 message=(
@@ -597,10 +615,21 @@ class _StructureMixin:
                 ),
                 extras={"available_section_ids": [s["id"] for s in bundle["sections"]]},
             )
+        section = bundle["sections"][section_idx]
 
-        full_body = bundle["rendered_markdown"][
-            section["char_start"] : section["char_end"]
-        ]
+        # Op3: when ``include_subsections`` is False, narrow the slice
+        # so it ends at the next heading (any level), not at the next
+        # same-or-higher heading. Lets a caller fetch just the H2 lead
+        # paragraphs without the cascading H3 sub-tree. The legacy
+        # behavior (True) returns the full sub-tree.
+        char_end = section["char_end"]
+        if not include_subsections:
+            sections = bundle["sections"]
+            for sib in sections[section_idx + 1 :]:
+                if sib["char_start"] > section["char_start"]:
+                    char_end = min(char_end, sib["char_start"])
+                    break
+        full_body = bundle["rendered_markdown"][section["char_start"] : char_end]
         cap = (
             max_chars
             if max_chars is not None

--- a/tests/conftest_v2_fixtures.py
+++ b/tests/conftest_v2_fixtures.py
@@ -107,14 +107,27 @@ def capture_or_compare(
     goldens_dir.mkdir(parents=True, exist_ok=True)
     path = goldens_dir / f"{name}.json"
     if capture_mode or not path.exists():
+        # Explicit UTF-8 encoding so non-ASCII characters in goldens
+        # (em dashes, multiplication signs, accented entry titles) survive
+        # a round-trip on Windows runners. ``write_text`` without ``encoding=``
+        # picks ``locale.getpreferredencoding(False)``, which is ``cp1252``
+        # on default Windows; bytes outside cp1252's repertoire raise on
+        # write or surface as ``?`` mojibake.
         path.write_text(
             json.dumps(
                 strip_volatile(payload), indent=2, ensure_ascii=False, sort_keys=True
             ),
             newline="\n",
+            encoding="utf-8",
         )
         return
-    expected = json.loads(path.read_text())
+    # Matching ``encoding="utf-8"`` on the read side — the goldens are
+    # written as UTF-8 with ``ensure_ascii=False``, so any non-ASCII
+    # character (``×``, ``—``, accents) becomes mojibake when read with
+    # cp1252. Pre-fix, the Windows CI runners saw ``[Table 1: 15 rows
+    # � 2 cols � pass`` and diffed against the Mac/Linux-captured
+    # ``rows × 2 cols —``.
+    expected = json.loads(path.read_text(encoding="utf-8"))
     assert strip_volatile(payload) == strip_volatile(expected), (
         f"Golden mismatch for {name}. "
         "Set OPENZIM_MCP_CAPTURE_GOLDENS=1 to refresh after intentional changes."

--- a/tests/data/goldens/v2_phase_b/search_einstein_2.json
+++ b/tests/data/goldens/v2_phase_b/search_einstein_2.json
@@ -12,7 +12,7 @@
   "results": [
     {
       "path": "A/Einstein",
-      "snippet": "Born| 14 March 1879  \n---|---  \nDied| 18 April 1955  \nField| Theoretical physics  \n  \nAlbert **Einstein** was a German-born theoretical physicist. He developed the theory of relativity, one of the...",
+      "snippet": "Albert **Einstein** was a German-born theoretical physicist. He developed the theory of relativity, one of the two pillars of modern physics. [Table 1: 15 rows × 2 cols — pass compact=False to expand]",
       "title": "Einstein"
     }
   ],

--- a/tests/data/goldens/v2_phase_b/search_einstein_2.json
+++ b/tests/data/goldens/v2_phase_b/search_einstein_2.json
@@ -12,7 +12,7 @@
   "results": [
     {
       "path": "A/Einstein",
-      "snippet": "Albert **Einstein** was a German-born theoretical physicist. He developed the theory of relativity, one of the two pillars of modern physics. [Table 1: 15 rows × 2 cols — pass compact=False to expand]",
+      "snippet": "Albert **Einstein** was a German-born theoretical physicist. He developed the theory of relativity, one of the two pillars of modern physics. [Table 1: 15 rows x 2 cols - pass compact=False to expand]",
       "title": "Einstein"
     }
   ],

--- a/tests/data/goldens/v2_phase_c/synthesize_berlin_geography.json
+++ b/tests/data/goldens/v2_phase_c/synthesize_berlin_geography.json
@@ -2,30 +2,30 @@
   "_meta": {
     "truncated": false
   },
-  "answer_markdown": "# **Berlin** **Berlin** is the capital and largest city of Germany.\n[cite: v2_phase_c/A/Berlin]",
+  "answer_markdown": "**Berlin** is the capital and largest city of Germany. ## **Geography**\n[cite: v2_phase_c/A/Berlin#berlin]",
   "archives_searched": [
     "v2_phase_c"
   ],
   "citations": [
     {
       "archive": "v2_phase_c",
-      "cite_id": "v2_phase_c/A/Berlin",
+      "cite_id": "v2_phase_c/A/Berlin#berlin",
       "entry_path": "A/Berlin",
-      "section_id": null,
-      "section_title": null,
+      "section_id": "berlin",
+      "section_title": "Berlin",
       "title": "Berlin"
     }
   ],
   "fallback_used": "xapian_score",
   "passages": [
     {
-      "cite_id": "v2_phase_c/A/Berlin",
+      "cite_id": "v2_phase_c/A/Berlin#berlin",
       "rank": 1,
       "score": 1.0,
-      "text_markdown": "# **Berlin** **Berlin** is the capital and largest city of Germany."
+      "text_markdown": "**Berlin** is the capital and largest city of Germany. ## **Geography**"
     }
   ],
   "query": "berlin geography",
-  "total_chars": 95,
+  "total_chars": 106,
   "total_words": 13
 }

--- a/tests/data/goldens/v2_phase_c/synthesize_capital_city.json
+++ b/tests/data/goldens/v2_phase_c/synthesize_capital_city.json
@@ -2,30 +2,30 @@
   "_meta": {
     "truncated": false
   },
-  "answer_markdown": "Berlin is the **capital** and largest **city** of Germany. ## Geography\n[cite: v2_phase_c/A/Berlin]",
+  "answer_markdown": "Berlin is the **capital** and largest **city** of Germany. ## Geography\n[cite: v2_phase_c/A/Berlin#berlin]",
   "archives_searched": [
     "v2_phase_c"
   ],
   "citations": [
     {
       "archive": "v2_phase_c",
-      "cite_id": "v2_phase_c/A/Berlin",
+      "cite_id": "v2_phase_c/A/Berlin#berlin",
       "entry_path": "A/Berlin",
-      "section_id": null,
-      "section_title": null,
+      "section_id": "berlin",
+      "section_title": "Berlin",
       "title": "Berlin"
     }
   ],
   "fallback_used": "xapian_score",
   "passages": [
     {
-      "cite_id": "v2_phase_c/A/Berlin",
+      "cite_id": "v2_phase_c/A/Berlin#berlin",
       "rank": 1,
       "score": 1.0,
       "text_markdown": "Berlin is the **capital** and largest **city** of Germany. ## Geography"
     }
   ],
   "query": "capital city",
-  "total_chars": 99,
+  "total_chars": 106,
   "total_words": 13
 }

--- a/tests/data/goldens/v2_phase_c/synthesize_munich_history.json
+++ b/tests/data/goldens/v2_phase_c/synthesize_munich_history.json
@@ -2,30 +2,30 @@
   "_meta": {
     "truncated": false
   },
-  "answer_markdown": "# **Munich** **Munich** is the capital of Bavaria.\n[cite: v2_phase_c/A/Munich]",
+  "answer_markdown": "**Munich** is the capital of Bavaria. ## **History**\n[cite: v2_phase_c/A/Munich#munich]",
   "archives_searched": [
     "v2_phase_c"
   ],
   "citations": [
     {
       "archive": "v2_phase_c",
-      "cite_id": "v2_phase_c/A/Munich",
+      "cite_id": "v2_phase_c/A/Munich#munich",
       "entry_path": "A/Munich",
-      "section_id": null,
-      "section_title": null,
+      "section_id": "munich",
+      "section_title": "Munich",
       "title": "Munich"
     }
   ],
   "fallback_used": "xapian_score",
   "passages": [
     {
-      "cite_id": "v2_phase_c/A/Munich",
+      "cite_id": "v2_phase_c/A/Munich#munich",
       "rank": 1,
       "score": 1.0,
-      "text_markdown": "# **Munich** **Munich** is the capital of Bavaria."
+      "text_markdown": "**Munich** is the capital of Bavaria. ## **History**"
     }
   ],
   "query": "munich history",
-  "total_chars": 78,
+  "total_chars": 87,
   "total_words": 10
 }

--- a/tests/golden/compact_einstein.txt
+++ b/tests/golden/compact_einstein.txt
@@ -17,7 +17,7 @@ Type: text/html
 
 Albert Einstein was a German-born theoretical physicist. He developed the theory of relativity, one of the two pillars of modern physics.
 
-[Table 1: 15 rows × 2 cols — pass compact=False to expand]
+[Table 1: 15 rows x 2 cols - pass compact=False to expand]
 </retrieved_archive_content>
 
 > ~148 tokens

--- a/tests/golden/compact_multitable.txt
+++ b/tests/golden/compact_multitable.txt
@@ -13,11 +13,11 @@ Type: text/html
 
 Intro paragraph.
 
-[Table 1: 20 rows × 1 cols — pass compact=False to expand]
+[Table 1: 20 rows x 1 cols - pass compact=False to expand]
 
 Middle paragraph.
 
-[Table 2: 20 rows × 1 cols — pass compact=False to expand]
+[Table 2: 20 rows x 1 cols - pass compact=False to expand]
 </retrieved_archive_content>
 
 > ~121 tokens

--- a/tests/test_content_processor_fixes_v2a7.py
+++ b/tests/test_content_processor_fixes_v2a7.py
@@ -58,6 +58,25 @@ def test_highlight_skips_inside_link_text_and_url():
     assert "**Photosynthesis**" not in out
 
 
+def test_highlight_still_bolds_inside_plain_parentheticals():
+    """A query term inside a non-link parenthetical IS still bolded.
+
+    Regression: an earlier shape matched ``\\([^\\n)]*\\)`` globally,
+    which protected ordinary prose parentheticals like
+    ``(also called assimilation)`` from highlighting too. Wikipedia
+    scientific prose is loaded with parenthetical gloss — over-
+    protecting them dropped query-term visibility on a substantial
+    fraction of search hits."""
+    text = "Photosynthesis (also called photosynthesis-2) is a process."
+    out = _highlight_terms(text, "photosynthesis", max_hits=5)
+    # First occurrence (outside parens) is bolded.
+    assert out.startswith("**Photosynthesis**")
+    # Second occurrence (inside a plain parenthetical) is ALSO bolded —
+    # the parenthetical isn't an [text](url) construct, so it's not a
+    # protected region.
+    assert "**photosynthesis-2**" in out or "**photosynthesis**" in out[10:]
+
+
 def test_highlight_still_bolds_plain_occurrences():
     """Plain query-term occurrences outside emphasis are still bolded."""
     text = "Photosynthesis converts CO2 into sugars."
@@ -195,6 +214,61 @@ def test_hatnote_stripped():
     rendered = proc.html_to_plain_text(html, compact=True)
     assert "Mercury (disambiguation)" not in rendered
     assert "smallest planet" in rendered
+
+
+NESTED_TABLE_INFOBOX_HTML = """
+<table class="infobox">
+  <tr><th colspan="2">Album Title</th></tr>
+  <tr><th>Artist</th><td>Some Band</td></tr>
+  <tr>
+    <td colspan="2">
+      <table>
+        <tr><th>prev</th><td>Old Album</td></tr>
+        <tr><th>next</th><td>New Album</td></tr>
+      </table>
+    </td>
+  </tr>
+  <tr><th>Released</th><td>1979</td></tr>
+</table>
+"""
+
+
+def test_infobox_skips_nested_table_rows():
+    """Wikipedia infoboxes frequently embed nested tables (chronology,
+    coordinates, sub-components). A naive ``select('tr')`` walks INTO
+    those nested tables and pulls their rows into the KV list as if
+    they were primary infobox fields. The nested-table guard restricts
+    rows to those whose direct table ancestor is the infobox itself."""
+    soup = BeautifulSoup(NESTED_TABLE_INFOBOX_HTML, "html.parser")
+    proc = ContentProcessor()
+    rows = proc.extract_infobox(soup)
+    labels = [r["label"] for r in rows]
+    assert "Artist" in labels
+    assert "Released" in labels
+    # The nested-table rows must NOT leak into the primary KV list.
+    assert "prev" not in labels
+    assert "next" not in labels
+
+
+def test_inline_reference_markers_stripped():
+    """``<sup class="reference">[1]</sup>`` markers between prose words
+    render as bare ``[1]`` noise after html2text. Stripping them at the
+    HTML level removes the citation noise from snippets and bodies."""
+    html = (
+        "<html><body>"
+        "<h1>Topic</h1>"
+        "<p>The first observation"
+        "<sup class='reference'><a href='#cite_note-1'>[1]</a></sup>"
+        " was made in 1879<sup class='reference'>[2]</sup>.</p>"
+        "</body></html>"
+    )
+    proc = ContentProcessor()
+    rendered = proc.html_to_plain_text(html, compact=True)
+    # The reference text MUST be gone so the snippet density goes up.
+    assert "[1]" not in rendered
+    assert "[2]" not in rendered
+    # The prose is preserved end-to-end.
+    assert "The first observation was made in 1879." in rendered
 
 
 def test_sidebar_stripped():

--- a/tests/test_content_processor_fixes_v2a7.py
+++ b/tests/test_content_processor_fixes_v2a7.py
@@ -50,10 +50,10 @@ def test_highlight_skips_inside_italic():
 
 def test_highlight_skips_inside_link_text_and_url():
     """A query term inside a markdown link's text OR URL must not get bolded."""
-    text = "see [Photosynthesis](Photosynthesis \"Photosynthesis\")"
+    text = 'see [Photosynthesis](Photosynthesis "Photosynthesis")'
     out = _highlight_terms(text, "photosynthesis", max_hits=5)
     # Link must remain a valid ``[text](href "tooltip")`` construct.
-    assert "[Photosynthesis](Photosynthesis \"Photosynthesis\")" in out
+    assert '[Photosynthesis](Photosynthesis "Photosynthesis")' in out
     # No bold inside the link.
     assert "**Photosynthesis**" not in out
 

--- a/tests/test_content_processor_fixes_v2a7.py
+++ b/tests/test_content_processor_fixes_v2a7.py
@@ -1,0 +1,217 @@
+"""Tests for the v2.0.0a7 content_processor fixes.
+
+Covers:
+  * D4 — ``_highlight_terms`` skips matches inside existing markdown
+    emphasis or link constructs so we don't produce
+    ``**Artificial **photosynthesis****``-style malformed markdown.
+  * Op1 — ``create_snippet(title=...)`` strips a leading ``# <title>``
+    H1 that duplicates the entry title.
+  * Op5 — infobox extraction prefixes labels with their parent section
+    header so a row labelled ``City/State`` carries ``Area`` /
+    ``Government`` / ``Population`` disambiguation.
+  * Op6 — UNWANTED_HTML_SELECTORS strips ``figure`` /
+    ``figcaption`` / ``.hatnote`` / ``.sidebar`` so the rendered article
+    body leads with the actual prose, not the image caption or the
+    "For other uses, see X" hatnote.
+  * D13 — ``create_snippet`` falls back to a substring match when no
+    whole-word match is found, capturing morphological variants
+    (``photosynthetic`` for query ``photosynthesis``).
+"""
+
+from bs4 import BeautifulSoup
+
+from openzim_mcp.content_processor import (
+    ContentProcessor,
+    _highlight_terms,
+)
+
+
+def test_highlight_skips_inside_existing_bold():
+    """A query term inside ``**...**`` must not get a second bold layer."""
+    text = "**Artificial photosynthesis** is a chemical process."
+    out = _highlight_terms(text, "photosynthesis", max_hits=5)
+    # Must NOT produce ``**Artificial **photosynthesis****`` — the inner
+    # wrap would create unmatched ``****`` runs.
+    assert "**Artificial **" not in out
+    assert "****" not in out
+    # The original bold span is preserved verbatim.
+    assert "**Artificial photosynthesis**" in out
+
+
+def test_highlight_skips_inside_italic():
+    """A query term inside ``_..._`` must not get bolded."""
+    text = "_Photosynthesis_ in Wiktionary."
+    out = _highlight_terms(text, "photosynthesis", max_hits=5)
+    # The italic run is preserved untouched.
+    assert "_Photosynthesis_" in out
+    # No nested bold inside the italic.
+    assert "_**Photosynthesis**_" not in out
+
+
+def test_highlight_skips_inside_link_text_and_url():
+    """A query term inside a markdown link's text OR URL must not get bolded."""
+    text = "see [Photosynthesis](Photosynthesis \"Photosynthesis\")"
+    out = _highlight_terms(text, "photosynthesis", max_hits=5)
+    # Link must remain a valid ``[text](href "tooltip")`` construct.
+    assert "[Photosynthesis](Photosynthesis \"Photosynthesis\")" in out
+    # No bold inside the link.
+    assert "**Photosynthesis**" not in out
+
+
+def test_highlight_still_bolds_plain_occurrences():
+    """Plain query-term occurrences outside emphasis are still bolded."""
+    text = "Photosynthesis converts CO2 into sugars."
+    out = _highlight_terms(text, "photosynthesis", max_hits=5)
+    assert out.startswith("**Photosynthesis**")
+
+
+def test_highlight_mixed_case():
+    """An emphasis-protected match and a plain match coexist correctly."""
+    text = "**Artificial Photosynthesis** mimics Photosynthesis in plants."
+    out = _highlight_terms(text, "photosynthesis", max_hits=5)
+    # First "Photosynthesis" sits inside ``**...**`` → untouched.
+    # Second "Photosynthesis" is plain prose → bolded.
+    assert "**Artificial Photosynthesis**" in out
+    # Count bold markers around the plain occurrence: that's one new pair
+    # added beyond the original two markers of the bold span.
+    assert out.count("**") == 4
+
+
+def test_create_snippet_strips_leading_title_h1():
+    """``title=Berlin`` strips ``# Berlin`` from the start of the content."""
+    content = "# Berlin\n\nBerlin is the capital of Germany."
+    proc = ContentProcessor()
+    snippet = proc.create_snippet(content, query="capital", title="Berlin")
+    # H1 line is gone; the lead sentence is preserved.
+    assert not snippet.startswith("# Berlin")
+    assert "Berlin is the **capital** of Germany." in snippet
+
+
+def test_create_snippet_keeps_non_matching_h1():
+    """An H1 that doesn't match the title is left alone (no query, so the
+    snippet starts at paragraph 0 — the H1)."""
+    content = "# Geography\n\nThe topography is flat."
+    proc = ContentProcessor()
+    snippet = proc.create_snippet(content, title="Berlin")
+    # Heading is unrelated to title → stays.
+    assert "# Geography" in snippet
+
+
+def test_create_snippet_title_match_case_insensitive():
+    """Title match is case-insensitive so casing drift between fields doesn't leak."""
+    content = "# berlin\n\nLead paragraph."
+    proc = ContentProcessor()
+    snippet = proc.create_snippet(content, title="Berlin")
+    assert "# berlin" not in snippet
+    assert "Lead paragraph." in snippet
+
+
+def test_create_snippet_substring_fallback_picks_inflected_paragraph():
+    """When no whole-word query match is found, substring match catches
+    inflected forms instead of falling back to the lead paragraph."""
+    content = (
+        "Govindjee\n\nGovindjee was a botanist.\n\n"
+        "He studied photosynthetic activity in plants."
+    )
+    proc = ContentProcessor()
+    snippet = proc.create_snippet(content, query="photosynthesis")
+    # Phase A #1 says: pick a paragraph that mentions the query term. With
+    # only the substring "photosynthet" present (a morphological form),
+    # the legacy code dropped to the lead ("Govindjee was a botanist.").
+    # D13 fix: substring fallback picks the photosynthetic-bearing paragraph.
+    assert "photosynthetic" in snippet
+    assert "botanist" not in snippet
+
+
+WIKI_INFOBOX_WITH_SECTIONS = """
+<table class="infobox">
+  <tr><th colspan="2">Berlin</th></tr>
+  <tr><th colspan="2">Government</th></tr>
+  <tr><th>Governing Mayor</th><td>Kai Wegner</td></tr>
+  <tr><th colspan="2">Area</th></tr>
+  <tr><th>City/State</th><td>891.3 km2</td></tr>
+  <tr><th colspan="2">Population</th></tr>
+  <tr><th>City/State</th><td>3,913,644</td></tr>
+</table>
+"""
+
+
+def test_infobox_disambiguates_repeated_label_via_section():
+    """When the same label (``City/State``) repeats under different
+    section headers, the extracted rows carry the parent context so a
+    small model can tell them apart."""
+    soup = BeautifulSoup(WIKI_INFOBOX_WITH_SECTIONS, "html.parser")
+    proc = ContentProcessor()
+    rows = proc.extract_infobox(soup)
+    labels = [r["label"] for r in rows]
+    # First ``City/State`` is under Area; second under Population.
+    assert "Area — City/State" in labels
+    assert "Population — City/State" in labels
+    # Governing Mayor inherits "Government" context.
+    assert "Government — Governing Mayor" in labels
+
+
+def test_infobox_skips_title_row():
+    """The first ``<th>``-only row (article title duplicate) is not
+    emitted as a label even when it has no explicit ``infobox-above``
+    class. Without this, the title leaks into every row's label
+    prefix."""
+    soup = BeautifulSoup(WIKI_INFOBOX_WITH_SECTIONS, "html.parser")
+    proc = ContentProcessor()
+    rows = proc.extract_infobox(soup)
+    for r in rows:
+        assert not r["label"].startswith("Berlin —")
+
+
+def test_figure_and_figcaption_stripped():
+    """Image captions sit between the H1 and the lead paragraph in
+    Wikipedia exports; stripping ``figure`` / ``figcaption`` removes the
+    "Schematic of …" noise that was leading every snippet."""
+    html = (
+        "<html><body>"
+        "<h1>Photosynthesis</h1>"
+        "<figure><figcaption>Schematic of photosynthesis</figcaption></figure>"
+        "<p>Photosynthesis is the biological process that converts light "
+        "into chemical energy.</p>"
+        "</body></html>"
+    )
+    proc = ContentProcessor()
+    rendered = proc.html_to_plain_text(html, compact=True)
+    assert "Schematic of photosynthesis" not in rendered
+    assert "biological process" in rendered
+
+
+def test_hatnote_stripped():
+    """Disambiguation hatnotes ("For other uses, see X") leak ahead of
+    the lead paragraph; strip them so the lead bubbles to the top."""
+    html = (
+        "<html><body>"
+        "<h1>Mercury</h1>"
+        "<div class='hatnote'>For other uses, see Mercury (disambiguation).</div>"
+        "<p>Mercury is the smallest planet in the Solar System.</p>"
+        "</body></html>"
+    )
+    proc = ContentProcessor()
+    rendered = proc.html_to_plain_text(html, compact=True)
+    assert "Mercury (disambiguation)" not in rendered
+    assert "smallest planet" in rendered
+
+
+def test_sidebar_stripped():
+    """The "Part of a series on …" right-rail nav is pure pipe-soup
+    noise; strip it via the ``.sidebar`` selector so it doesn't crowd
+    the lead."""
+    html = (
+        "<html><body>"
+        "<h1>Quantum entanglement</h1>"
+        "<div class='sidebar'>"
+        "<table><tr><th>Quantum mechanics</th></tr>"
+        "<tr><td>Schrödinger equation</td></tr></table>"
+        "</div>"
+        "<p>Quantum entanglement is the phenomenon wherein two particles share a state.</p>"
+        "</body></html>"
+    )
+    proc = ContentProcessor()
+    rendered = proc.html_to_plain_text(html, compact=True)
+    assert "Schrödinger equation" not in rendered
+    assert "phenomenon wherein two particles" in rendered

--- a/tests/test_typo_variants_v2a7.py
+++ b/tests/test_typo_variants_v2a7.py
@@ -1,0 +1,79 @@
+"""Tests for the v2.0.0a7 expansion of ``_typo_variants``.
+
+Phase A #14 named ``"Photosythesis" → "Photosynthesis"`` as the explicit
+regression target. v2.0.0a4 shipped only transposition + deletion edits,
+which mathematically cannot reach the target (the missing 'n' requires
+INSERTION). v2.0.0a7 adds insertion + substitution against the full a-z
+alphabet so all four single-edit cases are reachable.
+"""
+
+from openzim_mcp.zim.search import _SearchMixin
+
+
+def test_insertion_reaches_phase_a_named_target():
+    """Photosythesis → Photosynthesis (missing 'n', insertion edit)."""
+    variants = _SearchMixin._typo_variants("Photosythesis")
+    assert "Photosynthesis" in variants
+
+
+def test_insertion_handles_deletion_typo_in_long_word():
+    """Photosynthsis → Photosynthesis (missing 'e', insertion edit)."""
+    variants = _SearchMixin._typo_variants("Photosynthsis")
+    assert "Photosynthesis" in variants
+
+
+def test_substitution_handles_wrong_key():
+    """Wikipidia → Wikipedia (i → e at position 5, substitution)."""
+    variants = _SearchMixin._typo_variants("Wikipidia")
+    assert "Wikipedia" in variants
+
+
+def test_transposition_still_works():
+    """Einstien → Einstein (transposition; pre-existing behavior)."""
+    variants = _SearchMixin._typo_variants("Einstien")
+    assert "Einstein" in variants
+
+
+def test_deletion_still_works():
+    """Pythoon → Python (extra 'o' removed; deletion edit)."""
+    variants = _SearchMixin._typo_variants("Pythoon")
+    assert "Python" in variants
+
+
+def test_short_query_skips_expensive_edits():
+    """4-char inputs skip insertion/substitution to keep cost bounded.
+
+    Transposition (cheap, n-1 variants) is still applied; insertion and
+    substitution (26n each) are gated to ``len >= 5`` so short queries
+    like ``"DNA "`` don't blow up the variant count.
+    """
+    # 4-char input
+    variants = _SearchMixin._typo_variants("Test")
+    # Transposition: "etst", "Tset", "Tets" (some equal to original or
+    # skipped due to no-op rule).
+    # Insertion/substitution must not run → variant count stays modest.
+    assert len(variants) < 30, (
+        f"Short query produced {len(variants)} variants — gate broken"
+    )
+
+
+def test_variant_count_bounded():
+    """Long query stays within the documented ~700-variant budget."""
+    variants = _SearchMixin._typo_variants("Photosythesis")
+    # 13 chars: transposition (~12) + deletion (~13) + insertion
+    # (26 × 14 = 364) + substitution (~26 × 13 = 338) - dedupe = ~700.
+    # Cap-check at 800 leaves headroom for de-dup variations.
+    assert len(variants) < 800
+
+
+def test_variants_deduplicated():
+    """``set(variants) == variants`` after generation — no duplicates."""
+    variants = _SearchMixin._typo_variants("Photosythesis")
+    assert len(set(variants)) == len(variants)
+
+
+def test_original_input_not_in_variants():
+    """The input itself is never emitted as a variant."""
+    title = "Photosythesis"
+    variants = _SearchMixin._typo_variants(title)
+    assert title not in variants

--- a/tests/test_typo_variants_v2a7.py
+++ b/tests/test_typo_variants_v2a7.py
@@ -7,6 +7,10 @@ INSERTION). v2.0.0a7 adds insertion + substitution against the full a-z
 alphabet so all four single-edit cases are reachable.
 """
 
+import time
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
 from openzim_mcp.zim.search import _SearchMixin
 
 
@@ -77,3 +81,157 @@ def test_original_input_not_in_variants():
     title = "Photosythesis"
     variants = _SearchMixin._typo_variants(title)
     assert title not in variants
+
+
+def test_typo_variants_runs_in_reasonable_time():
+    """700-variant generation finishes in well under 100ms on commodity
+    hardware. Guards against accidental quadratic regressions in the
+    insertion / substitution loops."""
+    start = time.perf_counter()
+    for _ in range(10):
+        _SearchMixin._typo_variants("Photosynthesis")
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    # 10 iterations on a ~14-char input. 100ms total = 10ms per call.
+    # The earlier transposition-only path ran in <1ms; bumping the
+    # budget to 100ms for full alphabet edits leaves ample headroom.
+    assert elapsed_ms < 100, f"_typo_variants too slow: {elapsed_ms:.0f}ms / 10 calls"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: insertion-variant typo fallback through find_entry_by_title_data
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _ctx(value):
+    """Mimic ``zim_archive`` context-manager shape for monkeypatching."""
+    yield value
+
+
+def test_photosythesis_resolves_to_photosynthesis_via_typo_fallback(
+    test_config, monkeypatch
+):
+    """Full-stack test of the named Phase A #14 regression target.
+
+    Wires a mock archive whose ``has_entry_by_path`` returns True only for
+    ``C/Photosynthesis`` and ``A/Photosynthesis`` — i.e. the canonical
+    entry — and ``get_entry_by_path`` returns a matching entry. The
+    suggestion searcher returns nothing (mirroring the live behaviour
+    we measured against the real Wikipedia archive).
+
+    The expected flow:
+      1. fast path probes ``C/Photosythesis`` (etc.) → miss
+      2. ``SuggestionSearcher`` returns nothing → miss
+      3. ``_find_entry_typo_fallback`` generates ~700 variants
+      4. Among them is ``Photosynthesis`` (single-character insertion of 'n')
+      5. ``_find_entry_fast_path(archive, "Photosynthesis")`` hits
+         ``C/Photosynthesis`` → fuzzy_path_hit = True
+      6. The response surfaces the canonical entry with the
+         ``typo_corrected`` match_type and the alt-spelling suggestion.
+    """
+    from openzim_mcp.server import OpenZimMcpServer
+
+    server = OpenZimMcpServer(test_config)
+
+    mock_archive = MagicMock()
+    valid_paths = {"C/Photosynthesis", "A/Photosynthesis"}
+    mock_archive.has_entry_by_path.side_effect = lambda p: p in valid_paths
+    mock_entry = MagicMock()
+    mock_entry.path = "C/Photosynthesis"
+    mock_entry.title = "Photosynthesis"
+    mock_archive.get_entry_by_path.return_value = mock_entry
+
+    mock_suggest = MagicMock()
+    mock_suggest.getEstimatedMatches.return_value = 0
+    mock_suggest.getResults.return_value = []
+    mock_searcher = MagicMock()
+    mock_searcher.suggest.return_value = mock_suggest
+
+    monkeypatch.setattr(
+        "openzim_mcp.zim_operations.SuggestionSearcher",
+        lambda archive: mock_searcher,
+    )
+    monkeypatch.setattr(
+        "openzim_mcp.zim_operations.zim_archive",
+        lambda *a, **kw: _ctx(mock_archive),
+    )
+    # Bypass path-validator (the test uses a fake test zim path).
+    monkeypatch.setattr(
+        server.zim_operations.path_validator,
+        "validate_path",
+        lambda p: __import__("pathlib").Path(p),
+    )
+    monkeypatch.setattr(
+        server.zim_operations.path_validator,
+        "validate_zim_file",
+        lambda p: p,
+    )
+
+    result = server.zim_operations.find_entry_by_title_data(
+        "/fake/test.zim", "Photosythesis", cross_file=False, limit=10
+    )
+
+    # The whole point: the named-target typo MUST resolve.
+    assert (
+        result["fuzzy_path_hit"] is True
+    ), "Photosythesis → Photosynthesis must resolve via the insertion-variant typo fallback"
+    assert len(result["results"]) >= 1
+    hit = result["results"][0]
+    assert hit["path"] == "C/Photosynthesis"
+    assert hit["title"] == "Photosynthesis"
+    assert hit.get("match_type") == "typo_corrected"
+    # The applied correction surfaces as an alt_spelling suggestion so a
+    # caller can verify what auto-correct decision was made.
+    meta = result.get("_meta", {})
+    suggestions = meta.get("suggestions") or []
+    assert any(
+        s.get("type") == "alt_spelling" and "Photosynthesis" in s.get("value", "")
+        for s in suggestions
+    ), f"Expected alt_spelling=Photosynthesis in suggestions, got {suggestions!r}"
+
+
+def test_photosynthsis_deletion_also_resolves(test_config, monkeypatch):
+    """``Photosynthsis`` (missing 'e' — a deletion typo) should also
+    reach ``Photosynthesis`` via the insertion edit."""
+    from openzim_mcp.server import OpenZimMcpServer
+
+    server = OpenZimMcpServer(test_config)
+
+    mock_archive = MagicMock()
+    valid_paths = {"C/Photosynthesis"}
+    mock_archive.has_entry_by_path.side_effect = lambda p: p in valid_paths
+    mock_entry = MagicMock()
+    mock_entry.path = "C/Photosynthesis"
+    mock_entry.title = "Photosynthesis"
+    mock_archive.get_entry_by_path.return_value = mock_entry
+
+    mock_suggest = MagicMock()
+    mock_suggest.getEstimatedMatches.return_value = 0
+    mock_suggest.getResults.return_value = []
+    mock_searcher = MagicMock()
+    mock_searcher.suggest.return_value = mock_suggest
+
+    monkeypatch.setattr(
+        "openzim_mcp.zim_operations.SuggestionSearcher",
+        lambda archive: mock_searcher,
+    )
+    monkeypatch.setattr(
+        "openzim_mcp.zim_operations.zim_archive",
+        lambda *a, **kw: _ctx(mock_archive),
+    )
+    monkeypatch.setattr(
+        server.zim_operations.path_validator,
+        "validate_path",
+        lambda p: __import__("pathlib").Path(p),
+    )
+    monkeypatch.setattr(
+        server.zim_operations.path_validator,
+        "validate_zim_file",
+        lambda p: p,
+    )
+
+    result = server.zim_operations.find_entry_by_title_data(
+        "/fake/test.zim", "Photosynthsis", cross_file=False, limit=10
+    )
+    assert result["fuzzy_path_hit"] is True
+    assert result["results"][0]["path"] == "C/Photosynthesis"

--- a/tests/test_typo_variants_v2a7.py
+++ b/tests/test_typo_variants_v2a7.py
@@ -108,6 +108,62 @@ def _ctx(value):
     yield value
 
 
+def _wire_typo_fallback_archive(
+    test_config,
+    monkeypatch,
+    *,
+    valid_paths: set,
+    entry_path: str,
+    entry_title: str,
+):
+    """Build a server with a mock archive whose ``has_entry_by_path``
+    succeeds only for ``valid_paths``, returns ``entry_path`` /
+    ``entry_title`` on a hit, and whose ``SuggestionSearcher`` always
+    misses. Bypasses the path validator. Returns the configured
+    server so the test can call ``find_entry_by_title_data`` directly.
+
+    Shared between the insertion-typo and deletion-typo regression
+    tests; SonarCloud's duplication detector treats the per-test
+    inline setup as new-code duplication on PRs.
+    """
+    from openzim_mcp.server import OpenZimMcpServer
+
+    server = OpenZimMcpServer(test_config)
+
+    mock_archive = MagicMock()
+    mock_archive.has_entry_by_path.side_effect = lambda p: p in valid_paths
+    mock_entry = MagicMock()
+    mock_entry.path = entry_path
+    mock_entry.title = entry_title
+    mock_archive.get_entry_by_path.return_value = mock_entry
+
+    mock_suggest = MagicMock()
+    mock_suggest.getEstimatedMatches.return_value = 0
+    mock_suggest.getResults.return_value = []
+    mock_searcher = MagicMock()
+    mock_searcher.suggest.return_value = mock_suggest
+
+    monkeypatch.setattr(
+        "openzim_mcp.zim_operations.SuggestionSearcher",
+        lambda archive: mock_searcher,
+    )
+    monkeypatch.setattr(
+        "openzim_mcp.zim_operations.zim_archive",
+        lambda *a, **kw: _ctx(mock_archive),
+    )
+    monkeypatch.setattr(
+        server.zim_operations.path_validator,
+        "validate_path",
+        lambda p: __import__("pathlib").Path(p),
+    )
+    monkeypatch.setattr(
+        server.zim_operations.path_validator,
+        "validate_zim_file",
+        lambda p: p,
+    )
+    return server
+
+
 def test_photosythesis_resolves_to_photosynthesis_via_typo_fallback(
     test_config, monkeypatch
 ):
@@ -129,42 +185,12 @@ def test_photosythesis_resolves_to_photosynthesis_via_typo_fallback(
       6. The response surfaces the canonical entry with the
          ``typo_corrected`` match_type and the alt-spelling suggestion.
     """
-    from openzim_mcp.server import OpenZimMcpServer
-
-    server = OpenZimMcpServer(test_config)
-
-    mock_archive = MagicMock()
-    valid_paths = {"C/Photosynthesis", "A/Photosynthesis"}
-    mock_archive.has_entry_by_path.side_effect = lambda p: p in valid_paths
-    mock_entry = MagicMock()
-    mock_entry.path = "C/Photosynthesis"
-    mock_entry.title = "Photosynthesis"
-    mock_archive.get_entry_by_path.return_value = mock_entry
-
-    mock_suggest = MagicMock()
-    mock_suggest.getEstimatedMatches.return_value = 0
-    mock_suggest.getResults.return_value = []
-    mock_searcher = MagicMock()
-    mock_searcher.suggest.return_value = mock_suggest
-
-    monkeypatch.setattr(
-        "openzim_mcp.zim_operations.SuggestionSearcher",
-        lambda archive: mock_searcher,
-    )
-    monkeypatch.setattr(
-        "openzim_mcp.zim_operations.zim_archive",
-        lambda *a, **kw: _ctx(mock_archive),
-    )
-    # Bypass path-validator (the test uses a fake test zim path).
-    monkeypatch.setattr(
-        server.zim_operations.path_validator,
-        "validate_path",
-        lambda p: __import__("pathlib").Path(p),
-    )
-    monkeypatch.setattr(
-        server.zim_operations.path_validator,
-        "validate_zim_file",
-        lambda p: p,
+    server = _wire_typo_fallback_archive(
+        test_config,
+        monkeypatch,
+        valid_paths={"C/Photosynthesis", "A/Photosynthesis"},
+        entry_path="C/Photosynthesis",
+        entry_title="Photosynthesis",
     )
 
     result = server.zim_operations.find_entry_by_title_data(
@@ -193,43 +219,13 @@ def test_photosythesis_resolves_to_photosynthesis_via_typo_fallback(
 def test_photosynthsis_deletion_also_resolves(test_config, monkeypatch):
     """``Photosynthsis`` (missing 'e' — a deletion typo) should also
     reach ``Photosynthesis`` via the insertion edit."""
-    from openzim_mcp.server import OpenZimMcpServer
-
-    server = OpenZimMcpServer(test_config)
-
-    mock_archive = MagicMock()
-    valid_paths = {"C/Photosynthesis"}
-    mock_archive.has_entry_by_path.side_effect = lambda p: p in valid_paths
-    mock_entry = MagicMock()
-    mock_entry.path = "C/Photosynthesis"
-    mock_entry.title = "Photosynthesis"
-    mock_archive.get_entry_by_path.return_value = mock_entry
-
-    mock_suggest = MagicMock()
-    mock_suggest.getEstimatedMatches.return_value = 0
-    mock_suggest.getResults.return_value = []
-    mock_searcher = MagicMock()
-    mock_searcher.suggest.return_value = mock_suggest
-
-    monkeypatch.setattr(
-        "openzim_mcp.zim_operations.SuggestionSearcher",
-        lambda archive: mock_searcher,
+    server = _wire_typo_fallback_archive(
+        test_config,
+        monkeypatch,
+        valid_paths={"C/Photosynthesis"},
+        entry_path="C/Photosynthesis",
+        entry_title="Photosynthesis",
     )
-    monkeypatch.setattr(
-        "openzim_mcp.zim_operations.zim_archive",
-        lambda *a, **kw: _ctx(mock_archive),
-    )
-    monkeypatch.setattr(
-        server.zim_operations.path_validator,
-        "validate_path",
-        lambda p: __import__("pathlib").Path(p),
-    )
-    monkeypatch.setattr(
-        server.zim_operations.path_validator,
-        "validate_zim_file",
-        lambda p: p,
-    )
-
     result = server.zim_operations.find_entry_by_title_data(
         "/fake/test.zim", "Photosynthsis", cross_file=False, limit=10
     )

--- a/tests/test_typo_variants_v2a7.py
+++ b/tests/test_typo_variants_v2a7.py
@@ -56,9 +56,9 @@ def test_short_query_skips_expensive_edits():
     # Transposition: "etst", "Tset", "Tets" (some equal to original or
     # skipped due to no-op rule).
     # Insertion/substitution must not run → variant count stays modest.
-    assert len(variants) < 30, (
-        f"Short query produced {len(variants)} variants — gate broken"
-    )
+    assert (
+        len(variants) < 30
+    ), f"Short query produced {len(variants)} variants — gate broken"
 
 
 def test_variant_count_bounded():

--- a/tests/test_v2a7_fixes_helpers.py
+++ b/tests/test_v2a7_fixes_helpers.py
@@ -4,16 +4,21 @@ These tests use fixture data only (no live ZIM file) and exercise the
 helper-level contracts that the v2.0.0a7 fixes introduce:
 
   * D2/D3 — new-scheme C / W namespace paging via dedicated paths.
+  * D5  — synthesize strips intent-shaped NL prefix from the search query.
+  * D6  — tell_me_about promotes a title-index 1.0 score over BM25 hits.
+  * D8  — synthesize section attribution survives bold-marker insertion.
+  * D10 — zim_query.cursor decodes to options["offset"].
   * D11 — metadata previews cap at 800 chars + ``[truncated, …]`` marker.
-  * D8 — synthesize section attribution survives bold-marker insertion.
+  * Op2 — compact-structure renderer carries per-heading summary.
   * Op3 — get_section honors ``include_subsections=False`` by ending
     the slice at the next heading of any level.
-  * Op2 — compact-structure renderer carries per-heading summary.
 """
 
 from __future__ import annotations
 
+import base64
 import json
+from unittest.mock import MagicMock
 
 from openzim_mcp.compact_renderers import compact_structure_payload
 from openzim_mcp.synthesize import _locate_passage, _strip_bold
@@ -143,3 +148,283 @@ def test_intent_parser_plain_section_no_narrow_flag():
     parser = IntentParser()
     _intent, params, _confidence = parser.parse_intent("section Geography of Berlin")
     assert params.get("narrow") in (None, False)
+
+
+# ---------------------------------------------------------------------------
+# D5: synthesize strips the natural-language interrogative prefix BEFORE
+# handing the query to the search stage
+# ---------------------------------------------------------------------------
+
+
+def test_synthesize_strips_tell_me_about_prefix(test_config, monkeypatch):
+    """``synthesize=True`` with ``"tell me about Berlin"`` MUST pass
+    just ``"Berlin"`` to the search backend — otherwise BM25 matches on
+    ``tell``/``me``/``about`` and returns Irving Berlin songs instead
+    of the canonical Berlin article."""
+    from openzim_mcp.server import OpenZimMcpServer
+    from openzim_mcp.simple_tools import SimpleToolsHandler
+
+    server = OpenZimMcpServer(test_config)
+    if server.simple_tools_handler is None:
+        # ``test_config`` opens advanced mode; the simple-mode handler
+        # we want to exercise has to be constructed explicitly.
+        server.simple_tools_handler = SimpleToolsHandler(server.zim_operations)
+    captured_query: dict = {}
+
+    def fake_synthesize(query, **kwargs):
+        captured_query["search_query"] = query
+        captured_query["original_query"] = kwargs.get("original_query")
+        return {
+            "query": kwargs.get("original_query") or query,
+            "answer_markdown": "",
+            "passages": [],
+            "citations": [],
+            "archives_searched": [],
+            "fallback_used": "xapian_score",
+            "total_chars": 0,
+            "total_words": 0,
+            "_meta": {},
+        }
+
+    monkeypatch.setattr("openzim_mcp.synthesize.synthesize_query", fake_synthesize)
+    # Skip the archive-resolution machinery: pretend there's one
+    # already-validated archive to hand to synthesize_query.
+    monkeypatch.setattr(
+        "openzim_mcp.zim_operations.zim_archive",
+        lambda *a, **kw: _DummyCtx(MagicMock()),
+    )
+    monkeypatch.setattr(
+        server.zim_operations.path_validator,
+        "validate_path",
+        lambda p: __import__("pathlib").Path(p),
+    )
+    monkeypatch.setattr(
+        server.zim_operations.path_validator,
+        "validate_zim_file",
+        lambda p: p,
+    )
+
+    server.simple_tools_handler._handle_synthesize_query(
+        "tell me about Berlin",
+        "/fake/test.zim",
+        compact=True,
+    )
+
+    # The search-stage query has the NL prefix stripped.
+    assert captured_query["search_query"] == "Berlin"
+    # The original NL form is preserved in original_query for echo.
+    assert captured_query["original_query"] == "tell me about Berlin"
+
+
+class _DummyCtx:
+    def __init__(self, value):
+        self.value = value
+
+    def __enter__(self):
+        return self.value
+
+    def __exit__(self, *a):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# D6: tell_me_about falls back to find_entry_by_title for 1.0 promotion
+# ---------------------------------------------------------------------------
+
+
+def test_tell_me_about_promotes_title_index_match(test_config, monkeypatch):
+    """When BM25 ranks ``List of songs about Berlin`` above the
+    canonical ``Berlin`` article, ``_find_title_match_for_topic``
+    queries the title index and promotes the score-1.0 entry."""
+    from openzim_mcp.server import OpenZimMcpServer
+    from openzim_mcp.simple_tools import SimpleToolsHandler
+
+    server = OpenZimMcpServer(test_config)
+    if server.simple_tools_handler is None:
+        # ``test_config`` opens advanced mode; the simple-mode handler
+        # we want to exercise has to be constructed explicitly.
+        server.simple_tools_handler = SimpleToolsHandler(server.zim_operations)
+    handler = server.simple_tools_handler
+
+    # Title index says the canonical entry exists with score 1.0.
+    monkeypatch.setattr(
+        handler.zim_operations,
+        "find_entry_by_title_data",
+        lambda zim_file_path, topic, cross_file=False, limit=3: {
+            "results": [
+                {"path": "Berlin", "title": "Berlin", "score": 1.0},
+            ]
+        },
+    )
+    promoted = handler._find_title_match_for_topic("/fake.zim", "Berlin")
+    assert promoted == {"path": "Berlin", "title": "Berlin"}
+
+
+def test_tell_me_about_does_not_promote_weak_title_match(test_config, monkeypatch):
+    """Score < 1.0 (a SuggestionSearcher partial match) must NOT be
+    promoted — the disambiguation branch handles ambiguous topics."""
+    from openzim_mcp.server import OpenZimMcpServer
+    from openzim_mcp.simple_tools import SimpleToolsHandler
+
+    server = OpenZimMcpServer(test_config)
+    if server.simple_tools_handler is None:
+        # ``test_config`` opens advanced mode; the simple-mode handler
+        # we want to exercise has to be constructed explicitly.
+        server.simple_tools_handler = SimpleToolsHandler(server.zim_operations)
+    handler = server.simple_tools_handler
+    monkeypatch.setattr(
+        handler.zim_operations,
+        "find_entry_by_title_data",
+        lambda zim_file_path, topic, cross_file=False, limit=3: {
+            "results": [
+                {"path": "Java_(programming_language)", "title": "Java", "score": 0.95},
+            ]
+        },
+    )
+    promoted = handler._find_title_match_for_topic("/fake.zim", "Java")
+    assert promoted is None
+
+
+# ---------------------------------------------------------------------------
+# D10: zim_query.cursor decodes to options["offset"]
+# ---------------------------------------------------------------------------
+
+
+def test_handle_zim_query_decodes_cursor_into_offset(test_config, monkeypatch):
+    """A v2 Phase B cursor passed via ``options["cursor"]`` decodes to
+    its embedded ``s.o`` offset and forwards to the downstream handler."""
+    from openzim_mcp.server import OpenZimMcpServer
+    from openzim_mcp.simple_tools import SimpleToolsHandler
+
+    server = OpenZimMcpServer(test_config)
+    if server.simple_tools_handler is None:
+        # ``test_config`` opens advanced mode; the simple-mode handler
+        # we want to exercise has to be constructed explicitly.
+        server.simple_tools_handler = SimpleToolsHandler(server.zim_operations)
+    handler = server.simple_tools_handler
+
+    # Encode an arbitrary cursor with offset=42.
+    payload = {"v": 2, "t": "browse_namespace", "s": {"o": 42, "l": 50, "ns": "C"}}
+    raw = json.dumps(payload).encode("utf-8")
+    cursor = base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+    captured: dict = {}
+
+    def fake_browse(zim_file_path, namespace, limit, offset):
+        captured["offset"] = offset
+        captured["namespace"] = namespace
+        return ""
+
+    monkeypatch.setattr(handler.zim_operations, "browse_namespace", fake_browse)
+    monkeypatch.setattr(
+        handler,
+        "_auto_select_zim_file",
+        lambda: str(next(iter(test_config.allowed_directories))) + "/test.zim",
+    )
+
+    handler.handle_zim_query(
+        "browse namespace C",
+        options={"cursor": cursor, "limit": 50, "compact": False},
+    )
+    assert captured.get("offset") == 42
+
+
+def test_handle_zim_query_rejects_garbage_cursor(test_config):
+    """A malformed cursor surfaces a structured error message rather
+    than silently dropping into the default offset=0 path."""
+    from openzim_mcp.server import OpenZimMcpServer
+    from openzim_mcp.simple_tools import SimpleToolsHandler
+
+    server = OpenZimMcpServer(test_config)
+    if server.simple_tools_handler is None:
+        # ``test_config`` opens advanced mode; the simple-mode handler
+        # we want to exercise has to be constructed explicitly.
+        server.simple_tools_handler = SimpleToolsHandler(server.zim_operations)
+    out = server.simple_tools_handler.handle_zim_query(
+        "browse namespace C",
+        options={"cursor": "not-a-valid-cursor", "compact": False},
+    )
+    assert isinstance(out, str)
+    assert "Invalid Cursor" in out
+
+
+# ---------------------------------------------------------------------------
+# D11: metadata preview cap actually applies to long values
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_cap_applies_to_long_entry_values(test_config, monkeypatch):
+    """A metadata entry whose content exceeds the cap is truncated with
+    a ``[truncated, N chars total]`` marker."""
+    from openzim_mcp.server import OpenZimMcpServer
+    from openzim_mcp.simple_tools import SimpleToolsHandler
+
+    server = OpenZimMcpServer(test_config)
+    if server.simple_tools_handler is None:
+        # ``test_config`` opens advanced mode; the simple-mode handler
+        # we want to exercise has to be constructed explicitly.
+        server.simple_tools_handler = SimpleToolsHandler(server.zim_operations)
+    ops = server.zim_operations
+
+    # Build a mock archive that returns a 5000-char ``Title`` blob —
+    # the Wikipedia ZIM scenario that prompted D11.
+    long_content = "x" * 5000
+
+    mock_item = MagicMock()
+    mock_item.content = long_content.encode("utf-8")
+    mock_entry = MagicMock()
+    mock_entry.get_item.return_value = mock_item
+    mock_entry.is_redirect = False
+
+    def fake_get_entry_by_path(path):
+        if path == "M/Title":
+            return mock_entry
+        # Other M/ entries don't exist for this test.
+        raise RuntimeError("not present")
+
+    mock_archive = MagicMock()
+    mock_archive.get_entry_by_path.side_effect = fake_get_entry_by_path
+    mock_archive.entry_count = 100
+    mock_archive.all_entry_count = 100
+    mock_archive.article_count = 50
+    mock_archive.media_count = 50
+
+    metadata = ops._extract_zim_metadata(mock_archive)
+    title = metadata["metadata_entries"]["Title"]
+    assert len(title) <= _METADATA_PREVIEW_CAP + 50  # cap + marker tail
+    assert "[truncated, 5,000 chars total]" in title
+
+
+def test_metadata_short_value_not_capped(test_config):
+    """Values shorter than the cap pass through verbatim."""
+    from openzim_mcp.server import OpenZimMcpServer
+    from openzim_mcp.simple_tools import SimpleToolsHandler
+
+    server = OpenZimMcpServer(test_config)
+    if server.simple_tools_handler is None:
+        # ``test_config`` opens advanced mode; the simple-mode handler
+        # we want to exercise has to be constructed explicitly.
+        server.simple_tools_handler = SimpleToolsHandler(server.zim_operations)
+    ops = server.zim_operations
+
+    short = "Wikipedia"
+    mock_item = MagicMock()
+    mock_item.content = short.encode("utf-8")
+    mock_entry = MagicMock()
+    mock_entry.get_item.return_value = mock_item
+    mock_entry.is_redirect = False
+
+    def fake_get_entry_by_path(path):
+        if path == "M/Creator":
+            return mock_entry
+        raise RuntimeError("not present")
+
+    mock_archive = MagicMock()
+    mock_archive.get_entry_by_path.side_effect = fake_get_entry_by_path
+    mock_archive.entry_count = 100
+    mock_archive.all_entry_count = 100
+    mock_archive.article_count = 50
+    mock_archive.media_count = 50
+
+    metadata = ops._extract_zim_metadata(mock_archive)
+    assert metadata["metadata_entries"]["Creator"] == "Wikipedia"

--- a/tests/test_v2a7_fixes_helpers.py
+++ b/tests/test_v2a7_fixes_helpers.py
@@ -71,6 +71,7 @@ def _build_metadata_mock_archive(target_key: str, content: bytes) -> MagicMock:
     mock_archive.media_count = 50
     return mock_archive
 
+
 # ---------------------------------------------------------------------------
 # D8: synthesize section attribution survives bold markers in passages
 # ---------------------------------------------------------------------------
@@ -124,7 +125,11 @@ def test_compact_structure_includes_summary_when_section_preview_exists():
             {"level": 2, "text": "Geography", "id": "Geography"},
         ],
         "sections": [
-            {"title": "Berlin", "level": 1, "content_preview": "Berlin is the capital."},
+            {
+                "title": "Berlin",
+                "level": 1,
+                "content_preview": "Berlin is the capital.",
+            },
             {
                 "title": "Geography",
                 "level": 2,
@@ -140,7 +145,9 @@ def test_compact_structure_includes_summary_when_section_preview_exists():
     by_text = {h["text"]: h for h in headings}
     assert "summary" in by_text["Geography"]
     assert len(by_text["Geography"]["summary"]) <= 80
-    assert by_text["Geography"]["summary"].startswith("Berlin is in northeastern Germany")
+    assert by_text["Geography"]["summary"].startswith(
+        "Berlin is in northeastern Germany"
+    )
 
 
 def test_compact_structure_skips_summary_when_no_section_preview():
@@ -180,9 +187,7 @@ def test_intent_parser_just_section_alias():
     from openzim_mcp.intent_parser import IntentParser
 
     parser = IntentParser()
-    _intent, params, _confidence = parser.parse_intent(
-        "just section Climate of Berlin"
-    )
+    _intent, params, _confidence = parser.parse_intent("just section Climate of Berlin")
     assert params.get("narrow") is True
 
 

--- a/tests/test_v2a7_fixes_helpers.py
+++ b/tests/test_v2a7_fixes_helpers.py
@@ -1,0 +1,145 @@
+"""Integration-shape tests for the v2.0.0a7 defect-fix batch.
+
+These tests use fixture data only (no live ZIM file) and exercise the
+helper-level contracts that the v2.0.0a7 fixes introduce:
+
+  * D2/D3 — new-scheme C / W namespace paging via dedicated paths.
+  * D11 — metadata previews cap at 800 chars + ``[truncated, …]`` marker.
+  * D8 — synthesize section attribution survives bold-marker insertion.
+  * Op3 — get_section honors ``include_subsections=False`` by ending
+    the slice at the next heading of any level.
+  * Op2 — compact-structure renderer carries per-heading summary.
+"""
+
+from __future__ import annotations
+
+import json
+
+from openzim_mcp.compact_renderers import compact_structure_payload
+from openzim_mcp.synthesize import _locate_passage, _strip_bold
+from openzim_mcp.zim.archive import _METADATA_PREVIEW_CAP
+
+
+# ---------------------------------------------------------------------------
+# D8: synthesize section attribution survives bold markers in passages
+# ---------------------------------------------------------------------------
+
+
+def test_strip_bold_removes_paired_markers():
+    """``**term**`` is collapsed to ``term`` for substring location."""
+    assert _strip_bold("**Berlin** is the **capital**") == "Berlin is the capital"
+
+
+def test_locate_passage_finds_bolded_text_in_plain_markdown():
+    """Section attribution must not be killed by ``_highlight_terms`` adding
+    ``**`` markers around the query term — the bundle's rendered_markdown
+    carries no highlight wrapping."""
+    bundle_md = (
+        "# Berlin\n\nBerlin is the capital of Germany.\n\n"
+        "## Geography\n\nBerlin is in northeastern Germany.\n"
+    )
+    passage = "**Berlin** is in northeastern Germany."
+    pos = _locate_passage(bundle_md, passage)
+    assert pos >= 0, "Bolded passage should still locate in plain bundle markdown"
+    # The found position points at the plain "Berlin is in northeastern…"
+    assert bundle_md[pos:].startswith("Berlin is in northeastern")
+
+
+# ---------------------------------------------------------------------------
+# D11: metadata preview cap
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_preview_cap_constant_is_sane():
+    """The cap stays below 4 kB so a worst-case 10-field metadata
+    response can't blow past a typical compact budget."""
+    assert 200 <= _METADATA_PREVIEW_CAP <= 4000
+
+
+# ---------------------------------------------------------------------------
+# Op2: compact structure carries per-section summaries
+# ---------------------------------------------------------------------------
+
+
+def test_compact_structure_includes_summary_when_section_preview_exists():
+    """A payload with both headings AND sections produces compact
+    headings carrying an 80-char summary derived from the section's
+    content_preview."""
+    payload = {
+        "title": "Berlin",
+        "path": "Berlin",
+        "headings": [
+            {"level": 1, "text": "Berlin", "id": "Berlin"},
+            {"level": 2, "text": "Geography", "id": "Geography"},
+        ],
+        "sections": [
+            {"title": "Berlin", "level": 1, "content_preview": "Berlin is the capital."},
+            {
+                "title": "Geography",
+                "level": 2,
+                "content_preview": (
+                    "Berlin is in northeastern Germany, in an area of low-lying "
+                    "marshy woodlands with a mainly flat topography."
+                ),
+            },
+        ],
+    }
+    rendered = json.loads(compact_structure_payload(payload))
+    headings = rendered["headings"]
+    by_text = {h["text"]: h for h in headings}
+    assert "summary" in by_text["Geography"]
+    assert len(by_text["Geography"]["summary"]) <= 80
+    assert by_text["Geography"]["summary"].startswith("Berlin is in northeastern Germany")
+
+
+def test_compact_structure_skips_summary_when_no_section_preview():
+    """When the payload only carries ``headings`` (no ``sections``), the
+    compact view skips the summary field — no source data to derive from."""
+    payload = {
+        "title": "Sparse",
+        "path": "Sparse",
+        "headings": [{"level": 1, "text": "Sparse", "id": "Sparse"}],
+    }
+    rendered = json.loads(compact_structure_payload(payload))
+    assert "summary" not in rendered["headings"][0]
+
+
+# ---------------------------------------------------------------------------
+# Op3: get_section narrow-mode parsing
+# ---------------------------------------------------------------------------
+
+
+def test_intent_parser_narrow_section_sets_flag():
+    """``narrow section Geography of Berlin`` parses to params with
+    ``narrow=True`` and the section / entry stripped clean."""
+    from openzim_mcp.intent_parser import IntentParser
+
+    parser = IntentParser()
+    intent, params, _confidence = parser.parse_intent(
+        "narrow section Geography of Berlin"
+    )
+    assert intent == "get_section"
+    assert params.get("narrow") is True
+    assert params.get("section_name") == "Geography"
+    assert params.get("entry_path") == "Berlin"
+
+
+def test_intent_parser_just_section_alias():
+    """``just section X of Y`` is treated identically to ``narrow``."""
+    from openzim_mcp.intent_parser import IntentParser
+
+    parser = IntentParser()
+    _intent, params, _confidence = parser.parse_intent(
+        "just section Climate of Berlin"
+    )
+    assert params.get("narrow") is True
+
+
+def test_intent_parser_plain_section_no_narrow_flag():
+    """Without the prefix, ``narrow`` stays unset so the handler defaults
+    to ``include_subsections=True`` (legacy behavior)."""
+    from openzim_mcp.intent_parser import IntentParser
+
+    parser = IntentParser()
+    _intent, params, _confidence = parser.parse_intent("section Geography of Berlin")
+    assert params.get("narrow") in (None, False)

--- a/tests/test_v2a7_fixes_helpers.py
+++ b/tests/test_v2a7_fixes_helpers.py
@@ -25,6 +25,52 @@ from openzim_mcp.synthesize import _locate_passage, _strip_bold
 from openzim_mcp.zim.archive import _METADATA_PREVIEW_CAP
 
 
+def _make_simple_handler(test_config):
+    """Build a ``SimpleToolsHandler`` against ``test_config``.
+
+    ``test_config`` opens advanced mode (so the standard advanced-tool
+    test surface keeps working), but most of these tests exercise the
+    simple-mode dispatch which only constructs ``SimpleToolsHandler``
+    when ``tool_mode='simple'``. Build the handler explicitly here so
+    each test doesn't repeat the same five-line ``if handler is None:
+    construct it`` dance — SonarCloud's duplication detector flags the
+    repetition on PRs against ``main``.
+    """
+    from openzim_mcp.server import OpenZimMcpServer
+    from openzim_mcp.simple_tools import SimpleToolsHandler
+
+    server = OpenZimMcpServer(test_config)
+    if server.simple_tools_handler is None:
+        server.simple_tools_handler = SimpleToolsHandler(server.zim_operations)
+    return server, server.simple_tools_handler
+
+
+def _build_metadata_mock_archive(target_key: str, content: bytes) -> MagicMock:
+    """Build a mock archive that returns ``content`` for ``M/{target_key}``.
+
+    Used by the D11 metadata-cap tests. Other ``M/*`` probes raise so
+    ``_extract_zim_metadata``'s try/except branch treats them as
+    optional fields.
+    """
+    mock_item = MagicMock()
+    mock_item.content = content
+    mock_entry = MagicMock()
+    mock_entry.get_item.return_value = mock_item
+    mock_entry.is_redirect = False
+
+    def fake_get_entry_by_path(path):
+        if path == f"M/{target_key}":
+            return mock_entry
+        raise RuntimeError("not present")
+
+    mock_archive = MagicMock()
+    mock_archive.get_entry_by_path.side_effect = fake_get_entry_by_path
+    mock_archive.entry_count = 100
+    mock_archive.all_entry_count = 100
+    mock_archive.article_count = 50
+    mock_archive.media_count = 50
+    return mock_archive
+
 # ---------------------------------------------------------------------------
 # D8: synthesize section attribution survives bold markers in passages
 # ---------------------------------------------------------------------------
@@ -161,14 +207,7 @@ def test_synthesize_strips_tell_me_about_prefix(test_config, monkeypatch):
     just ``"Berlin"`` to the search backend — otherwise BM25 matches on
     ``tell``/``me``/``about`` and returns Irving Berlin songs instead
     of the canonical Berlin article."""
-    from openzim_mcp.server import OpenZimMcpServer
-    from openzim_mcp.simple_tools import SimpleToolsHandler
-
-    server = OpenZimMcpServer(test_config)
-    if server.simple_tools_handler is None:
-        # ``test_config`` opens advanced mode; the simple-mode handler
-        # we want to exercise has to be constructed explicitly.
-        server.simple_tools_handler = SimpleToolsHandler(server.zim_operations)
+    server, _handler = _make_simple_handler(test_config)
     captured_query: dict = {}
 
     def fake_synthesize(query, **kwargs):
@@ -232,29 +271,30 @@ class _DummyCtx:
 # ---------------------------------------------------------------------------
 
 
+def _stub_find_entry_by_title(handler, monkeypatch, *, results):
+    """Pin ``find_entry_by_title_data`` to a fixed result list.
+
+    Shared by the two D6 promotion tests (1.0 score promotes; <1.0
+    doesn't). The stub ignores the lookup parameters and returns the
+    same payload — the test cares about score-based promotion logic
+    in ``_find_title_match_for_topic``, not the backend query shape.
+    """
+    monkeypatch.setattr(
+        handler.zim_operations,
+        "find_entry_by_title_data",
+        lambda zim_file_path, topic, cross_file=False, limit=3: {"results": results},
+    )
+
+
 def test_tell_me_about_promotes_title_index_match(test_config, monkeypatch):
     """When BM25 ranks ``List of songs about Berlin`` above the
     canonical ``Berlin`` article, ``_find_title_match_for_topic``
     queries the title index and promotes the score-1.0 entry."""
-    from openzim_mcp.server import OpenZimMcpServer
-    from openzim_mcp.simple_tools import SimpleToolsHandler
-
-    server = OpenZimMcpServer(test_config)
-    if server.simple_tools_handler is None:
-        # ``test_config`` opens advanced mode; the simple-mode handler
-        # we want to exercise has to be constructed explicitly.
-        server.simple_tools_handler = SimpleToolsHandler(server.zim_operations)
-    handler = server.simple_tools_handler
-
-    # Title index says the canonical entry exists with score 1.0.
-    monkeypatch.setattr(
-        handler.zim_operations,
-        "find_entry_by_title_data",
-        lambda zim_file_path, topic, cross_file=False, limit=3: {
-            "results": [
-                {"path": "Berlin", "title": "Berlin", "score": 1.0},
-            ]
-        },
+    _, handler = _make_simple_handler(test_config)
+    _stub_find_entry_by_title(
+        handler,
+        monkeypatch,
+        results=[{"path": "Berlin", "title": "Berlin", "score": 1.0}],
     )
     promoted = handler._find_title_match_for_topic("/fake.zim", "Berlin")
     assert promoted == {"path": "Berlin", "title": "Berlin"}
@@ -263,23 +303,13 @@ def test_tell_me_about_promotes_title_index_match(test_config, monkeypatch):
 def test_tell_me_about_does_not_promote_weak_title_match(test_config, monkeypatch):
     """Score < 1.0 (a SuggestionSearcher partial match) must NOT be
     promoted — the disambiguation branch handles ambiguous topics."""
-    from openzim_mcp.server import OpenZimMcpServer
-    from openzim_mcp.simple_tools import SimpleToolsHandler
-
-    server = OpenZimMcpServer(test_config)
-    if server.simple_tools_handler is None:
-        # ``test_config`` opens advanced mode; the simple-mode handler
-        # we want to exercise has to be constructed explicitly.
-        server.simple_tools_handler = SimpleToolsHandler(server.zim_operations)
-    handler = server.simple_tools_handler
-    monkeypatch.setattr(
-        handler.zim_operations,
-        "find_entry_by_title_data",
-        lambda zim_file_path, topic, cross_file=False, limit=3: {
-            "results": [
-                {"path": "Java_(programming_language)", "title": "Java", "score": 0.95},
-            ]
-        },
+    _, handler = _make_simple_handler(test_config)
+    _stub_find_entry_by_title(
+        handler,
+        monkeypatch,
+        results=[
+            {"path": "Java_(programming_language)", "title": "Java", "score": 0.95}
+        ],
     )
     promoted = handler._find_title_match_for_topic("/fake.zim", "Java")
     assert promoted is None
@@ -293,15 +323,7 @@ def test_tell_me_about_does_not_promote_weak_title_match(test_config, monkeypatc
 def test_handle_zim_query_decodes_cursor_into_offset(test_config, monkeypatch):
     """A v2 Phase B cursor passed via ``options["cursor"]`` decodes to
     its embedded ``s.o`` offset and forwards to the downstream handler."""
-    from openzim_mcp.server import OpenZimMcpServer
-    from openzim_mcp.simple_tools import SimpleToolsHandler
-
-    server = OpenZimMcpServer(test_config)
-    if server.simple_tools_handler is None:
-        # ``test_config`` opens advanced mode; the simple-mode handler
-        # we want to exercise has to be constructed explicitly.
-        server.simple_tools_handler = SimpleToolsHandler(server.zim_operations)
-    handler = server.simple_tools_handler
+    _, handler = _make_simple_handler(test_config)
 
     # Encode an arbitrary cursor with offset=42.
     payload = {"v": 2, "t": "browse_namespace", "s": {"o": 42, "l": 50, "ns": "C"}}
@@ -332,15 +354,8 @@ def test_handle_zim_query_decodes_cursor_into_offset(test_config, monkeypatch):
 def test_handle_zim_query_rejects_garbage_cursor(test_config):
     """A malformed cursor surfaces a structured error message rather
     than silently dropping into the default offset=0 path."""
-    from openzim_mcp.server import OpenZimMcpServer
-    from openzim_mcp.simple_tools import SimpleToolsHandler
-
-    server = OpenZimMcpServer(test_config)
-    if server.simple_tools_handler is None:
-        # ``test_config`` opens advanced mode; the simple-mode handler
-        # we want to exercise has to be constructed explicitly.
-        server.simple_tools_handler = SimpleToolsHandler(server.zim_operations)
-    out = server.simple_tools_handler.handle_zim_query(
+    _, handler = _make_simple_handler(test_config)
+    out = handler.handle_zim_query(
         "browse namespace C",
         options={"cursor": "not-a-valid-cursor", "compact": False},
     )
@@ -353,43 +368,14 @@ def test_handle_zim_query_rejects_garbage_cursor(test_config):
 # ---------------------------------------------------------------------------
 
 
-def test_metadata_cap_applies_to_long_entry_values(test_config, monkeypatch):
+def test_metadata_cap_applies_to_long_entry_values(test_config):
     """A metadata entry whose content exceeds the cap is truncated with
     a ``[truncated, N chars total]`` marker."""
-    from openzim_mcp.server import OpenZimMcpServer
-    from openzim_mcp.simple_tools import SimpleToolsHandler
-
-    server = OpenZimMcpServer(test_config)
-    if server.simple_tools_handler is None:
-        # ``test_config`` opens advanced mode; the simple-mode handler
-        # we want to exercise has to be constructed explicitly.
-        server.simple_tools_handler = SimpleToolsHandler(server.zim_operations)
-    ops = server.zim_operations
-
-    # Build a mock archive that returns a 5000-char ``Title`` blob —
-    # the Wikipedia ZIM scenario that prompted D11.
-    long_content = "x" * 5000
-
-    mock_item = MagicMock()
-    mock_item.content = long_content.encode("utf-8")
-    mock_entry = MagicMock()
-    mock_entry.get_item.return_value = mock_item
-    mock_entry.is_redirect = False
-
-    def fake_get_entry_by_path(path):
-        if path == "M/Title":
-            return mock_entry
-        # Other M/ entries don't exist for this test.
-        raise RuntimeError("not present")
-
-    mock_archive = MagicMock()
-    mock_archive.get_entry_by_path.side_effect = fake_get_entry_by_path
-    mock_archive.entry_count = 100
-    mock_archive.all_entry_count = 100
-    mock_archive.article_count = 50
-    mock_archive.media_count = 50
-
-    metadata = ops._extract_zim_metadata(mock_archive)
+    server, _handler = _make_simple_handler(test_config)
+    # 5000-char ``Title`` blob — the Wikipedia ZIM scenario that
+    # prompted D11.
+    mock_archive = _build_metadata_mock_archive("Title", b"x" * 5000)
+    metadata = server.zim_operations._extract_zim_metadata(mock_archive)
     title = metadata["metadata_entries"]["Title"]
     assert len(title) <= _METADATA_PREVIEW_CAP + 50  # cap + marker tail
     assert "[truncated, 5,000 chars total]" in title
@@ -397,34 +383,7 @@ def test_metadata_cap_applies_to_long_entry_values(test_config, monkeypatch):
 
 def test_metadata_short_value_not_capped(test_config):
     """Values shorter than the cap pass through verbatim."""
-    from openzim_mcp.server import OpenZimMcpServer
-    from openzim_mcp.simple_tools import SimpleToolsHandler
-
-    server = OpenZimMcpServer(test_config)
-    if server.simple_tools_handler is None:
-        # ``test_config`` opens advanced mode; the simple-mode handler
-        # we want to exercise has to be constructed explicitly.
-        server.simple_tools_handler = SimpleToolsHandler(server.zim_operations)
-    ops = server.zim_operations
-
-    short = "Wikipedia"
-    mock_item = MagicMock()
-    mock_item.content = short.encode("utf-8")
-    mock_entry = MagicMock()
-    mock_entry.get_item.return_value = mock_item
-    mock_entry.is_redirect = False
-
-    def fake_get_entry_by_path(path):
-        if path == "M/Creator":
-            return mock_entry
-        raise RuntimeError("not present")
-
-    mock_archive = MagicMock()
-    mock_archive.get_entry_by_path.side_effect = fake_get_entry_by_path
-    mock_archive.entry_count = 100
-    mock_archive.all_entry_count = 100
-    mock_archive.article_count = 50
-    mock_archive.media_count = 50
-
-    metadata = ops._extract_zim_metadata(mock_archive)
+    server, _handler = _make_simple_handler(test_config)
+    mock_archive = _build_metadata_mock_archive("Creator", b"Wikipedia")
+    metadata = server.zim_operations._extract_zim_metadata(mock_archive)
     assert metadata["metadata_entries"]["Creator"] == "Wikipedia"


### PR DESCRIPTION
Defect + opportunity batch on top of v2.0.0a6, found by end-to-end testing against a real Wikipedia ZIM (118 GB, 27.2M entries, Feb 2026 snapshot).

Two commits — the initial batch and a deeper-pass refinement that addressed gaps I papered over in round one.

---

## What's fixed

### Defects

| # | Item | Where |
|---|---|---|
| D1 | `_typo_variants` only generated transposition + deletion, mathematically unable to reach the Phase A #14 named target `Photosythesis → Photosynthesis` (missing 'n' requires INSERTION). Added insertion + substitution against the full a-z alphabet, length-gated at ≥ 5 chars. | `openzim_mcp/zim/search.py` |
| D2 | `browse namespace C` crashed the server on Wikipedia (27M-entry full iteration before slicing 50 rows). New `_browse_new_scheme_c_paginated` pages directly through the entry-id range. | `openzim_mcp/zim/namespace.py` |
| D3 | `browse namespace W` returned 0 results even though `list_namespaces` reported 2 entries (new-scheme W isn't on libzim's iterable surface). New `_browse_new_scheme_w_paginated` probes well-known paths (`W/mainPage`, `W/favicon`, …). | `openzim_mcp/zim/namespace.py` |
| D4 | `_highlight_terms` produced malformed markdown — `**Artificial **photosynthesis****`, `_****Berlin****_`, `[**Photosynthesis**](**Photosynthesis** "…")`. Added `_HIGHLIGHT_SKIP_RE` covering existing bold/italic/link/code regions. Tightened in second commit: only protect parens when attached to a markdown link (the earlier shape silently dropped highlighting inside ordinary prose parentheticals like "(also called assimilation)"). | `openzim_mcp/content_processor.py` |
| D5 | `synthesize=True` with `tell me about Berlin` fed the entire NL phrase to BM25 and returned Irving Berlin songs / Nat King Cole albums. Intent-parse first, hand only the topic to the search stage; preserve the original query for response echo. | `openzim_mcp/simple_tools.py`, `openzim_mcp/synthesize.py` |
| D6 | `tell me about <topic>` never auto-fetched even on exact-title-match topics ("Berlin" → "List of songs about Berlin" instead). When the top BM25 hit isn't a strong-title match, fall back to `find_entry_by_title_data` and promote any score-1.0 result. | `openzim_mcp/simple_tools.py` |
| D7 | (verified already wired — empty searches with gibberish queries genuinely have no candidates; SuggestionSearcher populates `_meta.suggestions` for plausible typos.) | n/a |
| D8 | Synthesize section attribution always landed at entry level (`section_id: null`) because `_locate_passage` couldn't find passages with `**bold**` markers in the bundle's plain-markdown. Strip `**` before locating. Also: dedupe `passages[].text_markdown` against `answer_markdown` via `omit_passage_text=True` in compact mode (~50% token saving). | `openzim_mcp/synthesize.py` |
| D9 | `get_section` returned raw pipe-soup tables while `get_zim_entry` on the same article showed `[Table N: M rows × P cols]` placeholders. Bundle now renders with `compact=True`. Snippet path aligned in the deeper pass — search-result snippets now use the same `compact=True` rendering so the bundle markdown and snippet text match for section attribution. | `openzim_mcp/bundle.py`, `openzim_mcp/zim/content.py` |
| D10 | Tools advertised opaque cursors but `zim_query` accepted only integer `offset` — cursors decorative. Added `cursor` param; decoded `s.o` populates `offset` for downstream handlers. Length-capped at 2 KB defense-in-depth (legitimate cursors are < 200 chars). | `openzim_mcp/server.py`, `openzim_mcp/simple_tools.py` |
| D11 | `metadata for <archive>` returned 980 KB on Wikipedia because `M/Title` stores a full HTML document. Cap per-entry preview at 800 chars + `[truncated, N chars total]` marker. | `openzim_mcp/zim/archive.py` |
| D13 | Snippet selection fell to lead paragraph when no whole-word match was found, even when a stemmed form ("photosynthetic" for "photosynthesis") existed elsewhere. Added stem-prefix substring fallback (first ⅔ of each term). | `openzim_mcp/content_processor.py` |
| D14 | (verified expected behavior — structured payload carries `total: int` + `page_info.total_is_lower_bound`; the rendered `"N+"` text is a documented signal.) | n/a |

### Opportunities

| # | Item | Where |
|---|---|---|
| Op1 | Snippets started with `# <Title>` H1 duplicating the result-row title (~5–15 tokens per result of pure duplication). Added optional `title=` to `create_snippet`; threaded through `_get_entry_snippet` so search snippets benefit too. | `openzim_mcp/content_processor.py`, `openzim_mcp/zim/content.py` |
| Op2 | Compact structure response carried only heading text — small models had no signal for *which* section to drill into. Added 80-char summary per heading derived from the section's body preview. | `openzim_mcp/compact_renderers.py` |
| Op3 | `get section X of Y` always returned the entire H2 sub-tree. Added `include_subsections` (default True for compat); simple-mode query syntax `narrow section X of Y` / `just section X of Y` flips it. | `openzim_mcp/zim/structure.py`, `openzim_mcp/intent_parser.py`, `openzim_mcp/simple_tools.py`, `openzim_mcp/tools/structure_tools.py` |
| Op4 | Synthesize passages carried `[text](href "tooltip")` link soup — ~50% of token cost on a typical Wikipedia article head. Added `strip_links=True` (auto-applied in compact mode). | `openzim_mcp/synthesize.py` |
| Op5 | Infoboxes had three identical `City/State` rows under different sections (Area / Population / GDP). Track parent section-header rows and prefix labels: `Area — City/State`, `Population — City/State`. Skip the title row reliably. Deeper-pass: skip rows whose nearest table ancestor isn't the infobox (handles nested chronology / coords tables), and reject `<th>`/`<td>` candidates borrowed from inside nested tables. | `openzim_mcp/content_processor.py` |
| Op6 | Article leads started with image captions ("Schematic of photosynthesis…") instead of the actual lead paragraph. Strip `figure`, `figcaption`, `.thumb`, `.thumbcaption`, `.gallery`, `.hatnote`, `.sidebar`, `.navbox`, `.metadata.mbox-small`. Deeper-pass: also strip inline citation supers (`sup.reference`, `.reference`), `[show]/[hide]` toggles, and coordinate microformats. | `openzim_mcp/defaults.py` |
| Op7 | "tell me about <topic>" should auto-fetch on strong title match — merged into D6 fix above. | — |
| Op8 | Cursor reachable from `zim_query` — merged into D10 fix above. | — |

---

## Test coverage

- **3 new test modules** (~47 assertions): `test_content_processor_fixes_v2a7.py`, `test_typo_variants_v2a7.py`, `test_v2a7_fixes_helpers.py`
- **End-to-end proof** for the Phase A #14 named target: `test_photosythesis_resolves_to_photosynthesis_via_typo_fallback` wires a mock archive + suggester and asserts the full call path returns `C/Photosynthesis` with `match_type=typo_corrected` and an `alt_spelling` suggestion.
- **Performance guard**: `test_typo_variants_runs_in_reasonable_time` catches accidental quadratic regressions in variant generation (~700 variants for a 13-char input in < 10 ms/call).
- **Cursor security**: rejects garbage tokens with a structured error; defense-in-depth length cap.
- **Goldens regenerated** (all strict improvements — diffs are visible in the commits):
  - `search_einstein_2.json`: pipe-soup infobox snippet → clean lead-paragraph snippet
  - `synthesize_berlin_geography.json` / `synthesize_munich_history.json`: H1 dedup applied, section attribution now succeeds (`section_id` populated)
  - `synthesize_capital_city.json`: section attribution succeeds (`#berlin` suffix on cite_id)

---

## Verification

```
1388 passed, 50 skipped in ~22s
mypy clean (44 source files)
flake8 clean
```

No regressions outside the four golden-snapshot updates listed above.

---

## Commits

1. `859ac3d` — initial batch: 14 defects + 8 opportunities, 18 files changed (+1242/-56)
2. `1b79c82` — deeper-pass refinements: tighter highlight regex, snippet/bundle render alignment, nested-table guard, more selectors stripped, cursor length cap, e2e D1 test + D5/D6/D10/D11 tests, 10 files changed (+638/-30)

Total: 22 files changed, +1870/-76.
