### PR TITLE
fix(v2): post-a15 beta-test sweep — 10 defects across seven passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — post-a15 beta-test sweep — 4 live-Wikipedia defects (D4 / D5 / D6 / D7)
+## [Unreleased] — post-a15 beta-test sweep — 7 live-Wikipedia defects (D4 / D5 / D6 / D7 + P4-D1 / P4-D2 / P4-D3)
 
 The multi-pass live sweep of a15 against
-`wikipedia_en_all_maxi_2026-02.zim` (~118 GB, ~27.2 M entries) surfaced
-four user-facing defects: one in the `tell_me_about` disambig-page
-handling (Mercury), one in the intent parser's politeness-prefix
-regex, one in `find_by_title`'s response to namespace-prefixed input,
-and one schema-consistency gap in `walk_namespace`. Pass 2 self-
-audited every fix in both verbose and compact rendering modes and
+`wikipedia_en_all_maxi_2026-02.zim` (~118 GB, ~27.2 M entries) ran
+across five passes. Pass 1 surfaced four user-facing defects (D4 in
+the `tell_me_about` disambig-page handling for Mercury-class bare
+titles; D5 in the intent parser's politeness-prefix regex; D6 in
+`find_by_title`'s response to namespace-prefixed input; D7 a
+schema-consistency gap in `walk_namespace`). Pass 2 self-audited
+every D-fix in both verbose and compact rendering modes and
 exercised the canonical-article paths (Berlin / Apollo 11 / Java)
-that the disambig-detection logic must not regress. Pass 3 re-tested
+the disambig-detection logic must not regress. Pass 3 re-tested
 across a broader disambig set (Mars, Sun, Moon, Paris, Apollo bare),
 walked empty namespaces B / X / Z, and exercised cross-fix
-interactions (`could you find article titled M/Title`); both later
-passes found zero new defects.
+interactions (`could you find article titled M/Title`); both
+passes 2 and 3 found zero new defects. Pass 4 then deliberately
+stress-tested the four landed D-fixes from angles the earlier
+passes hadn't probed (more bare-title disambigs, pathological
+politeness combinations, find_by_title edge cases, walk_namespace
+malformed args) AND exercised the intent paths the earlier passes
+had barely touched (synthesize, browse namespace, show structure
+of, links in, suggestions for, search in namespace); it surfaced
+three more defects (P4-D1 / P4-D2 / P4-D3) — each one fixed in
+this commit. Pass 5 re-tested every fix and audited the regression
+shape; zero new defects.
 
 ### Fixed
 
@@ -76,19 +86,59 @@ passes found zero new defects.
   Fixed by passing `namespace_entry_count=0` in the short-circuit.
   Updated the `walk_A_10` golden to reflect the new schema; walk-M
   and walk-W goldens are unchanged (already carried the field).
+- **P4-D1: `suggestions for` (no actual prefix) now returns the
+  structured "Missing Search Term" error instead of silently
+  autocompleting against the literal word "for".** The regex's
+  optional `(?:for\s+)?` group failed to match without trailing
+  whitespace, so the mandatory capture greedily swallowed "for"
+  itself; the handler's existing missing-arg guard then saw a
+  non-empty `partial_query` and ran the suggestion fallback (which
+  spent ~70 s scanning for "for" — a high-frequency English token).
+  Fixed in `_extract_suggestions` by discarding a bare-"for"
+  capture so the guard takes over. Legitimate prefixes that happen
+  to start with "for" (e.g., `suggestions for forest`) still work.
+- **P4-D2: chained-intent detector no longer bypassed by a modal
+  lead-in.** `_chained_intent_guidance`'s
+  `_CHAINED_OPERATION_PREFIX_RE` is anchored at `^` and only
+  recognised operation verbs at position 0, so `could you tell me
+  about Photosynthesis then list namespaces` shifted the verb past
+  the anchor — `left_is_op` evaluated False, the chain gate failed,
+  and the query fell through to normal intent classification where
+  the higher-confidence `list_namespaces` won and silently dropped
+  the `tell me about` half. The D5 modal-strip lives inside
+  `_extract_tell_me_about`; it only runs AFTER the chain detector
+  has already decided. Fixed by pre-stripping the same modal
+  scaffold (`(?:could|can|would|will)\s+(?:you|we|i)\s+
+  (?:please\s+)?`) at the top of `_chained_intent_guidance` so
+  detection sees the cleaned query.
+- **P4-D3: `walk namespace` with a malformed argument now returns
+  a structured "Missing or Invalid Namespace" error instead of
+  silently walking C.** Multi-char (`AB`), digit (`1`), special
+  (`_`), and missing-argument forms all fell through to
+  `params.get("namespace", "C")` in `_handle_walk_namespace` with
+  no signal to the caller that the input was rejected. Sibling
+  tools (`find_by_title`, `links_in`, `suggestions`,
+  `tell_me_about`) already return structured missing-arg errors;
+  this one didn't. Fixed by adding an upfront guard that mirrors
+  their shape (rule / examples) before the C-default kicks in.
 
 ### Tests
 
-- **`tests/test_post_a15_beta_fixes.py`** — 25 regression tests
-  pinning the four defects. Each defect gets:
+- **`tests/test_post_a15_beta_fixes.py`** — 55 regression tests
+  pinning all seven defects. Each defect gets:
   - The fix-case test (Mercury body has no misleading trailer;
     "could you tell me about X" parses topic=X; "find article titled
     M/Title" returns redirect; `_build_walk_result` exposes the
-    zero-count field).
+    zero-count field; `suggestions for` triggers the missing-arg
+    guard; `could you tell me about X then list namespaces` is
+    detected as chained; `walk namespace AB` returns the missing-
+    namespace error).
   - Negative self-audit cases (Berlin keeps its disambig-twin
     footer; non-modal queries unchanged; lowercase a/b not
     redirected; `namespace_entry_count` omitted when caller passes
-    None).
+    None; legitimate `suggestions for forest` still captures the
+    prefix; non-chained `could you tell me about X` not tripped by
+    the chain detector; `walk namespace c` lowercase still works).
   - Cross-defect probes (Java disambig body suppresses
     `disambig_twin_path` footer too).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — post-a15 beta-test sweep — 7 live-Wikipedia defects (D4 / D5 / D6 / D7 + P4-D1 / P4-D2 / P4-D3)
+## [Unreleased] — post-a15 beta-test sweep — 10 live-Wikipedia defects across seven passes
 
 The multi-pass live sweep of a15 against
 `wikipedia_en_all_maxi_2026-02.zim` (~118 GB, ~27.2 M entries) ran
-across five passes. Pass 1 surfaced four user-facing defects (D4 in
+across seven passes. Pass 1 surfaced four user-facing defects (D4 in
 the `tell_me_about` disambig-page handling for Mercury-class bare
 titles; D5 in the intent parser's politeness-prefix regex; D6 in
 `find_by_title`'s response to namespace-prefixed input; D7 a
@@ -27,9 +27,18 @@ politeness combinations, find_by_title edge cases, walk_namespace
 malformed args) AND exercised the intent paths the earlier passes
 had barely touched (synthesize, browse namespace, show structure
 of, links in, suggestions for, search in namespace); it surfaced
-three more defects (P4-D1 / P4-D2 / P4-D3) — each one fixed in
-this commit. Pass 5 re-tested every fix and audited the regression
-shape; zero new defects.
+three more defects (P4-D1 / P4-D2 / P4-D3). Pass 5 verified those
+three fixes; zero new defects. Pass 6 went deeper — a source-level
+audit of every intent handler for the silent-default pattern
+P4-D3 fixed (`params.get("X", DEFAULT)`) caught the same shape in
+`_handle_browse`, and a parallel audit of every intent extractor
+for the trigger-word-capture pattern P4-D1 fixed caught a sibling
+extractor permissiveness in `_extract_browse`; plus a leading-
+politeness probe surfaced a third defect (P6-D3) — `please tell
+me about X` leaks the leading politeness into the parsed topic
+just like the original D5 did for modal verbs. Pass 7 verified
+all ten fixes and audited cumulative regressions across the three
+commits; zero new defects.
 
 ### Fixed
 
@@ -121,26 +130,61 @@ shape; zero new defects.
   `tell_me_about`) already return structured missing-arg errors;
   this one didn't. Fixed by adding an upfront guard that mirrors
   their shape (rule / examples) before the C-default kicks in.
+- **P6-D1 + P6-D2: `browse namespace` now reaches input-validation
+  parity with `walk namespace`.** Two cooperating gaps — the
+  handler `_handle_browse` had the same
+  `params.get("namespace", "C")` silent-default that P4-D3 fixed
+  for walk; AND the extractor `_extract_browse` accepted multi-char,
+  digit, and special-character namespace arguments
+  (`browse namespace AB / 1 / _`) without uppercasing lowercase
+  input — diverging from the strict
+  `_extract_walk_namespace`. The two siblings now agree: regex
+  tightened to `namespace\s+['"]?([A-Za-z])\b['"]?` with `.upper()`
+  on the captured letter, and the handler returns a structured
+  "Missing or Invalid Namespace" error when the extractor produces
+  nothing.
+- **P6-D3: leading `please` / `kindly` now strip cleanly from the
+  parsed topic.** `please tell me about Photosynthesis` and
+  `kindly describe Photosynthesis` previously parsed with the
+  politeness phrase leaking into the topic — same shape as the
+  pass-1 D5 defect but for non-modal politeness words. The article
+  still resolved via tail-probe rescue, but the parsed topic was
+  wrong. Fix extends the leading-strip in `_extract_tell_me_about`
+  to cover `please` / `kindly` AND wraps both the modal-strip and
+  the politeness-strip in a loop so composite phrases
+  (`please could you tell me about X`, `please please tell me
+  about X`) peel cleanly. Same loop also applied to the chain-
+  detector's `_chained_intent_guidance` pre-strip so leading
+  politeness doesn't bypass chain detection (mirror of P4-D2).
+  Leaves the existing trailing-politeness strip alone, so
+  `tell me about X please` still works, and the leading-only
+  anchor (`^\s*`) prevents stripping mid-query mentions of
+  `please` / `kindly` that are legitimately part of the topic.
 
 ### Tests
 
-- **`tests/test_post_a15_beta_fixes.py`** — 55 regression tests
-  pinning all seven defects. Each defect gets:
+- **`tests/test_post_a15_beta_fixes.py`** — 80 regression tests
+  pinning all ten defects. Each defect gets:
   - The fix-case test (Mercury body has no misleading trailer;
-    "could you tell me about X" parses topic=X; "find article titled
-    M/Title" returns redirect; `_build_walk_result` exposes the
+    `could you tell me about X` parses topic=X; `find article titled
+    M/Title` returns redirect; `_build_walk_result` exposes the
     zero-count field; `suggestions for` triggers the missing-arg
     guard; `could you tell me about X then list namespaces` is
     detected as chained; `walk namespace AB` returns the missing-
-    namespace error).
+    namespace error; `browse namespace AB` returns the same error
+    and `browse namespace c` lowercases to "C"; `please tell me
+    about X` strips cleanly).
   - Negative self-audit cases (Berlin keeps its disambig-twin
     footer; non-modal queries unchanged; lowercase a/b not
-    redirected; `namespace_entry_count` omitted when caller passes
-    None; legitimate `suggestions for forest` still captures the
-    prefix; non-chained `could you tell me about X` not tripped by
-    the chain detector; `walk namespace c` lowercase still works).
+    redirected by find_by_title; `namespace_entry_count` omitted
+    when caller passes None; legitimate `suggestions for forest`
+    still captures the prefix; non-chained `could you tell me about
+    X` not tripped by the chain detector; trailing `please` still
+    works; mid-query `please in linguistics` not stripped).
   - Cross-defect probes (Java disambig body suppresses
-    `disambig_twin_path` footer too).
+    `disambig_twin_path` footer too; `please could you tell me
+    about X` peels both layers; `please tell me about X then list
+    namespaces` trips chain detector).
 
 ## [2.0.0a15] — 2026-05-16 (alpha pre-release) — post-a14 beta-test sweep — section-affinity feature now actually works on real Wikipedia content
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,92 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased] — post-a15 beta-test sweep — 4 live-Wikipedia defects (D4 / D5 / D6 / D7)
+
+The multi-pass live sweep of a15 against
+`wikipedia_en_all_maxi_2026-02.zim` (~118 GB, ~27.2 M entries) surfaced
+four user-facing defects: one in the `tell_me_about` disambig-page
+handling (Mercury), one in the intent parser's politeness-prefix
+regex, one in `find_by_title`'s response to namespace-prefixed input,
+and one schema-consistency gap in `walk_namespace`. Pass 2 self-
+audited every fix in both verbose and compact rendering modes and
+exercised the canonical-article paths (Berlin / Apollo 11 / Java)
+that the disambig-detection logic must not regress. Pass 3 re-tested
+across a broader disambig set (Mars, Sun, Moon, Paris, Apollo bare),
+walked empty namespaces B / X / Z, and exercised cross-fix
+interactions (`could you find article titled M/Title`); both later
+passes found zero new defects.
+
+### Fixed
+
+- **D4: `tell me about Mercury` no longer attaches a misleading
+  `_May also refer to: Mercury_Monterey — use tell me about <full
+  title>_` footer to the disambiguation-page body.** Two cooperating
+  bugs: `SimpleToolsHandler._is_disambig_lead` returned False
+  whenever `pre_h2` exceeded 400 chars — Mercury's 628-char pre-H2
+  (the "most commonly refers to" preamble, three top-level entries,
+  and the "may also refer to" header) blew past the cap, so the
+  existing disambig-page detection in `_lead_with_toc` never fired;
+  AND the trailing-footer block in `_handle_tell_me_about` had no
+  way to suppress the `disambig_twin_path` / `related_extends_paths`
+  hints when the resolved body was itself a disambig page. Fixed
+  by checking only the trailing 400 characters of `pre_h2` (the
+  regex-free `endswith` stays bounded, but long preambles now
+  trigger) and by gating both trailing footers on a fresh
+  `body_is_disambig_page` check on the fetched body. Canonical
+  pages with disambig twins (Berlin) keep their footer; canonical
+  pages with extends-topic siblings (Apollo 11 → anniversaries /
+  lunar sample display / goodwill messages) keep their footer.
+- **D5: `could you tell me about Photosynthesis` now parses
+  `topic = "Photosynthesis"` instead of leaking the modal lead-in
+  into the topic.** The verb-prefix regex in
+  `_extract_tell_me_about` anchored at `^\s*` and never matched
+  "could you" / "can you" / "would you" / "will you", so the whole
+  query fell through to the `topic = query.strip()` fallback and
+  downstream relied on the tail-probe entity rescue to find the
+  article anyway. Fixed by stripping the modal scaffold
+  (`(?:could|can|would|will)\s+(?:you|we|i)\s+(?:please\s+)?`) before
+  the verb regex runs. Leaves non-modal queries unchanged; combines
+  cleanly with the existing trailing-politeness strip
+  (`could you tell me about X please` → topic=X).
+- **D6: `find article titled M/Title` now redirects to `get article
+  M/Title` instead of returning a silent `0_hits`.** The title index
+  only stores titles (M/Title's title is "Title"), so passing a ZIM
+  namespace path through the title-lookup backend was guaranteed to
+  return nothing — with no signal to the caller that the wrong tool
+  was in use. `_handle_find_by_title` now detects the
+  uppercase-letter + slash + non-empty-suffix shape upfront and
+  returns a structured **Namespace Path, Not a Title** message that
+  points at both `get article <path>` (direct lookup) and `find
+  article titled <stripped>` (title-only fallback). Lowercase
+  prefixes (`a/b`) and titles without the namespace shape pass
+  through to the backend unchanged.
+- **D7: `walk namespace A` (and any other empty new-scheme
+  namespace) now includes `namespace_entry_count: 0` in the
+  response.** The short-circuit at
+  `openzim_mcp/zim/namespace.py` for new-scheme non-C/M/W namespaces
+  built an empty result without passing `namespace_entry_count` to
+  `_build_walk_result`, so the field was omitted entirely while
+  walk-M and walk-W (which surface their bounded totals) included
+  it. Downstream consumers had to special-case "missing" vs "zero".
+  Fixed by passing `namespace_entry_count=0` in the short-circuit.
+  Updated the `walk_A_10` golden to reflect the new schema; walk-M
+  and walk-W goldens are unchanged (already carried the field).
+
+### Tests
+
+- **`tests/test_post_a15_beta_fixes.py`** — 25 regression tests
+  pinning the four defects. Each defect gets:
+  - The fix-case test (Mercury body has no misleading trailer;
+    "could you tell me about X" parses topic=X; "find article titled
+    M/Title" returns redirect; `_build_walk_result` exposes the
+    zero-count field).
+  - Negative self-audit cases (Berlin keeps its disambig-twin
+    footer; non-modal queries unchanged; lowercase a/b not
+    redirected; `namespace_entry_count` omitted when caller passes
+    None).
+  - Cross-defect probes (Java disambig body suppresses
+    `disambig_twin_path` footer too).
 
 ## [2.0.0a15] — 2026-05-16 (alpha pre-release) — post-a14 beta-test sweep — section-affinity feature now actually works on real Wikipedia content
 

--- a/openzim_mcp/intent_parser.py
+++ b/openzim_mcp/intent_parser.py
@@ -122,13 +122,22 @@ def safe_regex_sub(
 
 
 def _extract_browse(query: str, params: Dict[str, Any]) -> None:
+    # A15 post-a15 P6-D2: the original regex
+    # ``namespace\s+['\"]?([A-Za-z0-9_.-]+)['\"]?`` accepted multi-
+    # character, digit, and special-char namespace arguments
+    # (``browse namespace AB``, ``browse namespace 1``,
+    # ``browse namespace _``) and didn't uppercase lowercase input.
+    # The sibling ``_extract_walk_namespace`` is strict (single
+    # letter, ``.upper()``); these two should agree. Tighten the
+    # regex so a malformed argument fails to match and the handler's
+    # missing-arg guard fires consistently across the two tools.
     namespace_match = safe_regex_search(
-        r"namespace\s+['\"]?([A-Za-z0-9_.-]+)['\"]?",
+        r"namespace\s+['\"]?([A-Za-z])\b['\"]?",
         query,
         re.IGNORECASE,
     )
     if namespace_match:
-        params["namespace"] = namespace_match.group(1)
+        params["namespace"] = namespace_match.group(1).upper()
 
 
 def _extract_filtered_search(query: str, params: Dict[str, Any]) -> None:
@@ -333,12 +342,31 @@ def _extract_tell_me_about(query: str, params: Dict[str, Any]) -> None:
     # tail-probe entity resolver to rescue the actual article. Strip
     # the leading modal scaffold first so the verb regex sees the
     # cleaned query.
-    query = safe_regex_sub(
-        r"^\s*(?:could|can|would|will)\s+(?:you|we|i)\s+(?:please\s+)?",
-        "",
-        query,
-        flags=re.IGNORECASE,
-    ).strip()
+    #
+    # A15 post-a15 P6-D3: loop the strip so successive politeness
+    # phrases peel cleanly (``please could you tell me about X`` →
+    # ``could you tell me about X`` → ``tell me about X``). Two
+    # separate patterns rather than one combined regex because
+    # ``please`` is also legitimate trailing politeness (already
+    # handled below) — keeping the leading-only strip narrow
+    # (``please``, ``kindly``) avoids accidentally matching mid-
+    # query mentions.
+    for _ in range(3):
+        before = query
+        query = safe_regex_sub(
+            r"^\s*(?:please|kindly)\s+",
+            "",
+            query,
+            flags=re.IGNORECASE,
+        ).strip()
+        query = safe_regex_sub(
+            r"^\s*(?:could|can|would|will)\s+(?:you|we|i)\s+(?:please\s+)?",
+            "",
+            query,
+            flags=re.IGNORECASE,
+        ).strip()
+        if query == before:
+            break
     # A11 B2: verb prefix uses ``\b`` (word boundary) and the topic
     # capture is ``(.*?)`` (zero-or-more, non-greedy) so ``tell me
     # about`` / ``tell me about `` / ``describe`` produce ``topic=""``

--- a/openzim_mcp/intent_parser.py
+++ b/openzim_mcp/intent_parser.py
@@ -232,7 +232,19 @@ def _extract_suggestions(query: str, params: Dict[str, Any]) -> None:
     )
     suggest_match = safe_regex_search(suggest_pattern, query, re.IGNORECASE)
     if suggest_match:
-        params["partial_query"] = suggest_match.group(1).strip()
+        candidate = suggest_match.group(1).strip()
+        # A15 post-a15 P4-D1: when the user types ``suggestions for``
+        # with no actual prefix after it, the optional ``(?:for\s+)?``
+        # fails to match (no trailing whitespace before EOL), and the
+        # regex's mandatory capture group falls back to swallowing
+        # "for" itself as the prefix. Handler's missing-arg guard
+        # (``if not partial_query``) then never fires because "for"
+        # is non-empty. Treat a bare-"for" capture as if no prefix
+        # was supplied so the existing guard takes over and the user
+        # gets the structured "Missing Search Term" error instead of
+        # autocompleting against the literal "for".
+        if candidate.lower() != "for":
+            params["partial_query"] = candidate
 
 
 def _extract_search(query: str, params: Dict[str, Any]) -> None:

--- a/openzim_mcp/intent_parser.py
+++ b/openzim_mcp/intent_parser.py
@@ -313,6 +313,20 @@ def _extract_tell_me_about(query: str, params: Dict[str, Any]) -> None:
     punctuation. Falls back to the raw query so the search has
     *something* to look up if no prefix matched.
     """
+    # A15 post-a15: politeness lead-in ("could you tell me about X",
+    # "can you describe Y", "would you explain Z") used to bypass the
+    # verb prefix entirely — the regex anchors at ``^\s*`` and "could
+    # you" doesn't match the verb alternation, so the whole query fell
+    # through to ``topic = query.strip()`` and downstream relied on the
+    # tail-probe entity resolver to rescue the actual article. Strip
+    # the leading modal scaffold first so the verb regex sees the
+    # cleaned query.
+    query = safe_regex_sub(
+        r"^\s*(?:could|can|would|will)\s+(?:you|we|i)\s+(?:please\s+)?",
+        "",
+        query,
+        flags=re.IGNORECASE,
+    ).strip()
     # A11 B2: verb prefix uses ``\b`` (word boundary) and the topic
     # capture is ``(.*?)`` (zero-or-more, non-greedy) so ``tell me
     # about`` / ``tell me about `` / ``describe`` produce ``topic=""``

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -707,23 +707,33 @@ class SimpleToolsHandler:
         """
         if not query:
             return None
-        # A15 post-a15 P4-D2: strip leading modal politeness
-        # (``could you``, ``can you``, ``would you``, ``will you``)
-        # before splitting on the connector. The chained-detection
+        # A15 post-a15 P4-D2 + P6-D3: strip leading politeness
+        # (``please``, ``kindly``, ``could you``, ``can you``,
+        # ``would you``, ``will you``) before splitting on the
+        # connector. The chained-detection
         # `_CHAINED_OPERATION_PREFIX_RE` is anchored at ``^`` and only
-        # matches operation verbs at the very start; a modal prefix
-        # pushes the verb past position 0 so ``left_is_op`` evaluates
-        # False, the gate fails, and the chain falls through to normal
-        # intent classification — where ``list_namespaces`` (highest
-        # confidence) silently wins over the dropped ``tell me about``
-        # half. Mirror the same scaffold-strip ``_extract_tell_me_about``
-        # already uses so detection works on the cleaned query.
-        query = re.sub(
-            r"^\s*(?:could|can|would|will)\s+(?:you|we|i)\s+(?:please\s+)?",
-            "",
-            query,
-            flags=re.IGNORECASE,
-        ).strip()
+        # matches operation verbs at the very start; any politeness
+        # prefix pushes the verb past position 0 so ``left_is_op``
+        # evaluates False, the gate fails, and the chain falls
+        # through to normal intent classification — where
+        # ``list_namespaces`` (highest confidence) silently wins over
+        # the dropped ``tell me about`` half. Mirror the same
+        # scaffold-strip ``_extract_tell_me_about`` uses (including
+        # the loop so ``please could you tell me about X then ...``
+        # also peels cleanly).
+        for _ in range(3):
+            before_query = query
+            query = re.sub(
+                r"^\s*(?:please|kindly)\s+", "", query, flags=re.IGNORECASE
+            ).strip()
+            query = re.sub(
+                r"^\s*(?:could|can|would|will)\s+(?:you|we|i)\s+(?:please\s+)?",
+                "",
+                query,
+                flags=re.IGNORECASE,
+            ).strip()
+            if query == before_query:
+                break
         if not query:
             return None
         for connector_pat in cls._CHAINED_INTENT_CONNECTORS:
@@ -1469,9 +1479,26 @@ class SimpleToolsHandler:
         params: Dict[str, Any],
         options: Dict[str, Any],
     ) -> str:
+        # A15 post-a15 P6-D1: missing / malformed namespace argument
+        # used to fall through to ``params.get("namespace", "C")`` and
+        # silently browse C — exact analogue of the walk_namespace
+        # P4-D3 defect, same shape error, same fix. Mirror the
+        # walk_namespace missing-arg shape so the error surface is
+        # consistent across the simple-mode tools.
+        namespace = params.get("namespace")
+        if not namespace:
+            return (
+                "**Missing or Invalid Namespace**\n\n"
+                "**Issue**: `browse namespace` needs a single uppercase "
+                "namespace letter (A, C, M, W, etc.).\n"
+                "**Examples**:\n"
+                "- `browse namespace C` — main content entries\n"
+                "- `browse namespace M` — archive metadata\n"
+                "- `browse namespace W` — well-known entries"
+            )
         return self.zim_operations.browse_namespace(
             zim_file_path,
-            params.get("namespace", "C"),
+            namespace,
             options.get("limit", 50),
             options.get("offset", 0),
         )

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -1306,13 +1306,22 @@ class SimpleToolsHandler:
 
     @classmethod
     def _is_disambig_lead(cls, pre_h2: str) -> bool:
-        """Return True when ``pre_h2`` looks like a disambig-page lead."""
-        if len(pre_h2) >= 400:
-            return False
+        """Return True when ``pre_h2`` looks like a disambig-page lead.
+
+        Examines only the trailing 400 characters: pages like Mercury
+        carry a ``most commonly refers to:`` preamble with a list of
+        top-level entries BEFORE the ``may also refer to:`` line that
+        actually marks the end of the disambig lead. The full pre-H2
+        body is therefore well over 400 chars on those pages. The
+        original implementation bailed out at ``len(pre_h2) >= 400``
+        and missed them. The tail window keeps the regex-free
+        ``endswith`` bound while letting long preambles still trigger.
+        """
         # ``" ".join(s.split())`` collapses all whitespace runs (including
         # newlines and tabs) to single spaces. ``rstrip(":")`` accommodates
         # both ``may refer to:`` and the bare ``may refer to`` variants.
-        normalized = " ".join(pre_h2.lower().split()).rstrip(":").rstrip()
+        tail = pre_h2[-400:] if len(pre_h2) > 400 else pre_h2
+        normalized = " ".join(tail.lower().split()).rstrip(":").rstrip()
         return normalized.endswith(cls._DISAMBIG_LEAD_PHRASES)
 
     def _lead_with_toc(self, zim_file_path: str, entry_path: str, body: str) -> str:
@@ -2438,13 +2447,34 @@ class SimpleToolsHandler:
             f"_Source: `{top_path}`_\n\n"
             f"{article_body}"
         )
-        if disambig_twin_path:
+        # A15 post-a15: when the resolved article body IS itself a
+        # disambiguation page (Mercury, Java, etc. — bare titles that
+        # never had a dedicated article and live as disambig at the
+        # canonical path), both trailing footers are misleading:
+        # ``Note: this topic also has a disambiguation page`` points
+        # back at the same content, and ``May also refer to: <one
+        # extends-topic sibling>`` names a single random match while
+        # the body itself already enumerates dozens of alternates. The
+        # canonical-vs-disambig auto-pick that produced these hints
+        # was designed for cases like Berlin (canonical city article,
+        # separate Berlin_(disambiguation) twin) — when the auto-pick
+        # is the disambig page itself, drop them. Detection re-uses
+        # the same pre-H2 ``may refer to`` test the lead-with-TOC cut
+        # uses, on the fetched body.
+        h2_in_body = self._first_article_h2(article_body)
+        pre_h2_in_body = (
+            article_body[: h2_in_body.start()].rstrip()
+            if h2_in_body
+            else article_body.rstrip()
+        )
+        body_is_disambig_page = self._is_disambig_lead(pre_h2_in_body)
+        if disambig_twin_path and not body_is_disambig_page:
             result = result + (
                 f"\n\n_Note: this topic also has a disambiguation page — "
                 f"see `get article {disambig_twin_path}` for alternate "
                 f"meanings._"
             )
-        if related_extends_paths:
+        if related_extends_paths and not body_is_disambig_page:
             # A11 post-a11 C1: cap the hint at the first 4 alternates
             # so the footer stays small even on hub topics that
             # generated a long extends-list.
@@ -2778,6 +2808,34 @@ class SimpleToolsHandler:
                 "- 'find article titled Photosynthesis'\n"
                 "- 'find entry named \"World War II\"'\n"
                 "- 'what's the path for Cellular_respiration'\n"
+            )
+        # A15 post-a15: namespace-prefixed input like ``M/Title`` is a
+        # ZIM path, not a title. The title index only stores titles
+        # (e.g. M/Title's title is just "Title"), so passing the path
+        # to ``find_entry_by_title_data`` returns silently 0 hits with
+        # no signal that the user used the wrong tool. Redirect upfront
+        # so the caller knows to use ``get article`` for path lookup.
+        # Strict pattern (uppercase letter + ``/`` + non-empty
+        # suffix) matches ZIM namespace conventions without false-
+        # positiving real titles that legitimately contain ``/``
+        # (Wikipedia subpages like ``Foo/Bar`` would have a lowercase
+        # second char, etc.).
+        if (
+            len(title) >= 3
+            and title[0].isascii()
+            and title[0].isupper()
+            and title[1] == "/"
+            and title[2:].strip()
+        ):
+            return (
+                "**Namespace Path, Not a Title**\n\n"
+                f"`{title}` looks like a ZIM namespace path. The title "
+                "index only stores entry titles, so a path lookup "
+                "returns no hits.\n"
+                "**Try one of**:\n"
+                f"- `get article {title}` — direct path lookup\n"
+                f"- `find article titled {title[2:].strip()}` — "
+                "title-only lookup (drops the namespace prefix)\n"
             )
         if options.get("compact", False):
             data = self.zim_operations.find_entry_by_title_data(

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -707,6 +707,25 @@ class SimpleToolsHandler:
         """
         if not query:
             return None
+        # A15 post-a15 P4-D2: strip leading modal politeness
+        # (``could you``, ``can you``, ``would you``, ``will you``)
+        # before splitting on the connector. The chained-detection
+        # `_CHAINED_OPERATION_PREFIX_RE` is anchored at ``^`` and only
+        # matches operation verbs at the very start; a modal prefix
+        # pushes the verb past position 0 so ``left_is_op`` evaluates
+        # False, the gate fails, and the chain falls through to normal
+        # intent classification — where ``list_namespaces`` (highest
+        # confidence) silently wins over the dropped ``tell me about``
+        # half. Mirror the same scaffold-strip ``_extract_tell_me_about``
+        # already uses so detection works on the cleaned query.
+        query = re.sub(
+            r"^\s*(?:could|can|would|will)\s+(?:you|we|i)\s+(?:please\s+)?",
+            "",
+            query,
+            flags=re.IGNORECASE,
+        ).strip()
+        if not query:
+            return None
         for connector_pat in cls._CHAINED_INTENT_CONNECTORS:
             parts = re.split(connector_pat, query, maxsplit=1, flags=re.IGNORECASE)
             if len(parts) != 2:
@@ -2761,6 +2780,25 @@ class SimpleToolsHandler:
         params: Dict[str, Any],
         options: Dict[str, Any],
     ) -> str:
+        # A15 post-a15 P4-D3: ``walk namespace`` with a malformed
+        # argument (multi-char ``AB``, digit ``1``, special ``_``, or
+        # missing entirely) previously fell through to
+        # ``params.get("namespace", "C")`` and silently walked C —
+        # giving the caller no signal that their input was rejected.
+        # Mirror the missing-arg shape ``_handle_find_by_title`` /
+        # ``_handle_links`` / ``_handle_suggestions`` use so the error
+        # surface is consistent across the simple-mode tools.
+        namespace = params.get("namespace")
+        if not namespace:
+            return (
+                "**Missing or Invalid Namespace**\n\n"
+                "**Issue**: `walk namespace` needs a single uppercase "
+                "namespace letter (A, C, M, W, etc.).\n"
+                "**Examples**:\n"
+                "- `walk namespace C` — main content entries\n"
+                "- `walk namespace M` — archive metadata\n"
+                "- `walk namespace W` — well-known entries"
+            )
         # ``offset`` semantically maps to ``scan_at`` here — a resume
         # entry id, not pagination skip — but it's the only
         # general-purpose passthrough channel so we honour it. v2 walk
@@ -2774,14 +2812,14 @@ class SimpleToolsHandler:
         if options.get("compact", False):
             data = self.zim_operations.walk_namespace_data(
                 zim_file_path,
-                params.get("namespace", "C"),
+                namespace,
                 cursor_state=cursor_state,
                 limit=limit,
             )
             return compact_renderers.render_walk_namespace(data)
         return self.zim_operations.walk_namespace(
             zim_file_path,
-            params.get("namespace", "C"),
+            namespace,
             cursor=cursor_state,
             limit=limit,
         )

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -1552,6 +1552,14 @@ class _NamespaceMixin:
                 # iterable surface; short-circuit so callers don't pay the
                 # full-archive scan to discover that.
                 if has_new_scheme and namespace != "C":
+                    # A15 post-a15: pass ``namespace_entry_count=0`` so
+                    # the short-circuited empty result has the same
+                    # schema as the M / W walks (which surface their
+                    # bounded totals). Without this the field is
+                    # omitted entirely, forcing downstream consumers
+                    # to special-case "missing" vs "zero" — a schema-
+                    # consistency defect surfaced by ``walk namespace
+                    # A`` against a new-scheme Wikipedia archive.
                     return cast(
                         "WalkNamespaceResponse",
                         attach_meta(
@@ -1565,6 +1573,7 @@ class _NamespaceMixin:
                                 done=True,
                                 next_cursor=None,
                                 archive_entry_count=archive_entry_count,
+                                namespace_entry_count=0,
                             )
                         ),
                     )

--- a/tests/data/goldens/v2_phase_b/walk_A_10.json
+++ b/tests/data/goldens/v2_phase_b/walk_A_10.json
@@ -5,6 +5,7 @@
   "archive_entry_count": 4,
   "done": true,
   "namespace": "A",
+  "namespace_entry_count": 0,
   "page_info": {
     "limit": 10,
     "offset": 0,

--- a/tests/test_post_a15_beta_fixes.py
+++ b/tests/test_post_a15_beta_fixes.py
@@ -1,7 +1,9 @@
 """Regression tests for the post-a15 beta-test sweep (a16 fixes).
 
 The post-a15 live sweep against the 118 GB Wikipedia ZIM surfaced
-four user-facing defects:
+four user-facing defects in pass 1 (D4 / D5 / D6 / D7); pass 4 then
+added an explicit "stress-test the fixes from new angles" sweep that
+caught three more (P4-D1 / P4-D2 / P4-D3), all also pinned below:
 
 - D4 (Pass 1): ``tell me about Mercury`` — Mercury is a disambiguation
   page (no canonical article at the bare title), so the resolver
@@ -35,6 +37,34 @@ four user-facing defects:
   that walk-M / walk-W include — schema inconsistency in the
   short-circuit at ``namespace.py:1554``. Downstream consumers had
   to special-case "missing" vs "zero".
+
+- P4-D1 (Pass 4): ``suggestions for`` (no prefix supplied) silently
+  autocompleted against the literal word "for". The regex's optional
+  ``(?:for\\s+)?`` group fails to match without trailing whitespace,
+  so the mandatory capture greedily swallows "for" itself; the
+  handler's existing missing-arg guard then sees a non-empty
+  ``partial_query`` and runs the suggestion fallback (which spends
+  ~70 s scanning for "for" — a high-frequency English token).
+
+- P4-D2 (Pass 4): the chained-intent detector
+  (``_chained_intent_guidance``) only recognised operation verbs at
+  position 0 — its ``_CHAINED_OPERATION_PREFIX_RE`` is anchored at
+  ``^`` — so adding a modal lead-in (``could you tell me about X
+  then list namespaces``) pushed the verb past the anchor,
+  ``left_is_op`` evaluated False, the chain gate failed, and the
+  query fell through to normal intent classification. ``list
+  namespaces`` then won on confidence, the ``tell me about`` half
+  was dropped on the floor, and the caller got the wrong half
+  silently. The D5 modal-strip lives inside ``_extract_tell_me_about``
+  — it only runs AFTER the chain detector has decided.
+
+- P4-D3 (Pass 4): ``walk namespace`` with any malformed argument
+  (multi-char ``AB``, digit ``1``, special ``_``, or absent
+  entirely) silently fell through to ``params.get("namespace", "C")``
+  and walked the C-namespace. No signal to the caller that the
+  input was rejected. Sibling tools (``find_by_title``, ``links_in``,
+  ``suggestions``, ``tell_me_about``) all return structured
+  missing-arg errors.
 
 Each test pins one defect; failures here mean a regression on the
 specific bug.
@@ -453,3 +483,214 @@ class TestD4DisambigFooterSuppression:
         # Canonical article: the disambig-twin footer fires because
         # the body is NOT a disambig page.
         assert "this topic also has a disambiguation page" in out
+
+
+# ---------------------------------------------------------------------------
+# P4-D1: suggestions intent extraction must not capture "for" as the prefix
+# ---------------------------------------------------------------------------
+
+
+class TestP4D1SuggestionsForCapture:
+    """P4-D1: ``suggestions for`` (no prefix) used to autocomplete
+    against the literal word "for" because the regex's optional
+    ``(?:for\\s+)?`` failed to match without trailing whitespace and
+    the mandatory capture group greedily swallowed "for" itself. The
+    handler's missing-arg guard never saw an empty prefix. Fix
+    detects the bare-"for" capture and discards it.
+    """
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "suggestions for",
+            "suggestions for ",
+            "suggestions for  ",  # multi-space trail
+            "autocomplete for",
+            "hints for",
+        ],
+    )
+    def test_bare_for_not_captured_as_prefix(self, query: str) -> None:
+        intent, params, _ = IntentParser.parse_intent(query)
+        assert intent == "suggestions"
+        assert "partial_query" not in params or not params.get("partial_query")
+
+    @pytest.mark.parametrize(
+        "query,expected_prefix",
+        [
+            ("suggestions for cat", "cat"),
+            ("suggestions for Photo", "Photo"),
+            ("suggestions Photo", "Photo"),  # no-for form
+            ('suggestions for "Photo"', "Photo"),  # quote-stripped by _QUOTE_OPEN?
+            ("autocomplete cat", "cat"),
+            # Edge: a real prefix that starts with "for-" should still
+            # be captured.
+            ("suggestions for forest", "forest"),
+        ],
+    )
+    def test_real_prefix_still_captured(self, query: str, expected_prefix: str) -> None:
+        intent, params, _ = IntentParser.parse_intent(query)
+        assert intent == "suggestions"
+        assert params.get("partial_query") == expected_prefix
+
+    def test_missing_arg_guard_now_fires(self) -> None:
+        """End-to-end: the handler's existing missing-arg guard now
+        fires for ``suggestions for`` because the parser stops
+        producing a phantom "for" prefix.
+        """
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        mock.get_search_suggestions.side_effect = AssertionError(
+            "get_search_suggestions should not be called when prefix is empty"
+        )
+        handler = SimpleToolsHandler(mock)
+        out = handler.handle_zim_query("suggestions for", zim_file_path="/x.zim")
+        assert "Missing Search Term" in out
+        assert "suggestions for bio" in out  # example in the error body
+
+
+# ---------------------------------------------------------------------------
+# P4-D2: chained-intent detector must strip modal lead-in before splitting
+# ---------------------------------------------------------------------------
+
+
+class TestP4D2ChainDetectorModalLeadIn:
+    """P4-D2: ``could you tell me about Photosynthesis then list
+    namespaces`` was NOT rejected as chained because
+    ``_CHAINED_OPERATION_PREFIX_RE`` is anchored at ``^`` and the
+    modal lead-in pushes the verb past position 0. The chain gate
+    failed, fell through to normal intent classification, and the
+    higher-confidence ``list_namespaces`` won — silently dropping
+    the ``tell me about`` half. Fix pre-strips the modal scaffold
+    inside ``_chained_intent_guidance`` so detection sees the
+    cleaned query.
+    """
+
+    @pytest.fixture
+    def handler(self) -> SimpleToolsHandler:
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        # If the chain detector fires correctly, no backend should be
+        # touched — make them all explode.
+        mock.list_namespaces.side_effect = AssertionError(
+            "list_namespaces must not be called when chain detector fires"
+        )
+        mock.search_zim_file_data.side_effect = AssertionError(
+            "search must not be called when chain detector fires"
+        )
+        return SimpleToolsHandler(mock)
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "could you tell me about Photosynthesis then list namespaces",
+            "can you tell me about Photosynthesis then list namespaces",
+            "would you tell me about Photosynthesis and then list namespaces",
+            "will you tell me about Photosynthesis; list namespaces",
+            "could you please tell me about Photosynthesis then list namespaces",
+        ],
+    )
+    def test_modal_prefix_does_not_bypass_chain_detector(
+        self, handler: SimpleToolsHandler, query: str
+    ) -> None:
+        out = handler.handle_zim_query(query, zim_file_path="/x.zim")
+        assert "Chained Operations Detected" in out
+        assert "tell me about Photosynthesis" in out
+        assert "list namespaces" in out
+
+    def test_non_chained_modal_still_works(self) -> None:
+        """Sanity: a non-chained modal query (``could you tell me
+        about Photosynthesis``) must NOT trip the chain detector.
+        """
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        mock.search_zim_file_data.return_value = {
+            "results": [
+                {"path": "Photosynthesis", "title": "Photosynthesis", "score": 100}
+            ]
+        }
+        mock.get_zim_entry.return_value = "Photosynthesis body content."
+        mock.find_entry_by_title_data.return_value = {
+            "results": [
+                {"path": "Photosynthesis", "title": "Photosynthesis", "score": 1.0}
+            ]
+        }
+        mock.get_article_structure_data.return_value = {"sections": []}
+        handler = SimpleToolsHandler(mock)
+        out = handler.handle_zim_query(
+            "could you tell me about Photosynthesis",
+            zim_file_path="/x.zim",
+            options={"compact": False},
+        )
+        assert "Chained Operations Detected" not in out
+        assert "_Source: `Photosynthesis`_" in out
+
+
+# ---------------------------------------------------------------------------
+# P4-D3: walk_namespace must reject malformed namespace arguments
+# ---------------------------------------------------------------------------
+
+
+class TestP4D3WalkNamespaceMissingArg:
+    """P4-D3: ``walk namespace`` with a malformed argument silently
+    walked C — ``params.get("namespace", "C")`` defaulted whenever
+    the intent extractor failed to capture a valid single-letter
+    namespace. Fix returns a structured ``Missing or Invalid
+    Namespace`` error instead.
+    """
+
+    @pytest.fixture
+    def handler(self) -> SimpleToolsHandler:
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        mock.walk_namespace.side_effect = AssertionError(
+            "walk_namespace must not be called when namespace is malformed"
+        )
+        mock.walk_namespace_data.side_effect = AssertionError(
+            "walk_namespace_data must not be called when namespace is malformed"
+        )
+        return SimpleToolsHandler(mock)
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "walk namespace",  # no arg
+            "walk namespace AB",  # multi-char
+            "walk namespace 1",  # digit
+            "walk namespace _",  # special
+            "walk namespace ABCD",  # multi-letter
+        ],
+    )
+    def test_malformed_namespace_returns_structured_error(
+        self, handler: SimpleToolsHandler, query: str
+    ) -> None:
+        out = handler.handle_zim_query(query, zim_file_path="/x.zim")
+        assert "Missing or Invalid Namespace" in out
+        # Helpful examples included.
+        assert "walk namespace C" in out
+        assert "walk namespace M" in out
+
+    @pytest.mark.parametrize(
+        "query,expected_ns",
+        [
+            ("walk namespace A", "A"),
+            ("walk namespace C", "C"),
+            ("walk namespace M", "M"),
+            ("walk namespace W", "W"),
+            ("walk namespace c", "C"),  # lowercase coerced to upper
+        ],
+    )
+    def test_valid_namespace_passes_through(self, query: str, expected_ns: str) -> None:
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        mock.walk_namespace.return_value = "ok"
+        handler = SimpleToolsHandler(mock)
+        handler.handle_zim_query(query, zim_file_path="/x.zim")
+        mock.walk_namespace.assert_called_once()
+        call_args = mock.walk_namespace.call_args
+        # Second positional arg is namespace.
+        assert call_args.args[1] == expected_ns

--- a/tests/test_post_a15_beta_fixes.py
+++ b/tests/test_post_a15_beta_fixes.py
@@ -694,3 +694,178 @@ class TestP4D3WalkNamespaceMissingArg:
         call_args = mock.walk_namespace.call_args
         # Second positional arg is namespace.
         assert call_args.args[1] == expected_ns
+
+
+# ---------------------------------------------------------------------------
+# P6-D1 + P6-D2: browse_namespace input validation parity with walk_namespace
+# ---------------------------------------------------------------------------
+
+
+class TestP6BrowseNamespaceParity:
+    """P6-D1 / P6-D2: ``_handle_browse`` and ``_extract_browse``
+    were both lax compared to their walk_namespace siblings. The
+    extractor's regex ``namespace\\s+['\\\"]?([A-Za-z0-9_.-]+)['\\\"]?``
+    accepted multi-char (``AB``), digit (``1``), and special (``_``,
+    ``a.b``) inputs and didn't uppercase lowercase letters; the
+    handler then defaulted ``params.get("namespace", "C")`` whenever
+    the extract returned no namespace, so a missing argument also
+    silently walked C. Tightened the regex to ``namespace\\s+
+    ['\\\"]?([A-Za-z])\\b['\\\"]?`` + ``.upper()`` and added a
+    missing-arg guard mirroring walk_namespace's.
+    """
+
+    @pytest.fixture
+    def handler(self) -> SimpleToolsHandler:
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        mock.browse_namespace.side_effect = AssertionError(
+            "browse_namespace must not be called when namespace is malformed"
+        )
+        return SimpleToolsHandler(mock)
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "browse namespace",  # no arg
+            "browse namespace AB",  # multi-char (no \b after first letter)
+            "browse namespace 1",  # digit
+            "browse namespace _",  # special
+            "browse namespace ABCD",  # multi-letter
+        ],
+    )
+    def test_malformed_namespace_returns_structured_error(
+        self, handler: SimpleToolsHandler, query: str
+    ) -> None:
+        out = handler.handle_zim_query(query, zim_file_path="/x.zim")
+        assert "Missing or Invalid Namespace" in out
+        # Examples consistent with walk_namespace's missing-arg shape.
+        assert "browse namespace C" in out
+        assert "browse namespace M" in out
+
+    @pytest.mark.parametrize(
+        "query,expected_ns",
+        [
+            # Dotted / hyphenated input: ``\b`` boundary after the
+            # single letter causes the extractor to capture just the
+            # leading char — same behaviour as ``_extract_walk_namespace``
+            # today. Documenting parity, not a new behaviour.
+            ("browse namespace a.b", "A"),
+            ("browse namespace a-b", "A"),
+        ],
+    )
+    def test_word_boundary_truncation_matches_walk_namespace(
+        self, query: str, expected_ns: str
+    ) -> None:
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        mock.browse_namespace.return_value = "ok"
+        handler = SimpleToolsHandler(mock)
+        handler.handle_zim_query(query, zim_file_path="/x.zim")
+        mock.browse_namespace.assert_called_once()
+        assert mock.browse_namespace.call_args.args[1] == expected_ns
+
+    @pytest.mark.parametrize(
+        "query,expected_ns",
+        [
+            ("browse namespace A", "A"),
+            ("browse namespace C", "C"),
+            ("browse namespace M", "M"),
+            ("browse namespace W", "W"),
+            ("browse namespace c", "C"),  # lowercase coerced
+            ("browse namespace m", "M"),
+        ],
+    )
+    def test_valid_namespace_passes_through_uppercased(
+        self, query: str, expected_ns: str
+    ) -> None:
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        mock.browse_namespace.return_value = "ok"
+        handler = SimpleToolsHandler(mock)
+        handler.handle_zim_query(query, zim_file_path="/x.zim")
+        mock.browse_namespace.assert_called_once()
+        # Second positional arg is namespace.
+        assert mock.browse_namespace.call_args.args[1] == expected_ns
+
+
+# ---------------------------------------------------------------------------
+# P6-D3: leading politeness ("please", "kindly") and looped peel-back
+# ---------------------------------------------------------------------------
+
+
+class TestP6D3LeadingPoliteness:
+    """P6-D3: ``please tell me about Photosynthesis`` /
+    ``kindly tell me about Photosynthesis`` parsed with the
+    politeness phrase leaking into the topic — same shape as the
+    pass-1 D5 modal-strip defect but for ``please`` / ``kindly``
+    (not modal verbs). Extended the strip to cover these and to
+    loop so composite phrases (``please could you tell me about X``)
+    peel cleanly.
+    """
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "please tell me about Photosynthesis",
+            "Please tell me about Photosynthesis",  # case
+            "kindly tell me about Photosynthesis",
+            "kindly describe Photosynthesis",
+            "please describe Photosynthesis",
+            # Composite: leading "please" + modal
+            "please could you tell me about Photosynthesis",
+            "kindly would you explain Photosynthesis",
+            # Composite: modal + nested please (P5 order)
+            "could you please tell me about Photosynthesis",
+        ],
+    )
+    def test_leading_politeness_stripped(self, query: str) -> None:
+        intent, params, _ = IntentParser.parse_intent(query)
+        assert intent == "tell_me_about"
+        assert params["topic"] == "Photosynthesis"
+
+    def test_trailing_please_still_works(self) -> None:
+        # The existing trailing-politeness strip must not regress.
+        intent, params, _ = IntentParser.parse_intent(
+            "tell me about Photosynthesis please"
+        )
+        assert intent == "tell_me_about"
+        assert params["topic"] == "Photosynthesis"
+
+    def test_double_leading_please_loops(self) -> None:
+        # Stacked politeness — the loop must peel both layers.
+        intent, params, _ = IntentParser.parse_intent(
+            "please please tell me about Photosynthesis"
+        )
+        assert intent == "tell_me_about"
+        assert params["topic"] == "Photosynthesis"
+
+    def test_mid_query_please_unaffected(self) -> None:
+        # Sanity: "please" mentioned mid-query (in the topic itself)
+        # must not be stripped — the leading-only anchor (``^\s*``)
+        # prevents that.
+        intent, params, _ = IntentParser.parse_intent(
+            "tell me about the word please in linguistics"
+        )
+        assert intent == "tell_me_about"
+        assert "please" in params["topic"]
+
+    def test_leading_please_with_chain_still_detected(self) -> None:
+        # The chain detector's modal-strip was extended too. ``please
+        # tell me about X then list namespaces`` must trip the chain
+        # detector — without the chain-side strip, the verb sits
+        # past position 0 and the gate fails (same shape as P4-D2).
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        mock.list_namespaces.side_effect = AssertionError(
+            "list_namespaces must not be called when chain detector fires"
+        )
+        handler = SimpleToolsHandler(mock)
+        out = handler.handle_zim_query(
+            "please tell me about Photosynthesis then list namespaces",
+            zim_file_path="/x.zim",
+        )
+        assert "Chained Operations Detected" in out

--- a/tests/test_post_a15_beta_fixes.py
+++ b/tests/test_post_a15_beta_fixes.py
@@ -1,0 +1,455 @@
+"""Regression tests for the post-a15 beta-test sweep (a16 fixes).
+
+The post-a15 live sweep against the 118 GB Wikipedia ZIM surfaced
+four user-facing defects:
+
+- D4 (Pass 1): ``tell me about Mercury`` — Mercury is a disambiguation
+  page (no canonical article at the bare title), so the resolver
+  picked it as canonical and the
+  ``_handle_tell_me_about`` footer logic then appended ``_May also
+  refer to: Mercury_Monterey — use tell me about <full title>_``,
+  naming one random extends-topic sibling while the body itself
+  enumerates dozens of disambig entries. Two cooperating bugs: the
+  ``_is_disambig_lead`` detection had a 400-char cap on ``pre_h2``
+  and Mercury's pre-H2 is 628 chars (the "most commonly refers to"
+  preamble plus three top-level entries push it over), so the
+  disambig-page case never triggered the existing suppression logic;
+  AND the trailing footer block in ``_handle_tell_me_about`` didn't
+  check whether the resolved body was itself a disambig page.
+
+- D5 (Pass 1): ``could you tell me about Photosynthesis`` parsed with
+  ``topic = "could you tell me about Photosynthesis"`` — the leading
+  modal "could you" / "can you" / "would you" / "will you" didn't
+  match the verb-prefix regex and the whole query fell through to
+  the ``topic = query.strip()`` fallback. Article still resolved via
+  the tail-probe entity rescue, but the parsed topic is wrong.
+
+- D6 (Pass 1): ``find article titled M/Title`` returned 0 hits even
+  though ``get article M/Title`` succeeds — the title index only
+  stores titles (M/Title's title is "Title"), and the handler passed
+  the path straight through with no signal to the caller that the
+  wrong tool was in use.
+
+- D7 (Pass 1): ``walk namespace A`` against a new-scheme archive
+  returned a response missing the ``namespace_entry_count`` field
+  that walk-M / walk-W include — schema inconsistency in the
+  short-circuit at ``namespace.py:1554``. Downstream consumers had
+  to special-case "missing" vs "zero".
+
+Each test pins one defect; failures here mean a regression on the
+specific bug.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from openzim_mcp.intent_parser import IntentParser
+from openzim_mcp.simple_tools import SimpleToolsHandler
+
+# ---------------------------------------------------------------------------
+# D5: politeness lead-in ("could you / can you / would you / will you")
+# ---------------------------------------------------------------------------
+
+
+class TestD5PolitenessLeadIn:
+    """D5: the verb-prefix regex anchors at ``^\\s*`` and never matched
+    a leading modal ("could you tell me about X"). Fix strips the
+    modal scaffold before the verb regex sees the query.
+    """
+
+    @pytest.fixture
+    def parser(self) -> IntentParser:
+        return IntentParser()
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "could you tell me about Photosynthesis",
+            "Could You Tell Me About Photosynthesis",
+            "can you tell me about Photosynthesis",
+            "would you tell me about Photosynthesis",
+            "will you tell me about Photosynthesis",
+            "could you please tell me about Photosynthesis",
+            "can you describe Photosynthesis",
+            "would you explain Photosynthesis",
+            "could we tell me about Photosynthesis",  # weird but tolerated
+        ],
+    )
+    def test_modal_lead_in_stripped(self, parser: IntentParser, query: str) -> None:
+        intent, params, _ = IntentParser.parse_intent(query)
+        assert intent == "tell_me_about"
+        assert params["topic"] == "Photosynthesis"
+
+    def test_modal_lead_in_with_trailing_politeness(self, parser: IntentParser) -> None:
+        # Both ends should strip: leading "could you", trailing "please".
+        intent, params, _ = IntentParser.parse_intent(
+            "could you tell me about Photosynthesis please"
+        )
+        assert intent == "tell_me_about"
+        assert params["topic"] == "Photosynthesis"
+
+    def test_no_modal_unchanged(self, parser: IntentParser) -> None:
+        # Sanity: queries that never had a modal lead-in still work.
+        intent, params, _ = IntentParser.parse_intent("tell me about Photosynthesis")
+        assert intent == "tell_me_about"
+        assert params["topic"] == "Photosynthesis"
+
+
+# ---------------------------------------------------------------------------
+# D6: find_by_title namespace-path redirect
+# ---------------------------------------------------------------------------
+
+
+class TestD6FindByTitleNamespacePathRedirect:
+    """D6: ``find article titled M/Title`` returned silent 0 hits.
+    Fix detects the ``[A-Z]/...`` namespace-prefix shape and redirects
+    the caller to ``get article`` upfront, before the doomed backend
+    call.
+    """
+
+    @pytest.fixture
+    def handler(self) -> SimpleToolsHandler:
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        # If the redirect fires, these never get called — make them
+        # explode if they do, so accidental call surfaces clearly.
+        mock.find_entry_by_title_data.side_effect = AssertionError(
+            "find_entry_by_title_data should not be called for namespace paths"
+        )
+        mock.find_entry_by_title.side_effect = AssertionError(
+            "find_entry_by_title should not be called for namespace paths"
+        )
+        return SimpleToolsHandler(mock)
+
+    @pytest.mark.parametrize(
+        "title",
+        ["M/Title", "M/Counter", "A/Photosynthesis", "W/mainPage"],
+    )
+    def test_namespace_path_returns_redirect(
+        self, handler: SimpleToolsHandler, title: str
+    ) -> None:
+        out = handler.handle_zim_query(
+            f"find article titled {title}",
+            zim_file_path="/x.zim",
+            options={"compact": False},
+        )
+        assert "Namespace Path, Not a Title" in out
+        assert f"get article {title}" in out
+        # Suggests the title-only fallback too.
+        assert f"find article titled {title[2:]}" in out
+
+    def test_real_title_unaffected(self) -> None:
+        # ``find article titled Photosynthesis`` (no namespace prefix)
+        # must still hit the backend.
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        mock.find_entry_by_title_data.return_value = {
+            "query": "Photosynthesis",
+            "results": [{"path": "Photosynthesis", "title": "Photosynthesis"}],
+            "total": 1,
+        }
+        handler = SimpleToolsHandler(mock)
+        out = handler.handle_zim_query(
+            "find article titled Photosynthesis",
+            zim_file_path="/x.zim",
+            options={"compact": True},
+        )
+        assert "Namespace Path, Not a Title" not in out
+        # Backend was called.
+        mock.find_entry_by_title_data.assert_called_once()
+
+    def test_lowercase_first_char_not_redirected(self) -> None:
+        # ``find article titled a/b`` doesn't look like a namespace
+        # path (namespaces are uppercase) — let the backend handle it.
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        mock.find_entry_by_title.return_value = "no hits"
+        handler = SimpleToolsHandler(mock)
+        out = handler.handle_zim_query(
+            "find article titled a/b",
+            zim_file_path="/x.zim",
+            options={"compact": False},
+        )
+        assert "Namespace Path, Not a Title" not in out
+
+
+# ---------------------------------------------------------------------------
+# D7: walk_namespace empty new-scheme namespace schema
+# ---------------------------------------------------------------------------
+
+
+class TestD7WalkNamespaceEmptySchema:
+    """D7: the new-scheme non-C/M/W short-circuit at
+    ``namespace.py:1554`` returned an empty result without
+    ``namespace_entry_count``, while walk-M / walk-W include the
+    field. Fix passes ``namespace_entry_count=0``.
+    """
+
+    def test_empty_new_scheme_namespace_has_zero_count(self) -> None:
+        # Hit the build path directly — the surrounding archive setup
+        # is irrelevant to the schema-shape assertion.
+        from openzim_mcp.zim.namespace import _NamespaceMixin
+
+        result = _NamespaceMixin._build_walk_result(
+            namespace="A",
+            scan_at=0,
+            limit=200,
+            entries=[],
+            scanned_count=0,
+            scanned_through_id=None,
+            done=True,
+            next_cursor=None,
+            archive_entry_count=27_199_904,
+            namespace_entry_count=0,
+        )
+        assert "namespace_entry_count" in result
+        assert result["namespace_entry_count"] == 0
+        # Sibling fields still present.
+        assert result["namespace"] == "A"
+        assert result["results"] == []
+        assert result["done"] is True
+        assert result["archive_entry_count"] == 27_199_904
+
+    def test_build_walk_result_omits_field_when_none(self) -> None:
+        # Sanity: the helper's existing contract (omit when None) is
+        # preserved for callers that legitimately don't know the
+        # namespace total (e.g. mid-scan C iteration on old-scheme
+        # archives).
+        from openzim_mcp.zim.namespace import _NamespaceMixin
+
+        result = _NamespaceMixin._build_walk_result(
+            namespace="C",
+            scan_at=0,
+            limit=200,
+            entries=[],
+            scanned_count=0,
+            scanned_through_id=None,
+            done=True,
+            next_cursor=None,
+            archive_entry_count=100,
+            namespace_entry_count=None,
+        )
+        assert "namespace_entry_count" not in result
+
+    def test_short_circuit_call_site_passes_zero(self) -> None:
+        """Source-level assertion: the short-circuit branch for new-
+        scheme non-C/M/W namespaces must pass
+        ``namespace_entry_count=0`` to ``_build_walk_result``. Live-
+        sweep mocking of libzim is too brittle for a single-bug test,
+        so we pin the fix at the call site.
+        """
+        from pathlib import Path
+
+        src = (
+            Path(__file__).parent.parent / "openzim_mcp" / "zim" / "namespace.py"
+        ).read_text()
+        # Find the ``has_new_scheme and namespace != "C"`` short-circuit
+        # block and confirm the next ``_build_walk_result`` call inside
+        # it sets ``namespace_entry_count=0``.
+        marker = 'has_new_scheme and namespace != "C"'
+        idx = src.find(marker)
+        assert idx != -1, "short-circuit branch not found"
+        block = src[idx : idx + 1500]
+        assert "_build_walk_result(" in block
+        assert "namespace_entry_count=0" in block, (
+            "post-a15 D7 fix missing: the new-scheme non-C/M/W "
+            "short-circuit no longer passes namespace_entry_count=0, "
+            "regressing the schema-consistency contract surfaced by "
+            "walk namespace A against Wikipedia."
+        )
+
+
+# ---------------------------------------------------------------------------
+# D4: disambig page detection (long preamble) + footer suppression
+# ---------------------------------------------------------------------------
+
+
+# Mercury-shaped pre-H2 body: > 400 chars, ends with "may also refer
+# to:" right before the first ## section. Synthesized to reproduce
+# the exact failure mode the live sweep surfaced.
+MERCURY_STYLE_PRE_H2 = (
+    'Look up _**[Mercury](https://en.wiktionary.org/wiki/Mercury "wiktionary:'
+    'Mercury")**_ or _**[mercury](https://en.wiktionary.org/wiki/mercury '
+    '"wiktionary:mercury")**_ in Wiktionary, the free dictionary.\n\n'
+    "**Mercury** most commonly refers to: \n\n"
+    '  * [Mercury (planet)](Mercury_\\(planet\\) "Mercury \\(planet\\)"), '
+    "the closest planet to the Sun\n"
+    '  * [Mercury (element)](Mercury_\\(element\\) "Mercury \\(element\\)"), '
+    "a chemical element\n"
+    '  * [Mercury (mythology)](Mercury_\\(mythology\\) "Mercury '
+    '\\(mythology\\)"), a Roman deity\n\n'
+    "**Mercury** or **The Mercury** may also refer to:"
+)
+
+
+class TestD4DisambigDetectionLongPreamble:
+    """D4 part 1: ``_is_disambig_lead`` used to bail out at
+    ``len(pre_h2) >= 400`` and missed pages like Mercury whose
+    pre-H2 carries a 'most commonly refers to' preamble. Fix checks
+    only the trailing 400 chars.
+    """
+
+    def test_mercury_style_long_preamble_detected(self) -> None:
+        assert len(MERCURY_STYLE_PRE_H2) > 400
+        assert SimpleToolsHandler._is_disambig_lead(MERCURY_STYLE_PRE_H2)
+
+    def test_short_disambig_lead_still_detected(self) -> None:
+        # Existing behaviour preserved for short Martin-style pages.
+        short = "**Martin** may refer to:"
+        assert SimpleToolsHandler._is_disambig_lead(short)
+
+    def test_non_disambig_long_body_not_misdetected(self) -> None:
+        # A long pre-H2 that doesn't end with the trigger phrase
+        # must still return False — the tail-window check shouldn't
+        # false-positive on text that mentions "may refer to" earlier
+        # in the body.
+        not_disambig = (
+            "Photosynthesis is a system of biological processes by which " * 20
+        ) + "the chloroplast houses the reaction centers."
+        assert len(not_disambig) > 400
+        assert not SimpleToolsHandler._is_disambig_lead(not_disambig)
+
+    def test_mentions_phrase_earlier_but_not_at_tail_rejected(self) -> None:
+        # Defense against false positive: a body that mentions "may
+        # refer to" earlier but ends differently shouldn't trigger.
+        body = (
+            "The phrase 'may refer to' is sometimes used in legal "
+            "documents. " * 30
+            + "However, photosynthesis is a biological process unrelated "
+            "to such usage."
+        )
+        assert len(body) > 400
+        assert not SimpleToolsHandler._is_disambig_lead(body)
+
+
+class TestD4DisambigFooterSuppression:
+    """D4 part 2: when the resolved article body IS itself a
+    disambiguation page (Mercury-style), the trailing
+    ``_Note: this topic also has a disambiguation page_`` and
+    ``_May also refer to: <one extends-topic sibling>_`` footers are
+    misleading — the body already lists every alternative. Fix
+    detects the case and suppresses both footers.
+    """
+
+    @pytest.fixture
+    def make_handler(self):
+        def factory(
+            *, article_body: str, search_results: list, title_index: dict | None = None
+        ):
+            mock = MagicMock()
+            mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+            mock.search_zim_file_data.return_value = {"results": search_results}
+            mock.get_zim_entry.return_value = article_body
+            mock.config.meta.footer_enabled = False
+            mock.find_entry_by_title_data.return_value = (
+                {"results": [title_index]} if title_index else {"results": []}
+            )
+            mock.get_article_structure_data.return_value = {"sections": []}
+            return SimpleToolsHandler(mock), mock
+
+        return factory
+
+    def test_disambig_body_suppresses_extends_topic_footer(
+        self, make_handler: Any
+    ) -> None:
+        # Mercury-style disambig page as canonical, with one sibling
+        # extends-topic match (Mercury_Monterey). The misleading
+        # "_May also refer to: Mercury_Monterey_" footer must be
+        # dropped because the body already enumerates dozens of
+        # alternates.
+        disambig_body = (
+            f"# Mercury\n\n{MERCURY_STYLE_PRE_H2}\n\n"
+            "## Companies\n"
+            "  * [Mercury Communications](Mercury_Communications)\n"
+            "## Computing\n"
+            "  * [Mercury (programming language)](Mercury_(programming_language))\n"
+        )
+        handler, _ = make_handler(
+            article_body=disambig_body,
+            search_results=[
+                {"path": "Mercury", "title": "Mercury", "score": 100},
+                {
+                    "path": "Mercury_Monterey",
+                    "title": "Mercury Monterey",
+                    "score": 50,
+                },
+            ],
+            title_index={"path": "Mercury", "title": "Mercury", "score": 1.0},
+        )
+        out = handler.handle_zim_query(
+            "tell me about Mercury",
+            zim_file_path="/x.zim",
+            options={"compact": False},
+        )
+        assert "_Source: `Mercury`_" in out
+        # The misleading footer must be absent.
+        assert "May also refer to" not in out
+        assert "Mercury_Monterey — use" not in out
+        # But the body content is still there.
+        assert "may also refer to" in out.lower()  # from the body itself
+        assert "Mercury (programming language)" in out
+
+    def test_disambig_body_suppresses_twin_note_footer(self, make_handler: Any) -> None:
+        # When the resolved disambig body is paired with a twin
+        # disambig path (rare but possible), suppress that footer too —
+        # the twin redirects to the same kind of content.
+        disambig_body = (
+            f"# Java\n\n{MERCURY_STYLE_PRE_H2.replace('Mercury', 'Java')}\n\n"
+            "## Computing\n  * [Java (programming language)](Java_(programming_language))\n"
+        )
+        handler, _ = make_handler(
+            article_body=disambig_body,
+            search_results=[
+                {"path": "Java", "title": "Java", "score": 100},
+                {
+                    "path": "Java_(disambiguation)",
+                    "title": "Java (disambiguation)",
+                    "score": 80,
+                },
+            ],
+            title_index={"path": "Java", "title": "Java", "score": 1.0},
+        )
+        out = handler.handle_zim_query(
+            "tell me about Java",
+            zim_file_path="/x.zim",
+            options={"compact": False},
+        )
+        assert "_Source: `Java`_" in out
+        # The note footer that points to the (disambiguation) twin is
+        # redundant when the body itself is the disambig page.
+        assert "this topic also has a disambiguation page" not in out
+
+    def test_canonical_article_still_gets_footers(self, make_handler: Any) -> None:
+        # Sanity: canonical-article path (e.g., Berlin) keeps its
+        # disambig-twin "Note" footer. The fix must not regress this.
+        canonical_body = (
+            "# Berlin\n\n"
+            "Berlin is the capital of Germany. " * 50
+            + "\n\n## History\n\nBerlin was first documented in the 13th century. " * 10
+        )
+        handler, _ = make_handler(
+            article_body=canonical_body,
+            search_results=[
+                {"path": "Berlin", "title": "Berlin", "score": 100},
+                {
+                    "path": "Berlin_(disambiguation)",
+                    "title": "Berlin (disambiguation)",
+                    "score": 80,
+                },
+            ],
+            title_index={"path": "Berlin", "title": "Berlin", "score": 1.0},
+        )
+        out = handler.handle_zim_query(
+            "tell me about Berlin",
+            zim_file_path="/x.zim",
+            options={"compact": False},
+        )
+        assert "_Source: `Berlin`_" in out
+        # Canonical article: the disambig-twin footer fires because
+        # the body is NOT a disambig page.
+        assert "this topic also has a disambiguation page" in out


### PR DESCRIPTION
## Summary

Post-a15 beta-test sweep. Multi-pass live probe of `v2.0.0a15` against `wikipedia_en_all_maxi_2026-02.zim` (~118 GB, ~27.2 M entries) via the single `zim_query` MCP tool. Seven passes total — three live-query passes, one stress-test pass, one verification pass, one source-level audit pass, one final verification pass. Ten user-facing defects landed across three commits.

| Pass | Angle | Defects found |
|---|---|---|
| 1 (initial live probe) | adversarial set against running a15 | 4 (D4–D7) |
| 2 (self-audit pass-1) | verbose + compact modes; canonical articles must not regress | 0 |
| 3 (self-audit pass-2) | broader disambig set + empty namespaces + cross-fix probes | 0 |
| 4 (stress-test landed fixes from new angles + probe untested intents) | bare-title disambigs, pathological politeness, malformed `walk_namespace`, `synthesize` / `browse` / `show structure` / `links in` / `suggestions for` | 3 (P4-D1–P4-D3) |
| 5 (self-audit pass-4) | verify P4 fixes against live ZIM | 0 |
| 6 (source-level audit + leading-politeness) | grep every handler for the P4-D3 `params.get("X", DEFAULT)` shape and every extractor for the P4-D1 trigger-word-capture shape; probe `please` / `kindly` | 3 (P6-D1–P6-D3) |
| 7 (final cumulative verify) | all 10 fixes across the three commits | 0 |

**Methodology note:** Pass 6 introduces a new angle to the methodology — source-level audits of fix-shape analogues. When a fix lands for a bug class (silent-default in `walk_namespace`'s `params.get("namespace", "C")`; trigger-word-capture in `_extract_suggestions`'s optional-`for`-group regex), grep the codebase for the same shape and audit every sibling. Pass 6 caught two such analogues instantly (P6-D1 + P6-D2 in `browse_namespace`) this way after passes 2 / 3 / 5 had returned zero-defect on live probes.

## Fixes

| # | Surface | Description |
|---|---|---|
| **D4** | `SimpleToolsHandler._is_disambig_lead`, `_handle_tell_me_about` | `tell me about Mercury` no longer attaches a misleading `_May also refer to: Mercury_Monterey_` footer to the disambig body. Two cooperating bugs: `_is_disambig_lead`'s 400-char `pre_h2` cap (Mercury's pre-H2 is 628 chars) and the trailing-footer block having no way to suppress `disambig_twin_path` / `related_extends_paths` when the resolved body is itself a disambig page. Fixed by checking only the trailing 400 chars of `pre_h2` (regex-free `endswith` stays bounded) and gating both footers on a fresh `body_is_disambig_page` check. |
| **D5** | `_extract_tell_me_about` modal-strip | `could you tell me about Photosynthesis` now parses `topic="Photosynthesis"` instead of leaking the modal lead-in. Verb-prefix regex anchored at `^\s*` never matched "could/can/would/will you", so the query fell through to the `topic=query.strip()` fallback. Fixed by pre-stripping the modal scaffold `(?:could|can|would|will)\s+(?:you|we\|i)\s+(?:please\s+)?` before the verb regex runs. |
| **D6** | `_handle_find_by_title` namespace-path guard | `find article titled M/Title` returned silent `0_hits` because the title index only stores titles. Handler now detects the uppercase-letter + slash + non-empty-suffix shape upfront and returns a structured **Namespace Path, Not a Title** message pointing at both `get article <path>` and the title-only fallback. Lowercase `a/b` and non-namespace titles pass through unchanged. |
| **D7** | `openzim_mcp/zim/namespace.py` short-circuit | `walk namespace A` (and any empty new-scheme namespace) now includes `namespace_entry_count: 0` in the response. Previously omitted while walk-M / walk-W (bounded totals) included it — schema inconsistency. Fixed by passing `namespace_entry_count=0` in the short-circuit. `walk_A_10` golden updated. |
| **P4-D1** | `_extract_suggestions` bare-"for" guard | `suggestions for` (no actual prefix) no longer silently autocompletes against the literal word "for". The regex's optional `(?:for\s+)?` failed to match without trailing whitespace; the mandatory capture swallowed "for"; the handler's missing-arg guard never fired (~70 s backend scan per call). Fixed by discarding a bare-"for" capture so the guard takes over. `suggestions for forest` still works. |
| **P4-D2** | `_chained_intent_guidance` modal pre-strip | Chained-intent detector no longer bypassed by a modal lead-in. `_CHAINED_OPERATION_PREFIX_RE` is anchored at `^`; "could you tell me about Photosynthesis then list namespaces" pushed the verb past the anchor, the chain gate failed, and the `tell me about` half was dropped silently. The D5 modal-strip lives inside `_extract_tell_me_about` and only runs AFTER the chain detector. Fixed by applying the same modal scaffold strip at the top of `_chained_intent_guidance`. |
| **P4-D3** | `_handle_walk_namespace` missing-arg guard | `walk namespace AB / 1 / _ / <empty>` now returns a structured "Missing or Invalid Namespace" error instead of silently walking C via `params.get("namespace", "C")`. Sibling tools (`find_by_title`, `links_in`, `suggestions`, `tell_me_about`) already return structured errors; this one didn't. |
| **P6-D1 + P6-D2** | `_handle_browse` + `_extract_browse` input-validation parity with walk | `browse namespace` reaches input-validation parity with `walk namespace`. Two cooperating gaps — handler had the same `params.get("namespace", "C")` silent-default that P4-D3 fixed for walk; extractor accepted multi-char / digit / special args without uppercasing lowercase input. Regex tightened to `namespace\s+['"]?([A-Za-z])\b['"]?` + `.upper()`; handler returns the same structured "Missing or Invalid Namespace" error. |
| **P6-D3** | `_extract_tell_me_about` + `_chained_intent_guidance` leading-politeness strip | Leading `please` / `kindly` now strip cleanly. `please tell me about Photosynthesis` parsed with the politeness phrase in the topic (article still resolved via tail-probe but parsed topic was wrong). Extended the leading-strip to cover `please` / `kindly` AND wrapped both the modal-strip and politeness-strip in a loop so composite phrases (`please could you tell me about X`, `please please tell me about X`) peel cleanly. Same loop applied to `_chained_intent_guidance`. Leading-only anchor (`^\s*`) preserves mid-query `please` in topic. |

## Tests

- **1664 passing, 50 skipped** on the full suite (up from 1611 at HEAD-of-a15).
- New file: `tests/test_post_a15_beta_fixes.py` — 80 regression tests pinning all ten defects. Each defect gets:
  - The fix-case parametrised across the shape variations the surfacing pass used to find it.
  - Negative self-audit cases (Berlin keeps its disambig-twin footer; `suggestions for forest` still captures the prefix; non-chained `could you tell me about X` not tripped by chain detector; `browse namespace c` still lowercases to "C"; trailing-please still works; mid-query `please` not stripped; `_build_walk_result` omits the field when caller passes None; lowercase `a/b` not redirected by find_by_title; non-modal queries unchanged).
  - Cross-defect probes (Java disambig body suppresses `disambig_twin_path` footer too; `please could you tell me about X` peels both layers; `please tell me about X then list namespaces` trips chain detector).

## Verification

Tested in-process against `wikipedia_en_all_maxi_2026-02.zim` (~118 GB, ~27.2 M entries) across passes 1–7. Live re-verify after merge requires deploying to the Tailscale-hosted server (the in-session MCP server caches the original alpha and does not pick up source changes).

Local quality gates (matching CI):

- `make lint` ✅ (flake8 / isort / black — 142 files unchanged)
- `make type-check` ✅ (mypy — no issues in 45 source files)
- `make security` ✅ (bandit — 0 issues; pip-audit — no known vulnerabilities)
- `make test` ✅ (1664 passed, 50 skipped, 38 deselected; 82% coverage)

## Commits

- `13aff34` — D-series (4 fixes, passes 1–3)
- `60c4d82` — P4-series (3 self-audit fixes, passes 4–5)
- `18a3796` — P6-series (3 source-audit fixes, passes 6–7)
