### PR TITLE
fix(v2): post-a17 beta-test sweep — 3 defects across two passes

### DIFF
--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -305,6 +305,19 @@ class SimpleToolsHandler:
                 cursor_ns = state.get("ns")
                 if isinstance(cursor_ns, str) and cursor_ns:
                     options["_cursor_ns"] = cursor_ns
+                # Post-a17 P1-D3: stash the cursor's ``s.ai`` so
+                # cursor-rebuilding handlers (``_handle_walk_namespace``
+                # rebuilds ``{scan_at, l}`` from ``offset`` and passes
+                # that synthetic dict to ``walk_namespace_data``, whose
+                # unconditional ``verify_archive_identity`` then
+                # rejects the missing ``ai`` with a misleading
+                # "missing archive-identity field" error). Preserving
+                # the original ``ai`` round-trips it back through the
+                # check so a walk-namespace cursor returned by the
+                # tool can be replayed against the same archive.
+                cursor_ai = state.get("ai")
+                if isinstance(cursor_ai, str) and cursor_ai:
+                    options["_cursor_ai"] = cursor_ai
                 if isinstance(state, dict):  # always True now; kept for diff clarity
                     # D9 (beta): the original implementation treated the
                     # cursor's ``s.q`` field as decorative — only ``s.o``
@@ -1084,6 +1097,21 @@ class SimpleToolsHandler:
             m = re.search(pat, topic_stripped, re.IGNORECASE)
             if not m:
                 continue
+            # Post-a17 P1-D1: when the title itself contains the same
+            # connector pattern (``Big Rapids, Michigan`` carries a
+            # comma; ``Romeo and Juliet`` carries ``and``), the
+            # connector is structural to the title, not a multi-entity
+            # separator. The ``left_in == right_in`` branch below
+            # catches the simple case where both topic halves are full
+            # substrings — but subject-attribute prefixes
+            # (``notable people from Big Rapids, Michigan``,
+            # ``musicians from Romeo and Juliet``) leave the left half
+            # longer than the title, defeating that suppression. The
+            # docstring already names ``Vienna, Austria`` as a case
+            # this footer should NOT fire for; the earlier guard makes
+            # it work in the prefixed-topic shape too.
+            if re.search(pat, top_title, re.IGNORECASE):
+                return None
             left = topic_stripped[: m.start()].strip()
             right = topic_stripped[m.end() :].strip()
             if not left or not right:
@@ -3646,9 +3674,28 @@ class SimpleToolsHandler:
         # have to round-trip through base64.
         offset = int(options.get("offset", 0) or 0)
         limit = options.get("limit", 200)
-        cursor_state: Optional[Dict[str, Any]] = (
-            {"scan_at": offset, "l": limit} if offset > 0 else None
-        )
+        # Post-a17 P1-D3: include the cursor's original ``ai`` field
+        # when it was stashed by the dispatcher (see _decode_cursor at
+        # ~line 295). Without it, ``walk_namespace_data``'s
+        # unconditional ``verify_archive_identity`` rejects the
+        # synthetic cursor with a misleading "missing archive-identity
+        # field" error — even though the user was just round-tripping
+        # the cursor the tool itself emitted. ``ns`` is also threaded
+        # through so the cursor->namespace check stays meaningful when
+        # the handler-level guard (``_cursor_ns_mismatch`` above) is
+        # paired with the data-layer guard inside
+        # ``walk_namespace_data``.
+        cursor_state: Optional[Dict[str, Any]]
+        if offset > 0:
+            cursor_state = {"scan_at": offset, "l": limit}
+            cursor_ai = options.get("_cursor_ai")
+            if isinstance(cursor_ai, str) and cursor_ai:
+                cursor_state["ai"] = cursor_ai
+            cursor_ns = options.get("_cursor_ns")
+            if isinstance(cursor_ns, str) and cursor_ns:
+                cursor_state["ns"] = cursor_ns
+        else:
+            cursor_state = None
         if options.get("compact", False):
             data = self.zim_operations.walk_namespace_data(
                 zim_file_path,

--- a/openzim_mcp/title_promotion.py
+++ b/openzim_mcp/title_promotion.py
@@ -169,13 +169,23 @@ def find_title_match(
     }
 
 
-# Tokenizer matches the existing _TOKEN_RE / is_strong_title_match
-# convention in this module: lowercase alphanumeric runs only.
-# Underscores, punctuation, and whitespace all act as token boundaries.
-# Underscore is intentionally a boundary so path-form input like
-# "Big_Rapids,_Michigan" tokenizes to ["big", "rapids", "michigan"]
-# instead of treating "Big_Rapids" as one token.
-_TAIL_TOKEN_RE = re.compile(r"[a-z0-9]+")
+# Tokenizer for tail / window probe yielders. Unicode-aware so non-Latin
+# topics like ``München`` / ``Zürich`` / ``Köln`` tokenize to one token
+# (``["münchen"]``) instead of being split on the diacritic into
+# ``["m", "nchen"]`` etc. Post-a17 P1-D2: the ASCII-only ``[a-z0-9]+``
+# previously used here yielded ``"m"`` for ``München`` via
+# ``iter_query_windows``, which ``find_title_match`` then cleanly
+# resolved to the ``M`` letter article at score 1.0 — a confidently-
+# wrong answer at cert=0.85 for any place name with a diacritic. The
+# backend ``find_entry_by_title_data`` natively handles Unicode (probed
+# directly with ``find article titled München`` → resolves to Munich
+# at score 1.00), so the fix is to stop destroying the topic before it
+# reaches the backend. Underscores, punctuation, and whitespace remain
+# token boundaries — ``[^\W_]+`` keeps ``\w`` minus underscore so
+# path-form input like ``"Big_Rapids,_Michigan"`` still tokenizes to
+# ``["big", "rapids", "michigan"]``. ``re.UNICODE`` is the default in
+# Python 3 — naming it here keeps the intent explicit.
+_TAIL_TOKEN_RE = re.compile(r"[^\W_]+", re.UNICODE)
 
 
 def iter_query_tails(

--- a/tests/test_post_a17_beta_fixes.py
+++ b/tests/test_post_a17_beta_fixes.py
@@ -1,0 +1,405 @@
+"""Regression tests for the post-a17 beta-test sweep (a18 fixes).
+
+The post-a17 live sweep against the 118 GB Wikipedia ZIM surfaced
+three user-facing defects:
+
+- P1-D1: ``notable people from Big Rapids, Michigan`` and
+  ``musicians from Romeo and Juliet`` emitted a misleading
+  soft-connector footer claiming the article for ``Michigan`` /
+  ``Juliet`` was returned, when in fact a single entity whose title
+  structurally spans the connector (``Big Rapids, Michigan`` carries
+  a comma; ``Romeo and Juliet`` carries ``and``) was returned. The
+  existing ``left_in == right_in`` suppression only catches the case
+  where both topic halves are substrings of the title; a subject-
+  attribute prefix (``notable people from`` / ``musicians from``)
+  leaves the left half longer than the title, defeating that test.
+  Fix adds an earlier "title-spans-connector" suppression: when the
+  title itself matches the same connector regex, the connector is
+  structural to the title and the footer is suppressed.
+
+- P1-D2: ``tell me about München`` returned the ``M`` letter article
+  at cert=0.85; ``tell me about Zürich`` returned the ``Rich``
+  disambig; ``tell me about Köln`` returned the ``LN`` abbreviation.
+  Root cause: ``_TAIL_TOKEN_RE = [a-z0-9]+`` in title_promotion.py
+  stripped non-ASCII characters, so ``iter_query_tails("München")``
+  yielded ``["m", "nchen"]`` and ``iter_query_windows`` yielded
+  ``"m"``, which ``find_title_match`` cleanly resolved to the M
+  letter article. The backend natively handles Unicode topics
+  (``find article titled München`` resolves to Munich at score
+  1.00), so the fix is Unicode-aware tokenisation:
+  ``[^\\W_]+`` keeps ``\\w`` minus underscore.
+
+- P1-D3: ``walk namespace M`` emits a cursor; passing that cursor
+  back to ``walk namespace M`` produces the error ``Cursor for
+  'walk_namespace' missing archive-identity field. Re-issue the
+  request without a cursor.`` even though the cursor carries an
+  ``ai`` field. Root cause: the simple-tools cursor dispatcher
+  stashes only ``offset`` and ``_cursor_ns``, dropping ``ai``.
+  ``_handle_walk_namespace`` then rebuilds cursor_state as
+  ``{scan_at, l}`` without ``ai``; downstream
+  ``verify_archive_identity`` rejects the synthetic cursor. Fix
+  preserves ``s.ai`` (and ``s.ns``) through the dispatcher into the
+  rebuilt cursor_state.
+
+Each test pins one defect; failures here mean a regression on the
+specific bug.
+"""
+
+import base64
+import json
+import re
+from typing import Any
+from unittest.mock import MagicMock
+
+from openzim_mcp.pagination import Cursor, archive_identity
+from openzim_mcp.simple_tools import SimpleToolsHandler
+from openzim_mcp.title_promotion import iter_query_tails, iter_query_windows
+
+
+# ---------------------------------------------------------------------------
+# P1-D1: title-spans-connector suppresses soft-connector footer
+# ---------------------------------------------------------------------------
+
+
+class TestP1D1TitleSpansConnectorSuppression:
+    """P1-D1: when the resolved article's title structurally contains
+    the same connector pattern as the topic, the footer is suppressed
+    — even if a subject-attribute prefix on the topic prevents the
+    left half from being a substring of the title.
+
+    The pre-fix behaviour only suppressed when BOTH topic halves were
+    substrings of the title; this is the broader, principled
+    suppression rule.
+    """
+
+    def _make_handler(self, top_title: str) -> SimpleToolsHandler:
+        path = top_title.replace(" ", "_")
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        mock.search_zim_file_data.return_value = {
+            "results": [{"path": path, "title": top_title}],
+            "total": 1,
+        }
+        mock.get_zim_entry.return_value = "stub-body"
+        mock.find_entry_by_title_data.return_value = {
+            "results": [{"path": path, "title": top_title, "score": 1.0}],
+            "total": 1,
+        }
+        return SimpleToolsHandler(mock)
+
+    def test_comma_title_with_subject_attribute_prefix_suppresses(self) -> None:
+        # ``notable people from Big Rapids, Michigan`` resolved to
+        # ``Big Rapids, Michigan`` (single entity with comma in title).
+        # Pre-fix: footer claimed "Returned the article for `Michigan`.
+        # For `notable people from Big Rapids`, query separately..."
+        # Post-fix: title carries the connector → suppress.
+        handler = self._make_handler(top_title="Big Rapids, Michigan")
+        out = handler.handle_zim_query(
+            "tell me about notable people from Big Rapids, Michigan",
+            zim_file_path="/x.zim",
+            options={"compact": False},
+        )
+        assert "query contained" not in out, (
+            "soft-connector footer must be suppressed when the title "
+            "structurally spans the same connector as the topic"
+        )
+
+    def test_and_title_with_subject_attribute_prefix_suppresses(self) -> None:
+        # ``musicians from Romeo and Juliet`` resolved to
+        # ``Romeo and Juliet`` (single article whose title spans ``and``).
+        # Pre-fix: footer claimed "Returned the article for `Juliet`.
+        # For `musicians from Romeo`, query separately..."
+        # Post-fix: title contains ``and`` → suppress.
+        handler = self._make_handler(top_title="Romeo and Juliet")
+        out = handler.handle_zim_query(
+            "tell me about musicians from Romeo and Juliet",
+            zim_file_path="/x.zim",
+            options={"compact": False},
+        )
+        assert "query contained" not in out
+
+    def test_genuine_two_entity_query_still_emits_footer(self) -> None:
+        # Regression guard: ``musicians from Berlin and Paris`` with the
+        # resolved title ``Paris`` (no ``and`` in title) must STILL fire
+        # the footer — the suppression should be narrow.
+        handler = self._make_handler(top_title="Paris")
+        out = handler.handle_zim_query(
+            "tell me about musicians from Berlin and Paris",
+            zim_file_path="/x.zim",
+            options={"compact": False},
+        )
+        assert "query contained" in out
+        assert "Berlin" in out
+
+    def test_pre_fix_both_halves_in_title_still_suppresses(self) -> None:
+        # Regression guard: ``Berlin and Brandenburg`` resolved to
+        # ``Berlin and Brandenburg`` — title spans the connector AND
+        # both halves are substrings. Either suppression path is fine;
+        # ensure the footer doesn't appear.
+        handler = self._make_handler(top_title="Berlin and Brandenburg")
+        out = handler.handle_zim_query(
+            "tell me about Berlin and Brandenburg",
+            zim_file_path="/x.zim",
+            options={"compact": False},
+        )
+        assert "query contained" not in out
+
+
+# ---------------------------------------------------------------------------
+# P1-D2: Unicode-aware tail / window tokenisation
+# ---------------------------------------------------------------------------
+
+
+class TestP1D2UnicodeTailTokenisation:
+    """P1-D2: ``iter_query_tails`` / ``iter_query_windows`` must
+    preserve non-ASCII letters (``ü``, ``ö``, ``é``) so the title-
+    index probe sees the real topic and not an ASCII fragment that
+    happens to collide with an unrelated short article name.
+    """
+
+    def test_munchen_tokenises_as_single_unicode_token(self) -> None:
+        tails = list(iter_query_tails("München"))
+        # Pre-fix: ["m", "nchen"] yielded → tails ["m nchen", "nchen"];
+        # iter_query_windows yielded "m" which find_title_match cleanly
+        # resolved to the ``M`` letter article. Post-fix: single token.
+        assert tails == ["münchen"]
+        # And iter_query_windows yields nothing (only one token).
+        windows = list(iter_query_windows("München"))
+        assert windows == []
+
+    def test_zurich_tokenises_as_single_unicode_token(self) -> None:
+        # Pre-fix: ["z", "rich"] → "rich" matched the ``Rich`` disambig.
+        assert list(iter_query_tails("Zürich")) == ["zürich"]
+
+    def test_koln_tokenises_as_single_unicode_token(self) -> None:
+        # Pre-fix: ["k", "ln"] → "ln" matched the ``LN`` abbreviation.
+        assert list(iter_query_tails("Köln")) == ["köln"]
+
+    def test_multi_word_unicode_topic_preserved(self) -> None:
+        # Multi-word Unicode: each token preserves diacritics.
+        tails = list(iter_query_tails("Café de Flore"))
+        assert tails == [
+            "café de flore",
+            "de flore",
+            "flore",
+        ]
+
+    def test_ascii_only_topic_unchanged(self) -> None:
+        # Regression guard: the original "big rapids michigan" example
+        # must still tokenise to three single-word tokens.
+        tails = list(iter_query_tails("famous people from big rapids michigan"))
+        assert tails == [
+            "from big rapids michigan",
+            "big rapids michigan",
+            "rapids michigan",
+            "michigan",
+        ]
+
+    def test_underscore_still_acts_as_token_boundary(self) -> None:
+        # ``[^\W_]+`` deliberately keeps underscore as a boundary so
+        # path-form input like ``Big_Rapids,_Michigan`` doesn't yield
+        # one mega-token.
+        tails = list(iter_query_tails("Big_Rapids,_Michigan"))
+        assert tails == [
+            "big rapids michigan",
+            "rapids michigan",
+            "michigan",
+        ]
+
+    def test_digits_still_tokenise(self) -> None:
+        # Regression guard: numeric tokens still form their own tokens.
+        tails = list(iter_query_tails("Apollo 11"))
+        assert tails == ["apollo 11", "11"]
+
+
+# ---------------------------------------------------------------------------
+# P1-D3: walk_namespace cursor "ai" preserved across the simple-tools
+# dispatcher round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestP1D3WalkNamespaceCursorRoundTrip:
+    """P1-D3: a ``walk namespace M`` cursor emitted by the tool must
+    round-trip through the simple-tools dispatcher without losing
+    the ``ai`` archive-identity field — otherwise the data layer's
+    ``verify_archive_identity`` rejects the cursor with a misleading
+    "missing archive-identity field" error.
+    """
+
+    def _encode_walk_cursor(
+        self, *, offset: int, limit: int, namespace: str, ai: str
+    ) -> str:
+        # Mirror the shape ``_walk_new_scheme_metadata`` emits.
+        state: dict[str, Any] = {
+            "o": offset,
+            "l": limit,
+            "ns": namespace,
+            "ai": ai,
+        }
+        return Cursor.encode(tool="walk_namespace", state=state)  # type: ignore[arg-type]
+
+    def test_walk_namespace_cursor_ai_preserved_through_dispatcher(self) -> None:
+        """End-to-end: walk_namespace_data receives a cursor_state
+        carrying ``ai`` matching the archive when a cursor round-trips
+        through ``handle_zim_query``. Pre-fix: ``ai`` was dropped, the
+        rebuilt cursor_state was ``{scan_at, l}`` only,
+        ``verify_archive_identity`` raised "missing archive-identity
+        field" → the user got an error instead of page 2.
+        """
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [
+            {"path": "/data/wikipedia_en_all_maxi_2026-02.zim"}
+        ]
+        mock.config.meta.footer_enabled = False
+        # Track what the handler ends up passing to walk_namespace_data.
+        captured: dict[str, Any] = {}
+
+        def fake_walk_namespace_data(
+            zim_file_path: str,
+            namespace: str,
+            *,
+            cursor_state: Any = None,
+            limit: int = 200,
+        ) -> dict[str, Any]:
+            captured["zim_file_path"] = zim_file_path
+            captured["namespace"] = namespace
+            captured["cursor_state"] = cursor_state
+            captured["limit"] = limit
+            return {
+                "namespace": namespace,
+                "results": [],
+                "next_cursor": None,
+                "total": 0,
+                "done": True,
+                "page_info": {"offset": 3, "limit": limit, "returned_count": 0},
+                "discovery_method": "full_iteration",
+                "sampling_based": False,
+                "results_may_be_incomplete": False,
+            }
+
+        mock.walk_namespace_data.side_effect = fake_walk_namespace_data
+        handler = SimpleToolsHandler(mock)
+
+        # The 'ai' value comes from the source cursor — the handler
+        # should round-trip it through unchanged. ``compact=True``
+        # routes through ``walk_namespace_data`` (the v2 contract path
+        # that carries cursor_state); the legacy ``walk_namespace``
+        # call takes a different kwarg shape and would obscure the
+        # property under test.
+        cursor_token = self._encode_walk_cursor(
+            offset=3, limit=3, namespace="M", ai="e048666a9e92"
+        )
+        handler.handle_zim_query(
+            "walk namespace M",
+            zim_file_path="/data/wikipedia_en_all_maxi_2026-02.zim",
+            options={"compact": True, "cursor": cursor_token},
+        )
+
+        cursor_state = captured["cursor_state"]
+        assert cursor_state is not None, (
+            "cursor_state should be passed when a cursor decodes to "
+            "a non-zero offset"
+        )
+        assert cursor_state.get("ai") == "e048666a9e92", (
+            "Dispatcher must preserve the cursor's 'ai' field into the "
+            "rebuilt cursor_state — without it walk_namespace_data's "
+            "verify_archive_identity rejects the synthetic cursor."
+        )
+        # ``scan_at`` should be 3 (decoded from ``o``) and ``ns`` must
+        # also round-trip so the data-layer namespace-match guard fires
+        # in the right case.
+        assert cursor_state.get("scan_at") == 3
+        assert cursor_state.get("ns") == "M"
+
+    def test_walk_namespace_dispatcher_stashes_cursor_ai_into_options(self) -> None:
+        """Directly assert the dispatcher contract: stash ``_cursor_ai``
+        on the options dict so any handler can pull it out.
+        """
+        # We don't reach for handle_zim_query's internals here — the
+        # public-surface assertion is the end-to-end test above. This
+        # test wires a tiny mock to inspect the options dict that
+        # the dispatcher forwards.
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        captured_options: dict[str, Any] = {}
+
+        def capturing_walk_data(
+            zim_file_path: str,
+            namespace: str,
+            *,
+            cursor_state: Any = None,
+            limit: int = 200,
+        ) -> dict[str, Any]:
+            captured_options["cursor_state"] = cursor_state
+            return {
+                "namespace": namespace,
+                "results": [],
+                "next_cursor": None,
+                "total": 0,
+                "done": True,
+                "page_info": {"offset": 0, "limit": limit, "returned_count": 0},
+                "discovery_method": "full_iteration",
+                "sampling_based": False,
+                "results_may_be_incomplete": False,
+            }
+
+        mock.walk_namespace_data.side_effect = capturing_walk_data
+        handler = SimpleToolsHandler(mock)
+
+        # A cursor for namespace "M" with a known ai.
+        cursor_token = self._encode_walk_cursor(
+            offset=5, limit=10, namespace="M", ai="deadbeefcafe"
+        )
+        handler.handle_zim_query(
+            "walk namespace M",
+            zim_file_path="/x.zim",
+            options={"compact": True, "cursor": cursor_token},
+        )
+
+        cursor_state = captured_options["cursor_state"]
+        # Sanity-check the cursor payload round-tripped fully.
+        assert cursor_state is not None
+        assert cursor_state["ai"] == "deadbeefcafe"
+        assert cursor_state["ns"] == "M"
+        assert cursor_state["scan_at"] == 5
+
+    def test_no_cursor_means_no_cursor_state(self) -> None:
+        """Regression guard: when no cursor is passed and offset=0,
+        cursor_state should stay None (preserves the unconditional
+        "first page" path).
+        """
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        captured: dict[str, Any] = {}
+
+        def fake(
+            zim_file_path: str,
+            namespace: str,
+            *,
+            cursor_state: Any = None,
+            limit: int = 200,
+        ) -> dict[str, Any]:
+            captured["cursor_state"] = cursor_state
+            return {
+                "namespace": namespace,
+                "results": [],
+                "next_cursor": None,
+                "total": 0,
+                "done": True,
+                "page_info": {"offset": 0, "limit": limit, "returned_count": 0},
+                "discovery_method": "full_iteration",
+                "sampling_based": False,
+                "results_may_be_incomplete": False,
+            }
+
+        mock.walk_namespace_data.side_effect = fake
+        handler = SimpleToolsHandler(mock)
+        handler.handle_zim_query(
+            "walk namespace M",
+            zim_file_path="/x.zim",
+            options={"compact": True},
+        )
+        assert captured["cursor_state"] is None

--- a/tests/test_post_a17_beta_fixes.py
+++ b/tests/test_post_a17_beta_fixes.py
@@ -145,6 +145,39 @@ class TestP1D1TitleSpansConnectorSuppression:
         )
         assert "query contained" not in out
 
+    def test_pass2_slash_connector_in_title_suppresses(self) -> None:
+        # Pass-2 self-audit: same shape with a different connector
+        # — ``TCP/IP stack tutorial`` resolved to ``TCP/IP`` (title
+        # spans the slash). Pre-fix: would fire because "stack
+        # tutorial" isn't in the title. Post-fix: title contains
+        # ``/`` → suppress.
+        handler = self._make_handler(top_title="TCP/IP")
+        out = handler.handle_zim_query(
+            "tell me about TCP/IP stack tutorial",
+            zim_file_path="/x.zim",
+            options={"compact": False},
+        )
+        assert "query contained" not in out
+
+    def test_pass2_topic_with_no_connector_in_title_still_fires(
+        self,
+    ) -> None:
+        # Pass-2: defensive — when the title lacks the topic's
+        # connector entirely, the new suppression must NOT swallow
+        # the legitimate footer. ``Beethoven and Mozart`` resolved
+        # to ``Beethoven`` (no ``and`` in title) → substring tests
+        # fire normally → footer surfaces the dropped ``Mozart``
+        # half.
+        handler = self._make_handler(top_title="Beethoven")
+        out = handler.handle_zim_query(
+            "tell me about Beethoven and Mozart",
+            zim_file_path="/x.zim",
+            options={"compact": False},
+        )
+        # Title "Beethoven" doesn't span the connector → fires as before.
+        assert "query contained" in out
+        assert "Mozart" in out
+
 
 # ---------------------------------------------------------------------------
 # P1-D2: Unicode-aware tail / window tokenisation
@@ -211,6 +244,32 @@ class TestP1D2UnicodeTailTokenisation:
         # Regression guard: numeric tokens still form their own tokens.
         tails = list(iter_query_tails("Apollo 11"))
         assert tails == ["apollo 11", "11"]
+
+    def test_pass2_empty_topic_returns_no_tails(self) -> None:
+        # Pass-2 defensive: empty / whitespace topic must not yield
+        # tails to probe.
+        assert list(iter_query_tails("")) == []
+        assert list(iter_query_tails("   ")) == []
+
+    def test_pass2_mixed_latin_unicode_topic(self) -> None:
+        # Pass-2: mixed ASCII + non-Latin topic. ``New München``
+        # tokenises to two tokens (``new``, ``münchen``) so tail-
+        # probing tries "new münchen" then "münchen" — both Unicode-
+        # preserving.
+        tails = list(iter_query_tails("New München"))
+        assert tails == ["new münchen", "münchen"]
+
+    def test_pass2_single_unicode_char_topic(self) -> None:
+        # Pass-2: a topic that is JUST a single non-Latin character
+        # ("ñ") tokenises to one token preserving the character.
+        tails = list(iter_query_tails("ñ"))
+        assert tails == ["ñ"]
+
+    def test_pass2_punctuation_preserved_as_boundary_not_token(self) -> None:
+        # Pass-2: punctuation other than underscore still acts as a
+        # boundary (hyphens, apostrophes, commas, periods).
+        assert list(iter_query_tails("O'Brien")) == ["o brien", "brien"]
+        assert list(iter_query_tails("Coca-Cola")) == ["coca cola", "cola"]
 
 
 # ---------------------------------------------------------------------------
@@ -364,6 +423,69 @@ class TestP1D3WalkNamespaceCursorRoundTrip:
         assert cursor_state["ai"] == "deadbeefcafe"
         assert cursor_state["ns"] == "M"
         assert cursor_state["scan_at"] == 5
+
+    def test_pass2_cross_archive_cursor_still_rejected(self) -> None:
+        """Pass-2 self-audit: preserving ``ai`` must NOT weaken
+        cross-archive enforcement. When a cursor's ``ai`` is preserved
+        but doesn't match the current archive, the data-layer
+        ``verify_archive_identity`` should now raise the proper
+        "different archive" error (whereas pre-fix it raised
+        "missing archive-identity field"). The shape of the error
+        message is what changes; rejection still happens.
+
+        We exercise the dispatcher path here — when the rebuilt
+        cursor_state carries an ``ai`` field, the data layer's check
+        sees it. Production behaviour (raising
+        CursorMismatchError) is covered by the existing
+        walk_namespace_data tests in tests/test_pagination.py and
+        below by inspection of the rebuilt state.
+        """
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        captured: dict[str, Any] = {}
+
+        def fake_walk(
+            zim_file_path: str,
+            namespace: str,
+            *,
+            cursor_state: Any = None,
+            limit: int = 200,
+        ) -> dict[str, Any]:
+            captured["cursor_state"] = cursor_state
+            return {
+                "namespace": namespace,
+                "results": [],
+                "next_cursor": None,
+                "total": 0,
+                "done": True,
+                "page_info": {"offset": 0, "limit": limit, "returned_count": 0},
+                "discovery_method": "full_iteration",
+                "sampling_based": False,
+                "results_may_be_incomplete": False,
+            }
+
+        mock.walk_namespace_data.side_effect = fake_walk
+        handler = SimpleToolsHandler(mock)
+        cursor_token = self._encode_walk_cursor(
+            offset=3, limit=3, namespace="M", ai="WRONG_ARCHIVE"
+        )
+        handler.handle_zim_query(
+            "walk namespace M",
+            zim_file_path="/x.zim",
+            options={"compact": True, "cursor": cursor_token},
+        )
+        # The wrong-archive ``ai`` is still propagated through; the
+        # data layer (not under test here — only the dispatcher
+        # contract is) raises CursorMismatchError on the mismatch.
+        cursor_state = captured["cursor_state"]
+        assert cursor_state is not None
+        assert cursor_state["ai"] == "WRONG_ARCHIVE", (
+            "Dispatcher must preserve the cursor's ai verbatim — the "
+            "data layer is the only place that knows the expected ai "
+            "for the resolved archive path, so the check must run "
+            "there with the real value."
+        )
 
     def test_no_cursor_means_no_cursor_state(self) -> None:
         """Regression guard: when no cursor is passed and offset=0,

--- a/tests/test_post_a17_beta_fixes.py
+++ b/tests/test_post_a17_beta_fixes.py
@@ -52,7 +52,6 @@ from openzim_mcp.pagination import Cursor
 from openzim_mcp.simple_tools import SimpleToolsHandler
 from openzim_mcp.title_promotion import iter_query_tails, iter_query_windows
 
-
 # ---------------------------------------------------------------------------
 # P1-D1: title-spans-connector suppresses soft-connector footer
 # ---------------------------------------------------------------------------

--- a/tests/test_post_a17_beta_fixes.py
+++ b/tests/test_post_a17_beta_fixes.py
@@ -45,13 +45,10 @@ Each test pins one defect; failures here mean a regression on the
 specific bug.
 """
 
-import base64
-import json
-import re
 from typing import Any
 from unittest.mock import MagicMock
 
-from openzim_mcp.pagination import Cursor, archive_identity
+from openzim_mcp.pagination import Cursor
 from openzim_mcp.simple_tools import SimpleToolsHandler
 from openzim_mcp.title_promotion import iter_query_tails, iter_query_windows
 


### PR DESCRIPTION
## Summary

Live-MCP beta sweep against `wikipedia_en_all_maxi_2026-02.zim` (~118 GB, ~27.2M entries) on the freshly-shipped `v2.0.0a17` build. Pass 1 found three user-facing defects; pass 2 source-level self-audit found zero new defects.

## Defects (pass 1)

### P1-D1 — soft-connector footer false-fires on titles that structurally span the connector

**Query:** `notable people from Big Rapids, Michigan` (and `musicians from Romeo and Juliet`)

**Pre-fix:**

```
… [Notable people section body] …
_Note: your query contained `,` between two proper-noun phrases.
Returned the article for `Michigan`. For `notable people from Big Rapids`,
query separately with `tell me about notable people from Big Rapids`._
```

Actually returned `Big_Rapids,_Michigan` — a single entity whose title literally contains the comma. The footer is misleading.

**Root cause:** `_soft_connector_footer` (`openzim_mcp/simple_tools.py:1059`). The docstring already names `Vienna, Austria` as a case the footer should NOT fire for, but the existing `left_in == right_in` suppression only catches it when BOTH halves are full substrings of the title. With a subject-attribute prefix on the topic (`notable people from`, `musicians from`), the left half is longer than the title and `left_in` is False; the existing suppression misses the case even though the title cleanly spans the connector.

**Fix:** add an earlier "title-spans-connector" suppression. When `top_title` matches the same connector regex as the topic, the connector is structural to the title — return None immediately.

### P1-D2 — non-Latin topic strings resolve to wrong articles at cert=0.85

**Queries → wrong results:**

| Query | Returned | Should be |
| --- | --- | --- |
| `tell me about München` | `M` (letter) | Munich |
| `tell me about Zürich` | `Rich` (disambig) | Zurich |
| `tell me about Köln` | `LN` (abbreviation) | Cologne |

**Root cause:** `_TAIL_TOKEN_RE = [a-z0-9]+` in `openzim_mcp/title_promotion.py:178` splits the topic on non-ASCII characters. `iter_query_tails("München")` yields `["m", "nchen"]`; `iter_query_windows` (non-trailing windows) then yields `"m"`. `find_title_match("m")` cleanly resolves to the `M` letter article at score 1.0 — `_promote_topic_via_title_index` returns it as the canonical resolution, the handler fetches the article body, and the user sees `# M` `_Source: M_` at cert=0.85.

The backend itself handles Unicode natively — `find article titled München` resolves to Munich at score 1.00. The tokenization layer is what destroys the topic before the backend sees it.

**Fix:** change `_TAIL_TOKEN_RE` to `[^\W_]+` — Unicode-aware (`\w` minus underscore, so underscore still acts as a token boundary for path-form input like `Big_Rapids,_Michigan`). `iter_query_tails("München")` now yields `["münchen"]`, `find_entry_by_title_data("münchen")` returns Munich, and the promotion succeeds correctly.

### P1-D3 — walk_namespace cursor round-trip false-fails with "missing archive-identity field"

**Query:** `walk namespace M` → grab the emitted `next_cursor` → pass it back as `cursor=...`

**Pre-fix:** `**Error**: Cursor for 'walk_namespace' missing archive-identity field. Re-issue the request without a cursor.` — even though the cursor (decoded) carries `{"v":2,"t":"walk_namespace","s":{"o":3,"l":3,"ns":"M","ai":"e048666a9e92"}}`.

**Root cause:** the simple-tools cursor dispatcher (`openzim_mcp/simple_tools.py` ~line 295) decodes the cursor and stashes only `state["o"]` (as `options["offset"]`) and `state["ns"]` (as `options["_cursor_ns"]`). `_handle_walk_namespace` then rebuilds cursor_state from `offset` and `limit` only: `{"scan_at": offset, "l": limit}` — no `ai`. The data-layer `walk_namespace_data` unconditionally calls `Cursor.verify_archive_identity(cursor_state, ...)`, which raises `"missing archive-identity field"` because `state.get("ai")` is None.

Browse_namespace doesn't surface the same failure because its handler passes `offset` directly (no cursor_state envelope), and the browse data layer only verifies archive identity when an explicit `cursor_archive_identity` kwarg is passed.

**Fix:** stash `state["ai"]` (and re-stash `state["ns"]`) into options at decode time; `_handle_walk_namespace` includes them in the rebuilt cursor_state when present. The data-layer guard now has the real `ai` to compare against and properly distinguishes "missing" from "cross-archive mismatch".

## Pass-2 source-level audit (zero new defects)

- **P1-D1 sibling grep:** only one site uses the `left.lower() in title_lower` / `right.lower() in title_lower` shape (the soft-connector footer). No sibling defects.
- **P1-D2 sibling grep:** `_AFFINITY_TOKEN_RE` in `synthesize.py` and `_tokenize_for_relevance` in `zim/search.py` use the same `[a-z0-9]+` pattern, but they are **symmetric** tokenizers — same regex applied to both sides of the comparison, so the ASCII-token mismatch cancels out. The P1-D2 defect shape is a **unidirectional probe** that destroys the topic before the backend sees it, which is structurally different. No sibling defects.
- **P1-D3 sibling grep:** `verify_archive_identity` is also called from `browse_namespace_data`, `extract_article_links_data`, search cursor paths, and structure cursors. All of those gate on an explicit `cursor_archive_identity` kwarg that the simple-tools handlers don't pass; only walk_namespace builds a `cursor_state` envelope whose `ai` the data layer unconditionally checks. No sibling defects.

## Tests

21 regression tests in `tests/test_post_a17_beta_fixes.py`:

- **P1-D1** (6): comma title with subject-attribute prefix suppresses; "and" title with subject-attribute prefix suppresses; genuine two-entity query still fires; pre-fix both-halves-in-title still suppresses; slash-connector title-spans suppression (pass-2); no-connector-in-title still fires (pass-2).
- **P1-D2** (11): München / Zürich / Köln tokenize as single Unicode tokens; multi-word Unicode topic preserved; ASCII path unchanged (regression guard for original `big rapids michigan` example); underscore boundary preserved; digits preserved; empty topic (pass-2); mixed Latin + non-Latin (pass-2); single non-Latin char (pass-2); punctuation as boundary (pass-2).
- **P1-D3** (4): end-to-end cursor round-trip carries `ai`; dispatcher stashes `_cursor_ai` into options; no-cursor case preserved (cursor_state stays None); cross-archive `ai` mismatch propagated correctly (pass-2 — preserving `ai` must not weaken the cross-archive enforcement guard).

Full test suite: **1814 passed, 50 skipped**.

## Commits

- `d42213b` — pass-1 fixes (3 defects, 14 regression tests)
- `8f8a44e` — pass-2 self-audit (7 additional edge-case tests, zero new defects)

## Live-MCP probe set used

Wave-4 priority (least-tested code from a17):

- `famous musician from big rapids michigan` ✓ (originating bug, still works)
- `who is a famous musician from big rapids michigan` ✓
- `tell me about famous athletes from Detroit` ✓
- `describe famous writers from Boston` ✓ (no Writers section → falls through correctly)
- `notable people from Big Rapids, Michigan` ❌ **P1-D1** (misleading footer)
- `musicians from Berlin and Paris` ✓ (genuine multi-entity, footer correct)
- `musicians from Romeo and Juliet` ❌ **P1-D1** (misleading footer)
- `tell me about Big Rapids, Michigan` ✓ (bare entity, no subject decomposition)
- `tell me about München` / `Zürich` / `Köln` ❌ **P1-D2** (all three wrong at cert=0.85)
- `tell me about Vienna, Austria` ✓ (footer correct since title doesn't contain comma here)
- `tell me about TCP/IP` ✓ (disambiguation render, no false footer)

Recurring set (regression check):

- `tell me about Mercury` / `Java` / `Apollo 11` / `Tikal` ✓
- `tell me about Photosythesis` (typo) ✓ → Photosynthesis
- `tell me about Bilogy` (typo) ✓ → Biology
- `tell me about Berlin then Paris` (chained-intent) ✓ → rejected
- `could you tell me about France` (politeness modal) ✓
- `walk namespace M` ✓ / `walk namespace W` ✓ / `metadata for <file>` ✓ / `browse namespace M` ✓ (aggregator agreement: M=12 across all)
- `walk namespace M` cursor round-trip ❌ **P1-D3**
- `browse namespace M` with walk's cursor → silently accepts (deferred P1-D4 — separate cross-tool cursor reuse issue)
- `search Cat in namespace C` ✓ / `summary of Photosynthesis` ✓ / `links in Photosynthesis` ✓ / `articles related to Photosynthesis` ✓
- `tell me about M/Counter` ✓ (namespace-path redirect)
- `tell me about` (empty) ✓ / `walk namespace AB` ✓ / `walk namespace` ✓
- `limit=0`, `offset=-5`, garbage cursor — all properly error ✓

## Deferred (lower priority)

- **P1-D4**: `browse_namespace` silently accepts cursors emitted by `walk_namespace` (cross-tool reuse). Same shape as the cross-tool defects fixed in prior sweeps but for the simple-tools dispatch layer rather than the advanced tools. Worth a follow-up but isn't user-facing critical: the simple-tools dispatcher reads `state["o"]` as offset and walks browse from there, which for the metadata namespace happens to produce a continuation page coincidentally. A defence-in-depth fix would store `state["t"]` in options too and enforce `_cursor_t_mismatch` alongside the existing `_cursor_ns_mismatch`. Filing as a follow-up rather than bundling here to keep this sweep tight.

## Methodology note

This sweep ran two passes: pass 1 (live-MCP probing against the deployed a17 build) and pass 2 (source-level self-audit + sibling grep for the three landed fix shapes + edge-case unit tests). Pass 2 was source-level rather than live because the MCP server in the sweep environment couldn't be restarted to load the new build. The recent post-a16 sweep refinement (live-MCP probing catches a defect class unit tests structurally cannot) should still apply for a future pass-3 live re-probe after the new build deploys.
