### PR TITLE
fix(test): use floor assertion for M-namespace browse total (fixture drift)

### DIFF
--- a/tests/test_namespace_scheme_aware.py
+++ b/tests/test_namespace_scheme_aware.py
@@ -353,11 +353,29 @@ class TestBrowseNamespaceTotalIsAuthoritative:
         ops_for_zim_data: ZimOperations,
         basic_test_zim_files: Dict[str, Optional[Path]],
     ):
-        """For new-scheme M, totals come from archive.metadata_keys."""
+        """For new-scheme M, totals come from archive.metadata_keys.
+
+        The point of this test is the *route* + the *authoritative*
+        property — that ``browse_namespace`` discovers M via
+        ``archive.metadata_keys`` AND reports a hard total (not a
+        lower bound). The exact count is set by upstream
+        zim-testing-suite fixtures and has drifted between
+        refreshes (was 10 at fixture creation; observed 9 after
+        the 2026-05 refresh + 2026-05-18 P3-D3 filter that
+        excludes non-human-readable keys like binary
+        ``Illustration_*``). Use a conservative floor to stay
+        robust to minor upstream variation while still asserting
+        the routing + authoritativeness. Mirrors the floor in the
+        sibling ``test_metadata_namespace_from_metadata_keys``
+        (PR #136).
+        """
         zim = _require(basic_test_zim_files["nons"])
         result = json.loads(ops_for_zim_data.browse_namespace(str(zim), "M", limit=50))
-        # nons/small.zim has 10 metadata_keys
-        assert result["total"] == 10
+        # Conservative floor: any real-world ZIM has at least a handful
+        # of metadata keys (Title, Description, Creator, Language, Date,
+        # Tags). Robust to upstream fixture refreshes; still asserts
+        # the route is wired.
+        assert result["total"] >= 5
         assert not result["page_info"].get("total_is_lower_bound", False)
 
 


### PR DESCRIPTION
## Summary

Fixes the **Comprehensive Testing** job that went red on main after PR #142 merge (run 26056432512, SHA 3d87294):

```
FAILED tests/test_namespace_scheme_aware.py::TestBrowseNamespaceTotalIsAuthoritative::test_new_scheme_M_total_matches_metadata_keys
assert 9 == 10
```

Same pattern as PR #136: brittle exact-count assertion against upstream `zim-testing-suite` fixture drift. PR #136 fixed the sibling test_metadata_namespace_from_metadata_keys (in `TestListNamespacesNewScheme`) with a `>= 5` floor, but missed this near-identical assertion in `TestBrowseNamespaceTotalIsAuthoritative`. This PR mirrors that pattern.

## Root cause

Two pre-existing pressures on the count, both surfacing here:

1. **Upstream fixture refresh (2026-05)** — `nons/small.zim` metadata-keys count drifted from 10 → 9. PR #136 covered the list_namespaces path; the browse_namespace path in the same file was left exact-match.
2. **P3-D3 in wave 3 of post-a16 sweep (4752efc)** — added `is_human_readable_metadata_key` filter to `_enumerate_new_scheme_metadata` so `browse_namespace M` agrees with `list_namespaces` / `walk_namespace M` / `metadata for <file>` (correct fix for an aggregator-disagreement bug). Side-effect: drops the binary `Illustration_*` entry from the M count.

Neither factor is wrong in isolation; the test assertion just isn't drift-tolerant.

## The fix

Replace `assert result[\"total\"] == 10` with `assert result[\"total\"] >= 5`. Preserves the test's actual contracts:
- M is discovered via `archive.metadata_keys` (route)
- The total is authoritative, not a lower bound (`total_is_lower_bound` is False)

Updated docstring documents the rationale and cross-references PR #136 + P3-D3 so the pattern doesn't get re-introduced.

## Test plan

- [x] `make lint` clean
- [x] Targeted test class skipped locally (20 skipped — requires real ZIM test data, only Comprehensive Testing exercises it)
- [ ] Comprehensive Testing job (post-merge) passes — only verifiable on main per the workflow gate, same as PR #136