### PR TITLE
fix(test): make M-namespace count assertion robust to fixture drift

### DIFF
--- a/tests/test_namespace_scheme_aware.py
+++ b/tests/test_namespace_scheme_aware.py
@@ -110,14 +110,25 @@ class TestListNamespacesNewScheme:
     ):
         """M should be populated from archive.metadata_keys.
 
-        nons/small.zim has 10 metadata_keys (not derived from path parsing).
+        The point of this test is the *route*: M is discovered via
+        ``archive.metadata_keys`` rather than parsed from a path prefix.
+        nons/small.zim carries several metadata keys (Title, Description,
+        Creator, Date, etc.); the exact count is set by upstream
+        zim-testing-suite and has drifted between fixture refreshes
+        (was 10, observed 9 after a 2026-05 refresh), so the threshold
+        is intentionally a conservative floor rather than an
+        equal-to-N assertion.
         """
         zim = _require(basic_test_zim_files["nons"])
         result = json.loads(ops_for_zim_data.list_namespaces(str(zim)))
         assert (
             "M" in result["namespaces"]
         ), "M must be discovered via metadata_keys for new-scheme"
-        assert result["namespaces"]["M"]["total"] >= 10
+        # Conservative floor: any real-world ZIM has at least a handful of
+        # metadata keys (Title, Description, Creator, Language, Date,
+        # Tags). Robust to minor upstream fixture changes; still asserts
+        # the route is wired.
+        assert result["namespaces"]["M"]["total"] >= 5
 
 
 class TestListNamespacesOldScheme:


### PR DESCRIPTION
## Summary

Fixes the **Comprehensive Testing** job that's been red on main since `f87cc76` (2026-05-14). The job runs only on push-to-main and pulls fresh openzim/zim-testing-suite fixtures each time; an upstream refresh dropped `nons/small.zim` from 10 → 9 metadata keys, tripping a brittle exact-count assertion in `test_metadata_namespace_from_metadata_keys`.

## Why this is the right fix (not bumping to `>= 9`)

The test's point is the *route* — that M is discovered via `archive.metadata_keys` rather than parsed from a path prefix in new-scheme archives. The exact count is set by upstream fixtures and has now drifted twice in the test's lifetime. Lowering the threshold to a conservative floor of 5 (any real-world ZIM has at least Title/Description/Creator/Language/Date) keeps the assertion meaningful while surviving minor upstream variation.

Docstring updated to document why the threshold is a floor, not an equality.

## Test Plan

- [x] File parses, 20 tests collected
- [ ] Comprehensive Testing job (post-merge) passes — this is the only way to verify since the job runs against the live upstream fixtures and is gated to `main`