### PR TITLE
feat(v2): search-engine-style zim_query (A14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `zim_query` natural-language search-engine path: prose-shaped queries
+  like *"who are some famous people from big rapids, michigan"* now
+  resolve to the canonical entity (`Big_Rapids,_Michigan`) via greedy
+  length-down tail iteration in both default and `synthesize=True`
+  modes (`iter_query_tails` shared helper in `title_promotion`).
+- `synthesize=True` responses: section-heading affinity boost re-ranks
+  section-attributed passages so the *Notable people* section of a
+  city article leads when the query mentions "people". Tunable via
+  `SynthesizeConfig.section_affinity_threshold` (default 0.25) and
+  `section_affinity_boost` (default 1.5).
+- `synthesize=True` responses: new `considered_articles` and
+  `considered_sections` fields expose the candidate space for
+  multi-round refinement without re-running search.
+
+### Changed
+
+- Removed the 4-token short-circuit in `_promote_title_match`
+  (M26). Long prose queries with a clear entity tail now resolve
+  canonically instead of falling through to BM25 noise.
+- `SynthesizeResponse` TypedDict is now `total=False` to accommodate
+  the new optional fields. Existing callers populating all the
+  previously-required fields are unaffected.
+
 ## [2.0.0a13] — 2026-05-14 (alpha pre-release) — post-a12 beta-test sweep (8 defects across three passes)
 
 Three-pass beta-test of `v2.0.0a12` against the same 118 GB Wikipedia

--- a/docs/superpowers/plans/2026-05-15-search-engine-zim-query.md
+++ b/docs/superpowers/plans/2026-05-15-search-engine-zim-query.md
@@ -1,0 +1,1800 @@
+# Search-engine-style `zim_query` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `zim_query` return useful answers to natural-language questions like *"who are some famous people from big rapids, michigan"* by adding greedy-tail entity resolution to both default and synthesize paths, plus section-heading affinity ranking and multi-round handles to the synthesize response.
+
+**Architecture:** Three coordinated changes across five existing files. A new tail-iteration helper in `title_promotion.py` is shared between `synthesize._promote_title_match` (synthesize path) and `simple_tools._promote_topic_via_title_index` (default `tell_me_about` path). A new section-affinity boost stage in `synthesize.py` re-ranks passages whose section heading shares tokens with the query. `SynthesizeResponse` gains `considered_articles` + `considered_sections` so the next conversation turn can pivot without re-running search.
+
+**Tech Stack:** Python 3.11, Pydantic v2 (config), TypedDicts (response shapes), pytest with `MagicMock` fixtures (heavy mock-based testing per project convention).
+
+**Spec:** [`docs/superpowers/specs/2026-05-15-search-engine-zim-query-design.md`](../specs/2026-05-15-search-engine-zim-query-design.md)
+
+---
+
+## File Structure
+
+### Create
+- `tests/test_iter_query_tails.py` — Unit tests for the new `iter_query_tails` helper.
+- `tests/test_simple_tools_tail_probe.py` — Tests that `_promote_topic_via_title_index` uses the tail probe on prose-shaped topics.
+- `tests/test_synthesize_section_affinity.py` — Tests for the new `_boost_by_section_affinity` stage.
+- `tests/test_synthesize_considered_handles.py` — Tests for the new `considered_articles` + `considered_sections` response fields.
+
+### Modify
+- `openzim_mcp/title_promotion.py` — Add `iter_query_tails(query, max_len=4, min_len=1)` helper.
+- `openzim_mcp/simple_tools.py` — `_promote_topic_via_title_index` iterates `iter_query_tails(topic)` and probes each tail before giving up.
+- `openzim_mcp/synthesize.py` — `_promote_title_match` replaces the 4+ token short-circuit with `iter_query_tails`. New `_boost_by_section_affinity` stage. Response builder populates `considered_articles` + `considered_sections`.
+- `openzim_mcp/tool_schemas.py` — Add `ConsideredArticle` and `ConsideredSection` TypedDicts; extend `SynthesizeResponse` with two new optional fields (`total=False`).
+- `openzim_mcp/config.py` — Extend `SynthesizeConfig` with `section_affinity_threshold` (default `0.25`) and `section_affinity_boost` (default `1.5`).
+- `tests/test_synthesize_title_promotion_v2a9.py` — Existing test that asserts the 4-token short-circuit needs updating (the short-circuit is being removed).
+
+### One file, one responsibility
+- `iter_query_tails`: pure query-tokenization + tail-iteration. No I/O, no archive references. Lives in `title_promotion.py` because that module already houses the title-promotion utilities.
+- `_boost_by_section_affinity`: pure ranking-stage function. Takes passages + bundle_lookup + query + config; returns re-sorted passages. Lives in `synthesize.py` adjacent to `_attribute_sections` since both consume the same bundle.
+- `_build_considered_articles` / `_build_considered_sections`: pure helpers that derive the two new fields from existing state (`top_hits`, `bundle_lookup`, `capped`). Live in `synthesize.py`.
+
+---
+
+## Task 1: Add affinity-boost tunables to `SynthesizeConfig`
+
+**Files:**
+- Modify: `openzim_mcp/config.py:98-115`
+- Test: `tests/test_config.py` (existing — add one test)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_config.py`:
+
+```python
+def test_synthesize_config_has_section_affinity_tunables():
+    """Section-affinity ranking knobs default to documented values."""
+    from openzim_mcp.config import SynthesizeConfig
+
+    cfg = SynthesizeConfig()
+    assert cfg.section_affinity_threshold == 0.25
+    assert cfg.section_affinity_boost == 1.5
+
+
+def test_synthesize_config_rejects_invalid_section_affinity_bounds():
+    """Threshold must be in [0,1]; boost must be >= 1.0 (a multiplier)."""
+    from pydantic import ValidationError
+
+    from openzim_mcp.config import SynthesizeConfig
+
+    with pytest.raises(ValidationError):
+        SynthesizeConfig(section_affinity_threshold=1.5)
+    with pytest.raises(ValidationError):
+        SynthesizeConfig(section_affinity_threshold=-0.1)
+    with pytest.raises(ValidationError):
+        SynthesizeConfig(section_affinity_boost=0.5)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_config.py::test_synthesize_config_has_section_affinity_tunables tests/test_config.py::test_synthesize_config_rejects_invalid_section_affinity_bounds -v`
+Expected: FAIL with `AttributeError: 'SynthesizeConfig' object has no attribute 'section_affinity_threshold'`.
+
+- [ ] **Step 3: Add the fields to `SynthesizeConfig`**
+
+In `openzim_mcp/config.py`, modify `SynthesizeConfig`:
+
+```python
+class SynthesizeConfig(BaseModel):
+    """Phase C: tunables for `zim_query(synthesize=True)`.
+
+    All knobs are advisory — the synthesize pipeline obeys these as
+    soft budgets (e.g., output_char_budget truncates the *last* passage
+    rather than refusing to include it).
+    """
+
+    top_n: int = Field(default=5, ge=1, le=50, description="Final passages returned.")
+    per_archive_k: int = Field(
+        default=10, ge=1, le=100, description="Top-K from each archive before fusion."
+    )
+    output_char_budget: int = Field(
+        default=4800,
+        ge=500,
+        le=20000,
+        description="Soft cap on answer_markdown chars (~1200 tokens).",
+    )
+    section_affinity_threshold: float = Field(
+        default=0.25,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Minimum |query ∩ heading| / |heading| ratio before a "
+            "section-attributed passage gets the affinity boost."
+        ),
+    )
+    section_affinity_boost: float = Field(
+        default=1.5,
+        ge=1.0,
+        le=10.0,
+        description=(
+            "Multiplier applied to a passage's score when its section "
+            "heading affinity-matches the query. Conservative: won't "
+            "dominate strong BM25 hits."
+        ),
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_config.py::test_synthesize_config_has_section_affinity_tunables tests/test_config.py::test_synthesize_config_rejects_invalid_section_affinity_bounds -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add openzim_mcp/config.py tests/test_config.py
+git commit -m "feat(v2): SynthesizeConfig knobs for section-affinity ranking"
+```
+
+---
+
+## Task 2: Add `iter_query_tails` helper to `title_promotion.py`
+
+**Files:**
+- Modify: `openzim_mcp/title_promotion.py` (add new function at module level)
+- Test: `tests/test_iter_query_tails.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_iter_query_tails.py`:
+
+```python
+"""Tests for iter_query_tails — greedy length-down tail iteration over
+a natural-language query for entity-resolution title-index probes.
+
+Replaces the M26 4+ token short-circuit in _promote_title_match: instead
+of giving up on multi-word prose queries, generate every plausible
+entity tail and let the caller probe each one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openzim_mcp.title_promotion import iter_query_tails
+
+
+def test_iter_query_tails_yields_longest_first():
+    """Greedy: 4-token tail before 3-token before 2-token before 1-token."""
+    tails = list(iter_query_tails("a b c d e"))
+    assert tails == ["b c d e", "c d e", "d e", "e"]
+
+
+def test_iter_query_tails_caps_at_max_len_4_by_default():
+    """A 9-token query yields at most 4 tails (lengths 4, 3, 2, 1)."""
+    tails = list(iter_query_tails("who are some famous people from big rapids michigan"))
+    assert tails == [
+        "from big rapids michigan",
+        "big rapids michigan",
+        "rapids michigan",
+        "michigan",
+    ]
+
+
+def test_iter_query_tails_short_query_yields_what_fits():
+    """3-token query yields tails of length 3, 2, 1."""
+    tails = list(iter_query_tails("big rapids michigan"))
+    assert tails == ["big rapids michigan", "rapids michigan", "michigan"]
+
+
+def test_iter_query_tails_single_token_yields_one_tail():
+    tails = list(iter_query_tails("detroit"))
+    assert tails == ["detroit"]
+
+
+def test_iter_query_tails_empty_query_yields_nothing():
+    assert list(iter_query_tails("")) == []
+    assert list(iter_query_tails("   ")) == []
+
+
+def test_iter_query_tails_normalizes_whitespace():
+    """Multiple spaces / tabs collapse; surrounding whitespace stripped."""
+    tails = list(iter_query_tails("  big   rapids\tmichigan  "))
+    assert tails == ["big rapids michigan", "rapids michigan", "michigan"]
+
+
+def test_iter_query_tails_preserves_original_case_per_token():
+    """Tokens kept verbatim — case-sensitive callers (title-index) get
+    the user's casing untouched. The tail-probe API is responsible for
+    lowercasing if it needs to."""
+    tails = list(iter_query_tails("Big Rapids Michigan"))
+    assert tails[0] == "Big Rapids Michigan"
+
+
+def test_iter_query_tails_custom_max_len():
+    """Caller can cap the longest tail tried."""
+    tails = list(iter_query_tails("a b c d e f", max_len=2))
+    assert tails == ["e f", "f"]
+
+
+def test_iter_query_tails_custom_min_len():
+    """Caller can require multi-token tails (skip single-token misfires)."""
+    tails = list(iter_query_tails("a b c d e", min_len=2))
+    assert tails == ["b c d e", "c d e", "d e"]
+
+
+def test_iter_query_tails_punctuation_treated_as_token_break():
+    """Punctuation between words breaks tokens — 'big rapids, michigan'
+    has three tokens, not 'rapids,' as one."""
+    tails = list(iter_query_tails("big rapids, michigan"))
+    assert tails == ["big rapids michigan", "rapids michigan", "michigan"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_iter_query_tails.py -v`
+Expected: FAIL with `ImportError: cannot import name 'iter_query_tails' from 'openzim_mcp.title_promotion'`.
+
+- [ ] **Step 3: Add `iter_query_tails` to `title_promotion.py`**
+
+Append to `openzim_mcp/title_promotion.py` (after `find_title_match`):
+
+```python
+import re as _re
+
+# Tokenizer: alphanumeric runs only. Punctuation, whitespace, and
+# control chars all act as token boundaries. Matches the tokenization
+# convention already used elsewhere in the codebase (e.g.
+# is_strong_title_match) so tail-probe behavior is consistent with the
+# rest of the title-promotion module.
+_TAIL_TOKEN_RE = _re.compile(r"[\w]+", _re.UNICODE)
+
+
+def iter_query_tails(
+    query: str,
+    *,
+    max_len: int = 4,
+    min_len: int = 1,
+) -> Iterator[str]:
+    """Yield greedy length-down trailing token windows of ``query``.
+
+    Used by both ``_promote_title_match`` (synthesize path) and
+    ``_promote_topic_via_title_index`` (tell_me_about path) to probe
+    a multi-word natural-language query for an entity that resolves
+    against a ZIM archive's title index.
+
+    Example:
+        ``"who are some famous people from big rapids michigan"``
+        with default bounds yields:
+            ``"from big rapids michigan"``
+            ``"big rapids michigan"``
+            ``"rapids michigan"``
+            ``"michigan"``
+
+    The caller probes each yielded tail in order; the first to resolve
+    wins. Greedy length-down picks the most specific entity that
+    actually exists (``"big rapids michigan"`` beats ``"michigan"``
+    when both resolve).
+
+    Args:
+        query: Natural-language query. Tokenized on alphanumeric runs,
+            so punctuation between words is treated as a boundary
+            (``"big rapids, michigan"`` → 3 tokens).
+        max_len: Longest tail to yield. Default 4 — empirically, ZIM
+            article titles rarely exceed 4 tokens, and the cost of a
+            failed probe is microseconds, so a tight cap is safe.
+        min_len: Shortest tail to yield. Default 1. Callers that want
+            to skip single-token false positives can raise this.
+
+    Yields:
+        Tail strings reconstructed by joining tokens with single
+        spaces, in the order they were found in ``query``. Original
+        case is preserved (the caller is responsible for any
+        lowercasing the title index needs).
+    """
+    if not query or not query.strip():
+        return
+    tokens = _TAIL_TOKEN_RE.findall(query)
+    if not tokens:
+        return
+    upper = min(max_len, len(tokens))
+    lower = max(1, min_len)
+    for tail_len in range(upper, lower - 1, -1):
+        yield " ".join(tokens[-tail_len:])
+```
+
+Also add to the top of the file (if not already imported):
+
+```python
+from typing import Iterator
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_iter_query_tails.py -v`
+Expected: PASS (10 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add openzim_mcp/title_promotion.py tests/test_iter_query_tails.py
+git commit -m "feat(v2): iter_query_tails helper for entity tail-probe"
+```
+
+---
+
+## Task 3: Use `iter_query_tails` in `_promote_topic_via_title_index` (default `tell_me_about` path)
+
+**Files:**
+- Modify: `openzim_mcp/simple_tools.py:2141-2169` (`_promote_topic_via_title_index`)
+- Test: `tests/test_simple_tools_tail_probe.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_simple_tools_tail_probe.py`:
+
+```python
+"""Tests that the default-mode tell_me_about title-promotion path
+probes greedy tails of a prose-shaped topic before giving up.
+
+Without the tail probe, "some famous people from big rapids michigan"
+is passed verbatim to find_title_match, which returns nothing because
+no article has that exact title. The probe falls back to shorter tails
+and resolves "big rapids michigan" → Big_Rapids,_Michigan.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock
+
+from openzim_mcp.simple_tools import SimpleToolsHandler
+
+
+def _make_handler(title_responses: Dict[str, Optional[Dict[str, Any]]]) -> Any:
+    """Construct a SimpleToolsHandler whose find_entry_by_title_data
+    consults a topic→result dict. Returns the handler with mocked
+    zim_operations.find_entry_by_title_data."""
+    handler = SimpleToolsHandler.__new__(SimpleToolsHandler)
+    handler.zim_operations = MagicMock()
+
+    def fake_find(zim_path: str, topic: str, *, cross_file: bool = False, limit: int = 3):
+        result = title_responses.get(topic)
+        if result is None:
+            return {"results": []}
+        return {"results": [result]}
+
+    handler.zim_operations.find_entry_by_title_data.side_effect = fake_find
+    return handler
+
+
+def test_promote_resolves_via_shorter_tail():
+    """Full prose topic misses; 3-token tail hits."""
+    handler = _make_handler(
+        {
+            "big rapids michigan": {
+                "path": "Big_Rapids,_Michigan",
+                "title": "Big Rapids, Michigan",
+                "score": 1.0,
+                "zim_file": "wiki.zim",
+            }
+        }
+    )
+    result = handler._promote_topic_via_title_index(
+        "/fake/wiki.zim",
+        "some famous people from big rapids michigan",
+    )
+    assert result is not None
+    assert result["path"] == "Big_Rapids,_Michigan"
+
+
+def test_promote_resolves_via_single_token_tail():
+    """A 1-token entity at the end ('detroit') resolves when longer
+    tails miss."""
+    handler = _make_handler(
+        {
+            "detroit": {
+                "path": "Detroit",
+                "title": "Detroit",
+                "score": 1.0,
+                "zim_file": "wiki.zim",
+            }
+        }
+    )
+    result = handler._promote_topic_via_title_index(
+        "/fake/wiki.zim",
+        "what is the population of detroit",
+    )
+    assert result is not None
+    assert result["path"] == "Detroit"
+
+
+def test_promote_prefers_longest_resolving_tail():
+    """When both 'big rapids michigan' and 'michigan' resolve, the
+    longer (more specific) one wins."""
+    handler = _make_handler(
+        {
+            "big rapids michigan": {
+                "path": "Big_Rapids,_Michigan",
+                "title": "Big Rapids, Michigan",
+                "score": 1.0,
+                "zim_file": "wiki.zim",
+            },
+            "michigan": {
+                "path": "Michigan",
+                "title": "Michigan",
+                "score": 1.0,
+                "zim_file": "wiki.zim",
+            },
+        }
+    )
+    result = handler._promote_topic_via_title_index(
+        "/fake/wiki.zim",
+        "famous people from big rapids michigan",
+    )
+    assert result is not None
+    assert result["path"] == "Big_Rapids,_Michigan"
+
+
+def test_promote_returns_none_when_no_tail_resolves():
+    """All tails miss → None, caller falls back to BM25 search."""
+    handler = _make_handler({})  # nothing resolves
+    result = handler._promote_topic_via_title_index(
+        "/fake/wiki.zim", "completely unknown phrase here"
+    )
+    assert result is None
+
+
+def test_promote_single_token_topic_still_works():
+    """The existing exact-topic case (single-word topic) still
+    resolves via the 1-token tail (which equals the whole query)."""
+    handler = _make_handler(
+        {
+            "berlin": {
+                "path": "Berlin",
+                "title": "Berlin",
+                "score": 1.0,
+                "zim_file": "wiki.zim",
+            }
+        }
+    )
+    result = handler._promote_topic_via_title_index("/fake/wiki.zim", "berlin")
+    assert result is not None
+    assert result["path"] == "Berlin"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_simple_tools_tail_probe.py -v`
+Expected: FAIL — `test_promote_resolves_via_shorter_tail` and `test_promote_resolves_via_single_token_tail` fail because `find_title_match` is currently called once with the full topic.
+
+- [ ] **Step 3: Rewrite `_promote_topic_via_title_index` to use tail iteration**
+
+In `openzim_mcp/simple_tools.py`, replace the body of `_promote_topic_via_title_index` ([line 2141](openzim_mcp/simple_tools.py#L2141)):
+
+```python
+def _promote_topic_via_title_index(
+    self, zim_file_path: str, topic: str
+) -> Optional[Dict[str, Any]]:
+    """Promote a canonical title-index hit for ``topic`` past noisy BM25
+    ranking. Tries the strict 1.0-score gate first, then falls back to
+    the 0.8-score typo-tolerant gate.
+
+    Returns the resolved ``{path, title, zim_file}`` dict, or ``None``
+    when neither gate fires.
+
+    A14: when the full topic doesn't resolve, fall back to greedy
+    length-down tail probes (``iter_query_tails``). The motivating case
+    is prose-shaped tell_me_about topics ("famous people from big
+    rapids michigan") where the full string never resolves but a
+    trailing entity ("big rapids michigan") does. Greedy length-down
+    picks the most specific entity that exists.
+
+    D6 fix (v2.0.0a9): Xapian ranks ``List of songs about Berlin``
+    above the canonical ``Berlin`` article for ``query=Berlin``
+    because the title-match boost isn't strong enough. The 1.0 gate
+    promotes the canonical past that ranking.
+
+    D3 (beta): the 0.8 gate catches single-edit typos via the
+    ``_find_entry_typo_fallback`` chain
+    (``Photosythesis`` → ``Photosynthesis``, score 0.85). Without
+    this step ``tell me about Photosythesis`` fell all the way
+    through to Xapian search and returned a totally unrelated
+    article. The chain is conservative by construction
+    (length-gated at ≥5 chars, ≤700 variants).
+    """
+    from openzim_mcp.title_promotion import iter_query_tails
+
+    for tail in iter_query_tails(topic):
+        promoted = find_title_match(self.zim_operations, zim_file_path, tail)
+        if promoted is not None:
+            return promoted
+        promoted = find_title_match(
+            self.zim_operations, zim_file_path, tail, min_score=0.8
+        )
+        if promoted is not None:
+            return promoted
+    return None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_simple_tools_tail_probe.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Run the full simple_tools test suite to verify no regression**
+
+Run: `uv run pytest tests/test_simple_tools.py -v`
+Expected: All previously-passing tests still pass. (If any test asserted that `find_title_match` was called exactly once with the full topic, it will need to be updated to accept the tail-probe sequence — this is a known behavior change documented in the spec.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add openzim_mcp/simple_tools.py tests/test_simple_tools_tail_probe.py
+git commit -m "feat(v2): tail-probe entity resolution in tell_me_about
+
+Prose-shaped topics like 'famous people from big rapids michigan'
+now resolve to Big_Rapids,_Michigan via greedy length-down tail
+iteration over iter_query_tails(topic). Previously such topics were
+passed verbatim to find_title_match, missed, and fell through to
+BM25 noise."
+```
+
+---
+
+## Task 4: Use `iter_query_tails` in `_promote_title_match` (synthesize path)
+
+**Files:**
+- Modify: `openzim_mcp/synthesize.py:498-582` (`_promote_title_match`)
+- Modify: `tests/test_synthesize_title_promotion_v2a9.py` (existing test of the 4-token short-circuit needs updating)
+- Test: extends `tests/test_synthesize_title_promotion_v2a9.py` with new tail-probe coverage
+
+- [ ] **Step 1: Inspect the existing test that depends on the 4-token short-circuit**
+
+Look at `tests/test_synthesize_title_promotion_v2a9.py` for tests asserting the short-circuit. The expected one is named or commented around M26 / 4-token behavior. Read the file:
+
+Run: `uv run pytest tests/test_synthesize_title_promotion_v2a9.py -v --collect-only`
+
+Identify any test that depends on the 4-token cap firing. There should not be many — the cap was a recent addition. If one exists, it needs to be updated to reflect the new tail-probe behavior in a follow-up step.
+
+- [ ] **Step 2: Write new failing tests for the tail-probe behavior**
+
+Append to `tests/test_synthesize_title_promotion_v2a9.py`:
+
+```python
+def test_promote_title_match_tail_probe_resolves_short_tail():
+    """A14: prose-shaped query (>4 tokens) now probes greedy tails
+    instead of short-circuiting. 'famous people from big rapids
+    michigan' → 'big rapids michigan' resolves Big_Rapids,_Michigan."""
+    bm25_top_hits = [
+        ("wiki", {"path": "Famous_People_(film)", "snippet": "...", "score": 0.5}),
+    ]
+
+    def fake_title_match(archive: Any, query: str) -> Any:
+        if query == "big rapids michigan":
+            return {"path": "Big_Rapids,_Michigan", "snippet": "...", "score": 1.0}
+        return None
+
+    search_handler = MagicMock()
+    search_handler.title_match_hit.side_effect = fake_title_match
+    archive = MagicMock()
+
+    promoted = _promote_title_match(
+        bm25_top_hits,
+        query="famous people from big rapids michigan",
+        archives=[(archive, Path("/fake/wiki.zim"))],
+        archives_searched=["wiki"],
+        search_handler=search_handler,
+    )
+    assert promoted[0][1]["path"] == "Big_Rapids,_Michigan"
+
+
+def test_promote_title_match_tail_probe_prefers_longest_resolving_tail():
+    """When both 'big rapids michigan' and 'michigan' would resolve,
+    the longer (more specific) one wins."""
+    bm25_top_hits = [
+        ("wiki", {"path": "Some_Other_Article", "snippet": "...", "score": 0.5}),
+    ]
+
+    def fake_title_match(archive: Any, query: str) -> Any:
+        if query == "big rapids michigan":
+            return {"path": "Big_Rapids,_Michigan", "snippet": "...", "score": 1.0}
+        if query == "michigan":
+            return {"path": "Michigan", "snippet": "...", "score": 1.0}
+        return None
+
+    search_handler = MagicMock()
+    search_handler.title_match_hit.side_effect = fake_title_match
+    archive = MagicMock()
+
+    promoted = _promote_title_match(
+        bm25_top_hits,
+        query="famous people from big rapids michigan",
+        archives=[(archive, Path("/fake/wiki.zim"))],
+        archives_searched=["wiki"],
+        search_handler=search_handler,
+    )
+    assert promoted[0][1]["path"] == "Big_Rapids,_Michigan"
+
+
+def test_promote_title_match_tail_probe_no_short_circuit_for_long_queries():
+    """A14: M26's 4+ token short-circuit is removed. Long queries with
+    a clear entity tail now probe and resolve."""
+    bm25_top_hits = []
+
+    def fake_title_match(archive: Any, query: str) -> Any:
+        if query == "detroit":
+            return {"path": "Detroit", "snippet": "...", "score": 1.0}
+        return None
+
+    search_handler = MagicMock()
+    search_handler.title_match_hit.side_effect = fake_title_match
+    archive = MagicMock()
+
+    promoted = _promote_title_match(
+        bm25_top_hits,
+        query="what is the population of detroit",
+        archives=[(archive, Path("/fake/wiki.zim"))],
+        archives_searched=["wiki"],
+        search_handler=search_handler,
+    )
+    assert len(promoted) == 1
+    assert promoted[0][1]["path"] == "Detroit"
+
+
+def test_promote_title_match_tail_probe_falls_through_when_no_tail_resolves():
+    """All tails miss → return top_hits unchanged."""
+    bm25_top_hits = [
+        ("wiki", {"path": "Unrelated_Article", "snippet": "...", "score": 0.3}),
+    ]
+    search_handler = MagicMock()
+    search_handler.title_match_hit.return_value = None
+    archive = MagicMock()
+
+    promoted = _promote_title_match(
+        bm25_top_hits,
+        query="completely unknown phrase here that nothing matches",
+        archives=[(archive, Path("/fake/wiki.zim"))],
+        archives_searched=["wiki"],
+        search_handler=search_handler,
+    )
+    assert promoted == bm25_top_hits
+```
+
+- [ ] **Step 3: Run new tests to verify they fail**
+
+Run: `uv run pytest tests/test_synthesize_title_promotion_v2a9.py::test_promote_title_match_tail_probe_resolves_short_tail tests/test_synthesize_title_promotion_v2a9.py::test_promote_title_match_tail_probe_prefers_longest_resolving_tail tests/test_synthesize_title_promotion_v2a9.py::test_promote_title_match_tail_probe_no_short_circuit_for_long_queries tests/test_synthesize_title_promotion_v2a9.py::test_promote_title_match_tail_probe_falls_through_when_no_tail_resolves -v`
+Expected: FAIL — current code short-circuits on long queries and only probes the full query string.
+
+- [ ] **Step 4: Rewrite `_promote_title_match` to use tail iteration**
+
+In `openzim_mcp/synthesize.py`, replace the body of `_promote_title_match` ([line 498](openzim_mcp/synthesize.py#L498)). Keep the strong-top-hit guard intact; replace the 4-token cap + single-probe with the tail loop:
+
+```python
+def _promote_title_match(
+    top_hits: list[tuple[str, dict]],
+    *,
+    query: str,
+    archives: list[tuple[Archive, Path]],
+    archives_searched: list[str],
+    search_handler: Any,
+) -> list[tuple[str, dict]]:
+    """Promote a canonical title-index hit past BM25 noise (D3 / Op1).
+
+    A14: replaced the M26 4+ token short-circuit with greedy length-down
+    tail iteration via ``iter_query_tails``. Long natural-language
+    queries with a clear entity tail ("famous people from big rapids
+    michigan") now resolve to ``Big_Rapids,_Michigan`` instead of
+    falling through to BM25 noise.
+
+    Mirrors the title-promotion logic in ``tell_me_about``: when the
+    top BM25 hit isn't a strong title match for the query, ask each
+    archive's title-index fast path for the canonical entry. If one
+    archive answers, prepend that hit so the synthesized response
+    leads with the canonical article instead of a derivative.
+
+    Pre-existing BM25 hits are preserved — the promoted entry just
+    moves to rank 1. Already-strong top hits short-circuit so the
+    common case pays no extra archive probes.
+
+    Probe order is (tail-length, archive-order): for each tail in
+    greedy length-down order, try every archive. The first archive
+    that resolves any tail wins. This picks the most specific entity
+    that exists in any archive, biasing toward earlier-configured
+    archives only when tails of equal length tie.
+    """
+    from openzim_mcp.title_promotion import iter_query_tails
+
+    if top_hits:
+        top_hit_0 = top_hits[0][1]
+        top_path = str(top_hit_0.get("path", ""))
+        if is_strong_title_match(query, top_path, top_path.replace("_", " ")):
+            return top_hits
+
+    title_match_hit = getattr(search_handler, "title_match_hit", None)
+    if not callable(title_match_hit):
+        return top_hits
+
+    existing_paths = {(name, str(h.get("path", ""))) for name, h in top_hits}
+    for tail in iter_query_tails(query):
+        for (archive, _vp), archive_name in zip(archives, archives_searched):
+            try:
+                promoted = title_match_hit(archive, tail)
+            except Exception as e:
+                logger.debug(
+                    "title_match_hit failed for %s on tail %r: %s",
+                    archive_name,
+                    tail,
+                    e,
+                )
+                continue
+            if not isinstance(promoted, dict):
+                continue
+            promoted_path = str(promoted.get("path", ""))
+            if not promoted_path:
+                continue
+            if (archive_name, promoted_path) in existing_paths:
+                reordered: list[tuple[str, dict]] = [
+                    (n, h)
+                    for n, h in top_hits
+                    if not (n == archive_name and str(h.get("path", "")) == promoted_path)
+                ]
+                promoted_hit = next(
+                    h
+                    for n, h in top_hits
+                    if n == archive_name and str(h.get("path", "")) == promoted_path
+                )
+                return [(archive_name, promoted_hit), *reordered]
+            return [(archive_name, promoted), *top_hits]
+    return top_hits
+```
+
+- [ ] **Step 5: Run new tests to verify they pass**
+
+Run: `uv run pytest tests/test_synthesize_title_promotion_v2a9.py -v`
+Expected: All new tail-probe tests PASS. Pre-existing tests should continue to pass — the strong-top-hit guard and the existing single-token / canonical-title cases all go through the tail loop with the same outcome.
+
+- [ ] **Step 6: Run the full synthesize test suite to verify no regression**
+
+Run: `uv run pytest tests/test_synthesize.py tests/test_synthesize_title_promotion_v2a9.py tests/test_synthesize_meta_d7d8_v2a9.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add openzim_mcp/synthesize.py tests/test_synthesize_title_promotion_v2a9.py
+git commit -m "feat(v2): tail-probe entity resolution in synthesize
+
+Drops the M26 4+ token short-circuit in _promote_title_match.
+Replaces it with greedy length-down tail iteration via the shared
+iter_query_tails helper. Long question-shaped queries with a clear
+entity tail now resolve canonically instead of falling through to
+BM25 noise."
+```
+
+---
+
+## Task 5: Section-affinity boost stage in `synthesize.py`
+
+**Files:**
+- Modify: `openzim_mcp/synthesize.py` (add `_boost_by_section_affinity` and wire it into `synthesize_query`)
+- Test: `tests/test_synthesize_section_affinity.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_synthesize_section_affinity.py`:
+
+```python
+"""Tests for _boost_by_section_affinity — re-ranks section-attributed
+passages whose section heading shares tokens with the query.
+
+The motivating case: query 'famous people from big rapids michigan'
+should bubble the #Notable_people passage above the #History passage
+because 'people' (query token) appears in 'Notable people' (heading
+tokens) but not in 'History'.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+from unittest.mock import MagicMock
+
+from openzim_mcp.config import SynthesizeConfig
+from openzim_mcp.synthesize import _boost_by_section_affinity
+
+
+def _passage(cite_id: str, score: float, rank: int = 0) -> Dict[str, Any]:
+    return {
+        "cite_id": cite_id,
+        "text_markdown": f"text for {cite_id}",
+        "rank": rank,
+        "score": score,
+    }
+
+
+def _bundle_lookup_for(
+    sections_by_path: Dict[str, List[Dict[str, Any]]],
+) -> Any:
+    """Build a fake bundle_lookup that returns sections for known paths."""
+
+    def lookup(archive_name: str, entry_path: str) -> Any:
+        sections = sections_by_path.get(entry_path)
+        if sections is None:
+            return None
+        return {"sections": sections, "rendered_markdown": ""}
+
+    return lookup
+
+
+def test_boost_promotes_passage_when_section_heading_matches_query():
+    """'famous people' query → 'Notable people' heading gets boosted
+    past 'History'."""
+    passages = [
+        _passage("wiki/Big_Rapids,_Michigan#History", score=1.0, rank=1),
+        _passage("wiki/Big_Rapids,_Michigan#Notable_people", score=0.6, rank=2),
+    ]
+    bundle_lookup = _bundle_lookup_for(
+        {
+            "Big_Rapids,_Michigan": [
+                {"id": "History", "title": "History", "char_start": 0, "char_end": 100},
+                {
+                    "id": "Notable_people",
+                    "title": "Notable people",
+                    "char_start": 100,
+                    "char_end": 200,
+                },
+            ]
+        }
+    )
+    cfg = SynthesizeConfig()  # threshold=0.25, boost=1.5
+
+    out = _boost_by_section_affinity(
+        passages,
+        query="famous people from big rapids michigan",
+        bundle_lookup=bundle_lookup,
+        config=cfg,
+    )
+
+    # Affinity: 'Notable people' has tokens {notable, people}; query has
+    # {famous, people, from, big, rapids, michigan}. Intersect = {people}.
+    # Affinity = 1/2 = 0.5 >= 0.25. Score becomes 0.6 * 1.5 = 0.9, still
+    # below 1.0. So this test verifies the score is boosted but History
+    # may still be rank 0 unless we also raise the boost. Adjust: drop
+    # the History score below Notable_people post-boost.
+    paths_in_order = [p["cite_id"] for p in out]
+    notable_idx = paths_in_order.index("wiki/Big_Rapids,_Michigan#Notable_people")
+    history_idx = paths_in_order.index("wiki/Big_Rapids,_Michigan#History")
+    # Notable_people boosted to 0.9, History stays at 1.0. History first.
+    # This test asserts the BOOST is applied, not necessarily that it
+    # flips the order (which depends on the gap).
+    notable_passage = out[notable_idx]
+    assert notable_passage["score"] == 0.6 * 1.5
+
+
+def test_boost_flips_order_when_boosted_passage_overtakes():
+    """When the boosted passage's new score exceeds the prior leader,
+    it ranks first."""
+    passages = [
+        _passage("wiki/Big_Rapids,_Michigan#History", score=0.5, rank=1),
+        _passage("wiki/Big_Rapids,_Michigan#Notable_people", score=0.4, rank=2),
+    ]
+    bundle_lookup = _bundle_lookup_for(
+        {
+            "Big_Rapids,_Michigan": [
+                {"id": "History", "title": "History", "char_start": 0, "char_end": 100},
+                {
+                    "id": "Notable_people",
+                    "title": "Notable people",
+                    "char_start": 100,
+                    "char_end": 200,
+                },
+            ]
+        }
+    )
+    cfg = SynthesizeConfig()
+
+    out = _boost_by_section_affinity(
+        passages,
+        query="famous people from big rapids",
+        bundle_lookup=bundle_lookup,
+        config=cfg,
+    )
+    # Notable_people: 0.4 * 1.5 = 0.6. History: 0.5. Notable_people wins.
+    assert out[0]["cite_id"] == "wiki/Big_Rapids,_Michigan#Notable_people"
+
+
+def test_boost_no_op_when_no_query_token_in_heading():
+    """No shared tokens → no boost, original order preserved."""
+    passages = [
+        _passage("wiki/Big_Rapids,_Michigan#History", score=1.0, rank=1),
+        _passage("wiki/Big_Rapids,_Michigan#Geography", score=0.6, rank=2),
+    ]
+    bundle_lookup = _bundle_lookup_for(
+        {
+            "Big_Rapids,_Michigan": [
+                {"id": "History", "title": "History", "char_start": 0, "char_end": 100},
+                {
+                    "id": "Geography",
+                    "title": "Geography",
+                    "char_start": 100,
+                    "char_end": 200,
+                },
+            ]
+        }
+    )
+    cfg = SynthesizeConfig()
+
+    out = _boost_by_section_affinity(
+        passages,
+        query="who founded big rapids",
+        bundle_lookup=bundle_lookup,
+        config=cfg,
+    )
+    # No 'history' or 'geography' tokens in query → no boost
+    assert out[0]["score"] == 1.0
+    assert out[1]["score"] == 0.6
+
+
+def test_boost_skips_article_level_citations():
+    """Passages without a #section_id suffix are left untouched."""
+    passages = [
+        _passage("wiki/Big_Rapids,_Michigan", score=1.0, rank=1),
+        _passage("wiki/Big_Rapids,_Michigan#Notable_people", score=0.6, rank=2),
+    ]
+    bundle_lookup = _bundle_lookup_for(
+        {
+            "Big_Rapids,_Michigan": [
+                {
+                    "id": "Notable_people",
+                    "title": "Notable people",
+                    "char_start": 0,
+                    "char_end": 200,
+                },
+            ]
+        }
+    )
+    cfg = SynthesizeConfig()
+
+    out = _boost_by_section_affinity(
+        passages,
+        query="famous people",
+        bundle_lookup=bundle_lookup,
+        config=cfg,
+    )
+    # Article-level passage score unchanged
+    article_passage = next(
+        p for p in out if p["cite_id"] == "wiki/Big_Rapids,_Michigan"
+    )
+    assert article_passage["score"] == 1.0
+
+
+def test_boost_threshold_gate_blocks_weak_overlap():
+    """Single token overlap against a 5-token heading is 1/5 = 0.2,
+    below the default threshold of 0.25. No boost."""
+    passages = [
+        _passage(
+            "wiki/Foo#A_Very_Long_Heading_Name_Here", score=1.0, rank=1
+        ),
+    ]
+    bundle_lookup = _bundle_lookup_for(
+        {
+            "Foo": [
+                {
+                    "id": "A_Very_Long_Heading_Name_Here",
+                    "title": "A very long heading name here",
+                    "char_start": 0,
+                    "char_end": 100,
+                },
+            ]
+        }
+    )
+    cfg = SynthesizeConfig()
+
+    out = _boost_by_section_affinity(
+        passages,
+        query="long stuff",  # 'long' overlaps; 1/6 ≈ 0.167 (after dedupe) < 0.25
+        bundle_lookup=bundle_lookup,
+        config=cfg,
+    )
+    assert out[0]["score"] == 1.0
+
+
+def test_boost_handles_missing_section_in_bundle():
+    """Section_id present on cite_id but not found in bundle → skip
+    silently, no boost, no crash."""
+    passages = [
+        _passage("wiki/Foo#nonexistent_section", score=1.0, rank=1),
+    ]
+    bundle_lookup = _bundle_lookup_for({"Foo": []})  # empty sections list
+    cfg = SynthesizeConfig()
+
+    out = _boost_by_section_affinity(
+        passages,
+        query="anything goes here",
+        bundle_lookup=bundle_lookup,
+        config=cfg,
+    )
+    assert out[0]["score"] == 1.0
+
+
+def test_boost_handles_bundle_lookup_returning_none():
+    """Bundle lookup returns None → no crash, no boost."""
+    passages = [
+        _passage("wiki/Foo#Section", score=1.0, rank=1),
+    ]
+
+    def none_lookup(archive_name: str, entry_path: str) -> Any:
+        return None
+
+    cfg = SynthesizeConfig()
+
+    out = _boost_by_section_affinity(
+        passages,
+        query="anything",
+        bundle_lookup=none_lookup,
+        config=cfg,
+    )
+    assert out[0]["score"] == 1.0
+
+
+def test_boost_handles_bundle_lookup_raising():
+    """Bundle lookup raises → no crash, no boost, logged at debug."""
+    passages = [
+        _passage("wiki/Foo#Section", score=1.0, rank=1),
+    ]
+
+    def raising_lookup(archive_name: str, entry_path: str) -> Any:
+        raise RuntimeError("bundle build failed")
+
+    cfg = SynthesizeConfig()
+
+    out = _boost_by_section_affinity(
+        passages,
+        query="anything",
+        bundle_lookup=raising_lookup,
+        config=cfg,
+    )
+    assert out[0]["score"] == 1.0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_synthesize_section_affinity.py -v`
+Expected: FAIL — `_boost_by_section_affinity` does not yet exist.
+
+- [ ] **Step 3: Implement `_boost_by_section_affinity` and wire into pipeline**
+
+Add to `openzim_mcp/synthesize.py` after `_attribute_sections` (around line 311):
+
+```python
+# ---------------------------------------------------------------------------
+# Pipeline stage 5b: section-heading affinity boost (A14)
+# ---------------------------------------------------------------------------
+
+# Same tokenizer used in iter_query_tails — alphanumeric runs only.
+_AFFINITY_TOKEN_RE = re.compile(r"[\w]+", re.UNICODE)
+
+
+def _affinity_tokens(text: str) -> set[str]:
+    """Lowercase alphanumeric token set. Empty set for empty input."""
+    if not text:
+        return set()
+    return {t.lower() for t in _AFFINITY_TOKEN_RE.findall(text)}
+
+
+def _boost_by_section_affinity(
+    passages: list[SynthesizePassage],
+    *,
+    query: str,
+    bundle_lookup: Callable[[str, str], Any],
+    config: SynthesizeConfig,
+) -> list[SynthesizePassage]:
+    """Re-rank passages by section-heading affinity with the query.
+
+    For each passage with a ``#section_id`` suffix on its cite_id,
+    look up the section's heading in the bundle and compute
+    ``|query_tokens ∩ heading_tokens| / |heading_tokens|``. When that
+    affinity is ≥ ``config.section_affinity_threshold``, multiply the
+    passage's score by ``config.section_affinity_boost``. Re-sort the
+    list by score descending.
+
+    Article-level citations (no section_id), passages whose section
+    isn't in the bundle, and bundle-lookup failures are all no-ops:
+    the passage is preserved with its original score.
+
+    No-op when the query has no tokens (empty or whitespace-only).
+
+    Bundle caching: each (archive, entry_path) is looked up once and
+    its section→title map memoized for the duration of the call.
+    """
+    query_tokens = _affinity_tokens(query)
+    if not query_tokens:
+        return passages
+
+    threshold = config.section_affinity_threshold
+    boost = config.section_affinity_boost
+
+    # Memoize section title lookups per (archive, entry_path) so a bundle
+    # with multiple matching passages doesn't re-fetch.
+    titles_by_key: dict[tuple[str, str], dict[str, str]] = {}
+
+    def section_titles_for(archive_name: str, entry_path: str) -> dict[str, str]:
+        key = (archive_name, entry_path)
+        if key in titles_by_key:
+            return titles_by_key[key]
+        try:
+            bundle = bundle_lookup(archive_name, entry_path)
+        except Exception as e:
+            logger.debug(
+                "section-affinity bundle lookup failed for %s/%s: %s",
+                archive_name,
+                entry_path,
+                e,
+            )
+            titles_by_key[key] = {}
+            return titles_by_key[key]
+        if bundle is None:
+            titles_by_key[key] = {}
+            return titles_by_key[key]
+        titles = {
+            str(s.get("id", "")): str(s.get("title", ""))
+            for s in bundle.get("sections", [])
+            if s.get("id")
+        }
+        titles_by_key[key] = titles
+        return titles
+
+    boosted: list[SynthesizePassage] = []
+    for passage in passages:
+        cite_id = passage["cite_id"]
+        if "#" not in cite_id:
+            boosted.append(passage)
+            continue
+        base, _, section_id = cite_id.partition("#")
+        archive_name, _, entry_path = base.partition("/")
+        if not archive_name or not entry_path or not section_id:
+            boosted.append(passage)
+            continue
+        titles = section_titles_for(archive_name, entry_path)
+        heading = titles.get(section_id, "")
+        heading_tokens = _affinity_tokens(heading)
+        if not heading_tokens:
+            boosted.append(passage)
+            continue
+        overlap = heading_tokens & query_tokens
+        affinity = len(overlap) / len(heading_tokens)
+        if affinity >= threshold:
+            new_p = dict(passage)
+            new_p["score"] = float(passage["score"]) * boost
+            boosted.append(cast("SynthesizePassage", new_p))
+        else:
+            boosted.append(passage)
+
+    boosted.sort(key=lambda p: float(p.get("score", 0.0)), reverse=True)
+    return boosted
+```
+
+Wire it into `synthesize_query` (around [line 997-1001](openzim_mcp/synthesize.py#L997)):
+
+```python
+    attributed = _attribute_sections(
+        all_passages, bundle_lookup=bundle_lookup, hit_keys=hit_keys
+    )
+    # A14 (Change B): section-heading affinity boost. Promotes passages
+    # whose section heading shares tokens with the query past lexically-
+    # weaker BM25 leaders. No-op for article-level citations and for
+    # queries with no token overlap against any heading.
+    attributed = _boost_by_section_affinity(
+        attributed,
+        query=query,
+        bundle_lookup=bundle_lookup,
+        config=config,
+    )
+    pre_cap_chars = sum(len(p["text_markdown"]) for p in attributed)
+    capped = _enforce_budget(attributed, char_budget=config.output_char_budget)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_synthesize_section_affinity.py -v`
+Expected: All 8 tests PASS.
+
+- [ ] **Step 5: Run the full synthesize test suite to verify no regression**
+
+Run: `uv run pytest tests/test_synthesize.py tests/test_synthesize_title_promotion_v2a9.py tests/test_synthesize_meta_d7d8_v2a9.py tests/test_synthesize_section_affinity.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add openzim_mcp/synthesize.py tests/test_synthesize_section_affinity.py
+git commit -m "feat(v2): section-heading affinity boost in synthesize
+
+New _boost_by_section_affinity stage runs after _attribute_sections.
+Passages whose section heading shares >= 25%% of its tokens with the
+query get a 1.5x score multiplier and re-sort. Bounded archive-
+agnostic — the archive's own section headings provide the matching
+vocabulary, no curated synonym tables."
+```
+
+---
+
+## Task 6: Extend `SynthesizeResponse` with `considered_articles` + `considered_sections`
+
+**Files:**
+- Modify: `openzim_mcp/tool_schemas.py:555-564` (`SynthesizeResponse`)
+- Test: `tests/test_tool_schemas.py` (existing — add one test)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_tool_schemas.py` (or create a new test file if no `test_tool_schemas.py` exists — check first with `ls tests/test_tool_schemas.py`):
+
+```python
+def test_synthesize_response_accepts_considered_articles_and_sections():
+    """A14: SynthesizeResponse exposes considered_articles and
+    considered_sections for multi-round refinement. Both fields are
+    optional (total=False) so existing callers aren't forced to set
+    them."""
+    from openzim_mcp.tool_schemas import (
+        ConsideredArticle,
+        ConsideredSection,
+        SynthesizeResponse,
+    )
+
+    article: ConsideredArticle = {
+        "archive": "wiki",
+        "entry_path": "Big_Rapids_Township,_Michigan",
+        "title": "Big Rapids Township, Michigan",
+        "score": 0.42,
+    }
+    section: ConsideredSection = {
+        "section_id": "History",
+        "title": "History",
+    }
+    response: SynthesizeResponse = {
+        "query": "q",
+        "answer_markdown": "a",
+        "passages": [],
+        "citations": [],
+        "archives_searched": ["wiki"],
+        "fallback_used": "rrf_fusion",
+        "total_chars": 1,
+        "total_words": 1,
+        "_meta": {},  # type: ignore[typeddict-item]
+        "considered_articles": [article],
+        "considered_sections": [section],
+    }
+    # The TypedDict accepts the shape — assertion is structural.
+    assert response["considered_articles"][0]["title"] == "Big Rapids Township, Michigan"
+    assert response["considered_sections"][0]["title"] == "History"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_tool_schemas.py::test_synthesize_response_accepts_considered_articles_and_sections -v`
+Expected: FAIL with `ImportError: cannot import name 'ConsideredArticle' from 'openzim_mcp.tool_schemas'`.
+
+- [ ] **Step 3: Add the new TypedDicts and extend `SynthesizeResponse`**
+
+In `openzim_mcp/tool_schemas.py`, add before `SynthesizeResponse` (around line 555):
+
+```python
+class ConsideredArticle(TypedDict, total=False):
+    """A14: an article hit not selected as the featured citation, surfaced
+    so the caller can pivot in a follow-up turn without re-running search.
+
+    ``archive`` + ``entry_path`` form the handle the caller passes to
+    ``get_zim_entries`` (or composes into a `cite_id`). ``score`` is the
+    underlying ranking score at the point of selection — informational,
+    not part of the handle.
+    """
+
+    archive: str
+    entry_path: str
+    title: str
+    score: float
+
+
+class ConsideredSection(TypedDict, total=False):
+    """A14: a section of the featured article not selected as the featured
+    passage. ``section_id`` is the handle the caller passes to
+    ``get_section`` (or composes into a `cite_id` suffix).
+    """
+
+    section_id: str
+    title: str
+```
+
+Modify `SynthesizeResponse` (around line 555). Change from `class SynthesizeResponse(TypedDict):` to `class SynthesizeResponse(TypedDict, total=False):` so the new fields are optional. Add the two fields:
+
+```python
+class SynthesizeResponse(TypedDict, total=False):
+    query: str
+    answer_markdown: str
+    passages: list[SynthesizePassage]
+    citations: list[Citation]
+    archives_searched: list[str]
+    fallback_used: Literal["xapian_score", "rrf_fusion", "reranker"]
+    total_chars: int
+    total_words: int
+    _meta: MetaEnvelope
+    # A14: multi-round handles. Empty lists when no candidate space
+    # exists (zero-hit response, or no resolved entity article).
+    considered_articles: list[ConsideredArticle]
+    considered_sections: list[ConsideredSection]
+```
+
+**Note:** Switching the existing fields to `total=False` is intentional — pre-existing callers continue to populate them (they're always set in the synthesize_query return path), so runtime behavior is unchanged. The TypedDict signature loosens to allow the additive shape.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_tool_schemas.py::test_synthesize_response_accepts_considered_articles_and_sections -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run mypy to verify no type regression**
+
+Run: `uv run mypy openzim_mcp/synthesize.py openzim_mcp/tool_schemas.py openzim_mcp/simple_tools.py`
+Expected: No new errors. Pre-existing errors (if any) unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add openzim_mcp/tool_schemas.py tests/test_tool_schemas.py
+git commit -m "feat(v2): ConsideredArticle + ConsideredSection types
+
+Two new optional fields on SynthesizeResponse expose the candidate
+space — articles ranked but not featured, sections of the featured
+article not picked — as handles a follow-up turn can drill into."
+```
+
+---
+
+## Task 7: Populate `considered_articles` + `considered_sections` in `synthesize_query`
+
+**Files:**
+- Modify: `openzim_mcp/synthesize.py` (add `_build_considered_articles`, `_build_considered_sections`, wire into return)
+- Test: `tests/test_synthesize_considered_handles.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_synthesize_considered_handles.py`:
+
+```python
+"""Tests for considered_articles + considered_sections population in
+synthesize_query (A14).
+
+The featured passage's article and section are excluded from the
+considered lists — these surfaces are for *alternatives* the caller can
+pivot to, not duplicates of what's already in citations[].
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from openzim_mcp.config import SynthesizeConfig
+from openzim_mcp.synthesize import (
+    _build_considered_articles,
+    _build_considered_sections,
+    synthesize_query,
+)
+
+
+def test_build_considered_articles_excludes_featured_and_caps_at_3():
+    """Top_hits with 6 entries; passage capped to 1 (featured). The
+    considered_articles list has the remaining 5 sorted by their
+    original ranking, capped at 3."""
+    top_hits = [
+        ("wiki", {"path": "Big_Rapids,_Michigan", "title": "Big Rapids, Michigan", "score": 1.0}),
+        ("wiki", {"path": "Big_Rapids_Township,_Michigan", "title": "Big Rapids Twp", "score": 0.7}),
+        ("wiki", {"path": "Ferris_State_University", "title": "Ferris State", "score": 0.6}),
+        ("wiki", {"path": "Mecosta_County,_Michigan", "title": "Mecosta County", "score": 0.5}),
+        ("wiki", {"path": "Pere_Marquette_River", "title": "Pere Marquette River", "score": 0.4}),
+        ("wiki", {"path": "Muskegon_River", "title": "Muskegon River", "score": 0.3}),
+    ]
+    capped_passages = [
+        {"cite_id": "wiki/Big_Rapids,_Michigan#Notable_people", "text_markdown": "...", "rank": 1, "score": 1.5}
+    ]
+    result = _build_considered_articles(top_hits, capped_passages, max_n=3)
+    assert len(result) == 3
+    assert all(a["entry_path"] != "Big_Rapids,_Michigan" for a in result)
+    # Preserved order
+    assert result[0]["entry_path"] == "Big_Rapids_Township,_Michigan"
+    assert result[1]["entry_path"] == "Ferris_State_University"
+    assert result[2]["entry_path"] == "Mecosta_County,_Michigan"
+
+
+def test_build_considered_articles_empty_when_only_featured():
+    """One top_hit, captured as the featured passage → empty list."""
+    top_hits = [
+        ("wiki", {"path": "Big_Rapids,_Michigan", "title": "Big Rapids", "score": 1.0}),
+    ]
+    capped_passages = [
+        {"cite_id": "wiki/Big_Rapids,_Michigan#Notable_people", "text_markdown": "...", "rank": 1, "score": 1.5}
+    ]
+    result = _build_considered_articles(top_hits, capped_passages, max_n=3)
+    assert result == []
+
+
+def test_build_considered_sections_returns_sections_minus_featured():
+    """Featured passage cites Big_Rapids,_Michigan#Notable_people.
+    considered_sections returns all OTHER sections in that article's
+    bundle."""
+    capped_passages = [
+        {"cite_id": "wiki/Big_Rapids,_Michigan#Notable_people", "text_markdown": "...", "rank": 1, "score": 1.5}
+    ]
+
+    def bundle_lookup(archive_name: str, entry_path: str) -> Any:
+        if entry_path == "Big_Rapids,_Michigan":
+            return {
+                "sections": [
+                    {"id": "History", "title": "History"},
+                    {"id": "Geography", "title": "Geography"},
+                    {"id": "Notable_people", "title": "Notable people"},
+                    {"id": "Demographics", "title": "Demographics"},
+                ]
+            }
+        return None
+
+    result = _build_considered_sections(capped_passages, bundle_lookup, max_n=10)
+    ids = [s["section_id"] for s in result]
+    assert "Notable_people" not in ids
+    assert set(ids) == {"History", "Geography", "Demographics"}
+
+
+def test_build_considered_sections_empty_when_featured_is_article_level():
+    """Featured passage has no #section_id → no featured article-and-
+    section pair to anchor against. Return empty list."""
+    capped_passages = [
+        {"cite_id": "wiki/Big_Rapids,_Michigan", "text_markdown": "...", "rank": 1, "score": 1.0}
+    ]
+
+    def bundle_lookup(archive_name: str, entry_path: str) -> Any:
+        return {"sections": [{"id": "History", "title": "History"}]}
+
+    result = _build_considered_sections(capped_passages, bundle_lookup, max_n=10)
+    assert result == []
+
+
+def test_build_considered_sections_empty_when_no_passages():
+    """Zero-hit response → no featured article → empty list."""
+    result = _build_considered_sections([], lambda a, e: None, max_n=10)
+    assert result == []
+
+
+def test_build_considered_sections_caps_at_max_n():
+    """A long article (20 sections) capped at max_n=10."""
+    sections = [
+        {"id": f"S{i}", "title": f"Section {i}"} for i in range(20)
+    ]
+    capped_passages = [
+        {"cite_id": "wiki/Foo#S0", "text_markdown": "...", "rank": 1, "score": 1.0}
+    ]
+
+    def bundle_lookup(archive_name: str, entry_path: str) -> Any:
+        return {"sections": sections}
+
+    result = _build_considered_sections(capped_passages, bundle_lookup, max_n=10)
+    assert len(result) == 10
+    # S0 (featured) is excluded
+    assert all(s["section_id"] != "S0" for s in result)
+
+
+def test_synthesize_response_includes_considered_fields():
+    """End-to-end check: synthesize_query returns a response that
+    includes both new fields. Heavy mock-based test reusing the test
+    fixtures from test_synthesize_title_promotion_v2a9.py style."""
+    # This is a focused smoke test that verifies the fields are present
+    # in the response shape. A full integration test would require live
+    # ZIM fixtures, which are out of scope for unit tests.
+    archive = MagicMock()
+    search_handler = MagicMock()
+    # Minimal hit: one search result, no title-index promotion.
+    search_handler.search_top_k.return_value = [
+        {"path": "Foo", "title": "Foo", "snippet": "snippet body", "score": 1.0}
+    ]
+    search_handler.title_match_hit.return_value = None
+    cache = MagicMock()
+    cache.get.return_value = None
+    cache.set = MagicMock()
+    content_processor = MagicMock()
+    content_processor.html_to_plain_text.side_effect = lambda html: html
+
+    # Patch the bundle build to return a minimal bundle with one section.
+    with patch("openzim_mcp.synthesize._make_bundle_lookup") as mock_make:
+        def fake_lookup(archive_name: str, entry_path: str) -> Any:
+            return {
+                "rendered_markdown": "snippet body",
+                "sections": [
+                    {"id": "Lead", "title": "Lead", "char_start": 0, "char_end": 100},
+                    {"id": "Other", "title": "Other", "char_start": 100, "char_end": 200},
+                ],
+            }
+
+        mock_make.return_value = fake_lookup
+
+        response = synthesize_query(
+            "foo",
+            archives=[(archive, Path("/fake/wiki.zim"))],
+            search_handler=search_handler,
+            cache=cache,
+            content_processor=content_processor,
+            config=SynthesizeConfig(),
+        )
+
+    assert "considered_articles" in response
+    assert "considered_sections" in response
+    assert isinstance(response["considered_articles"], list)
+    assert isinstance(response["considered_sections"], list)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_synthesize_considered_handles.py -v`
+Expected: FAIL — `_build_considered_articles` and `_build_considered_sections` do not yet exist.
+
+- [ ] **Step 3: Implement the two helpers**
+
+Add to `openzim_mcp/synthesize.py` near the response-assembly section (after `_build_citations`, around line 416):
+
+```python
+# ---------------------------------------------------------------------------
+# A14: multi-round handle builders for SynthesizeResponse
+# ---------------------------------------------------------------------------
+
+_DEFAULT_CONSIDERED_ARTICLES_MAX = 3
+_DEFAULT_CONSIDERED_SECTIONS_MAX = 10
+
+
+def _featured_article_key(
+    capped_passages: list[SynthesizePassage],
+) -> Optional[tuple[str, str, Optional[str]]]:
+    """Decompose the top capped passage's cite_id into (archive, entry_path,
+    section_id). Returns None when there are no passages.
+
+    Used to identify which article+section to exclude from the considered
+    handles — the caller already sees the featured citation, so surfacing
+    it again as a "consider this instead" is noise.
+    """
+    if not capped_passages:
+        return None
+    return _parse_cite_id(capped_passages[0]["cite_id"])
+
+
+def _build_considered_articles(
+    top_hits: list[tuple[str, dict]],
+    capped_passages: list[SynthesizePassage],
+    *,
+    max_n: int = _DEFAULT_CONSIDERED_ARTICLES_MAX,
+) -> list[Any]:
+    """Top-N article hits NOT represented in capped_passages.
+
+    Preserves the order from top_hits (which is post-promotion, post-
+    demotion ranking). Each entry exposes (archive, entry_path, title,
+    score) so the caller can pass it directly to get_zim_entries or
+    compose a cite_id.
+    """
+    featured = _featured_article_key(capped_passages)
+    featured_key: Optional[tuple[str, str]] = None
+    if featured is not None:
+        featured_key = (featured[0], featured[1])
+    out: list[dict[str, Any]] = []
+    for archive_name, hit in top_hits:
+        entry_path = str(hit.get("path", ""))
+        if not entry_path:
+            continue
+        if featured_key is not None and (archive_name, entry_path) == featured_key:
+            continue
+        out.append(
+            {
+                "archive": archive_name,
+                "entry_path": entry_path,
+                "title": str(hit.get("title", entry_path)),
+                "score": float(hit.get("score", 0.0)),
+            }
+        )
+        if len(out) >= max_n:
+            break
+    return cast("list[Any]", out)
+
+
+def _build_considered_sections(
+    capped_passages: list[SynthesizePassage],
+    bundle_lookup: Callable[[str, str], Any],
+    *,
+    max_n: int = _DEFAULT_CONSIDERED_SECTIONS_MAX,
+) -> list[Any]:
+    """Sections of the featured passage's article, minus the featured
+    section itself. Capped at max_n.
+
+    Returns an empty list when:
+      - There are no passages.
+      - The featured passage has no #section_id (article-level
+        citation — there's no "featured section" to anchor against).
+      - The featured article's bundle lookup returns None or raises.
+      - The bundle's section list is empty.
+    """
+    featured = _featured_article_key(capped_passages)
+    if featured is None:
+        return []
+    archive_name, entry_path, featured_section_id = featured
+    if not featured_section_id:
+        return []
+    try:
+        bundle = bundle_lookup(archive_name, entry_path)
+    except Exception as e:
+        logger.debug(
+            "considered_sections bundle lookup failed for %s/%s: %s",
+            archive_name,
+            entry_path,
+            e,
+        )
+        return []
+    if bundle is None:
+        return []
+    out: list[dict[str, Any]] = []
+    for section in bundle.get("sections", []):
+        section_id = str(section.get("id", ""))
+        if not section_id or section_id == featured_section_id:
+            continue
+        out.append(
+            {
+                "section_id": section_id,
+                "title": str(section.get("title", section_id)),
+            }
+        )
+        if len(out) >= max_n:
+            break
+    return cast("list[Any]", out)
+```
+
+Wire into `synthesize_query` return (replace lines 1045-1058):
+
+```python
+    considered_articles = _build_considered_articles(top_hits, capped)
+    considered_sections = _build_considered_sections(capped, bundle_lookup)
+    return cast(
+        "SynthesizeResponse",
+        {
+            "query": response_query,
+            "answer_markdown": answer_md,
+            "passages": response_passages,
+            "citations": citations,
+            "archives_searched": archives_searched,
+            "fallback_used": fallback_used,
+            "total_chars": len(answer_md),
+            "total_words": len(answer_md.split()),
+            "_meta": cast("Any", meta),
+            "considered_articles": considered_articles,
+            "considered_sections": considered_sections,
+        },
+    )
+```
+
+Also update `_zero_hits_response` ([search for its definition](openzim_mcp/synthesize.py) — Bash: `grep -n "def _zero_hits_response" openzim_mcp/synthesize.py`) to set both new fields to empty lists, keeping the response shape consistent.
+
+- [ ] **Step 4: Find and update `_zero_hits_response`**
+
+Run: `grep -n "_zero_hits_response\|def _zero" openzim_mcp/synthesize.py`
+
+Add `considered_articles: []` and `considered_sections: []` to whatever dict it returns. Show the edit by adding to the returned dict literal.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_synthesize_considered_handles.py -v`
+Expected: All 7 tests PASS.
+
+- [ ] **Step 6: Run the full synthesize test suite to verify no regression**
+
+Run: `uv run pytest tests/test_synthesize.py tests/test_synthesize_title_promotion_v2a9.py tests/test_synthesize_meta_d7d8_v2a9.py tests/test_synthesize_section_affinity.py tests/test_synthesize_considered_handles.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add openzim_mcp/synthesize.py tests/test_synthesize_considered_handles.py
+git commit -m "feat(v2): considered_articles + considered_sections in synthesize
+
+Synthesize responses now surface the candidate space — top-3 article
+hits not featured, top-10 sections of the featured article not picked
+— so a follow-up turn can pivot via get_zim_entries / get_section
+without re-running search. The featured citation's article and
+section are excluded from these lists."
+```
+
+---
+
+## Task 8: End-to-end smoke test against the motivating query
+
+**Files:**
+- Modify: `CHANGELOG.md` — add unreleased a14 entry
+- No code changes; pure verification
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `uv run pytest tests/ -v`
+Expected: All tests PASS. Watch for any pre-existing tests that depended on the M26 4-token short-circuit or the old `SynthesizeResponse` shape (`total=False` change) — update them inline if needed.
+
+- [ ] **Step 2: Run mypy on the touched files**
+
+Run: `uv run mypy openzim_mcp/synthesize.py openzim_mcp/simple_tools.py openzim_mcp/title_promotion.py openzim_mcp/tool_schemas.py openzim_mcp/config.py`
+Expected: No new errors.
+
+- [ ] **Step 3: Run the linter / formatter**
+
+Run: `uv run black --check openzim_mcp/ tests/ && uv run isort --check-only openzim_mcp/ tests/`
+Expected: PASS. If any formatting drift, run `uv run black openzim_mcp/ tests/ && uv run isort openzim_mcp/ tests/` and re-commit.
+
+- [ ] **Step 4: Add an unreleased CHANGELOG entry**
+
+Read the existing `CHANGELOG.md`, find the unreleased section (or create one above the most recent `## [X.Y.Za<N>]` header following the same format), and add:
+
+```markdown
+## [Unreleased]
+
+### Added
+
+- `zim_query` natural-language search-engine path: prose-shaped queries
+  like *"who are some famous people from big rapids, michigan"* now
+  resolve to the canonical entity (`Big_Rapids,_Michigan`) via greedy
+  length-down tail iteration in both default and `synthesize=True`
+  modes (`iter_query_tails` shared helper in `title_promotion`).
+- `synthesize=True` responses: section-heading affinity boost re-ranks
+  section-attributed passages so the *Notable people* section of a
+  city article leads when the query mentions "people". Tunable via
+  `SynthesizeConfig.section_affinity_threshold` (default 0.25) and
+  `section_affinity_boost` (default 1.5).
+- `synthesize=True` responses: new `considered_articles` and
+  `considered_sections` fields expose the candidate space for
+  multi-round refinement without re-running search.
+
+### Changed
+
+- Removed the 4-token short-circuit in `_promote_title_match`
+  (M26). Long prose queries with a clear entity tail now resolve
+  canonically instead of falling through to BM25 noise.
+- `SynthesizeResponse` TypedDict is now `total=False` to accommodate
+  the new optional fields. Existing callers populating all the
+  previously-required fields are unaffected.
+```
+
+- [ ] **Step 5: Commit the CHANGELOG entry**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): a14 search-engine zim_query path"
+```
+
+- [ ] **Step 6: Live beta-test sweep (manual, against the 118 GB Wikipedia ZIM)**
+
+This step is **manual** and follows the [a-series beta-testing methodology](../../v2/README.md). It is NOT scripted into the implementation plan; it runs after the alpha is cut.
+
+Test set (from the spec's testing section):
+
+- Motivating: `zim_query("who are some famous people from big rapids michigan")` — verify the response leads with Big_Rapids,_Michigan content. In `synthesize=True`, verify `citations[0].section_id == "Notable_people"` (or whatever the bundle calls it; check `considered_sections` for the actual heading list).
+- Wikipedia question-shape battery: *"history of Detroit"*, *"geography of Iceland"*, *"economy of Vietnam"*, *"notable people from Big Rapids"*, *"famous residents of Detroit"*. Verify section targeting.
+- Cross-article: *"jazz musicians from Detroit"*, *"WWII battles in Africa"*. Verify `considered_articles` surfaces useful pivots.
+- Regression on existing adversarial set: single-word topics, politeness-tail variants, canonical-with-disambig-twin (Berlin, Tokyo, Mercury, Apollo 11), single-edit typos, chained-intent queries. Confirms no regression from the 4-token short-circuit removal.
+- Non-Wikipedia archive if available — Stack Exchange or Wikitravel ZIM with a question whose answer is in a known section. Verify the affinity boost matches against *that archive's* section vocabulary.
+
+Findings cycle back as new unit tests in subsequent commits, per the a8 → a13 pattern.
+
+---
+
+## Spec Coverage Check
+
+| Spec section | Task(s) |
+|---|---|
+| Change A₀ (shared `iter_query_tails`) | Task 2 |
+| Change A₁ (synthesize tail probe) | Task 4 |
+| Change A₂ (tell_me_about tail probe) | Task 3 |
+| Change B (section affinity) | Task 1 (config), Task 5 (logic) |
+| Change C (`considered_*`) | Task 6 (schema), Task 7 (population) |
+| "Why no stopword strip" — design rationale | Implemented as the absence of any stopword strip in Tasks 2, 3, 4, 5. Affinity tokens come straight from `_AFFINITY_TOKEN_RE.findall(text)` with no removal pass. |
+| Default-mode vs synthesize-mode coverage | Task 3 (default), Tasks 4–7 (synthesize) |
+| Edge cases: no entity / no heading match / no section / non-English | Covered by tests in Tasks 2, 3, 4, 5, 7 |
+| Performance bound | Task 8 step 1 (full test suite); not separately measured (implementation cost is sub-millisecond per the spec's analysis) |
+| Live beta-test sweep | Task 8 step 6 (manual) |
+
+## Open Items For Implementation
+
+- **`Iterator` import in `title_promotion.py` (Task 2):** the file may already import from `typing`; verify and merge into the existing import block.
+- **`_zero_hits_response` shape (Task 7 step 4):** the implementer needs to find and update this helper. The grep command is provided.
+- **`tests/test_tool_schemas.py` existence (Task 6):** the implementer should check whether the file exists. If not, create it with a minimal header and the one new test.
+- **Pre-existing M26 short-circuit test (Task 4 step 1):** if `tests/test_synthesize_title_promotion_v2a9.py` has a test that explicitly asserts the 4-token short-circuit behavior, it needs to be deleted or rewritten to assert the new tail-probe behavior. The implementer should grep for "M26" or "4-token" in the test file before starting.

--- a/docs/superpowers/specs/2026-05-15-search-engine-zim-query-design.md
+++ b/docs/superpowers/specs/2026-05-15-search-engine-zim-query-design.md
@@ -14,7 +14,7 @@ Today the same query short-circuits entity resolution because the query has more
 
 ## Non-goals
 
-- **No new tool, no new intent, no new module.** Three localized edits to existing files.
+- **No new tool, no new intent, no new module.** Localized edits to four existing files; one small new helper function in `title_promotion.py`.
 - **No curated question-pattern table.** No mapping of question shapes to section names.
 - **No curated section-name synonyms.** No `{notable_people: ["Notable people", "Famous residents", ...]}` table.
 - **No Wikipedia-shaped assumptions.** Section ranking uses each archive's own section headings — works equally on Stack Exchange, Wikitravel, Project Gutenberg, medical wikis.
@@ -33,7 +33,8 @@ Today the same query short-circuits entity resolution because the query has more
 
 | Decision | Choice |
 |---|---|
-| Architecture shape | **Three localized edits.** No new `qa.py` module. No new intent. No new tool. |
+| Architecture shape | **Localized edits, no new module.** One shared helper in `title_promotion.py`; entity-resolution edits in both `synthesize.py` and `simple_tools.py`; affinity stage + response fields in `synthesize.py`/`tool_schemas.py`. No new intent. No new tool. |
+| Dual-path coverage | **Both `tell_me_about` (default) and `synthesize` paths** get the greedy tail probe (Change A). Section-affinity boost (Change B) and `considered_*` handles (Change C) are synthesize-only — the default path keeps its markdown-string contract. See "Default-mode vs synthesize-mode coverage". |
 | Response shape | **Featured excerpt + fallbacks.** Lead with one section excerpt; expose alternative articles and alternative sections as handles. |
 | Query scope | **All single-entity questions, plus cross-article fallback.** When no entity resolves, fall back to existing BM25 + the new affinity boost across all hits. |
 | Entity resolution | **Greedy length-down tail probe.** Try trailing 4 tokens, then 3, then 2, then 1 against each archive's title index. First hit wins. |
@@ -45,15 +46,28 @@ Today the same query short-circuits entity resolution because the query has more
 
 ## Architecture
 
-Three changes across existing files:
+Four changes across existing files (Change A applies to two parallel code paths via a shared helper):
 
 | Change | File | Function / location | Why here |
 |---|---|---|---|
-| A — Greedy tail probe for entity resolution | [`synthesize.py`](../../../openzim_mcp/synthesize.py) | `_promote_title_match` ([line 498](../../../openzim_mcp/synthesize.py#L498)) | Title-match promotion already lives here. The fix replaces one heuristic (token count) with another (greedy tail probe). |
+| A₀ — Shared greedy tail-iterator helper | [`title_promotion.py`](../../../openzim_mcp/title_promotion.py) | New `iter_query_tails(query, max_len=4, min_len=1)` | Both paths need the same tail-generation logic. Drying it once keeps the entity-extraction heuristic in one place. |
+| A₁ — Greedy tail probe in synthesize path | [`synthesize.py`](../../../openzim_mcp/synthesize.py) | `_promote_title_match` ([line 498](../../../openzim_mcp/synthesize.py#L498)) | Replace the 4-token short-circuit with a tail probe that iterates `iter_query_tails(query)` and resolves each candidate via `title_match_hit`. |
+| A₂ — Greedy tail probe in tell_me_about path | [`simple_tools.py`](../../../openzim_mcp/simple_tools.py) | `_promote_topic_via_title_index` ([line 2141](../../../openzim_mcp/simple_tools.py#L2141)) | The default-mode path the motivating query routes through. Without this, the motivating query is unchanged in default mode — `find_title_match` is called with the full prose topic and returns nothing. |
 | B — Section-heading affinity boost | [`synthesize.py`](../../../openzim_mcp/synthesize.py) | New stage after `_attribute_sections` ([line 242](../../../openzim_mcp/synthesize.py#L242)), called from the synthesize orchestrator | Section attribution already runs; affinity scoring as a post-attribution stage keeps the change contained. |
-| C — `considered_articles` + `considered_sections` in response | [`synthesize.py`](../../../openzim_mcp/synthesize.py) response builder + [`compact_renderers.py`](../../../openzim_mcp/compact_renderers.py) | Wherever the structured response is assembled | Response shape is rendered separately for compact vs JSON modes. Both renderers get the new fields. |
+| C — `considered_articles` + `considered_sections` in response | [`tool_schemas.py`](../../../openzim_mcp/tool_schemas.py) + [`synthesize.py`](../../../openzim_mcp/synthesize.py) response builder | Add fields to `SynthesizeResponse` TypedDict; populate in `synthesize_query` after passage capping. | `SynthesizeResponse` is the only structured response shape we're extending. The default-mode `tell_me_about` keeps its current markdown-string contract (see "Default-mode vs synthesize-mode" below). |
 
-No new module. No new intent in [`intent_parser.py`](../../../openzim_mcp/intent_parser.py). No new tool. Existing `tell_me_about` path gets smarter; existing `synthesize` path gets smarter; response shape gains two fields.
+No new module. No new intent in [`intent_parser.py`](../../../openzim_mcp/intent_parser.py). No new tool. Tunable constants land in [`constants.py`](../../../openzim_mcp/constants.py).
+
+### Default-mode vs synthesize-mode coverage
+
+The motivating query *"who are some famous people from big rapids, michigan"* takes **two different code paths** depending on whether the caller sets `synthesize=True`:
+
+| Path | Caller flag | Today | After this plan |
+|---|---|---|---|
+| Default (`_handle_tell_me_about`) | `synthesize=False` (default) | `find_title_match(topic)` probes the full prose string, returns nothing, falls through to BM25 search noise | A₂ + A₀: tail probe resolves `Big_Rapids,_Michigan`, fetches and returns the article body (markdown string). Entity correct, but no section targeting. |
+| Synthesize (`_handle_synthesize_query`) | `synthesize=True` | 4+ token short-circuit skips title-index probe entirely | A₁ + A₀ + B + C: tail probe resolves the entity, affinity boost picks `#Notable_people` as the featured passage, response carries `considered_articles` + `considered_sections` handles. |
+
+The full Google-style featured-snippet experience requires `synthesize=True`. The default mode gets correct entity resolution and the article body — strictly better than today's BM25-noise outcome, but not section-targeted. Auto-routing question-shaped queries with substantive intent beyond the entity to synthesize mode is a **future enhancement**, out of scope for this plan.
 
 ---
 

--- a/docs/superpowers/specs/2026-05-15-search-engine-zim-query-design.md
+++ b/docs/superpowers/specs/2026-05-15-search-engine-zim-query-design.md
@@ -1,0 +1,299 @@
+# Search-engine-style `zim_query` (Design Spec)
+
+**Status:** Draft
+**Date:** 2026-05-15
+**Target:** v2.0.0a14 (sweep candidate)
+
+---
+
+## Goal
+
+Make `zim_query` behave like a search engine for natural-language questions: take a query like *"who are some famous people from big rapids, michigan"* and return the most relevant section excerpt (the *Notable people* section of *Big Rapids, Michigan*) as the featured answer, plus a candidate space of alternative articles and sections that a follow-up turn can pivot to.
+
+Today the same query short-circuits entity resolution because the query has more than 4 tokens ([`synthesize.py:540`](../../../openzim_mcp/synthesize.py#L540)), so no canonical article gets promoted, and there is no notion that the answer lives in a specific section of one article.
+
+## Non-goals
+
+- **No new tool, no new intent, no new module.** Three localized edits to existing files.
+- **No curated question-pattern table.** No mapping of question shapes to section names.
+- **No curated section-name synonyms.** No `{notable_people: ["Notable people", "Famous residents", ...]}` table.
+- **No Wikipedia-shaped assumptions.** Section ranking uses each archive's own section headings — works equally on Stack Exchange, Wikitravel, Project Gutenberg, medical wikis.
+- **No new ontology, no English-stopword list.** The design has zero curated artifacts left after the brainstorm pass dropped the stopword strip.
+- **No server-side multi-turn state.** Multi-round refinement emerges from the response shape exposing handles (cite_ids, section_ids) the caller can pass back. The server stays stateless per call.
+- **No new ML deps, no embeddings, no reranker.** Pure lexical token overlap.
+- **No cross-archive question-answering reasoning.** Cross-article scope is handled by surfacing `considered_articles` so the caller can pivot — not by the server reasoning across multiple articles.
+
+## Foundational principles
+
+1. **The archive supplies the vocabulary.** Section ranking is "does this query share tokens with the section headings *this article actually has*." We never assert what a section "should" be called.
+2. **The LLM is the reasoner.** The MCP server's job is to be a great index + reader. Question-answering composition happens turn-by-turn at the caller, not in the server.
+3. **Honest tradeoffs over Wikipedia-only polish.** Pure token overlap will miss `"famous people" ↔ "Notable people"` synonyms. The miss is covered by `considered_sections` in the response, not by a curated table.
+
+## Decisions captured during brainstorming
+
+| Decision | Choice |
+|---|---|
+| Architecture shape | **Three localized edits.** No new `qa.py` module. No new intent. No new tool. |
+| Response shape | **Featured excerpt + fallbacks.** Lead with one section excerpt; expose alternative articles and alternative sections as handles. |
+| Query scope | **All single-entity questions, plus cross-article fallback.** When no entity resolves, fall back to existing BM25 + the new affinity boost across all hits. |
+| Entity resolution | **Greedy length-down tail probe.** Try trailing 4 tokens, then 3, then 2, then 1 against each archive's title index. First hit wins. |
+| Section ranking | **Token-overlap affinity boost.** Multiply RRF score by `1.5` when query and section heading share ≥ 0.25 of the heading's tokens. |
+| Stopword/question-word stripping | **None.** Adds curation surface for no measurable win (see "Why no stopword strip" below). |
+| Synonym buckets / question templates | **None.** Curated artifacts shifted the design toward Wikipedia-shaped assumptions; dropped. |
+
+---
+
+## Architecture
+
+Three changes across existing files:
+
+| Change | File | Function / location | Why here |
+|---|---|---|---|
+| A — Greedy tail probe for entity resolution | [`synthesize.py`](../../../openzim_mcp/synthesize.py) | `_promote_title_match` ([line 498](../../../openzim_mcp/synthesize.py#L498)) | Title-match promotion already lives here. The fix replaces one heuristic (token count) with another (greedy tail probe). |
+| B — Section-heading affinity boost | [`synthesize.py`](../../../openzim_mcp/synthesize.py) | New stage after `_attribute_sections` ([line 242](../../../openzim_mcp/synthesize.py#L242)), called from the synthesize orchestrator | Section attribution already runs; affinity scoring as a post-attribution stage keeps the change contained. |
+| C — `considered_articles` + `considered_sections` in response | [`synthesize.py`](../../../openzim_mcp/synthesize.py) response builder + [`compact_renderers.py`](../../../openzim_mcp/compact_renderers.py) | Wherever the structured response is assembled | Response shape is rendered separately for compact vs JSON modes. Both renderers get the new fields. |
+
+No new module. No new intent in [`intent_parser.py`](../../../openzim_mcp/intent_parser.py). No new tool. Existing `tell_me_about` path gets smarter; existing `synthesize` path gets smarter; response shape gains two fields.
+
+---
+
+## Change A — Greedy tail probe (entity resolution)
+
+Replace the token-count gate in `_promote_title_match`:
+
+**Current** ([`synthesize.py:540`](../../../openzim_mcp/synthesize.py#L540)):
+```python
+_content_query_token_count = 4
+if len(_re.findall(r"[a-z0-9]+", query.lower())) > _content_query_token_count:
+    return top_hits
+```
+
+**Replace with:** greedy length-down tail probe.
+
+```
+tokens = tokenize(query)        # lowercase word tokens, in order
+for tail_len in (4, 3, 2, 1):
+    if tail_len > len(tokens):
+        continue
+    candidate = " ".join(tokens[-tail_len:])
+    for archive, archive_name in zip(archives, archives_searched):
+        hit = title_match_hit(archive, candidate)
+        if isinstance(hit, dict) and hit.get("path"):
+            return _promote(hit, top_hits, archive_name)
+return top_hits
+```
+
+The strong-top-hit short-circuit ([`synthesize.py:529`](../../../openzim_mcp/synthesize.py#L529)) still runs first — when BM25 already returned a strong title match at rank 1, no probe runs.
+
+**Why greedy length-down:** entities tend to be the longest sub-tail that still resolves. *"big rapids michigan"* is a better resolution than *"michigan"* — both probably hit the title index, but the former is the more specific entity. Trying 4→3→2→1 picks the most specific.
+
+**Cost:** up to 4 cheap title-index probes per archive on the worst case, when no probe hits until the 1-token tail (or none of them do). Title-index probes are microseconds — bounded by `archive_count × 4`, negligible.
+
+## Change B — Section-heading affinity boost
+
+New stage in the synthesize pipeline, runs after `_attribute_sections`, before `_enforce_budget`:
+
+```
+# bundle["sections"] is the existing list used by _attribute_sections
+# Each entry: {"id": str, "title": str, "char_start": int, "char_end": int}
+section_title_by_id = {s["id"]: s["title"] for s in bundle.get("sections", [])}
+query_tokens = tokenize(query)                       # lowercase [a-z0-9]+
+
+for passage in passages:
+    cite_id = passage["cite_id"]                     # existing SynthesizePassage field
+    if "#" not in cite_id:
+        continue                                      # article-level citation, no section
+    section_id = cite_id.split("#", 1)[1]
+    heading = section_title_by_id.get(section_id, "")
+    heading_tokens = set(tokenize(heading))
+    if not heading_tokens:
+        continue
+    overlap = heading_tokens & set(query_tokens)
+    affinity = len(overlap) / len(heading_tokens)
+    if affinity >= AFFINITY_THRESHOLD:                # default 0.25
+        passage["score"] *= AFFINITY_BOOST            # default 1.5
+
+passages.sort(key=lambda p: p["score"], reverse=True)
+```
+
+The exact attribute access (`passage["score"]` vs `passage.score`) follows whatever shape `SynthesizePassage` already uses in [`synthesize.py`](../../../openzim_mcp/synthesize.py) — the implementation plan resolves this against the current type def.
+
+**Tunable constants** in [`constants.py`](../../../openzim_mcp/constants.py):
+
+| Constant | Default | Rationale |
+|---|---|---|
+| `SECTION_AFFINITY_THRESHOLD` | `0.25` | One matching token in a 4-token heading qualifies. Conservative — won't fire on 1-of-10 weak overlaps. |
+| `SECTION_AFFINITY_BOOST` | `1.5` | Won't dominate strong BM25 hits (a top-ranked passage with score 1.0 beats a rank-3 passage at 0.6 × 1.5 = 0.9). Only flips ranking among already-competitive passages. |
+
+Both are tuneable in beta-test sweeps.
+
+**Tokenization:** lowercase + `re.findall(r"[a-z0-9]+", text)`. No stopword strip — see "Why no stopword strip" below.
+
+**No-op cases:**
+- Passage has no `#section_id` (article-level citation) → skipped.
+- Section heading not found in bundle → skipped.
+- Empty heading or empty query → skipped.
+- No token overlap → no boost.
+
+## Change C — Response shape (multi-round handles)
+
+Two new top-level fields on `SynthesizeResponse`:
+
+```json
+{
+  "answer_markdown": "...",
+  "citations": [...],
+  "fallback_used": "rrf_fusion",
+  "considered_articles": [
+    {"archive": "wikipedia_en_all_maxi_2026-02", "path": "Big_Rapids_Township,_Michigan", "title": "Big Rapids Township, Michigan", "score": 0.42},
+    {"archive": "wikipedia_en_all_maxi_2026-02", "path": "Ferris_State_University", "title": "Ferris State University", "score": 0.38}
+  ],
+  "considered_sections": [
+    {"section_id": "History",          "title": "History"},
+    {"section_id": "Geography",        "title": "Geography"},
+    {"section_id": "Demographics",     "title": "Demographics"},
+    {"section_id": "Government",       "title": "Government"},
+    {"section_id": "Education",        "title": "Education"}
+  ]
+}
+```
+
+**`considered_articles`:** top 3–5 hits *not* selected as the featured citation. Drawn from the post-promotion `top_hits` list, minus whichever ended up rendered. Each entry exposes the same `archive` + `path` the caller can pass to `get_zim_entries`.
+
+**`considered_sections`:** all sections of the featured article's bundle, minus the featured section. Drawn from the bundle's section list. Each entry exposes the `section_id` the caller can pass to `get_section`.
+
+Both fields are *optional* on the response model — empty list when no candidates exist (e.g. cross-archive question with no entity-resolved article).
+
+**Compact-mode rendering** ([`compact_renderers.py`](../../../openzim_mcp/compact_renderers.py)): appended to the existing rendered output as two short markdown tails, subject to the existing 6000-char hard cap. Truncated if necessary — full structured payload is always available via `structuredContent`.
+
+```
+### Other articles
+- Big_Rapids_Township,_Michigan
+- Ferris_State_University
+
+### Other sections in this article
+- History
+- Geography
+- Demographics
+- Government
+- Education
+```
+
+**JSON mode:** fields emitted directly on the structured payload.
+
+---
+
+## Data flow walkthrough
+
+For *"who are some famous people from big rapids, michigan"*:
+
+1. **Intent parser** ([`intent_parser.py:599`](../../../openzim_mcp/intent_parser.py#L599)) matches `who are` → `tell_me_about`, `topic="some famous people from big rapids, michigan"`. *(Unchanged.)*
+2. **`tell_me_about` handler** runs `synthesize(query=topic)`. *(Unchanged.)*
+3. **Per-archive BM25 + RRF fusion** ([`synthesize.py:82`](../../../openzim_mcp/synthesize.py#L82)). Top hits include `Big_Rapids,_Michigan`, `Big_Rapids_Township,_Michigan`, plus lexical noise. *(Unchanged.)*
+4. **Change A — `_promote_title_match` tail probe:** trailing 4 tokens *"from big rapids michigan"* → no title hit. Trailing 3 *"big rapids michigan"* → `title_match_hit` resolves to `Big_Rapids,_Michigan`. Promote to rank 1.
+5. **`_extract_passages` + `_attribute_sections`** ([`synthesize.py:242`](../../../openzim_mcp/synthesize.py#L242)): pull snippet windows, attribute each to `Big_Rapids,_Michigan#Notable_people`, `…#History`, `…#Geography`, etc. *(Unchanged.)*
+6. **Change B — affinity boost:** query tokens `{who, are, some, famous, people, from, big, rapids, michigan}`.
+   - `Notable_people` heading → `{notable, people}`. Overlap `{people}`. Affinity `1/2 = 0.5` ≥ 0.25. **Boost ×1.5.**
+   - `History` → `{history}`. Overlap `{}`. No boost.
+   - `Geography` → `{geography}`. No boost.
+   - `Demographics` → `{demographics}`. No boost.
+7. Re-sort. `…#Notable_people` passage at rank 1.
+8. **`_enforce_budget` + `_build_citations`** ([`synthesize.py:331`](../../../openzim_mcp/synthesize.py#L331)): render featured passage with `cite_id = Big_Rapids,_Michigan#Notable_people`. *(Unchanged.)*
+9. **Change C — response builder:** populate `considered_articles` (Big_Rapids_Township, Ferris_State_University, …) + `considered_sections` (History, Geography, Demographics, …).
+
+Caller gets back: featured passage with names + handles to pivot to History, Geography, etc. on the follow-up turn.
+
+---
+
+## Why no stopword strip
+
+The brainstorm pass initially proposed a small English stopword/question-word strip (~20 words) to clean the query before tokenization. Walking through the affinity math showed the strip is essentially inert:
+
+**Affinity is normalized by *heading length*, not query length.** Adding `{who, are, some, from}` to query tokens doesn't change the intersection (those tokens aren't in any section heading) and doesn't change the denominator. The score is identical with or without the strip.
+
+**For Change A**, the greedy length-down probe finds the entity without help — *"from big rapids michigan"* misses on the title index, then *"big rapids michigan"* hits. Cost is up to 3 extra cheap probes when the entity is short. Title-index probes are microseconds.
+
+Dropping the strip removes:
+- All curated English vocabulary from the design.
+- The non-English-archive edge case (e.g. French Wikipedia "qui est" stripping).
+- A "what's the default stopword list" review question.
+
+Net: zero curated artifacts in the final design.
+
+---
+
+## Edge cases and failure modes
+
+| Case | Behavior |
+|---|---|
+| No entity resolves (tail probe finds nothing in any archive) | Falls through to existing BM25 + RRF. Affinity boost (Change B) still runs against whatever section attribution produces. |
+| Entity resolves but no section heading shares tokens with query | No boost fires. Featured passage is BM25 rank 1 — usually the article lead. `considered_sections` still surfaces all sections for follow-up. |
+| Cross-article question (*"jazz musicians from Detroit"*) | Tail probe resolves *Detroit*; affinity rarely matches strongly (sections are *History*, *Government*, etc., not *Jazz musicians*). Response leads with BM25 top hit; `considered_articles` surfaces alternatives the caller can pivot to. |
+| Archive has no section structure (Project Gutenberg single-file book, single-page Stack Exchange answer) | `_attribute_sections` returns article-level cite_id, affinity scorer has nothing to score, behavior degenerates to today's BM25. No regression. |
+| Query is exact existing title (*"Photosynthesis"*) | Strong-top-hit short-circuit at [`synthesize.py:529`](../../../openzim_mcp/synthesize.py#L529) fires first. Tail probe never runs. Behavior unchanged. |
+| Empty query after `tell_me_about` strip (*"tell me about "*) | Handled at [`simple_tools.py:429`](../../../openzim_mcp/simple_tools.py#L429); never reaches synthesize. Unchanged. |
+| Tail probe ties (4-token tail and 3-token tail both hit) | Greedy: 4-token wins. Won't happen in practice unless someone has a 4-token title indexed; deterministic by ordering. |
+| Affinity ties (two sections both score 0.5) | Tie broken by original BM25 score (existing secondary sort). Deterministic. |
+| Same query token appears in multiple section headings (*"History"* and *"Early history"*) | Both get boosted. Existing dedup in citations handles the rest. |
+| Non-English archive | No stopword strip means no English bias. Tokenization (`[a-z0-9]+`) drops accented characters — a known limitation, but the existing pipeline has the same property. No regression from this design. |
+
+---
+
+## Performance
+
+- **Change A:** up to 4 extra `title_match_hit` calls per archive on the worst case. Each is the cheap title-index path, not full search. Bounded by `archive_count × 4`, sub-millisecond.
+- **Change B:** O(passages × sections) token-set intersections, capped at ~30 passages × ~30 sections = 900 small set ops. Sub-millisecond.
+- **Change C:** response payload grows by ~5 article handles + ~20 section handles. Compact-mode hard cap (6000 chars) still applies; the tails truncate first if needed.
+
+No new caches, no new deps.
+
+---
+
+## Testing
+
+**Unit tests** ([`tests/`](../../../tests/)):
+
+- `_promote_title_match` greedy tail probe — parameterized cases:
+  - Single-token entity (*"detroit"*) — 1-token tail hits.
+  - Multi-token entity (*"big rapids michigan"*) — 3-token tail hits, longer tails miss.
+  - No-entity-tail (*"how do plants make food"*) — all tail lengths miss, falls through.
+  - Entity at the front of the query — tail probe still finds it via shorter tails.
+  - Adversarial overlap (*"who is who"*) — bounded probe terminates.
+  - Query with only stopwords — no entity found, falls through.
+  - Empty query — graceful no-op.
+  - Strong-top-hit short-circuit still wins when BM25 already returned the canonical title.
+- Section affinity scorer — heading/query pairs:
+  - `"famous people"` × `"Notable people"` → affinity 0.5, boosts.
+  - `"famous people"` × `"History"` → 0.0, no boost.
+  - `"people"` × `"People"` → 1.0, boosts.
+  - Identical query and heading → 1.0, boosts.
+  - Empty heading → skipped.
+  - Threshold boundary (0.25 exact) → boosts.
+- Response builder:
+  - `considered_articles` populated correctly, excludes the featured citation's article.
+  - `considered_sections` populated correctly, excludes the featured citation's section, capped at the bundle's section count.
+  - Compact-mode rendering under the 6000-char cap; both tails truncate before structured fields drop.
+  - JSON-mode emission.
+
+**Live beta-test sweep** (per the [a-series methodology](../../../README.md)): the design lands in a new alpha, then gets sweep-tested against the 118 GB Wikipedia ZIM.
+
+Adversarial sweep set:
+- The motivating query: *"who are some famous people from big rapids, michigan"* — verify featured passage is in `Big_Rapids,_Michigan#Notable_people`.
+- Wikipedia question-shape battery: *"history of Detroit"*, *"geography of Iceland"*, *"economy of Vietnam"*, *"notable people from Big Rapids"*, *"famous residents of Detroit"*. Each should pull the right section.
+- Cross-article scope: *"jazz musicians from Detroit"*, *"WWII battles in Africa"*. Verify `considered_articles` surfaces useful pivots even when the featured passage is wrong.
+- Existing adversarial set from the [a-series memory](../../../memory) still passes — single-word topics, politeness-tail variants, canonical-with-disambig-twin (Berlin, Tokyo, Mercury, Apollo 11), single-edit typos, chained-intent queries. Confirms no regression from the 4+ token short-circuit removal.
+- Non-Wikipedia archive smoke test if available — Stack Exchange or Wikitravel ZIM with a question whose answer is in a known section. Verify the affinity boost matches against *that archive's* section vocabulary, not Wikipedia's.
+
+Beta-test findings cycle back as new unit tests, same as a8 → a13.
+
+---
+
+## Open questions
+
+None at spec-write time. All decisions captured above.
+
+## Risks
+
+- **Affinity boost dominates strong BM25 in a way we didn't anticipate.** Mitigation: the boost factor (`1.5`) is conservative; a top BM25 hit (score 1.0) still beats a rank-3 hit at `0.6 × 1.5 = 0.9`. Tune in sweep.
+- **Greedy tail probe pulls wrong entity when query has multiple proper nouns** (e.g. *"battles between Rome and Carthage"* — does the 2-token tail *"and carthage"* miss but *"carthage"* resolve? Yes — that's the correct entity for this query, but the same logic applied to *"X versus Y"* might pick the wrong side). Mitigation: the existing strong-top-hit short-circuit ([`synthesize.py:529`](../../../openzim_mcp/synthesize.py#L529)) catches the case where BM25 already found the right entity at rank 1. Beta-test sweep will surface remaining cases.
+- **`considered_sections` token cost.** A Wikipedia city article has ~20 sections; serialized that's ~500 bytes. Compact mode handles via the 6000-char cap; structured mode is unbounded but small. Monitor in sweep.

--- a/docs/superpowers/specs/2026-05-15-search-engine-zim-query-design.md
+++ b/docs/superpowers/specs/2026-05-15-search-engine-zim-query-design.md
@@ -159,8 +159,8 @@ Two new top-level fields on `SynthesizeResponse`:
   "citations": [...],
   "fallback_used": "rrf_fusion",
   "considered_articles": [
-    {"archive": "wikipedia_en_all_maxi_2026-02", "path": "Big_Rapids_Township,_Michigan", "title": "Big Rapids Township, Michigan", "score": 0.42},
-    {"archive": "wikipedia_en_all_maxi_2026-02", "path": "Ferris_State_University", "title": "Ferris State University", "score": 0.38}
+    {"archive": "wikipedia_en_all_maxi_2026-02", "entry_path": "Big_Rapids_Township,_Michigan", "title": "Big Rapids Township, Michigan", "score": 0.42},
+    {"archive": "wikipedia_en_all_maxi_2026-02", "entry_path": "Ferris_State_University", "title": "Ferris State University", "score": 0.38}
   ],
   "considered_sections": [
     {"section_id": "History",          "title": "History"},
@@ -172,26 +172,13 @@ Two new top-level fields on `SynthesizeResponse`:
 }
 ```
 
-**`considered_articles`:** top 3–5 hits *not* selected as the featured citation. Drawn from the post-promotion `top_hits` list, minus whichever ended up rendered. Each entry exposes the same `archive` + `path` the caller can pass to `get_zim_entries`.
+**`considered_articles`:** top 3 hits *not* selected as the featured citation. Drawn from the post-promotion `top_hits` list, minus whichever ended up rendered. Each entry exposes the same `archive` + `entry_path` the caller can pass to `get_zim_entries`.
 
-**`considered_sections`:** all sections of the featured article's bundle, minus the featured section. Drawn from the bundle's section list. Each entry exposes the `section_id` the caller can pass to `get_section`.
+**`considered_sections`:** top 10 sections of the featured article's bundle (document order), minus the featured section. Each entry exposes the `section_id` the caller can pass to `get_section`.
 
 Both fields are *optional* on the response model — empty list when no candidates exist (e.g. cross-archive question with no entity-resolved article).
 
-**Compact-mode rendering** ([`compact_renderers.py`](../../../openzim_mcp/compact_renderers.py)): appended to the existing rendered output as two short markdown tails, subject to the existing 6000-char hard cap. Truncated if necessary — full structured payload is always available via `structuredContent`.
-
-```
-### Other articles
-- Big_Rapids_Township,_Michigan
-- Ferris_State_University
-
-### Other sections in this article
-- History
-- Geography
-- Demographics
-- Government
-- Education
-```
+**Compact-mode rendering deferred.** This release ships the new fields on the structured payload (`structuredContent`) only. LLM consumers reading `structuredContent` directly get the candidate space; legacy clients that only read the compact text envelope will not see these fields surfaced as markdown tails. Adding `### Other articles` / `### Other sections in this article` tails in [`compact_renderers.py`](../../../openzim_mcp/compact_renderers.py) is a follow-up if a legacy consumer needs it.
 
 **JSON mode:** fields emitted directly on the structured payload.
 

--- a/openzim_mcp/config.py
+++ b/openzim_mcp/config.py
@@ -113,6 +113,25 @@ class SynthesizeConfig(BaseModel):
         le=20000,
         description="Soft cap on answer_markdown chars (~1200 tokens).",
     )
+    section_affinity_threshold: float = Field(
+        default=0.25,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Minimum |query ∩ heading| / |heading| ratio before a "
+            "section-attributed passage gets the affinity boost."
+        ),
+    )
+    section_affinity_boost: float = Field(
+        default=1.5,
+        ge=1.0,
+        le=10.0,
+        description=(
+            "Multiplier applied to a passage's score when its section "
+            "heading affinity-matches the query. Conservative: won't "
+            "dominate strong BM25 hits."
+        ),
+    )
 
 
 class LoggingConfig(BaseModel):

--- a/openzim_mcp/server.py
+++ b/openzim_mcp/server.py
@@ -256,7 +256,12 @@ class OpenZimMcpServer:
             Args:
                 query: REQUIRED. Translated from user intent — never the
                     user's raw message.
-                zim_file_path: Optional (auto-selected if one archive).
+                zim_file_path: Optional. The on-disk path of a .zim file
+                    (e.g. `/data/wikipedia_en_all_maxi.zim`) — NOT an
+                    article title, topic, or made-up filename. Omit
+                    entirely and the tool auto-selects the one loaded
+                    archive (or opens all of them when `synthesize=True`).
+                    Use `list available ZIM files` to see real paths.
                 limit: Max search/browse results (default: 3).
                 offset: Pagination offset (default: 0).
                 max_content_length: Article body cap (default: 4000).
@@ -287,6 +292,12 @@ class OpenZimMcpServer:
                     attribution, and citation rendering. Returns a
                     SynthesizeResponse dict instead of markdown text.
                     Defaults to False (legacy markdown path unchanged).
+                    NOTE: this is a mode toggle, not a "search harder"
+                    flag. Don't flip it on a follow-up just because the
+                    previous response was unhelpful — refine the `query`
+                    or `offset` instead. The synthesize pipeline runs
+                    one structured query and returns one answer; calling
+                    it twice with the same query yields the same answer.
 
             Returns:
                 Markdown string (synthesize=False) or SynthesizeResponse

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -25,7 +25,12 @@ from .intent_parser import IntentParser, safe_regex_sub
 from .meta import build_meta, format_footer
 from .responses import ToolErrorPayload, tool_error
 from .security import sanitize_context_for_error
-from .title_promotion import _TOKEN_RE, find_title_match, is_strong_title_match
+from .title_promotion import (
+    _TOKEN_RE,
+    find_title_match,
+    is_strong_title_match,
+    iter_query_tails,
+)
 from .tool_schemas import SearchResponse, SynthesizeResponse
 from .zim_operations import ZimOperations
 
@@ -2141,12 +2146,13 @@ class SimpleToolsHandler:
     def _promote_topic_via_title_index(
         self, zim_file_path: str, topic: str
     ) -> Optional[Dict[str, Any]]:
-        """Promote a canonical title-index hit for ``topic`` past noisy BM25
-        ranking. Tries the strict 1.0-score gate first, then falls back to
-        the 0.8-score typo-tolerant gate.
-
-        Returns the resolved ``{path, title, zim_file}`` dict, or ``None``
-        when neither gate fires.
+        """Resolve ``topic`` to a canonical title-index hit, probing greedy
+        length-down tails (``iter_query_tails``). First pass tries the strict
+        1.0-score gate on every tail in length-down order; second pass tries
+        the 0.8-score typo-tolerant gate on every tail. Returns the first hit,
+        or ``None`` when no tail resolves. The two-pass structure ensures an
+        exact match on a clean shorter tail beats a fuzzy match on a noisier
+        longer tail.
 
         D6 fix (v2.0.0a9): Xapian ranks ``List of songs about Berlin``
         above the canonical ``Berlin`` article for ``query=Berlin``
@@ -2160,13 +2166,33 @@ class SimpleToolsHandler:
         through to Xapian search and returned a totally unrelated
         article. The chain is conservative by construction
         (length-gated at ≥5 chars, ≤700 variants).
+
+        A14: when the full topic doesn't resolve, fall back to greedy
+        length-down tail probes (``iter_query_tails``). The motivating
+        case is prose-shaped tell_me_about topics ("famous people from
+        big rapids michigan") where the full string never resolves but a
+        trailing entity ("big rapids michigan") does. Greedy length-down
+        picks the most specific entity that exists.
         """
-        promoted = find_title_match(self.zim_operations, zim_file_path, topic)
-        if promoted is not None:
-            return promoted
-        return find_title_match(
-            self.zim_operations, zim_file_path, topic, min_score=0.8
-        )
+        # First pass: strict 1.0-score gate across every tail. Prefer an
+        # exact title match on any tail (even a short one) over a typo-
+        # tolerant fuzzy match on a longer noisier tail. Without this
+        # ordering, a 0.8 fuzzy hit on "from big rapids michigan" could
+        # beat a 1.0 exact hit on the cleaner "big rapids michigan".
+        for tail in iter_query_tails(topic):
+            promoted = find_title_match(self.zim_operations, zim_file_path, tail)
+            if promoted is not None:
+                return promoted
+        # Second pass: 0.8 typo-tolerant gate. Only fires when no tail
+        # resolved strictly — catches single-edit typos like
+        # ``Photosythesis`` → ``Photosynthesis``.
+        for tail in iter_query_tails(topic):
+            promoted = find_title_match(
+                self.zim_operations, zim_file_path, tail, min_score=0.8
+            )
+            if promoted is not None:
+                return promoted
+        return None
 
     def _handle_tell_me_about(
         self,

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -330,6 +330,24 @@ class SimpleToolsHandler:
                     ),
                     context=f"cursor={token[:64]}",
                 )
+        # Normalize hallucinated ``zim_file_path`` BEFORE branching to the
+        # synthesize pipeline. Small models pass bare filenames
+        # (``"wikipedia.zim"``) or article titles (``"Big Rapids,
+        # Michigan.zim"``) when the parameter is documented as optional;
+        # the path validator anchors them to the process CWD and produces
+        # a confusing ``Access denied`` error. Pre-A14 fix, only the
+        # intent-classification branch (below) ran this resolver — the
+        # synthesize branch bypassed it, so the same hallucinated path
+        # succeeded with ``synthesize=False`` and failed with
+        # ``synthesize=True``. Lifting the resolver here makes both
+        # branches share one policy. The ``zim_file_path is None`` case
+        # is intentionally NOT normalized here: synthesize opens all
+        # archives for multi-archive RRF fusion when no path is given,
+        # while the intent branch auto-selects when exactly one archive
+        # is available.
+        if zim_file_path:
+            zim_file_path = self._normalize_zim_file_path(zim_file_path)
+
         if options.get("synthesize"):
             try:
                 return self._handle_synthesize_query(
@@ -472,47 +490,13 @@ class SimpleToolsHandler:
                         f"{self.zim_operations.list_zim_files()}"
                         "\n<!-- intent=no_zim_file_specified cert=1.00 -->"
                     )
-            else:
-                # Small models routinely hallucinate generic filenames such
-                # as "wikipedia.zim" when this argument is documented as
-                # optional, then the path validator rejects them with a
-                # confusing "Access denied" error. Three cases:
-                #
-                #   1. The candidate matches a real ZIM file's full path or
-                #      basename: resolve to the real path. Basename-only
-                #      matches normalize hallucinated bare filenames to
-                #      whatever directory the actual file lives in.
-                #
-                #   2. The candidate is a bare filename (no path
-                #      separator) and matches nothing: treat it as a
-                #      hallucination and fall back to auto-select when
-                #      exactly one ZIM is available.
-                #
-                #   3. The candidate has a path separator and matches
-                #      nothing: trust it. A slashed path is a deliberate
-                #      caller choice (H14 regression: explicit paths must
-                #      reach the backend), and the path validator will
-                #      surface a clearer error than silent auto-replacement.
-                resolved = self._resolve_zim_path(zim_file_path)
-                if resolved is not None:
-                    if resolved != zim_file_path:
-                        self._track("zim_path_resolved_by_basename")
-                        logger.info(
-                            f"Resolved hallucinated zim_file_path "
-                            f"'{zim_file_path}' to '{resolved}' via "
-                            f"basename match."
-                        )
-                    zim_file_path = resolved
-                elif "/" not in zim_file_path and "\\" not in zim_file_path:
-                    auto_selected = self._auto_select_zim_file()
-                    if auto_selected:
-                        self._track("zim_path_replaced_with_auto_select")
-                        logger.info(
-                            f"Discarded hallucinated zim_file_path "
-                            f"'{zim_file_path}'; auto-selected "
-                            f"'{auto_selected}'."
-                        )
-                        zim_file_path = auto_selected
+            # Hallucinated paths were already normalized at the top of
+            # ``handle_zim_query`` (see comment above the synthesize branch).
+            # By this point, ``zim_file_path`` is either a known real path,
+            # an auto-selected fallback, or an unmatched slashed path that
+            # the caller deliberately wrote (H14: explicit paths must reach
+            # the backend and surface a clear error there, not a silent
+            # auto-replacement).
 
             handler = self._INTENT_HANDLERS.get(
                 intent, SimpleToolsHandler._handle_search
@@ -3034,6 +3018,46 @@ class SimpleToolsHandler:
                 omit_passage_text=compact,
                 strip_links=compact,
             )
+
+    def _normalize_zim_file_path(self, candidate: str) -> str:
+        """Resolve hallucinated ZIM file paths or fall back to auto-select.
+
+        Returns the (possibly rewritten) path. Three cases — matches the
+        policy that previously lived inline in ``handle_zim_query`` for
+        the intent-classification branch only:
+
+          1. ``candidate`` matches a real ZIM file's full path or basename:
+             return the real path. Basename-only matches normalize bare-
+             filename hallucinations like ``"wikipedia.zim"`` to whatever
+             directory the file actually lives in.
+
+          2. ``candidate`` is a bare filename (no path separator) and
+             matches nothing: treat it as a hallucination and substitute
+             the auto-selected archive when exactly one is loaded.
+
+          3. ``candidate`` has a path separator and matches nothing: trust
+             it (H14: explicit paths must reach the backend, which will
+             surface a clearer error than silent replacement).
+        """
+        resolved = self._resolve_zim_path(candidate)
+        if resolved is not None:
+            if resolved != candidate:
+                self._track("zim_path_resolved_by_basename")
+                logger.info(
+                    f"Resolved hallucinated zim_file_path "
+                    f"'{candidate}' to '{resolved}' via basename match."
+                )
+            return resolved
+        if "/" not in candidate and "\\" not in candidate:
+            auto_selected = self._auto_select_zim_file()
+            if auto_selected:
+                self._track("zim_path_replaced_with_auto_select")
+                logger.info(
+                    f"Discarded hallucinated zim_file_path "
+                    f"'{candidate}'; auto-selected '{auto_selected}'."
+                )
+                return auto_selected
+        return candidate
 
     def _resolve_zim_path(self, candidate: str) -> Optional[str]:
         """Try to resolve ``candidate`` to a real ZIM file's full path.

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -332,6 +332,84 @@ def _affinity_tokens(text: str) -> set[str]:
     return set(_AFFINITY_TOKEN_RE.findall(text.lower()))
 
 
+def _section_titles_for(
+    archive_name: str,
+    entry_path: str,
+    *,
+    bundle_lookup: Callable[[str, str], Any],
+    cache: dict[tuple[str, str], dict[str, str]],
+) -> dict[str, str]:
+    """Memoized ``section_id → title`` map for one bundle.
+
+    Bundle lookup failures (exceptions or ``None`` returns) are
+    cached as empty dicts so a flaky bundle is not retried within
+    the same affinity pass.
+    """
+    key = (archive_name, entry_path)
+    if key in cache:
+        return cache[key]
+    try:
+        bundle = bundle_lookup(archive_name, entry_path)
+    except Exception as e:
+        logger.debug(
+            "section-affinity bundle lookup failed for %s/%s: %s",
+            archive_name,
+            entry_path,
+            e,
+        )
+        cache[key] = {}
+        return cache[key]
+    if bundle is None:
+        cache[key] = {}
+        return cache[key]
+    titles = {
+        str(s.get("id", "")): str(s.get("title", ""))
+        for s in bundle.get("sections", [])
+        if s.get("id")
+    }
+    cache[key] = titles
+    return titles
+
+
+def _maybe_boost_passage(
+    passage: SynthesizePassage,
+    *,
+    query_tokens: set[str],
+    bundle_lookup: Callable[[str, str], Any],
+    cache: dict[tuple[str, str], dict[str, str]],
+    threshold: float,
+    boost: float,
+) -> SynthesizePassage:
+    """Return a fresh copy of ``passage`` with its score possibly boosted.
+
+    No-op cases (returned with original score):
+      * cite_id has no ``#section_id`` suffix
+      * cite_id doesn't parse as ``archive/entry_path#section_id``
+      * section isn't found in the bundle (or bundle lookup failed)
+      * heading shares fewer than ``threshold`` of its tokens with the query
+
+    Always returns a freshly-allocated dict so the caller may mutate it.
+    """
+    new_p = cast("SynthesizePassage", dict(passage))
+    cite_id = passage["cite_id"]
+    if "#" not in cite_id:
+        return new_p
+    base, _, section_id = cite_id.partition("#")
+    archive_name, _, entry_path = base.partition("/")
+    if not archive_name or not entry_path or not section_id:
+        return new_p
+    titles = _section_titles_for(
+        archive_name, entry_path, bundle_lookup=bundle_lookup, cache=cache
+    )
+    heading_tokens = _affinity_tokens(titles.get(section_id, ""))
+    if not heading_tokens:
+        return new_p
+    affinity = len(heading_tokens & query_tokens) / len(heading_tokens)
+    if affinity >= threshold:
+        new_p["score"] = float(passage["score"]) * boost
+    return new_p
+
+
 def _boost_by_section_affinity(
     passages: list[SynthesizePassage],
     *,
@@ -346,85 +424,33 @@ def _boost_by_section_affinity(
     ``|query_tokens ∩ heading_tokens| / |heading_tokens|``. When that
     affinity is ≥ ``config.section_affinity_threshold``, multiply the
     passage's score by ``config.section_affinity_boost``. Re-sort the
-    list by score descending.
+    list by score descending and re-number ranks.
 
-    Article-level citations (no section_id), passages whose section
-    isn't in the bundle, and bundle-lookup failures are all no-ops:
-    the passage is preserved with its original score.
-
-    No-op when the query has no tokens (empty or whitespace-only).
-
-    Bundle caching: each (archive, entry_path) is looked up at most
-    once and its section→title map memoized for the duration of the
-    call.
+    Article-level citations, passages whose section isn't in the
+    bundle, and bundle-lookup failures are all no-ops: the passage is
+    preserved with its original score. No-op when the query has no
+    tokens. Bundle lookup is memoized per ``(archive, entry_path)``
+    for the duration of the call.
     """
     query_tokens = _affinity_tokens(query)
     if not query_tokens:
         return passages
 
-    threshold = config.section_affinity_threshold
-    boost = config.section_affinity_boost
-
-    titles_by_key: dict[tuple[str, str], dict[str, str]] = {}
-
-    def section_titles_for(archive_name: str, entry_path: str) -> dict[str, str]:
-        key = (archive_name, entry_path)
-        if key in titles_by_key:
-            return titles_by_key[key]
-        try:
-            bundle = bundle_lookup(archive_name, entry_path)
-        except Exception as e:
-            logger.debug(
-                "section-affinity bundle lookup failed for %s/%s: %s",
-                archive_name,
-                entry_path,
-                e,
-            )
-            titles_by_key[key] = {}
-            return titles_by_key[key]
-        if bundle is None:
-            titles_by_key[key] = {}
-            return titles_by_key[key]
-        titles = {
-            str(s.get("id", "")): str(s.get("title", ""))
-            for s in bundle.get("sections", [])
-            if s.get("id")
-        }
-        titles_by_key[key] = titles
-        return titles
-
-    boosted: list[SynthesizePassage] = []
-    for passage in passages:
-        cite_id = passage["cite_id"]
-        if "#" not in cite_id:
-            # Copy-on-append keeps the mutation model uniform: the
-            # rank-renumbering loop below can mutate any item in `boosted`
-            # without leaking back to the caller's input list.
-            boosted.append(cast("SynthesizePassage", dict(passage)))
-            continue
-        base, _, section_id = cite_id.partition("#")
-        archive_name, _, entry_path = base.partition("/")
-        if not archive_name or not entry_path or not section_id:
-            # Copy-on-append: same rationale as above.
-            boosted.append(cast("SynthesizePassage", dict(passage)))
-            continue
-        titles = section_titles_for(archive_name, entry_path)
-        heading = titles.get(section_id, "")
-        heading_tokens = _affinity_tokens(heading)
-        if not heading_tokens:
-            # Copy-on-append: same rationale as above.
-            boosted.append(cast("SynthesizePassage", dict(passage)))
-            continue
-        overlap = heading_tokens & query_tokens
-        affinity = len(overlap) / len(heading_tokens)
-        if affinity >= threshold:
-            new_p = dict(passage)
-            new_p["score"] = float(passage["score"]) * boost
-            boosted.append(cast(SynthesizePassage, new_p))
-        else:
-            # Copy-on-append: same rationale as above.
-            boosted.append(cast("SynthesizePassage", dict(passage)))
-
+    cache: dict[tuple[str, str], dict[str, str]] = {}
+    # Copy-on-append (each helper call returns a fresh dict) keeps the
+    # mutation model uniform: the rank-renumbering loop below can mutate
+    # any item in ``boosted`` without leaking back to the caller's list.
+    boosted = [
+        _maybe_boost_passage(
+            p,
+            query_tokens=query_tokens,
+            bundle_lookup=bundle_lookup,
+            cache=cache,
+            threshold=config.section_affinity_threshold,
+            boost=config.section_affinity_boost,
+        )
+        for p in passages
+    ]
     boosted.sort(key=lambda p: float(p.get("score", 0.0)), reverse=True)
     # A14: rank reflects the post-boost ordering. Without this, downstream
     # consumers of passages[].rank get stale BM25 positions even though the

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -799,7 +799,9 @@ def _promote_title_match(
                 reordered: list[tuple[str, dict]] = [
                     (n, h)
                     for n, h in top_hits
-                    if not (n == archive_name and str(h.get("path", "")) == promoted_path)
+                    if not (
+                        n == archive_name and str(h.get("path", "")) == promoted_path
+                    )
                 ]
                 promoted_hit = next(
                     h

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -311,6 +311,118 @@ def _attribute_sections(
 
 
 # ---------------------------------------------------------------------------
+# Pipeline stage 5b: section-heading affinity boost (A14)
+# ---------------------------------------------------------------------------
+
+# Same tokenizer convention used in iter_query_tails / is_strong_title_match.
+# Alphanumeric runs only; punctuation and whitespace are token boundaries.
+_AFFINITY_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _affinity_tokens(text: str) -> set[str]:
+    """Lowercase alphanumeric token set. Empty set for empty input."""
+    if not text:
+        return set()
+    return set(_AFFINITY_TOKEN_RE.findall(text.lower()))
+
+
+def _boost_by_section_affinity(
+    passages: list[SynthesizePassage],
+    *,
+    query: str,
+    bundle_lookup: Callable[[str, str], Any],
+    config: "SynthesizeConfig",
+) -> list[SynthesizePassage]:
+    """Re-rank passages by section-heading affinity with the query.
+
+    For each passage with a ``#section_id`` suffix on its cite_id,
+    look up the section's heading in the bundle and compute
+    ``|query_tokens ∩ heading_tokens| / |heading_tokens|``. When that
+    affinity is ≥ ``config.section_affinity_threshold``, multiply the
+    passage's score by ``config.section_affinity_boost``. Re-sort the
+    list by score descending.
+
+    Article-level citations (no section_id), passages whose section
+    isn't in the bundle, and bundle-lookup failures are all no-ops:
+    the passage is preserved with its original score.
+
+    No-op when the query has no tokens (empty or whitespace-only).
+
+    Bundle caching: each (archive, entry_path) is looked up at most
+    once and its section→title map memoized for the duration of the
+    call.
+    """
+    query_tokens = _affinity_tokens(query)
+    if not query_tokens:
+        return passages
+
+    threshold = config.section_affinity_threshold
+    boost = config.section_affinity_boost
+
+    titles_by_key: dict[tuple[str, str], dict[str, str]] = {}
+
+    def section_titles_for(archive_name: str, entry_path: str) -> dict[str, str]:
+        key = (archive_name, entry_path)
+        if key in titles_by_key:
+            return titles_by_key[key]
+        try:
+            bundle = bundle_lookup(archive_name, entry_path)
+        except Exception as e:
+            logger.debug(
+                "section-affinity bundle lookup failed for %s/%s: %s",
+                archive_name,
+                entry_path,
+                e,
+            )
+            titles_by_key[key] = {}
+            return titles_by_key[key]
+        if bundle is None:
+            titles_by_key[key] = {}
+            return titles_by_key[key]
+        titles = {
+            str(s.get("id", "")): str(s.get("title", ""))
+            for s in bundle.get("sections", [])
+            if s.get("id")
+        }
+        titles_by_key[key] = titles
+        return titles
+
+    boosted: list[SynthesizePassage] = []
+    for passage in passages:
+        cite_id = passage["cite_id"]
+        if "#" not in cite_id:
+            boosted.append(passage)
+            continue
+        base, _, section_id = cite_id.partition("#")
+        archive_name, _, entry_path = base.partition("/")
+        if not archive_name or not entry_path or not section_id:
+            boosted.append(passage)
+            continue
+        titles = section_titles_for(archive_name, entry_path)
+        heading = titles.get(section_id, "")
+        heading_tokens = _affinity_tokens(heading)
+        if not heading_tokens:
+            boosted.append(passage)
+            continue
+        overlap = heading_tokens & query_tokens
+        affinity = len(overlap) / len(heading_tokens)
+        if affinity >= threshold:
+            new_p = dict(passage)
+            new_p["score"] = float(passage["score"]) * boost
+            boosted.append(cast(SynthesizePassage, new_p))
+        else:
+            boosted.append(passage)
+
+    boosted.sort(key=lambda p: float(p.get("score", 0.0)), reverse=True)
+    # A14: rank reflects the post-boost ordering. Without this, downstream
+    # consumers of passages[].rank get stale BM25 positions even though the
+    # score-sorted order has changed.
+    for i, p in enumerate(boosted, start=1):
+        p["rank"] = i
+    return boosted
+
+
+# ---------------------------------------------------------------------------
 # Pipeline stage 6: answer rendering
 # ---------------------------------------------------------------------------
 
@@ -991,6 +1103,16 @@ def synthesize_query(
     )
     attributed = _attribute_sections(
         all_passages, bundle_lookup=bundle_lookup, hit_keys=hit_keys
+    )
+    # A14 (Change B): section-heading affinity boost. Promotes passages
+    # whose section heading shares tokens with the query past lexically-
+    # weaker BM25 leaders. No-op for article-level citations and for
+    # queries with no token overlap against any heading.
+    attributed = _boost_by_section_affinity(
+        attributed,
+        query=query,
+        bundle_lookup=bundle_lookup,
+        config=config,
     )
     pre_cap_chars = sum(len(p["text_markdown"]) for p in attributed)
     capped = _enforce_budget(attributed, char_budget=config.output_char_budget)

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -29,7 +29,13 @@ if TYPE_CHECKING:
 
 from openzim_mcp import bundle as _bundle_mod
 from openzim_mcp.title_promotion import is_strong_title_match, iter_query_tails
-from openzim_mcp.tool_schemas import Citation, SynthesizePassage, SynthesizeResponse
+from openzim_mcp.tool_schemas import (
+    Citation,
+    ConsideredArticle,
+    ConsideredSection,
+    SynthesizePassage,
+    SynthesizeResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -528,6 +534,122 @@ def _build_citations(
     return list(seen.values())
 
 
+# ---------------------------------------------------------------------------
+# A14: multi-round handle builders for SynthesizeResponse
+# ---------------------------------------------------------------------------
+
+_DEFAULT_CONSIDERED_ARTICLES_MAX = 3
+_DEFAULT_CONSIDERED_SECTIONS_MAX = 10
+
+
+def _featured_article_key(
+    capped_passages: list[SynthesizePassage],
+) -> Optional[tuple[str, str, Optional[str]]]:
+    """Decompose the top capped passage's cite_id into
+    (archive, entry_path, section_id). Returns None when there are
+    no passages.
+
+    Used to identify which article+section to exclude from the
+    considered handles — the caller already sees the featured
+    citation, so surfacing it again as a "consider this instead"
+    is noise.
+    """
+    if not capped_passages:
+        return None
+    return _parse_cite_id(capped_passages[0]["cite_id"])
+
+
+def _build_considered_articles(
+    top_hits: list[tuple[str, dict]],
+    capped_passages: list[SynthesizePassage],
+    *,
+    max_n: int = _DEFAULT_CONSIDERED_ARTICLES_MAX,
+) -> list[ConsideredArticle]:
+    """Top-N article hits NOT represented by the featured passage.
+
+    Preserves order from top_hits (post-promotion, post-demotion).
+    Each entry carries (archive, entry_path, title, score) — the
+    caller can pass it to ``get_zim_entries`` or compose a cite_id.
+    """
+    featured = _featured_article_key(capped_passages)
+    featured_key: Optional[tuple[str, str]] = None
+    if featured is not None:
+        featured_key = (featured[0], featured[1])
+    out: list[ConsideredArticle] = []
+    for archive_name, hit in top_hits:
+        entry_path = str(hit.get("path", ""))
+        if not entry_path:
+            continue
+        if featured_key is not None and (archive_name, entry_path) == featured_key:
+            continue
+        out.append(
+            cast(
+                "ConsideredArticle",
+                {
+                    "archive": archive_name,
+                    "entry_path": entry_path,
+                    "title": str(hit.get("title", entry_path)),
+                    "score": float(hit.get("score", 0.0)),
+                },
+            )
+        )
+        if len(out) >= max_n:
+            break
+    return out
+
+
+def _build_considered_sections(
+    capped_passages: list[SynthesizePassage],
+    bundle_lookup: Callable[[str, str], Any],
+    *,
+    max_n: int = _DEFAULT_CONSIDERED_SECTIONS_MAX,
+) -> list[ConsideredSection]:
+    """Sections of the featured passage's article, minus the featured
+    section itself. Capped at max_n.
+
+    Empty list when:
+      - There are no passages.
+      - The featured passage has no #section_id.
+      - The featured article's bundle lookup returns None or raises.
+      - The bundle's section list is empty.
+    """
+    featured = _featured_article_key(capped_passages)
+    if featured is None:
+        return []
+    archive_name, entry_path, featured_section_id = featured
+    if not featured_section_id:
+        return []
+    try:
+        bundle = bundle_lookup(archive_name, entry_path)
+    except Exception as e:
+        logger.debug(
+            "considered_sections bundle lookup failed for %s/%s: %s",
+            archive_name,
+            entry_path,
+            e,
+        )
+        return []
+    if bundle is None:
+        return []
+    out: list[ConsideredSection] = []
+    for section in bundle.get("sections", []):
+        section_id = str(section.get("id", ""))
+        if not section_id or section_id == featured_section_id:
+            continue
+        out.append(
+            cast(
+                "ConsideredSection",
+                {
+                    "section_id": section_id,
+                    "title": str(section.get("title", section_id)),
+                },
+            )
+        )
+        if len(out) >= max_n:
+            break
+    return out
+
+
 # Markdown link/image regex shared between simple_tools._strip_markdown_links
 # and synthesize. Same disjoint-alternation shape as the simple_tools regex
 # so the pattern engine doesn't backtrack against unclosed brackets.
@@ -998,6 +1120,8 @@ def _zero_hits_response(
             "total_chars": 0,
             "total_words": 0,
             "_meta": cast("Any", meta),
+            "considered_articles": [],
+            "considered_sections": [],
         },
     )
 
@@ -1159,6 +1283,8 @@ def synthesize_query(
     response_passages: list[SynthesizePassage] = capped
     if omit_passage_text:
         response_passages = []
+    considered_articles = _build_considered_articles(top_hits, capped)
+    considered_sections = _build_considered_sections(capped, bundle_lookup)
     return cast(
         "SynthesizeResponse",
         {
@@ -1171,5 +1297,7 @@ def synthesize_query(
             "total_chars": len(answer_md),
             "total_words": len(answer_md.split()),
             "_meta": cast("Any", meta),
+            "considered_articles": considered_articles,
+            "considered_sections": considered_sections,
         },
     )

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -397,18 +397,23 @@ def _boost_by_section_affinity(
     for passage in passages:
         cite_id = passage["cite_id"]
         if "#" not in cite_id:
-            boosted.append(passage)
+            # Copy-on-append keeps the mutation model uniform: the
+            # rank-renumbering loop below can mutate any item in `boosted`
+            # without leaking back to the caller's input list.
+            boosted.append(cast("SynthesizePassage", dict(passage)))
             continue
         base, _, section_id = cite_id.partition("#")
         archive_name, _, entry_path = base.partition("/")
         if not archive_name or not entry_path or not section_id:
-            boosted.append(passage)
+            # Copy-on-append: same rationale as above.
+            boosted.append(cast("SynthesizePassage", dict(passage)))
             continue
         titles = section_titles_for(archive_name, entry_path)
         heading = titles.get(section_id, "")
         heading_tokens = _affinity_tokens(heading)
         if not heading_tokens:
-            boosted.append(passage)
+            # Copy-on-append: same rationale as above.
+            boosted.append(cast("SynthesizePassage", dict(passage)))
             continue
         overlap = heading_tokens & query_tokens
         affinity = len(overlap) / len(heading_tokens)
@@ -417,7 +422,8 @@ def _boost_by_section_affinity(
             new_p["score"] = float(passage["score"]) * boost
             boosted.append(cast(SynthesizePassage, new_p))
         else:
-            boosted.append(passage)
+            # Copy-on-append: same rationale as above.
+            boosted.append(cast("SynthesizePassage", dict(passage)))
 
     boosted.sort(key=lambda p: float(p.get("score", 0.0)), reverse=True)
     # A14: rank reflects the post-boost ordering. Without this, downstream

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from openzim_mcp.content_processor import ContentProcessor
 
 from openzim_mcp import bundle as _bundle_mod
-from openzim_mcp.title_promotion import is_strong_title_match
+from openzim_mcp.title_promotion import is_strong_title_match, iter_query_tails
 from openzim_mcp.tool_schemas import Citation, SynthesizePassage, SynthesizeResponse
 
 logger = logging.getLogger(__name__)
@@ -505,6 +505,12 @@ def _promote_title_match(
 ) -> list[tuple[str, dict]]:
     """Promote a canonical title-index hit past BM25 noise (D3 / Op1).
 
+    A14: replaced the M26 4+ token short-circuit with greedy length-down
+    tail iteration via ``iter_query_tails``. Long natural-language
+    queries with a clear entity tail ("famous people from big rapids
+    michigan") now resolve to ``Big_Rapids,_Michigan`` instead of
+    falling through to BM25 noise.
+
     Mirrors the title-promotion logic in ``tell_me_about``: when the
     top BM25 hit isn't a strong title match for the query, ask each
     archive's title-index fast path for the canonical entry. If one
@@ -515,10 +521,11 @@ def _promote_title_match(
     moves to rank 1. Already-strong top hits short-circuit so the
     common case pays no extra archive probes.
 
-    No-op when ``query`` is multi-word phrasing that isn't really a
-    topic ask (handled upstream by ``intent_parser``) — by then
-    ``query`` is the topic itself, so a fast-path title lookup is
-    the right shape.
+    Probe order is (tail-length, archive-order): for each tail in
+    greedy length-down order, try every archive. The first archive
+    that resolves any tail wins. This picks the most specific entity
+    that exists in any archive, biasing toward earlier-configured
+    archives only when tails of equal length tie.
     """
     if top_hits:
         top_hit_0 = top_hits[0][1]
@@ -529,56 +536,44 @@ def _promote_title_match(
         if is_strong_title_match(query, top_path, top_path.replace("_", " ")):
             return top_hits
 
-    # M26: skip the per-archive title probe for multi-word queries that
-    # are clearly content questions rather than entity lookups. The
-    # title-index fast path returns nothing useful for ``effects of
-    # climate change on arctic biodiversity`` but still costs a
-    # find_entry_by_title call per archive (with its case-variant and
-    # namespace sweeps). 4+ tokens is the threshold that empirically
-    # separates entity names ("Martin Luther King Jr") from prose
-    # ("what is the cause of X").
-    _content_query_token_count = 4
-    import re as _re
-
-    if len(_re.findall(r"[a-z0-9]+", query.lower())) > _content_query_token_count:
-        return top_hits
-
     title_match_hit = getattr(search_handler, "title_match_hit", None)
     if not callable(title_match_hit):
         return top_hits
 
-    # Probe each archive's title-index fast path in order. The first
-    # archive that resolves wins — for single-archive synthesize this
-    # is trivially deterministic; for multi-archive the order is
-    # ``archives_searched`` (set by ``_do_per_archive_search``).
     existing_paths = {(name, str(h.get("path", ""))) for name, h in top_hits}
-    for (archive, _vp), archive_name in zip(archives, archives_searched):
-        try:
-            promoted = title_match_hit(archive, query)
-        except Exception as e:
-            logger.debug("title_match_hit failed for %s: %s", archive_name, e)
-            continue
-        # Defensive: tolerate mock handlers that return non-dict
-        # sentinel values; only act on a real hit payload.
-        if not isinstance(promoted, dict):
-            continue
-        promoted_path = str(promoted.get("path", ""))
-        if not promoted_path:
-            continue
-        if (archive_name, promoted_path) in existing_paths:
-            # Already present — re-rank it to first instead of duplicating.
-            reordered: list[tuple[str, dict]] = [
-                (n, h)
-                for n, h in top_hits
-                if not (n == archive_name and str(h.get("path", "")) == promoted_path)
-            ]
-            promoted_hit = next(
-                h
-                for n, h in top_hits
-                if n == archive_name and str(h.get("path", "")) == promoted_path
-            )
-            return [(archive_name, promoted_hit), *reordered]
-        return [(archive_name, promoted), *top_hits]
+    for tail in iter_query_tails(query):
+        for (archive, _vp), archive_name in zip(archives, archives_searched):
+            try:
+                promoted = title_match_hit(archive, tail)
+            except Exception as e:
+                logger.debug(
+                    "title_match_hit failed for %s on tail %r: %s",
+                    archive_name,
+                    tail,
+                    e,
+                )
+                continue
+            # Defensive: tolerate mock handlers that return non-dict
+            # sentinel values; only act on a real hit payload.
+            if not isinstance(promoted, dict):
+                continue
+            promoted_path = str(promoted.get("path", ""))
+            if not promoted_path:
+                continue
+            if (archive_name, promoted_path) in existing_paths:
+                # Already present — re-rank it to first instead of duplicating.
+                reordered: list[tuple[str, dict]] = [
+                    (n, h)
+                    for n, h in top_hits
+                    if not (n == archive_name and str(h.get("path", "")) == promoted_path)
+                ]
+                promoted_hit = next(
+                    h
+                    for n, h in top_hits
+                    if n == archive_name and str(h.get("path", "")) == promoted_path
+                )
+                return [(archive_name, promoted_hit), *reordered]
+            return [(archive_name, promoted), *top_hits]
     return top_hits
 
 

--- a/openzim_mcp/title_promotion.py
+++ b/openzim_mcp/title_promotion.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterator, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -167,3 +167,66 @@ def find_title_match(
         "title": str(top.get("title", "")),
         "zim_file": str(top.get("zim_file", zim_file_path)),
     }
+
+
+# Tokenizer matches the existing _TOKEN_RE / is_strong_title_match
+# convention in this module: lowercase alphanumeric runs only.
+# Underscores, punctuation, and whitespace all act as token boundaries.
+# Underscore is intentionally a boundary so path-form input like
+# "Big_Rapids,_Michigan" tokenizes to ["big", "rapids", "michigan"]
+# instead of treating "Big_Rapids" as one token.
+_TAIL_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def iter_query_tails(
+    query: str,
+    *,
+    max_len: int = 4,
+    min_len: int = 1,
+) -> Iterator[str]:
+    """Yield greedy length-down trailing token windows of ``query``.
+
+    Used by both ``_promote_title_match`` (synthesize path) and
+    ``_promote_topic_via_title_index`` (tell_me_about path) to probe
+    a multi-word natural-language query for an entity that resolves
+    against a ZIM archive's title index.
+
+    Example:
+        ``"who are some famous people from big rapids michigan"``
+        with default bounds yields:
+            ``"from big rapids michigan"``
+            ``"big rapids michigan"``
+            ``"rapids michigan"``
+            ``"michigan"``
+
+    The caller probes each yielded tail in order; the first to resolve
+    wins. Greedy length-down picks the most specific entity that
+    actually exists (``"big rapids michigan"`` beats ``"michigan"``
+    when both resolve).
+
+    Args:
+        query: Natural-language query. Tokenized on alphanumeric runs,
+            so punctuation between words is treated as a boundary
+            (``"big rapids, michigan"`` → 3 tokens).
+        max_len: Longest tail to yield. Default 4 — empirically, ZIM
+            article titles rarely exceed 4 tokens, and the cost of a
+            failed probe is microseconds, so a tight cap is safe.
+        min_len: Shortest tail to yield. Default 1. Callers that want
+            to skip single-token false positives can raise this.
+
+    Yields:
+        Tail strings reconstructed by joining tokens with single
+        spaces, in the order they were found in ``query``, lowercased.
+        The title-index lookups consumed by callers are case-insensitive,
+        so the lowercase form is what reaches the probe regardless of
+        the caller's input casing.
+    """
+    if not query or not query.strip():
+        return
+    tokens = _TAIL_TOKEN_RE.findall(query.lower())
+    if not tokens:
+        return
+    upper = min(max_len, len(tokens))
+    lower = max(1, min_len)
+    for tail_len in range(upper, lower - 1, -1):
+        yield " ".join(tokens[-tail_len:])

--- a/openzim_mcp/tool_schemas.py
+++ b/openzim_mcp/tool_schemas.py
@@ -552,7 +552,33 @@ class SynthesizePassage(TypedDict):
     score: float
 
 
-class SynthesizeResponse(TypedDict):
+class ConsideredArticle(TypedDict, total=False):
+    """A14: an article hit not selected as the featured citation, surfaced
+    so the caller can pivot in a follow-up turn without re-running search.
+
+    ``archive`` + ``entry_path`` form the handle the caller passes to
+    ``get_zim_entries`` (or composes into a ``cite_id``). ``score`` is the
+    underlying ranking score at the point of selection — informational,
+    not part of the handle.
+    """
+
+    archive: str
+    entry_path: str
+    title: str
+    score: float
+
+
+class ConsideredSection(TypedDict, total=False):
+    """A14: a section of the featured article not selected as the featured
+    passage. ``section_id`` is the handle the caller passes to
+    ``get_section`` (or composes into a ``cite_id`` suffix).
+    """
+
+    section_id: str
+    title: str
+
+
+class SynthesizeResponse(TypedDict, total=False):
     query: str
     answer_markdown: str
     passages: list[SynthesizePassage]
@@ -562,6 +588,10 @@ class SynthesizeResponse(TypedDict):
     total_chars: int
     total_words: int
     _meta: MetaEnvelope
+    # A14: multi-round handles. Empty lists when no candidate space
+    # exists (zero-hit response, or no resolved entity article).
+    considered_articles: list[ConsideredArticle]
+    considered_sections: list[ConsideredSection]
 
 
 # ---------------------------------------------------------------------------

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -223,12 +223,54 @@ def _format_filtered_response(
             f"of {total_filtered_text} — "
             f"pass `offset={offset + limit}` for the next page\n"
         )
+        # A14: when the result set is much larger than a small model can
+        # productively page through, nudge toward refining the query
+        # instead. Pre-A14, a "notable people from X" search returning
+        # 4000 hits would lead an 8B model to either give up or mechanically
+        # page until its context budget died. The O2 saturation warning at
+        # ≥1M hits caught only stop-word collisions; mid-tier hit counts
+        # had no equivalent guidance.
+        if _is_large_result_set(scan.filtered_count, len(results)):
+            parts.append(_refinement_nudge() + "\n")
     else:
         parts.append(
             f"Showing {offset + 1}-{offset + len(results)} "
             f"of {total_filtered_text} (end of results)\n"
         )
     return "".join(parts)
+
+
+# A14: threshold above which the response surfaces a refinement nudge
+# alongside the next-page hint. Picked so that a 3-result page facing
+# >65× more results triggers the nudge — well below the 1M stop-word
+# saturation O2 threshold but high enough to avoid nagging on normal
+# topical searches (10-100 hits).
+_REFINEMENT_NUDGE_TOTAL_THRESHOLD = 200
+_REFINEMENT_NUDGE_PAGE_RATIO = 20  # total ≥ page_size × ratio
+
+
+def _is_large_result_set(total: int, page_size: int) -> bool:
+    """Return True when the unpaged total is large enough that mechanical
+    paging is unlikely to be productive for a small model. Used to decide
+    whether to attach the refinement nudge to the pagination footer.
+    """
+    if page_size <= 0:
+        return False
+    return (
+        total >= _REFINEMENT_NUDGE_TOTAL_THRESHOLD
+        and total >= page_size * _REFINEMENT_NUDGE_PAGE_RATIO
+    )
+
+
+def _refinement_nudge() -> str:
+    """One-line nudge appended to large-result-set pagination footers.
+
+    Keep this terse — every byte costs the agentic loop on each turn.
+    """
+    return (
+        "Tip: result set is large — try refining with a quoted phrase or a "
+        "more specific term instead of paging through all hits."
+    )
 
 
 class _SearchMixin:
@@ -716,6 +758,15 @@ class _SearchMixin:
                 f"of {total_results} — "
                 f"pass `offset={next_offset}` for the next page\n"
             )
+            # A14: see ``_format_filtered_response`` for the rationale —
+            # nudge toward query refinement when the total is much
+            # larger than a small model can productively page through.
+            # The ≥1M O2 saturation note above handles stop-word
+            # collisions; this fills the mid-tier gap (200-1M).
+            if total_results < 1_000_000 and _is_large_result_set(
+                total_results, len(results)
+            ):
+                result_text += _refinement_nudge() + "\n"
         else:
             result_text += (
                 f"Showing {offset + 1}-{offset + len(results)} "

--- a/tests/data/goldens/v2_phase_c/synthesize_berlin_geography.json
+++ b/tests/data/goldens/v2_phase_c/synthesize_berlin_geography.json
@@ -16,12 +16,27 @@
       "title": "Berlin"
     }
   ],
+  "considered_articles": [],
+  "considered_sections": [
+    {
+      "section_id": "geography",
+      "title": "Geography"
+    },
+    {
+      "section_id": "climate",
+      "title": "Climate"
+    },
+    {
+      "section_id": "history",
+      "title": "History"
+    }
+  ],
   "fallback_used": "xapian_score",
   "passages": [
     {
       "cite_id": "v2_phase_c/A/Berlin#berlin",
       "rank": 1,
-      "score": 1.0,
+      "score": 1.5,
       "text_markdown": "**Berlin** is the capital and largest city of Germany.\n\n## **Geography**"
     }
   ],

--- a/tests/data/goldens/v2_phase_c/synthesize_capital_city.json
+++ b/tests/data/goldens/v2_phase_c/synthesize_capital_city.json
@@ -16,6 +16,21 @@
       "title": "Berlin"
     }
   ],
+  "considered_articles": [],
+  "considered_sections": [
+    {
+      "section_id": "geography",
+      "title": "Geography"
+    },
+    {
+      "section_id": "climate",
+      "title": "Climate"
+    },
+    {
+      "section_id": "history",
+      "title": "History"
+    }
+  ],
   "fallback_used": "xapian_score",
   "passages": [
     {

--- a/tests/data/goldens/v2_phase_c/synthesize_munich_history.json
+++ b/tests/data/goldens/v2_phase_c/synthesize_munich_history.json
@@ -16,12 +16,23 @@
       "title": "Munich"
     }
   ],
+  "considered_articles": [],
+  "considered_sections": [
+    {
+      "section_id": "history",
+      "title": "History"
+    },
+    {
+      "section_id": "culture",
+      "title": "Culture"
+    }
+  ],
   "fallback_used": "xapian_score",
   "passages": [
     {
       "cite_id": "v2_phase_c/A/Munich#munich",
       "rank": 1,
-      "score": 1.0,
+      "score": 1.5,
       "text_markdown": "**Munich** is the capital of Bavaria.\n\n## **History**"
     }
   ],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -424,3 +424,28 @@ def test_synthesize_config_defaults() -> None:
     assert cfg.synthesize.top_n == 5
     assert cfg.synthesize.per_archive_k == 10
     assert cfg.synthesize.output_char_budget == 4800
+
+
+def test_synthesize_config_has_section_affinity_tunables():
+    """Section-affinity ranking knobs default to documented values."""
+    from openzim_mcp.config import SynthesizeConfig
+
+    cfg = SynthesizeConfig()
+    assert cfg.section_affinity_threshold == 0.25
+    assert cfg.section_affinity_boost == 1.5
+
+
+def test_synthesize_config_rejects_invalid_section_affinity_bounds():
+    """Threshold must be in [0,1]; boost must be >= 1.0 (a multiplier)."""
+    from pydantic import ValidationError
+
+    from openzim_mcp.config import SynthesizeConfig
+
+    with pytest.raises(ValidationError):
+        SynthesizeConfig(section_affinity_threshold=1.5)
+    with pytest.raises(ValidationError):
+        SynthesizeConfig(section_affinity_threshold=-0.1)
+    with pytest.raises(ValidationError):
+        SynthesizeConfig(section_affinity_boost=0.5)
+    with pytest.raises(ValidationError):
+        SynthesizeConfig(section_affinity_boost=10.5)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -431,8 +431,8 @@ def test_synthesize_config_has_section_affinity_tunables():
     from openzim_mcp.config import SynthesizeConfig
 
     cfg = SynthesizeConfig()
-    assert cfg.section_affinity_threshold == 0.25
-    assert cfg.section_affinity_boost == 1.5
+    assert cfg.section_affinity_threshold == pytest.approx(0.25)
+    assert cfg.section_affinity_boost == pytest.approx(1.5)
 
 
 def test_synthesize_config_rejects_invalid_section_affinity_bounds():

--- a/tests/test_iter_query_tails.py
+++ b/tests/test_iter_query_tails.py
@@ -1,0 +1,91 @@
+"""Tests for iter_query_tails — greedy length-down tail iteration over
+a natural-language query for entity-resolution title-index probes.
+
+Replaces the M26 4+ token short-circuit in _promote_title_match: instead
+of giving up on multi-word prose queries, generate every plausible
+entity tail and let the caller probe each one.
+"""
+
+from __future__ import annotations
+
+from openzim_mcp.title_promotion import iter_query_tails
+
+
+def test_iter_query_tails_yields_longest_first():
+    """Greedy: 4-token tail before 3-token before 2-token before 1-token."""
+    tails = list(iter_query_tails("a b c d e"))
+    assert tails == ["b c d e", "c d e", "d e", "e"]
+
+
+def test_iter_query_tails_caps_at_max_len_4_by_default():
+    """A 9-token query yields at most 4 tails (lengths 4, 3, 2, 1)."""
+    tails = list(iter_query_tails("who are some famous people from big rapids michigan"))
+    assert tails == [
+        "from big rapids michigan",
+        "big rapids michigan",
+        "rapids michigan",
+        "michigan",
+    ]
+
+
+def test_iter_query_tails_short_query_yields_what_fits():
+    """3-token query yields tails of length 3, 2, 1."""
+    tails = list(iter_query_tails("big rapids michigan"))
+    assert tails == ["big rapids michigan", "rapids michigan", "michigan"]
+
+
+def test_iter_query_tails_single_token_yields_one_tail():
+    tails = list(iter_query_tails("detroit"))
+    assert tails == ["detroit"]
+
+
+def test_iter_query_tails_empty_query_yields_nothing():
+    assert list(iter_query_tails("")) == []
+    assert list(iter_query_tails("   ")) == []
+
+
+def test_iter_query_tails_normalizes_whitespace():
+    """Multiple spaces / tabs collapse; surrounding whitespace stripped."""
+    tails = list(iter_query_tails("  big   rapids\tmichigan  "))
+    assert tails == ["big rapids michigan", "rapids michigan", "michigan"]
+
+
+def test_iter_query_tails_lowercases_tails():
+    """Tails are lowercased so case-sensitive callers receive a normalized form."""
+    tails = list(iter_query_tails("Big Rapids Michigan"))
+    assert tails[0] == "big rapids michigan"
+
+
+def test_iter_query_tails_custom_max_len():
+    """Caller can cap the longest tail tried."""
+    tails = list(iter_query_tails("a b c d e f", max_len=2))
+    assert tails == ["e f", "f"]
+
+
+def test_iter_query_tails_custom_min_len():
+    """Caller can require multi-token tails (skip single-token misfires)."""
+    tails = list(iter_query_tails("a b c d e", min_len=2))
+    assert tails == ["b c d e", "c d e", "d e"]
+
+
+def test_iter_query_tails_punctuation_treated_as_token_break():
+    """Punctuation between words breaks tokens — 'big rapids, michigan'
+    has three tokens, not 'rapids,' as one."""
+    tails = list(iter_query_tails("big rapids, michigan"))
+    assert tails == ["big rapids michigan", "rapids michigan", "michigan"]
+
+
+def test_iter_query_tails_underscore_treated_as_token_break():
+    """Path-form input like 'Big_Rapids,_Michigan' tokenizes as three
+    separate words, not as one underscore-joined token. Critical for
+    LLMs that may paste a ZIM entry path verbatim into a query."""
+    tails = list(iter_query_tails("Big_Rapids,_Michigan"))
+    assert tails == ["big rapids michigan", "rapids michigan", "michigan"]
+
+
+def test_iter_query_tails_max_len_zero_yields_nothing():
+    """max_len=0 (or any value < 1) silently yields nothing. Documents
+    the clamping behavior so accidental zero from a config doesn't
+    silently break the probe."""
+    assert list(iter_query_tails("big rapids michigan", max_len=0)) == []
+    assert list(iter_query_tails("big rapids michigan", max_len=-1)) == []

--- a/tests/test_iter_query_tails.py
+++ b/tests/test_iter_query_tails.py
@@ -19,7 +19,9 @@ def test_iter_query_tails_yields_longest_first():
 
 def test_iter_query_tails_caps_at_max_len_4_by_default():
     """A 9-token query yields at most 4 tails (lengths 4, 3, 2, 1)."""
-    tails = list(iter_query_tails("who are some famous people from big rapids michigan"))
+    tails = list(
+        iter_query_tails("who are some famous people from big rapids michigan")
+    )
     assert tails == [
         "from big rapids michigan",
         "big rapids michigan",

--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -426,6 +426,131 @@ class TestSearchPaginationFooterFormat:
         assert "**End of results**" not in out
 
 
+class TestLargeResultSetRefinementNudge:
+    """A14: when a search returns far more hits than a small page can
+    cover, the response footer surfaces a refinement nudge alongside the
+    next-page hint. Pre-A14, an 8B model facing "notable people from X"
+    (4000 hits, page size 3) would either give up or page mechanically
+    until its context budget died — the existing O2 saturation warning
+    only fired at ≥1M hits, so mid-tier counts had no signal at all.
+    """
+
+    def test_nudge_appears_when_total_far_exceeds_page(self):
+        from openzim_mcp.zim.search import _FilteredScanState, _format_filtered_response
+
+        scan = _FilteredScanState(
+            filtered_count=4000,
+            scanned=4000,
+            scan_cap_hit=False,
+            total_filtered_is_lower_bound=False,
+        )
+        results = [
+            {
+                "title": f"R{i}",
+                "path": f"C/R{i}",
+                "namespace": "C",
+                "content_type": "text/html",
+                "snippet": "...",
+            }
+            for i in range(3)
+        ]
+        out = _format_filtered_response(
+            query="notable people from big rapids michigan",
+            filter_text="",
+            results=results,
+            scan=scan,
+            total_results=4000,
+            offset=0,
+            limit=3,
+        )
+        assert "Showing 1-3 of 4000" in out
+        assert "pass `offset=3` for the next page" in out
+        # The new refinement nudge fires for 4000-hit / 3-result pages.
+        assert "refining with a quoted phrase" in out
+        assert "more specific term" in out
+
+    def test_nudge_absent_for_modest_total(self):
+        from openzim_mcp.zim.search import _FilteredScanState, _format_filtered_response
+
+        scan = _FilteredScanState(
+            filtered_count=42,
+            scanned=100,
+            scan_cap_hit=False,
+            total_filtered_is_lower_bound=False,
+        )
+        results = [
+            {
+                "title": f"R{i}",
+                "path": f"C/R{i}",
+                "namespace": "C",
+                "content_type": "text/html",
+                "snippet": "...",
+            }
+            for i in range(5)
+        ]
+        out = _format_filtered_response(
+            query="x",
+            filter_text="",
+            results=results,
+            scan=scan,
+            total_results=42,
+            offset=0,
+            limit=5,
+        )
+        # 42 hits is well below the threshold; no nudge.
+        assert "refining with a quoted phrase" not in out
+
+    def test_nudge_absent_at_end_of_results(self):
+        from openzim_mcp.zim.search import _FilteredScanState, _format_filtered_response
+
+        # Even at high total, the last page already exhausts results —
+        # no point nudging refinement once there's nothing left to page to.
+        scan = _FilteredScanState(
+            filtered_count=4000,
+            scanned=4000,
+            scan_cap_hit=False,
+            total_filtered_is_lower_bound=False,
+        )
+        results = [
+            {
+                "title": "R0",
+                "path": "C/R0",
+                "namespace": "C",
+                "content_type": "text/html",
+                "snippet": "...",
+            }
+        ]
+        out = _format_filtered_response(
+            query="x",
+            filter_text="",
+            results=results,
+            scan=scan,
+            total_results=4000,
+            offset=3999,
+            limit=3,
+        )
+        assert "end of results" in out
+        assert "refining with a quoted phrase" not in out
+
+    def test_threshold_helper(self):
+        """The threshold is a function of both absolute total and the
+        total-to-page ratio, so a 250-hit response with a 25-result page
+        doesn't trigger (paging works fine) but the same 250 with a 3-
+        result page does (paging would take 80+ turns).
+        """
+        from openzim_mcp.zim.search import _is_large_result_set
+
+        # Below absolute threshold.
+        assert _is_large_result_set(50, 3) is False
+        # Above absolute threshold, but page ratio low (250/25 = 10 < 20).
+        assert _is_large_result_set(250, 25) is False
+        # Above both thresholds — fires.
+        assert _is_large_result_set(250, 3) is True
+        assert _is_large_result_set(4000, 3) is True
+        # Defensive: zero/negative page_size never fires.
+        assert _is_large_result_set(4000, 0) is False
+
+
 class TestSearchAllLimitAlias:
     """`limit` is accepted as an alias of `limit_per_file` on search_all."""
 

--- a/tests/test_simple_tools.py
+++ b/tests/test_simple_tools.py
@@ -2048,6 +2048,110 @@ class TestZimPathHallucinationHandling:
         handler = SimpleToolsHandler(mock)
         assert handler._resolve_zim_path("anything.zim") is None
 
+    def test_synthesize_bare_filename_match_resolves_before_validation(
+        self, handler, mock_zim_operations
+    ):
+        """A14: ``synthesize=True`` must run the same hallucination
+        resolver as the intent-classification branch. Pre-A14, the
+        synthesize path bypassed it and handed the raw caller string
+        to ``path_validator.validate_path`` — so a bare filename that
+        matched a known basename succeeded with ``synthesize=False``
+        but failed with ``synthesize=True`` (path-anchor-to-CWD
+        produced ``/app/wikipedia_en_all_maxi.zim``, outside the
+        allowed dirs). Verify the resolver runs ahead of the synthesize
+        branch by asserting the dispatcher receives the normalized path.
+        """
+        with patch.object(handler, "_handle_synthesize_query") as mock_synth:
+            mock_synth.return_value = {
+                "answer_markdown": "ok",
+                "passages": [],
+                "citations": [],
+                "archives_searched": [],
+            }
+            handler.handle_zim_query(
+                "berlin",
+                zim_file_path="wikipedia_en_all_maxi.zim",
+                options={"synthesize": True},
+            )
+        # The synthesize dispatcher received the resolved full path,
+        # not the bare hallucinated name.
+        mock_synth.assert_called_once_with(
+            "berlin",
+            "/var/lib/zim/wikipedia_en_all_maxi.zim",
+            compact=False,
+        )
+
+    def test_synthesize_bare_filename_no_match_triggers_auto_select(
+        self, handler, mock_zim_operations
+    ):
+        """A14: synthesize branch also gets the auto-select fallback for
+        unmatched bare filenames (e.g. ``"Big Rapids, Michigan.zim"``
+        — an article title hallucinated as a path). With exactly one
+        archive loaded, the synthesize dispatcher should receive that
+        archive's real path.
+        """
+        with patch.object(handler, "_handle_synthesize_query") as mock_synth:
+            mock_synth.return_value = {
+                "answer_markdown": "ok",
+                "passages": [],
+                "citations": [],
+                "archives_searched": [],
+            }
+            handler.handle_zim_query(
+                "May Erlewine",
+                zim_file_path="Big Rapids, Michigan.zim",
+                options={"synthesize": True},
+            )
+        mock_synth.assert_called_once_with(
+            "May Erlewine",
+            "/var/lib/zim/wikipedia_en_all_maxi.zim",
+            compact=False,
+        )
+
+    def test_synthesize_slashed_unmatched_path_passed_through(
+        self, handler, mock_zim_operations
+    ):
+        """A14: a deliberate slashed path that doesn't match the listing
+        must still reach the synthesize pipeline verbatim — same H14
+        rule as the intent branch. The backend path validator can then
+        surface a clearer error than silent replacement.
+        """
+        explicit = "/some/other/wikipedia.zim"
+        with patch.object(handler, "_handle_synthesize_query") as mock_synth:
+            mock_synth.return_value = {
+                "answer_markdown": "ok",
+                "passages": [],
+                "citations": [],
+                "archives_searched": [],
+            }
+            handler.handle_zim_query(
+                "berlin",
+                zim_file_path=explicit,
+                options={"synthesize": True},
+            )
+        mock_synth.assert_called_once_with("berlin", explicit, compact=False)
+
+    def test_synthesize_no_path_skips_resolver(self, handler, mock_zim_operations):
+        """A14: when ``zim_file_path`` is None, the resolver is
+        intentionally skipped on the synthesize branch — synthesize
+        opens all loaded archives for multi-archive RRF fusion. The
+        dispatcher must receive None unchanged, not an auto-selected
+        single path.
+        """
+        with patch.object(handler, "_handle_synthesize_query") as mock_synth:
+            mock_synth.return_value = {
+                "answer_markdown": "ok",
+                "passages": [],
+                "citations": [],
+                "archives_searched": [],
+            }
+            handler.handle_zim_query(
+                "berlin",
+                zim_file_path=None,
+                options={"synthesize": True},
+            )
+        mock_synth.assert_called_once_with("berlin", None, compact=False)
+
 
 class TestLowConfidenceNoteAppendedConsistently:
     """Regression for finding 8.13: every intent branch appends the note.

--- a/tests/test_simple_tools_tail_probe.py
+++ b/tests/test_simple_tools_tail_probe.py
@@ -1,0 +1,186 @@
+"""Tests that the default-mode tell_me_about title-promotion path
+probes greedy tails of a prose-shaped topic before giving up.
+
+Without the tail probe, "some famous people from big rapids michigan"
+is passed verbatim to find_title_match, which returns nothing because
+no article has that exact title. The probe falls back to shorter tails
+and resolves "big rapids michigan" → Big_Rapids,_Michigan.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock
+
+from openzim_mcp.simple_tools import SimpleToolsHandler
+
+
+def _make_handler(title_responses: Dict[str, Optional[Dict[str, Any]]]) -> Any:
+    """Construct a SimpleToolsHandler whose find_entry_by_title_data
+    consults a topic→result dict. Returns the handler with mocked
+    zim_operations.find_entry_by_title_data.
+
+    The keys in title_responses are *lowercase* — find_title_match
+    inside _promote_topic_via_title_index sees whatever string the
+    caller passes, but iter_query_tails lowercases tails before
+    handing them to find_title_match. So this fixture matches against
+    lowercase keys to mirror real call behavior.
+    """
+    handler = SimpleToolsHandler.__new__(SimpleToolsHandler)
+    handler.zim_operations = MagicMock()
+
+    def fake_find(zim_path: str, topic: str, *, cross_file: bool = False, limit: int = 3):
+        result = title_responses.get(topic)
+        if result is None:
+            return {"results": []}
+        return {"results": [result]}
+
+    handler.zim_operations.find_entry_by_title_data.side_effect = fake_find
+    return handler
+
+
+def test_promote_resolves_via_shorter_tail():
+    """Full prose topic misses; 3-token tail hits."""
+    handler = _make_handler(
+        {
+            "big rapids michigan": {
+                "path": "Big_Rapids,_Michigan",
+                "title": "Big Rapids, Michigan",
+                "score": 1.0,
+                "zim_file": "wiki.zim",
+            }
+        }
+    )
+    result = handler._promote_topic_via_title_index(
+        "/fake/wiki.zim",
+        "some famous people from big rapids michigan",
+    )
+    assert result is not None
+    assert result["path"] == "Big_Rapids,_Michigan"
+
+
+def test_promote_resolves_via_single_token_tail():
+    """A 1-token entity at the end ('detroit') resolves when longer
+    tails miss."""
+    handler = _make_handler(
+        {
+            "detroit": {
+                "path": "Detroit",
+                "title": "Detroit",
+                "score": 1.0,
+                "zim_file": "wiki.zim",
+            }
+        }
+    )
+    result = handler._promote_topic_via_title_index(
+        "/fake/wiki.zim",
+        "what is the population of detroit",
+    )
+    assert result is not None
+    assert result["path"] == "Detroit"
+
+
+def test_promote_prefers_longest_resolving_tail():
+    """When both 'big rapids michigan' and 'michigan' resolve, the
+    longer (more specific) one wins."""
+    handler = _make_handler(
+        {
+            "big rapids michigan": {
+                "path": "Big_Rapids,_Michigan",
+                "title": "Big Rapids, Michigan",
+                "score": 1.0,
+                "zim_file": "wiki.zim",
+            },
+            "michigan": {
+                "path": "Michigan",
+                "title": "Michigan",
+                "score": 1.0,
+                "zim_file": "wiki.zim",
+            },
+        }
+    )
+    result = handler._promote_topic_via_title_index(
+        "/fake/wiki.zim",
+        "famous people from big rapids michigan",
+    )
+    assert result is not None
+    assert result["path"] == "Big_Rapids,_Michigan"
+
+
+def test_promote_returns_none_when_no_tail_resolves():
+    """All tails miss → None, caller falls back to BM25 search."""
+    handler = _make_handler({})
+    result = handler._promote_topic_via_title_index(
+        "/fake/wiki.zim", "completely unknown phrase here"
+    )
+    assert result is None
+
+
+def test_promote_single_token_topic_still_works():
+    """The existing exact-topic case (single-word topic) still
+    resolves via the 1-token tail (which equals the whole query)."""
+    handler = _make_handler(
+        {
+            "berlin": {
+                "path": "Berlin",
+                "title": "Berlin",
+                "score": 1.0,
+                "zim_file": "wiki.zim",
+            }
+        }
+    )
+    result = handler._promote_topic_via_title_index("/fake/wiki.zim", "berlin")
+    assert result is not None
+    assert result["path"] == "Berlin"
+
+
+def test_promote_strict_gate_wins_over_fuzzy_on_longer_tail():
+    """A 1.0 exact match on a short clean tail beats a 0.8 fuzzy
+    match on a longer noisier tail. Without the two-pass structure,
+    fuzzy-gate firing on tail N would beat strict-gate firing on
+    tail N+1 (shorter). This regression-locks the desired ordering."""
+    # 'big rapids michigan' (3-token tail) has an EXACT 1.0 match.
+    # 'from big rapids michigan' (4-token tail) would FUZZY-match
+    # something unrelated at 0.85 if the gates interleaved per tail —
+    # but two-pass structure puts strict-gate-on-shorter-tail before
+    # fuzzy-gate-on-longer-tail.
+    handler = SimpleToolsHandler.__new__(SimpleToolsHandler)
+    handler.zim_operations = MagicMock()
+
+    def fake_find(zim_path: str, topic: str, *, cross_file: bool = False, limit: int = 3):
+        # Strict 1.0 hit on the clean 3-token tail
+        if topic == "big rapids michigan":
+            return {
+                "results": [
+                    {
+                        "path": "Big_Rapids,_Michigan",
+                        "title": "Big Rapids, Michigan",
+                        "score": 1.0,
+                        "zim_file": "wiki.zim",
+                    }
+                ]
+            }
+        # Fuzzy 0.85 hit on the noisier 4-token tail
+        if topic == "from big rapids michigan":
+            return {
+                "results": [
+                    {
+                        "path": "From_Big_Mistake_Article",
+                        "title": "From Big Mistake Article",
+                        "score": 0.85,
+                        "zim_file": "wiki.zim",
+                    }
+                ]
+            }
+        return {"results": []}
+
+    handler.zim_operations.find_entry_by_title_data.side_effect = fake_find
+
+    result = handler._promote_topic_via_title_index(
+        "/fake/wiki.zim",
+        "some famous people from big rapids michigan",
+    )
+    # Two-pass: strict gate clears all tails first → 1.0 hit on the
+    # 3-token tail wins. The fuzzy hit never gets a chance.
+    assert result is not None
+    assert result["path"] == "Big_Rapids,_Michigan"

--- a/tests/test_simple_tools_tail_probe.py
+++ b/tests/test_simple_tools_tail_probe.py
@@ -29,7 +29,9 @@ def _make_handler(title_responses: Dict[str, Optional[Dict[str, Any]]]) -> Any:
     handler = SimpleToolsHandler.__new__(SimpleToolsHandler)
     handler.zim_operations = MagicMock()
 
-    def fake_find(zim_path: str, topic: str, *, cross_file: bool = False, limit: int = 3):
+    def fake_find(
+        zim_path: str, topic: str, *, cross_file: bool = False, limit: int = 3
+    ):
         result = title_responses.get(topic)
         if result is None:
             return {"results": []}
@@ -147,7 +149,9 @@ def test_promote_strict_gate_wins_over_fuzzy_on_longer_tail():
     handler = SimpleToolsHandler.__new__(SimpleToolsHandler)
     handler.zim_operations = MagicMock()
 
-    def fake_find(zim_path: str, topic: str, *, cross_file: bool = False, limit: int = 3):
+    def fake_find(
+        zim_path: str, topic: str, *, cross_file: bool = False, limit: int = 3
+    ):
         # Strict 1.0 hit on the clean 3-token tail
         if topic == "big rapids michigan":
             return {

--- a/tests/test_structured_tool_output.py
+++ b/tests/test_structured_tool_output.py
@@ -879,6 +879,11 @@ class TestZimQuerySynthesize:
                 "rrf_fusion",
                 "reranker",
             )
+            # A14: multi-round handles are part of the wire format
+            assert "considered_articles" in payload
+            assert "considered_sections" in payload
+            assert isinstance(payload["considered_articles"], list)
+            assert isinstance(payload["considered_sections"], list)
 
     @pytest.mark.asyncio
     async def test_zim_query_no_synthesize_returns_string(

--- a/tests/test_synthesize_considered_handles.py
+++ b/tests/test_synthesize_considered_handles.py
@@ -1,0 +1,183 @@
+"""Tests for considered_articles + considered_sections population in
+synthesize_query (A14).
+
+The featured passage's article and section are excluded from the
+considered lists — these surfaces are for *alternatives* the caller can
+pivot to, not duplicates of what's already in citations[].
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from openzim_mcp.synthesize import (
+    _build_considered_articles,
+    _build_considered_sections,
+)
+
+
+def test_build_considered_articles_excludes_featured_and_caps_at_3():
+    """Top_hits with 6 entries; passage capped to 1 (featured). The
+    considered_articles list has the remaining 5 in order, capped at 3."""
+    top_hits = [
+        ("wiki", {"path": "Big_Rapids,_Michigan", "title": "Big Rapids, Michigan", "score": 1.0}),
+        ("wiki", {"path": "Big_Rapids_Township,_Michigan", "title": "Big Rapids Twp", "score": 0.7}),
+        ("wiki", {"path": "Ferris_State_University", "title": "Ferris State", "score": 0.6}),
+        ("wiki", {"path": "Mecosta_County,_Michigan", "title": "Mecosta County", "score": 0.5}),
+        ("wiki", {"path": "Pere_Marquette_River", "title": "Pere Marquette River", "score": 0.4}),
+        ("wiki", {"path": "Muskegon_River", "title": "Muskegon River", "score": 0.3}),
+    ]
+    capped_passages = [
+        {
+            "cite_id": "wiki/Big_Rapids,_Michigan#Notable_people",
+            "text_markdown": "...",
+            "rank": 1,
+            "score": 1.5,
+        }
+    ]
+    result = _build_considered_articles(top_hits, capped_passages, max_n=3)
+    assert len(result) == 3
+    assert all(a["entry_path"] != "Big_Rapids,_Michigan" for a in result)
+    assert result[0]["entry_path"] == "Big_Rapids_Township,_Michigan"
+    assert result[1]["entry_path"] == "Ferris_State_University"
+    assert result[2]["entry_path"] == "Mecosta_County,_Michigan"
+
+
+def test_build_considered_articles_empty_when_only_featured():
+    """One top_hit, captured as the featured passage → empty list."""
+    top_hits = [
+        ("wiki", {"path": "Big_Rapids,_Michigan", "title": "Big Rapids", "score": 1.0}),
+    ]
+    capped_passages = [
+        {
+            "cite_id": "wiki/Big_Rapids,_Michigan#Notable_people",
+            "text_markdown": "...",
+            "rank": 1,
+            "score": 1.5,
+        }
+    ]
+    result = _build_considered_articles(top_hits, capped_passages, max_n=3)
+    assert result == []
+
+
+def test_build_considered_articles_includes_all_when_no_passages():
+    """No featured passage → no exclusion applied; all top_hits pass through (capped at max_n)."""
+    top_hits = [
+        ("wiki", {"path": "A", "title": "A", "score": 1.0}),
+        ("wiki", {"path": "B", "title": "B", "score": 0.5}),
+    ]
+    result = _build_considered_articles(top_hits, [], max_n=3)
+    # With no featured to exclude, all top_hits make it (capped)
+    assert len(result) == 2
+    assert result[0]["entry_path"] == "A"
+
+
+def test_build_considered_sections_returns_sections_minus_featured():
+    """Featured cites Big_Rapids,_Michigan#Notable_people.
+    considered_sections returns all OTHER sections in that article."""
+    capped_passages = [
+        {
+            "cite_id": "wiki/Big_Rapids,_Michigan#Notable_people",
+            "text_markdown": "...",
+            "rank": 1,
+            "score": 1.5,
+        }
+    ]
+
+    def bundle_lookup(archive_name: str, entry_path: str) -> Any:
+        if entry_path == "Big_Rapids,_Michigan":
+            return {
+                "sections": [
+                    {"id": "History", "title": "History"},
+                    {"id": "Geography", "title": "Geography"},
+                    {"id": "Notable_people", "title": "Notable people"},
+                    {"id": "Demographics", "title": "Demographics"},
+                ]
+            }
+        return None
+
+    result = _build_considered_sections(capped_passages, bundle_lookup, max_n=10)
+    ids = [s["section_id"] for s in result]
+    assert "Notable_people" not in ids
+    assert set(ids) == {"History", "Geography", "Demographics"}
+
+
+def test_build_considered_sections_empty_when_featured_is_article_level():
+    """Featured passage has no #section_id → no anchor → []."""
+    capped_passages = [
+        {
+            "cite_id": "wiki/Big_Rapids,_Michigan",
+            "text_markdown": "...",
+            "rank": 1,
+            "score": 1.0,
+        }
+    ]
+
+    def bundle_lookup(archive_name: str, entry_path: str) -> Any:
+        return {"sections": [{"id": "History", "title": "History"}]}
+
+    result = _build_considered_sections(capped_passages, bundle_lookup, max_n=10)
+    assert result == []
+
+
+def test_build_considered_sections_empty_when_no_passages():
+    """Zero-hit response → no featured article → []."""
+    result = _build_considered_sections([], lambda a, e: None, max_n=10)
+    assert result == []
+
+
+def test_build_considered_sections_caps_at_max_n():
+    """20-section article capped at max_n=10."""
+    sections = [{"id": f"S{i}", "title": f"Section {i}"} for i in range(20)]
+    capped_passages = [
+        {
+            "cite_id": "wiki/Foo#S0",
+            "text_markdown": "...",
+            "rank": 1,
+            "score": 1.0,
+        }
+    ]
+
+    def bundle_lookup(archive_name: str, entry_path: str) -> Any:
+        return {"sections": sections}
+
+    result = _build_considered_sections(capped_passages, bundle_lookup, max_n=10)
+    assert len(result) == 10
+    # S0 (featured) is excluded
+    assert all(s["section_id"] != "S0" for s in result)
+
+
+def test_build_considered_sections_handles_bundle_none():
+    """Bundle lookup returns None → []."""
+    capped_passages = [
+        {
+            "cite_id": "wiki/Foo#Section",
+            "text_markdown": "...",
+            "rank": 1,
+            "score": 1.0,
+        }
+    ]
+
+    def none_lookup(archive_name: str, entry_path: str) -> Any:
+        return None
+
+    result = _build_considered_sections(capped_passages, none_lookup, max_n=10)
+    assert result == []
+
+
+def test_build_considered_sections_handles_bundle_lookup_raising():
+    """Bundle lookup raises → [] (no crash)."""
+    capped_passages = [
+        {
+            "cite_id": "wiki/Foo#Section",
+            "text_markdown": "...",
+            "rank": 1,
+            "score": 1.0,
+        }
+    ]
+
+    def raising_lookup(archive_name: str, entry_path: str) -> Any:
+        raise RuntimeError("bundle build failed")
+
+    result = _build_considered_sections(capped_passages, raising_lookup, max_n=10)
+    assert result == []

--- a/tests/test_synthesize_considered_handles.py
+++ b/tests/test_synthesize_considered_handles.py
@@ -20,11 +20,42 @@ def test_build_considered_articles_excludes_featured_and_caps_at_3():
     """Top_hits with 6 entries; passage capped to 1 (featured). The
     considered_articles list has the remaining 5 in order, capped at 3."""
     top_hits = [
-        ("wiki", {"path": "Big_Rapids,_Michigan", "title": "Big Rapids, Michigan", "score": 1.0}),
-        ("wiki", {"path": "Big_Rapids_Township,_Michigan", "title": "Big Rapids Twp", "score": 0.7}),
-        ("wiki", {"path": "Ferris_State_University", "title": "Ferris State", "score": 0.6}),
-        ("wiki", {"path": "Mecosta_County,_Michigan", "title": "Mecosta County", "score": 0.5}),
-        ("wiki", {"path": "Pere_Marquette_River", "title": "Pere Marquette River", "score": 0.4}),
+        (
+            "wiki",
+            {
+                "path": "Big_Rapids,_Michigan",
+                "title": "Big Rapids, Michigan",
+                "score": 1.0,
+            },
+        ),
+        (
+            "wiki",
+            {
+                "path": "Big_Rapids_Township,_Michigan",
+                "title": "Big Rapids Twp",
+                "score": 0.7,
+            },
+        ),
+        (
+            "wiki",
+            {"path": "Ferris_State_University", "title": "Ferris State", "score": 0.6},
+        ),
+        (
+            "wiki",
+            {
+                "path": "Mecosta_County,_Michigan",
+                "title": "Mecosta County",
+                "score": 0.5,
+            },
+        ),
+        (
+            "wiki",
+            {
+                "path": "Pere_Marquette_River",
+                "title": "Pere Marquette River",
+                "score": 0.4,
+            },
+        ),
         ("wiki", {"path": "Muskegon_River", "title": "Muskegon River", "score": 0.3}),
     ]
     capped_passages = [

--- a/tests/test_synthesize_section_affinity.py
+++ b/tests/test_synthesize_section_affinity.py
@@ -80,9 +80,23 @@ def test_boost_promotes_passage_when_section_heading_matches_query():
     assert notable_passage["score"] == pytest.approx(0.6 * 1.5)
 
 
-def test_boost_flips_order_when_boosted_passage_overtakes():
-    """When the boosted passage's new score exceeds the prior leader,
-    it ranks first."""
+def test_boost_flips_order_and_renumbers_rank():
+    """When the affinity boost re-sorts by score, the displaced passage's
+    cite_id appears at position 1 AND the ``rank`` field is renumbered
+    to match the new ordering.
+
+    Regression-locks two coupled behaviors:
+      (1) ordering — score-sort happens after the boost multiplier, so
+          the boosted passage can overtake a prior leader;
+      (2) rank renumbering — downstream consumers reading
+          ``passages[].rank`` get the current positions, not stale
+          BM25 positions inconsistent with the order they appear in.
+
+    Both fall out of the same ``_boost_by_section_affinity`` call, but
+    the rank-renumbering step is easy to forget after a sort, so the
+    paired assertions guard against accidental regression of (2) while
+    (1) keeps passing.
+    """
     passages = [
         _passage("wiki/Big_Rapids,_Michigan#History", score=0.5, rank=1),
         _passage("wiki/Big_Rapids,_Michigan#Notable_people", score=0.4, rank=2),
@@ -108,8 +122,11 @@ def test_boost_flips_order_when_boosted_passage_overtakes():
         bundle_lookup=bundle_lookup,
         config=cfg,
     )
-    # Notable_people: 0.4 * 1.5 = 0.6. History: 0.5. Notable_people wins.
+    # Notable_people: 0.4 * 1.5 = 0.6. History: 0.5. Notable_people now
+    # leads on score and on rank; History gets rank 2.
     assert out[0]["cite_id"] == "wiki/Big_Rapids,_Michigan#Notable_people"
+    assert out[0]["rank"] == 1
+    assert out[1]["rank"] == 2
 
 
 def test_boost_no_op_when_no_query_token_in_heading():
@@ -334,40 +351,3 @@ def test_boost_bundle_lookup_called_once_per_unique_article():
         config=cfg,
     )
     assert call_count["n"] == 1
-
-
-def test_boost_renumbers_rank_to_match_new_order():
-    """After the affinity boost re-sorts by score, the passages'
-    ``rank`` field is renumbered to match the new ordering. Otherwise
-    downstream consumers reading `passages[].rank` get stale BM25
-    positions inconsistent with the order they actually appear in."""
-    passages = [
-        _passage("wiki/Big_Rapids,_Michigan#History", score=0.5, rank=1),
-        _passage("wiki/Big_Rapids,_Michigan#Notable_people", score=0.4, rank=2),
-    ]
-    bundle_lookup = _bundle_lookup_for(
-        {
-            "Big_Rapids,_Michigan": [
-                {"id": "History", "title": "History", "char_start": 0, "char_end": 100},
-                {
-                    "id": "Notable_people",
-                    "title": "Notable people",
-                    "char_start": 100,
-                    "char_end": 200,
-                },
-            ]
-        }
-    )
-    cfg = SynthesizeConfig()
-
-    out = _boost_by_section_affinity(
-        passages,
-        query="famous people from big rapids",
-        bundle_lookup=bundle_lookup,
-        config=cfg,
-    )
-    # Notable_people boosted 0.4 → 0.6, History stays 0.5. Notable_people
-    # is now first AND its rank should be 1; History gets rank 2.
-    assert out[0]["cite_id"] == "wiki/Big_Rapids,_Michigan#Notable_people"
-    assert out[0]["rank"] == 1
-    assert out[1]["rank"] == 2

--- a/tests/test_synthesize_section_affinity.py
+++ b/tests/test_synthesize_section_affinity.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
+import pytest
+
 from openzim_mcp.config import SynthesizeConfig
 from openzim_mcp.synthesize import _boost_by_section_affinity
 
@@ -59,7 +61,7 @@ def test_boost_promotes_passage_when_section_heading_matches_query():
             ]
         }
     )
-    cfg = SynthesizeConfig()  # threshold=0.25, boost=1.5
+    cfg = SynthesizeConfig()
 
     out = _boost_by_section_affinity(
         passages,
@@ -70,11 +72,12 @@ def test_boost_promotes_passage_when_section_heading_matches_query():
 
     # Affinity for Notable_people heading: heading tokens {notable, people};
     # query tokens include {people}. Intersect = {people}. Affinity = 1/2 = 0.5.
-    # 0.5 >= 0.25 → boost. New score = 0.6 * 1.5 = 0.9.
+    # 0.5 >= default threshold 0.25, so the default boost 1.5 applies:
+    # new score = 0.6 * 1.5 = 0.9.
     notable_passage = next(
         p for p in out if p["cite_id"] == "wiki/Big_Rapids,_Michigan#Notable_people"
     )
-    assert notable_passage["score"] == 0.6 * 1.5
+    assert notable_passage["score"] == pytest.approx(0.6 * 1.5)
 
 
 def test_boost_flips_order_when_boosted_passage_overtakes():
@@ -142,8 +145,8 @@ def test_boost_no_op_when_no_query_token_in_heading():
     geography_passage = next(
         p for p in out if p["cite_id"] == "wiki/Big_Rapids,_Michigan#Geography"
     )
-    assert history_passage["score"] == 1.0
-    assert geography_passage["score"] == 0.6
+    assert history_passage["score"] == pytest.approx(1.0)
+    assert geography_passage["score"] == pytest.approx(0.6)
 
 
 def test_boost_skips_article_level_citations():
@@ -175,7 +178,7 @@ def test_boost_skips_article_level_citations():
     article_passage = next(
         p for p in out if p["cite_id"] == "wiki/Big_Rapids,_Michigan"
     )
-    assert article_passage["score"] == 1.0
+    assert article_passage["score"] == pytest.approx(1.0)
 
 
 def test_boost_threshold_gate_blocks_weak_overlap():
@@ -206,7 +209,7 @@ def test_boost_threshold_gate_blocks_weak_overlap():
         bundle_lookup=bundle_lookup,
         config=cfg,
     )
-    assert out[0]["score"] == 1.0
+    assert out[0]["score"] == pytest.approx(1.0)
 
 
 def test_boost_handles_missing_section_in_bundle():
@@ -224,7 +227,7 @@ def test_boost_handles_missing_section_in_bundle():
         bundle_lookup=bundle_lookup,
         config=cfg,
     )
-    assert out[0]["score"] == 1.0
+    assert out[0]["score"] == pytest.approx(1.0)
 
 
 def test_boost_handles_bundle_lookup_returning_none():
@@ -244,7 +247,7 @@ def test_boost_handles_bundle_lookup_returning_none():
         bundle_lookup=none_lookup,
         config=cfg,
     )
-    assert out[0]["score"] == 1.0
+    assert out[0]["score"] == pytest.approx(1.0)
 
 
 def test_boost_handles_bundle_lookup_raising():
@@ -264,7 +267,7 @@ def test_boost_handles_bundle_lookup_raising():
         bundle_lookup=raising_lookup,
         config=cfg,
     )
-    assert out[0]["score"] == 1.0
+    assert out[0]["score"] == pytest.approx(1.0)
 
 
 def test_boost_empty_query_is_no_op():
@@ -292,7 +295,7 @@ def test_boost_empty_query_is_no_op():
         bundle_lookup=bundle_lookup,
         config=cfg,
     )
-    assert out[0]["score"] == 1.0
+    assert out[0]["score"] == pytest.approx(1.0)
 
 
 def test_boost_bundle_lookup_called_once_per_unique_article():

--- a/tests/test_synthesize_section_affinity.py
+++ b/tests/test_synthesize_section_affinity.py
@@ -1,0 +1,370 @@
+"""Tests for _boost_by_section_affinity — re-ranks section-attributed
+passages whose section heading shares tokens with the query.
+
+The motivating case: query 'famous people from big rapids michigan'
+should bubble the #Notable_people passage above the #History passage
+because 'people' (query token) appears in 'Notable people' (heading
+tokens) but not in 'History'.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from openzim_mcp.config import SynthesizeConfig
+from openzim_mcp.synthesize import _boost_by_section_affinity
+
+
+def _passage(cite_id: str, score: float, rank: int = 0) -> Dict[str, Any]:
+    return {
+        "cite_id": cite_id,
+        "text_markdown": f"text for {cite_id}",
+        "rank": rank,
+        "score": score,
+    }
+
+
+def _bundle_lookup_for(
+    sections_by_path: Dict[str, List[Dict[str, Any]]],
+) -> Any:
+    """Build a fake bundle_lookup that returns sections for known paths."""
+
+    def lookup(archive_name: str, entry_path: str) -> Any:
+        sections = sections_by_path.get(entry_path)
+        if sections is None:
+            return None
+        return {"sections": sections, "rendered_markdown": ""}
+
+    return lookup
+
+
+def test_boost_promotes_passage_when_section_heading_matches_query():
+    """'famous people' query → 'Notable people' heading gets boosted.
+    Verifies the multiplication happened; ordering effects covered in
+    next test."""
+    passages = [
+        _passage("wiki/Big_Rapids,_Michigan#History", score=1.0, rank=1),
+        _passage("wiki/Big_Rapids,_Michigan#Notable_people", score=0.6, rank=2),
+    ]
+    bundle_lookup = _bundle_lookup_for(
+        {
+            "Big_Rapids,_Michigan": [
+                {"id": "History", "title": "History", "char_start": 0, "char_end": 100},
+                {
+                    "id": "Notable_people",
+                    "title": "Notable people",
+                    "char_start": 100,
+                    "char_end": 200,
+                },
+            ]
+        }
+    )
+    cfg = SynthesizeConfig()  # threshold=0.25, boost=1.5
+
+    out = _boost_by_section_affinity(
+        passages,
+        query="famous people from big rapids michigan",
+        bundle_lookup=bundle_lookup,
+        config=cfg,
+    )
+
+    # Affinity for Notable_people heading: heading tokens {notable, people};
+    # query tokens include {people}. Intersect = {people}. Affinity = 1/2 = 0.5.
+    # 0.5 >= 0.25 → boost. New score = 0.6 * 1.5 = 0.9.
+    notable_passage = next(
+        p for p in out if p["cite_id"] == "wiki/Big_Rapids,_Michigan#Notable_people"
+    )
+    assert notable_passage["score"] == 0.6 * 1.5
+
+
+def test_boost_flips_order_when_boosted_passage_overtakes():
+    """When the boosted passage's new score exceeds the prior leader,
+    it ranks first."""
+    passages = [
+        _passage("wiki/Big_Rapids,_Michigan#History", score=0.5, rank=1),
+        _passage("wiki/Big_Rapids,_Michigan#Notable_people", score=0.4, rank=2),
+    ]
+    bundle_lookup = _bundle_lookup_for(
+        {
+            "Big_Rapids,_Michigan": [
+                {"id": "History", "title": "History", "char_start": 0, "char_end": 100},
+                {
+                    "id": "Notable_people",
+                    "title": "Notable people",
+                    "char_start": 100,
+                    "char_end": 200,
+                },
+            ]
+        }
+    )
+    cfg = SynthesizeConfig()
+
+    out = _boost_by_section_affinity(
+        passages,
+        query="famous people from big rapids",
+        bundle_lookup=bundle_lookup,
+        config=cfg,
+    )
+    # Notable_people: 0.4 * 1.5 = 0.6. History: 0.5. Notable_people wins.
+    assert out[0]["cite_id"] == "wiki/Big_Rapids,_Michigan#Notable_people"
+
+
+def test_boost_no_op_when_no_query_token_in_heading():
+    """No shared tokens → no boost, original order preserved."""
+    passages = [
+        _passage("wiki/Big_Rapids,_Michigan#History", score=1.0, rank=1),
+        _passage("wiki/Big_Rapids,_Michigan#Geography", score=0.6, rank=2),
+    ]
+    bundle_lookup = _bundle_lookup_for(
+        {
+            "Big_Rapids,_Michigan": [
+                {"id": "History", "title": "History", "char_start": 0, "char_end": 100},
+                {
+                    "id": "Geography",
+                    "title": "Geography",
+                    "char_start": 100,
+                    "char_end": 200,
+                },
+            ]
+        }
+    )
+    cfg = SynthesizeConfig()
+
+    out = _boost_by_section_affinity(
+        passages,
+        query="who founded big rapids",
+        bundle_lookup=bundle_lookup,
+        config=cfg,
+    )
+    history_passage = next(
+        p for p in out if p["cite_id"] == "wiki/Big_Rapids,_Michigan#History"
+    )
+    geography_passage = next(
+        p for p in out if p["cite_id"] == "wiki/Big_Rapids,_Michigan#Geography"
+    )
+    assert history_passage["score"] == 1.0
+    assert geography_passage["score"] == 0.6
+
+
+def test_boost_skips_article_level_citations():
+    """Passages without a #section_id suffix are left untouched."""
+    passages = [
+        _passage("wiki/Big_Rapids,_Michigan", score=1.0, rank=1),
+        _passage("wiki/Big_Rapids,_Michigan#Notable_people", score=0.6, rank=2),
+    ]
+    bundle_lookup = _bundle_lookup_for(
+        {
+            "Big_Rapids,_Michigan": [
+                {
+                    "id": "Notable_people",
+                    "title": "Notable people",
+                    "char_start": 0,
+                    "char_end": 200,
+                },
+            ]
+        }
+    )
+    cfg = SynthesizeConfig()
+
+    out = _boost_by_section_affinity(
+        passages,
+        query="famous people",
+        bundle_lookup=bundle_lookup,
+        config=cfg,
+    )
+    article_passage = next(
+        p for p in out if p["cite_id"] == "wiki/Big_Rapids,_Michigan"
+    )
+    assert article_passage["score"] == 1.0
+
+
+def test_boost_threshold_gate_blocks_weak_overlap():
+    """One matching token in a 6-token heading is 1/6 ≈ 0.167,
+    below the default threshold of 0.25. No boost."""
+    passages = [
+        _passage("wiki/Foo#A_Very_Long_Heading_Name_Here", score=1.0, rank=1),
+    ]
+    bundle_lookup = _bundle_lookup_for(
+        {
+            "Foo": [
+                {
+                    "id": "A_Very_Long_Heading_Name_Here",
+                    "title": "A very long heading name here",
+                    "char_start": 0,
+                    "char_end": 100,
+                },
+            ]
+        }
+    )
+    cfg = SynthesizeConfig()
+
+    # Query has only 'long' as overlap (heading tokens: a, very, long, heading, name, here = 6 tokens).
+    # Affinity = 1/6 ≈ 0.167 < 0.25.
+    out = _boost_by_section_affinity(
+        passages,
+        query="long stuff",
+        bundle_lookup=bundle_lookup,
+        config=cfg,
+    )
+    assert out[0]["score"] == 1.0
+
+
+def test_boost_handles_missing_section_in_bundle():
+    """Section_id present on cite_id but not found in bundle → skip
+    silently, no boost, no crash."""
+    passages = [
+        _passage("wiki/Foo#nonexistent_section", score=1.0, rank=1),
+    ]
+    bundle_lookup = _bundle_lookup_for({"Foo": []})
+    cfg = SynthesizeConfig()
+
+    out = _boost_by_section_affinity(
+        passages,
+        query="anything goes here",
+        bundle_lookup=bundle_lookup,
+        config=cfg,
+    )
+    assert out[0]["score"] == 1.0
+
+
+def test_boost_handles_bundle_lookup_returning_none():
+    """Bundle lookup returns None → no crash, no boost."""
+    passages = [
+        _passage("wiki/Foo#Section", score=1.0, rank=1),
+    ]
+
+    def none_lookup(archive_name: str, entry_path: str) -> Any:
+        return None
+
+    cfg = SynthesizeConfig()
+
+    out = _boost_by_section_affinity(
+        passages,
+        query="anything",
+        bundle_lookup=none_lookup,
+        config=cfg,
+    )
+    assert out[0]["score"] == 1.0
+
+
+def test_boost_handles_bundle_lookup_raising():
+    """Bundle lookup raises → no crash, no boost."""
+    passages = [
+        _passage("wiki/Foo#Section", score=1.0, rank=1),
+    ]
+
+    def raising_lookup(archive_name: str, entry_path: str) -> Any:
+        raise RuntimeError("bundle build failed")
+
+    cfg = SynthesizeConfig()
+
+    out = _boost_by_section_affinity(
+        passages,
+        query="anything",
+        bundle_lookup=raising_lookup,
+        config=cfg,
+    )
+    assert out[0]["score"] == 1.0
+
+
+def test_boost_empty_query_is_no_op():
+    """Empty query has no tokens → return passages unchanged."""
+    passages = [
+        _passage("wiki/Foo#Notable_people", score=1.0, rank=1),
+    ]
+    bundle_lookup = _bundle_lookup_for(
+        {
+            "Foo": [
+                {
+                    "id": "Notable_people",
+                    "title": "Notable people",
+                    "char_start": 0,
+                    "char_end": 100,
+                },
+            ]
+        }
+    )
+    cfg = SynthesizeConfig()
+
+    out = _boost_by_section_affinity(
+        passages,
+        query="",
+        bundle_lookup=bundle_lookup,
+        config=cfg,
+    )
+    assert out[0]["score"] == 1.0
+
+
+def test_boost_bundle_lookup_called_once_per_unique_article():
+    """When two passages cite the same article's different sections,
+    the bundle is looked up only once (memoization)."""
+    passages = [
+        _passage("wiki/Big_Rapids,_Michigan#Section_A", score=1.0, rank=1),
+        _passage("wiki/Big_Rapids,_Michigan#Section_B", score=0.8, rank=2),
+    ]
+    call_count = {"n": 0}
+
+    def counting_lookup(archive_name: str, entry_path: str) -> Any:
+        call_count["n"] += 1
+        return {
+            "sections": [
+                {
+                    "id": "Section_A",
+                    "title": "Section A",
+                    "char_start": 0,
+                    "char_end": 50,
+                },
+                {
+                    "id": "Section_B",
+                    "title": "Section B",
+                    "char_start": 50,
+                    "char_end": 100,
+                },
+            ]
+        }
+
+    cfg = SynthesizeConfig()
+    _boost_by_section_affinity(
+        passages,
+        query="section",  # match against headings
+        bundle_lookup=counting_lookup,
+        config=cfg,
+    )
+    assert call_count["n"] == 1
+
+
+def test_boost_renumbers_rank_to_match_new_order():
+    """After the affinity boost re-sorts by score, the passages'
+    ``rank`` field is renumbered to match the new ordering. Otherwise
+    downstream consumers reading `passages[].rank` get stale BM25
+    positions inconsistent with the order they actually appear in."""
+    passages = [
+        _passage("wiki/Big_Rapids,_Michigan#History", score=0.5, rank=1),
+        _passage("wiki/Big_Rapids,_Michigan#Notable_people", score=0.4, rank=2),
+    ]
+    bundle_lookup = _bundle_lookup_for(
+        {
+            "Big_Rapids,_Michigan": [
+                {"id": "History", "title": "History", "char_start": 0, "char_end": 100},
+                {
+                    "id": "Notable_people",
+                    "title": "Notable people",
+                    "char_start": 100,
+                    "char_end": 200,
+                },
+            ]
+        }
+    )
+    cfg = SynthesizeConfig()
+
+    out = _boost_by_section_affinity(
+        passages,
+        query="famous people from big rapids",
+        bundle_lookup=bundle_lookup,
+        config=cfg,
+    )
+    # Notable_people boosted 0.4 → 0.6, History stays 0.5. Notable_people
+    # is now first AND its rank should be 1; History gets rank 2.
+    assert out[0]["cite_id"] == "wiki/Big_Rapids,_Michigan#Notable_people"
+    assert out[0]["rank"] == 1
+    assert out[1]["rank"] == 2

--- a/tests/test_synthesize_title_promotion_v2a9.py
+++ b/tests/test_synthesize_title_promotion_v2a9.py
@@ -325,3 +325,147 @@ def test_search_compact_no_splice_when_title_match_already_present():
     paths = [r["path"] for r in spliced["results"]]
     # No duplication, Berlin first.
     assert paths == ["Berlin", "List_of_songs_about_Berlin"]
+
+
+# ---------------------------------------------------------------------------
+# A14: tail-probe entity resolution (replaces M26 4-token short-circuit)
+# ---------------------------------------------------------------------------
+
+
+def test_promote_title_match_tail_probe_resolves_short_tail():
+    """A14: prose-shaped query (>4 tokens) now probes greedy tails
+    instead of short-circuiting. 'famous people from big rapids
+    michigan' → 'big rapids michigan' resolves Big_Rapids,_Michigan."""
+    bm25_top_hits = [
+        ("wiki", {"path": "Famous_People_(film)", "snippet": "...", "score": 0.5}),
+    ]
+
+    def fake_title_match(archive: Any, query: str) -> Any:
+        if query == "big rapids michigan":
+            return {"path": "Big_Rapids,_Michigan", "snippet": "...", "score": 1.0}
+        return None
+
+    search_handler = MagicMock()
+    search_handler.title_match_hit.side_effect = fake_title_match
+    archive = MagicMock()
+
+    promoted = _promote_title_match(
+        bm25_top_hits,
+        query="famous people from big rapids michigan",
+        archives=[(archive, Path("/fake/wiki.zim"))],
+        archives_searched=["wiki"],
+        search_handler=search_handler,
+    )
+    assert promoted[0][1]["path"] == "Big_Rapids,_Michigan"
+
+
+def test_promote_title_match_tail_probe_prefers_longest_resolving_tail():
+    """When both 'big rapids michigan' and 'michigan' would resolve,
+    the longer (more specific) one wins."""
+    bm25_top_hits = [
+        ("wiki", {"path": "Some_Other_Article", "snippet": "...", "score": 0.5}),
+    ]
+
+    def fake_title_match(archive: Any, query: str) -> Any:
+        if query == "big rapids michigan":
+            return {"path": "Big_Rapids,_Michigan", "snippet": "...", "score": 1.0}
+        if query == "michigan":
+            return {"path": "Michigan", "snippet": "...", "score": 1.0}
+        return None
+
+    search_handler = MagicMock()
+    search_handler.title_match_hit.side_effect = fake_title_match
+    archive = MagicMock()
+
+    promoted = _promote_title_match(
+        bm25_top_hits,
+        query="famous people from big rapids michigan",
+        archives=[(archive, Path("/fake/wiki.zim"))],
+        archives_searched=["wiki"],
+        search_handler=search_handler,
+    )
+    assert promoted[0][1]["path"] == "Big_Rapids,_Michigan"
+
+
+def test_promote_title_match_tail_probe_no_short_circuit_for_long_queries():
+    """A14: M26's 4+ token short-circuit is removed. Long queries with
+    a clear entity tail now probe and resolve."""
+    bm25_top_hits: list[tuple[str, dict]] = []
+
+    def fake_title_match(archive: Any, query: str) -> Any:
+        if query == "detroit":
+            return {"path": "Detroit", "snippet": "...", "score": 1.0}
+        return None
+
+    search_handler = MagicMock()
+    search_handler.title_match_hit.side_effect = fake_title_match
+    archive = MagicMock()
+
+    promoted = _promote_title_match(
+        bm25_top_hits,
+        query="what is the population of detroit",
+        archives=[(archive, Path("/fake/wiki.zim"))],
+        archives_searched=["wiki"],
+        search_handler=search_handler,
+    )
+    assert len(promoted) == 1
+    assert promoted[0][1]["path"] == "Detroit"
+
+
+def test_promote_title_match_tail_probe_falls_through_when_no_tail_resolves():
+    """All tails miss → return top_hits unchanged."""
+    bm25_top_hits = [
+        ("wiki", {"path": "Unrelated_Article", "snippet": "...", "score": 0.3}),
+    ]
+    search_handler = MagicMock()
+    search_handler.title_match_hit.return_value = None
+    archive = MagicMock()
+
+    promoted = _promote_title_match(
+        bm25_top_hits,
+        query="completely unknown phrase here that nothing matches",
+        archives=[(archive, Path("/fake/wiki.zim"))],
+        archives_searched=["wiki"],
+        search_handler=search_handler,
+    )
+    assert promoted == bm25_top_hits
+
+
+def test_promote_title_match_tail_probe_prefers_longer_tail_across_archives():
+    """tail × archive ordering: an archive that hits a LONGER tail
+    beats an archive that hits a SHORTER tail. Locks in the docstring
+    claim that the most specific entity in any archive wins.
+
+    Without this ordering, a future refactor that swaps the loop
+    nesting to ``archive × tail`` would silently prefer archive[0]'s
+    shorter-tail hit over archive[1]'s longer-tail hit."""
+    bm25_top_hits: list[tuple[str, dict]] = []
+    archive0 = MagicMock()
+    archive1 = MagicMock()
+
+    def fake_title_match(archive: Any, query: str) -> Any:
+        # archive0 only resolves the 1-token tail
+        if archive is archive0 and query == "michigan":
+            return {"path": "Michigan", "snippet": "...", "score": 1.0}
+        # archive1 resolves the 3-token tail
+        if archive is archive1 and query == "big rapids michigan":
+            return {"path": "Big_Rapids,_Michigan", "snippet": "...", "score": 1.0}
+        return None
+
+    search_handler = MagicMock()
+    search_handler.title_match_hit.side_effect = fake_title_match
+
+    promoted = _promote_title_match(
+        bm25_top_hits,
+        query="famous people from big rapids michigan",
+        archives=[
+            (archive0, Path("/fake/wiki0.zim")),
+            (archive1, Path("/fake/wiki1.zim")),
+        ],
+        archives_searched=["wiki0", "wiki1"],
+        search_handler=search_handler,
+    )
+    assert len(promoted) == 1
+    # The 3-token tail in archive1 beats the 1-token tail in archive0
+    assert promoted[0][0] == "wiki1"
+    assert promoted[0][1]["path"] == "Big_Rapids,_Michigan"

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -228,5 +228,7 @@ def test_synthesize_response_accepts_considered_articles_and_sections():
         "considered_sections": [section],
     }
     # Structural assertion: the TypedDict shape accepts these fields.
-    assert response["considered_articles"][0]["title"] == "Big Rapids Township, Michigan"
+    assert (
+        response["considered_articles"][0]["title"] == "Big Rapids Township, Michigan"
+    )
     assert response["considered_sections"][0]["title"] == "History"

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -191,3 +191,42 @@ def test_synthesize_response_has_required_fields() -> None:
         "_meta",
     ):
         assert key in hints, f"SynthesizeResponse missing {key}"
+
+
+def test_synthesize_response_accepts_considered_articles_and_sections():
+    """A14: SynthesizeResponse exposes considered_articles and
+    considered_sections for multi-round refinement. Both fields are
+    optional (total=False) so existing callers aren't forced to set
+    them."""
+    from openzim_mcp.tool_schemas import (
+        ConsideredArticle,
+        ConsideredSection,
+        SynthesizeResponse,
+    )
+
+    article: ConsideredArticle = {
+        "archive": "wiki",
+        "entry_path": "Big_Rapids_Township,_Michigan",
+        "title": "Big Rapids Township, Michigan",
+        "score": 0.42,
+    }
+    section: ConsideredSection = {
+        "section_id": "History",
+        "title": "History",
+    }
+    response: SynthesizeResponse = {
+        "query": "q",
+        "answer_markdown": "a",
+        "passages": [],
+        "citations": [],
+        "archives_searched": ["wiki"],
+        "fallback_used": "rrf_fusion",
+        "total_chars": 1,
+        "total_words": 1,
+        "_meta": {},  # type: ignore[typeddict-item]
+        "considered_articles": [article],
+        "considered_sections": [section],
+    }
+    # Structural assertion: the TypedDict shape accepts these fields.
+    assert response["considered_articles"][0]["title"] == "Big Rapids Township, Michigan"
+    assert response["considered_sections"][0]["title"] == "History"


### PR DESCRIPTION
## Summary

Three coordinated changes that turn `zim_query` into a search-engine-style entry point for natural-language questions. Motivating query: *"who are some famous people from big rapids, michigan"* — today this falls through to BM25 noise; after this branch it resolves the canonical entity and (in `synthesize=True` mode) features the `Notable people` section as the lead passage.

- **Greedy tail-probe entity resolution** in both default and `synthesize=True` paths via a new shared `iter_query_tails` helper in `title_promotion.py`. Replaces the M26 4-token short-circuit. The default `tell_me_about` path uses a two-pass structure (all 1.0 gates across all tails first, then all 0.8 gates) so a fuzzy match on a long noisy tail can't beat an exact match on a clean short tail.
- **Section-heading affinity boost** in `synthesize` — new `_boost_by_section_affinity` stage re-ranks section-attributed passages whose heading shares ≥25% of its tokens with the query (×1.5 multiplier). Tunable via `SynthesizeConfig.section_affinity_threshold` / `section_affinity_boost`. Archive-agnostic: the archive's own section headings supply the vocabulary, no curated tables.
- **Multi-round handles** on `SynthesizeResponse` — new `considered_articles` (top 3 hits not featured) and `considered_sections` (top 10 sections of featured article, minus featured) so the next conversation turn can pivot via `get_zim_entries` / `get_section` without re-running search.

Design and rationale: [`docs/superpowers/specs/2026-05-15-search-engine-zim-query-design.md`](docs/superpowers/specs/2026-05-15-search-engine-zim-query-design.md). Implementation plan: [`docs/superpowers/plans/2026-05-15-search-engine-zim-query.md`](docs/superpowers/plans/2026-05-15-search-engine-zim-query.md).

### Notable design points

- **No curated artifacts.** No question templates, no synonym buckets, no English stopword list. The only tokenizer is `[a-z0-9]+` + `.lower()`, used identically in `iter_query_tails`, `_affinity_tokens`, and `is_strong_title_match`.
- **Archive-agnostic.** Section ranking matches against whatever headings the archive actually emits. Works equally on Wikipedia, Stack Exchange, Wikitravel, Project Gutenberg.
- **`SynthesizeResponse` is now `TypedDict(total=False)`** to accept the two new optional fields. Existing callers populating every field are unaffected.

## Test Plan

- [x] 1567 unit / integration tests pass (1521 baseline + 46 new)
- [x] mypy clean on all 5 touched modules
- [x] black + isort clean
- [x] Golden snapshots refreshed for the 3 affected synthesize fixtures (score boost + new fields)
- [ ] **Live beta-test sweep against the 118 GB Wikipedia ZIM** (manual, runs after a14 alpha tag) — adversarial set from the a-series methodology, including the motivating query, Wikipedia question-shape battery (history/geography/economy of X, notable people from X), cross-article scope (jazz musicians from Detroit), and the existing regression set (single-word topics, politeness-tail variants, disambig twins, single-edit typos, chained-intent queries).
- [ ] **Non-Wikipedia archive smoke test** if available — Stack Exchange or Wikitravel ZIM, verify affinity matches against that archive's heading vocabulary.

## Follow-up watchpoints for the live sweep

1. Cross-archive duplicates with `~N` stem suffix — `considered_articles` exclusion uses `(archive, entry_path)`, so `wiki` + `wiki~2` of the same article appear separately. Verify.
2. Common-token queries like `"history"` will boost every section containing "history" simultaneously — watch ranking ties.
3. Synthesize path uses strict `title_match_hit` only (no 0.8 typo fallback like `tell_me_about`). Typo queries in synthesize mode won't get entity resolution. Confirm whether material or theoretical.
4. Long articles (Wikipedia: Germany has ~80 sections) — `considered_sections` capped at 10 in document order, may surface preamble sections rather than relevant ones.
5. Plan doc still shows the superseded `\w+` tokenizer at lines 244 / 1069 (production code and spec are correct). Historical artifact — update in a follow-up doc-only commit if desired.

## Commits

\`\`\`
0833ca0 feat(v2): SynthesizeConfig knobs for section-affinity ranking
7ac430d feat(v2): iter_query_tails helper for entity tail-probe
9878828 feat(v2): tail-probe entity resolution in tell_me_about
b0dabfb feat(v2): tail-probe entity resolution in synthesize
285f98c feat(v2): section-heading affinity boost in synthesize
b15b63d feat(v2): ConsideredArticle + ConsideredSection types
3ab2753 feat(v2): considered_articles + considered_sections in synthesize
494ea70 style: black/isort formatting after a14 implementation
f74cc61 docs(changelog): a14 search-engine zim_query path
73c8bda fix(v2): final-review cleanup for a14 search-engine path
\`\`\`