### PR TITLE
fix(test): align search_all per-file assertions with H14 error shape

### DIFF
--- a/tests/test_response_contract.py
+++ b/tests/test_response_contract.py
@@ -95,9 +95,11 @@ class TestContractShape:
         assert payload["done"] is True
         # And each per-archive result inside also conforms.
         for entry in payload["results"]:
-            inner = entry["result"]
-            if inner.get("error") is True:
+            # H14: per-file row carries ``error`` as a sibling of ``result``;
+            # ``result`` is None on failure, a SearchResponse on success.
+            if entry.get("error") is True:
                 continue  # inner ZIM lacked Xapian index — skip that entry
+            inner = entry["result"]
             _assert_contract(inner)
 
     @pytest.mark.asyncio

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -462,14 +462,20 @@ class TestStructuredOutput:
         assert payload["next_cursor"] is None
         assert "page_info" in payload
         for entry in payload["results"]:
+            # H14: per-file row carries ``error`` as a sibling of ``result``.
+            # On failure (e.g. ZIM lacks FT Xapian index, archive failed to
+            # open), ``result`` is None and ``error_message`` /
+            # ``error_operation`` ride alongside ``error=True``. On success,
+            # ``result`` is a SearchResponse dict.
+            if entry.get("error") is True:
+                assert entry["result"] is None
+                assert "error_operation" in entry
+                assert "error_message" in entry
+                continue
             inner = entry["result"]
             assert isinstance(
                 inner, dict
-            ), f"per_file[].result should be dict, got {type(inner)}"
-            if inner.get("error") is True:
-                # Per-archive search failed (e.g. ZIM lacks FT Xapian index);
-                # the error envelope replaces SearchResponse for that entry.
-                continue
+            ), f"per_file[].result should be dict on success, got {type(inner)}"
             # inner is itself a SearchResponse — it has its own results list
             assert "results" in inner
             assert "done" in inner


### PR DESCRIPTION
Fixes CI failure on main: https://github.com/cameronrye/openzim-mcp/actions/runs/25708762262

## Root cause

#128 (a9 review wave) reshaped `search_all`'s per-file error contract under design key **H14**. Previously each `results[].result` was `Union[SearchResponse, ToolErrorPayload]` — callers had to type-sniff. The new contract makes `result` a single shape: `Optional[SearchResponse]`, with failure flagged on a sibling `error: bool` plus `error_message` / `error_operation` (see [`_SearchAllPerFile`](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/tool_schemas.py#L147)).

Two test assertions still spoke the old contract:

- [tests/test_response_contract.py:99](tests/test_response_contract.py#L99) — `inner.get("error")` on `entry["result"]`
- [tests/test_structured_tool_output.py:469](tests/test_structured_tool_output.py#L469) — same pattern plus an `isinstance(inner, dict)` precondition

When the comprehensive test job runs against the bundled `zim-testing-suite` fixtures, `nons/small.zim` has no FT Xapian index, so it now gets a failure entry with `result=None`. The stale assertions hit `None.get("error")` → `AttributeError`, breaking CI on main.

```
FAILED tests/test_response_contract.py::TestContractShape::test_search_all_contract_top_level - AttributeError: 'NoneType' object has no attribute 'get'
FAILED tests/test_structured_tool_output.py::TestStructuredOutput::test_search_all_returns_structured_content - AssertionError: per_file[].result should be dict, got <class 'NoneType'>
```

## Fix

Branch on `entry["error"]` (the new sibling key) before dereferencing `entry["result"]`. On the success branch, `result` is still a real `SearchResponse` dict and the inner contract check runs unchanged. On the failure branch, assert the documented failure-row keys (`result is None`, `error_operation`, `error_message`) so future drift is caught.

## Verification

```
$ ZIM_TEST_DATA_DIR=test_data/zim-testing-suite uv run pytest \
    tests/test_response_contract.py \
    tests/test_structured_tool_output.py \
    tests/test_search_all.py \
    tests/test_search_tools.py
======================== 60 passed, 26 skipped =========================
```

Production code is unchanged — only the stale test expectations were updated to match the H14 contract declared in `tool_schemas._SearchAllPerFile`.