### PR TITLE
fix(v2): post-a18 beta-test sweep — 3 defects across two passes

### DIFF
--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -318,6 +318,21 @@ class SimpleToolsHandler:
                 cursor_ai = state.get("ai")
                 if isinstance(cursor_ai, str) and cursor_ai:
                     options["_cursor_ai"] = cursor_ai
+                # Post-a18 P1-D4: stash the cursor's tool name so the
+                # simple-tools dispatcher can reject cross-tool reuse
+                # (e.g. a ``walk_namespace`` cursor passed to
+                # ``browse namespace M`` silently walked browse from
+                # walk's offset). The advanced tools already enforce
+                # tool-binding via ``Cursor.decode(expected_tool=...)``;
+                # the simple-tools layer decoded the cursor in-place
+                # earlier in this block, bypassing that check. The
+                # ``_cursor_tool_mismatch`` helper fires in each
+                # cursor-consuming handler (``_handle_browse`` /
+                # ``_handle_walk_namespace``) so the user sees a clear
+                # rejection instead of a silent wrong-result.
+                cursor_t = decoded_payload.get("t")
+                if isinstance(cursor_t, str) and cursor_t:
+                    options["_cursor_t"] = cursor_t
                 if isinstance(state, dict):  # always True now; kept for diff clarity
                     # D9 (beta): the original implementation treated the
                     # cursor's ``s.q`` field as decorative — only ``s.o``
@@ -1069,7 +1084,14 @@ class SimpleToolsHandler:
         r"\s*/\s*",
     )
 
-    def _soft_connector_footer(self, topic: str, top_title: str) -> Optional[str]:
+    def _soft_connector_footer(
+        self,
+        topic: str,
+        top_title: str,
+        *,
+        zim_file_path: Optional[str] = None,
+        top_path: Optional[str] = None,
+    ) -> Optional[str]:
         """A16 post-a16 D1 (pass-2): when ``topic`` contains an ambiguous
         connector between two substantive proper-noun-shaped halves
         AND the returned ``top_title`` only includes one of them,
@@ -1087,6 +1109,18 @@ class SimpleToolsHandler:
         the dropped half without raising a hard chain warning that
         would force the caller to re-run for the obvious-single
         topic cases.
+
+        Post-a18 P3-D2: ``zim_file_path`` / ``top_path`` (optional)
+        unlock title-alias resolution as a fallback for the
+        "neither half is a substring" branch. The substring check is
+        unreliable when the resolved title is an English-aliased form
+        of a non-Latin topic half (``München`` resolves to
+        ``Munich`` via the title-alias index; substring matching
+        can't see through that). When both halves miss the substring
+        check, probe the title index for each half; if a half
+        resolves to ``top_path``, treat it as "in title"
+        semantically. Without these kwargs the function falls back
+        to the legacy substring-only behaviour.
         """
         if not topic or not top_title:
             return None
@@ -1126,6 +1160,17 @@ class SimpleToolsHandler:
             title_lower = top_title.lower()
             left_in = left.lower() in title_lower
             right_in = right.lower() in title_lower
+            if not left_in and not right_in and zim_file_path and top_path:
+                # Post-a18 P3-D2: substring check fails when the
+                # resolved title is an English-aliased form of a
+                # non-Latin half (München → Munich). Fall back to
+                # title-alias resolution: probe the title index for
+                # each half and treat any half whose top-scored hit
+                # equals ``top_path`` as "in title". Cheap (in-memory
+                # title-index hit) and only fires on the rare
+                # both-missed branch.
+                left_in = self._half_resolves_to_top(zim_file_path, left, top_path)
+                right_in = self._half_resolves_to_top(zim_file_path, right, top_path)
             if left_in == right_in:
                 # Both in title → returned article is the full
                 # phrase (``Romeo and Juliet``); neither in title →
@@ -1142,6 +1187,37 @@ class SimpleToolsHandler:
                 f"with `tell me about {dropped}`._"
             )
         return None
+
+    def _half_resolves_to_top(
+        self, zim_file_path: str, half: str, top_path: str
+    ) -> bool:
+        """Post-a18 P3-D2 helper: probe the title index for ``half`` and
+        return True iff its top-scored title-index hit's path equals
+        ``top_path``. The fallback substring check in
+        ``_soft_connector_footer`` uses this to recognise non-Latin
+        topic halves that resolve to English-aliased titles
+        (``München`` -> ``Munich``).
+
+        Errors in the backend are swallowed (return False) so a
+        transient failure can't widen the footer's behaviour
+        accidentally — the substring check stays authoritative when
+        title-alias probing can't help.
+        """
+        try:
+            data = self.zim_operations.find_entry_by_title_data(
+                zim_file_path, half, cross_file=False, limit=1
+            )
+        except Exception:
+            return False
+        if not isinstance(data, dict):
+            return False
+        results = data.get("results") or []
+        if not results:
+            return False
+        first = results[0]
+        if not isinstance(first, dict):
+            return False
+        return str(first.get("path") or "") == top_path
 
     @classmethod
     def _is_substantive_topic(cls, text: str) -> bool:
@@ -1477,6 +1553,38 @@ class SimpleToolsHandler:
     )
 
     @staticmethod
+    def _cursor_tool_mismatch(
+        options: Dict[str, Any], request_tool: str
+    ) -> Optional[str]:
+        """Post-a18 P1-D4: return a structured error when the decoded
+        cursor's ``s.t`` (issuing tool) differs from the handler's
+        own tool name. The simple-tools dispatcher decodes cursors
+        in-place earlier, bypassing the advanced tools'
+        ``Cursor.decode(expected_tool=...)`` enforcement; this helper
+        restores cross-tool rejection at the handler edge.
+
+        Returns ``None`` when no cursor was passed, when the cursor
+        had no ``t`` field, or when both match. The error shape
+        mirrors the existing ``s.ns`` / ``s.q`` / ``s.ai`` mismatch
+        errors so callers programmatically branching on
+        ``cursor_decode`` keep working unchanged.
+        """
+        cursor_t = options.get("_cursor_t")
+        if not isinstance(cursor_t, str) or not cursor_t:
+            return None
+        if cursor_t == request_tool:
+            return None
+        return (
+            "**Cursor / Tool Mismatch**\n\n"
+            "**Issue**: the cursor was issued by "
+            f"`{cursor_t}` but this call routes to "
+            f"`{request_tool}`. Drop the cursor and call again "
+            "without it (or restart the paginated call with the "
+            "tool that issued the cursor).\n\n"
+            "<!-- intent=cursor_decode cert=1.00 -->"
+        )
+
+    @staticmethod
     def _cursor_ns_mismatch(
         options: Dict[str, Any], request_namespace: str
     ) -> Optional[str]:
@@ -1726,6 +1834,23 @@ class SimpleToolsHandler:
     # articles produce density 1-4 placeholder-only leads.
     _EMPTY_LEAD_DENSITY_THRESHOLD = 5
 
+    # Post-a18 P3-D1: compact-mode table placeholder emitted by
+    # ``ContentProcessor.replace_oversized_tables`` (see
+    # ``openzim_mcp/content_processor.py`` ~line 819) when a table
+    # exceeds the row/char threshold. The bundle that
+    # ``get_section_data`` reads is always built with ``compact=True``
+    # (see ``openzim_mcp/bundle.py`` ~line 307), so a section that
+    # only contains oversized tables returns to the subject-attribute
+    # path as a string dominated by these placeholders.
+    # ``_maybe_render_subject_section`` detects placeholder dominance
+    # and substitutes a ``compact=False`` recovery pointer to avoid
+    # surfacing zero-content responses to small LLMs (the same
+    # hallucination shape wave 4 was designed to prevent).
+    _TABLE_PLACEHOLDER_RE = re.compile(
+        r"\[Table\s+\d+:\s+\d+\s+rows\s+x\s+\d+\s+cols\s+-\s+"
+        r"pass compact=False to expand\]"
+    )
+
     @classmethod
     def _is_disambig_lead(cls, pre_h2: str) -> bool:
         """Return True when ``pre_h2`` looks like a disambig-page lead.
@@ -1952,6 +2077,16 @@ class SimpleToolsHandler:
                 "- `browse namespace M` — archive metadata\n"
                 "- `browse namespace W` — well-known entries"
             )
+        # Post-a18 P1-D4: cursor's tool must match this handler.
+        # Walk-namespace's cursor previously walked browse silently
+        # because the simple-tools dispatcher only read ``s.o`` and
+        # ``s.ns`` from the decoded cursor — neither encoded the
+        # issuing tool. The advanced tools already enforce this via
+        # ``Cursor.decode(expected_tool=...)``; this restores the
+        # check at the simple-tools handler edge.
+        tool_mismatch = self._cursor_tool_mismatch(options, "browse_namespace")
+        if tool_mismatch is not None:
+            return tool_mismatch
         # P3-D7: cursor's namespace must match the request's namespace.
         mismatch = self._cursor_ns_mismatch(options, namespace)
         if mismatch is not None:
@@ -3147,7 +3282,12 @@ class SimpleToolsHandler:
         # picked vs. dropped. Suppressed when the returned title
         # already contains both halves (``Romeo and Juliet`` is one
         # article whose title spans the connector — no footer needed).
-        soft_footer = self._soft_connector_footer(topic, top_title)
+        soft_footer = self._soft_connector_footer(
+            topic,
+            top_title,
+            zim_file_path=zim_file_path,
+            top_path=top_path,
+        )
         if soft_footer:
             result = result + soft_footer
         return result
@@ -3333,6 +3473,37 @@ class SimpleToolsHandler:
         body_text = body_text.strip()
         if not body_text:
             return None
+        # Post-a18 P3-D1: detect table-dominated sections (compact mode
+        # strips oversized tables to ``[Table N: M rows x P cols - pass
+        # compact=False to expand]`` placeholders, leaving the LLM with
+        # zero substantive content). Munich's ``Notable people`` section
+        # is two H3 sub-tables — pre-fix, ``musicians from München``
+        # returned just the two placeholders, exactly the content-less-
+        # response shape that triggers small-model hallucination. The
+        # bundle is always built with ``compact=True`` (see bundle.py),
+        # so ``get_section_data`` can't re-emit the expanded tables;
+        # instead, surface a direct pointer to the ``compact=False``
+        # recovery call so the caller knows what to do.
+        section_text = target.get("text") or section_id
+        placeholder_count = len(self._TABLE_PLACEHOLDER_RE.findall(body_text))
+        stripped_for_density = self._TABLE_PLACEHOLDER_RE.sub("", body_text)
+        substantive_chars = len("".join(stripped_for_density.split()))
+        if placeholder_count >= 1 and substantive_chars < 100:
+            self._track("subject_attribute_table_dominated")
+            tables_word = "table" if placeholder_count == 1 else "tables"
+            return (
+                f"# {top_title or topic}\n\n"
+                f"_Source: `{top_path}` (section: {section_text})_\n\n"
+                f"_The **{section_text}** section of `{top_path}` "
+                f"is rendered as {placeholder_count} {tables_word} "
+                f"that compact mode strips. "
+                f"Re-issue `tell me about {top_path}` with "
+                f"`compact=False` to see the full article including "
+                f"table bodies, or `get section {section_id} of "
+                f"{top_path}` with `compact=False` for just this "
+                f"section._\n"
+                f"<!-- intent=subject_attribute_section cert=1.00 -->"
+            )
         max_len = options.get("max_content_length")
         truncated = False
         full_len = len(body_text)
@@ -3340,7 +3511,6 @@ class SimpleToolsHandler:
             body_text = body_text[:max_len]
             truncated = True
         self._track("subject_attribute_section_returned")
-        section_text = target.get("text") or section_id
         result = (
             f"# {top_title or topic}\n\n"
             f"_Source: `{top_path}` (section: {section_text})_\n\n"
@@ -3362,7 +3532,12 @@ class SimpleToolsHandler:
         # attribute early-return at the call site (_handle_tell_me_about
         # before _soft_connector_footer fires) would silently swallow
         # the drop.
-        soft_footer = self._soft_connector_footer(topic, top_title or top_path)
+        soft_footer = self._soft_connector_footer(
+            topic,
+            top_title or top_path,
+            zim_file_path=zim_file_path,
+            top_path=top_path,
+        )
         if soft_footer:
             result = result + soft_footer
         # Double-marker is intentional: the outer handle_zim_query will
@@ -3661,6 +3836,13 @@ class SimpleToolsHandler:
                 "- `walk namespace M` — archive metadata\n"
                 "- `walk namespace W` — well-known entries"
             )
+        # Post-a18 P1-D4 (defence-in-depth): walk's own handler
+        # rejects cursors issued by other tools (browse / search /
+        # links) for the same reason ``_handle_browse`` does — see
+        # the comment there.
+        tool_mismatch = self._cursor_tool_mismatch(options, "walk_namespace")
+        if tool_mismatch is not None:
+            return tool_mismatch
         # P3-D7: cursor's namespace must match the request's namespace.
         # See _decode_cursor for the stash; the legacy ``ai`` / ``q``
         # mismatch checks already follow this shape.

--- a/tests/test_post_a18_beta_fixes.py
+++ b/tests/test_post_a18_beta_fixes.py
@@ -1,0 +1,467 @@
+"""Regression tests for the post-a18 beta-test sweep (a19 fixes).
+
+The post-a18 live-MCP sweep against the 118 GB Wikipedia ZIM after
+the post-a17 fixes deployed surfaced three new defects (two
+EXPOSED by a18's Unicode tail-tokenisation fix that couldn't have
+been reproduced before; one DEFERRED from the post-a17 sweep):
+
+- P3-D1: ``musicians from München`` resolved correctly via the
+  new Unicode tail probe to Munich, then subject-attribute
+  decomposition fired on the Notable people section. But the
+  section content is two H3 sub-tables (``Born in Munich`` /
+  ``Notable residents``) which compact mode renders as
+  ``[Table N: M rows x P cols - pass compact=False to expand]``
+  placeholders. The LLM gets zero substantive content from a
+  query that should list musicians — the exact hallucination
+  shape wave 4's empty-lead fallback was designed to prevent.
+  Fix: detect placeholder dominance in
+  ``_maybe_render_subject_section`` and substitute a
+  ``compact=False`` recovery pointer instead of returning
+  table placeholders as data.
+
+- P3-D2: ``tell me about Berlin and München`` resolved correctly
+  to Munich (right-promote), but the soft-connector footer was
+  silently suppressed. The substring check ``"berlin" in
+  "munich"`` is False, ``"münchen" in "munich"`` is also False
+  (German ``München`` is the alias of English ``Munich``;
+  substring matching can't see through that), so
+  ``left_in == right_in == False`` hit the "neither in title —
+  unclear which was picked" suppression. User doesn't learn
+  Berlin was dropped. Fix: when both halves fail substring, fall
+  back to title-alias probing — if a half's title-index hit
+  resolves to ``top_path``, treat it as "in title".
+
+- P1-D4 (deferred from post-a17 sweep): ``browse namespace M``
+  silently accepts cursors emitted by ``walk_namespace`` — the
+  simple-tools dispatcher decoded ``s.o`` and ``s.ns`` from any
+  decoded cursor, ignoring ``s.t`` (issuing tool). The advanced
+  tools already enforce tool-binding via
+  ``Cursor.decode(expected_tool=...)``; this restores the check
+  at the simple-tools handler edge by stashing ``_cursor_t`` and
+  adding ``_cursor_tool_mismatch``, which both browse and walk
+  handlers fire.
+
+Each test pins one defect; failures here mean a regression on
+the specific bug.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from openzim_mcp.pagination import Cursor
+from openzim_mcp.simple_tools import SimpleToolsHandler
+
+# ---------------------------------------------------------------------------
+# P3-D1: subject-attribute section dominated by table placeholders falls
+# back to a ``compact=False`` recovery pointer
+# ---------------------------------------------------------------------------
+
+
+class TestP3D1TableDominatedSubjectAttribute:
+    """P3-D1: when subject-attribute decomposition would otherwise
+    return a section body whose only substantive content is table
+    placeholders, surface a ``compact=False`` recovery pointer
+    instead. The placeholder strings carry no information for the
+    LLM and otherwise trigger the same hallucination shape wave 4
+    was built to prevent.
+    """
+
+    def _make_handler_for_subject_section(
+        self,
+        *,
+        topic: str,
+        top_title: str,
+        section_text: str,
+        section_id: str,
+        section_body: str,
+    ) -> SimpleToolsHandler:
+        """Wire a SimpleToolsHandler to a mock that reaches the
+        subject-attribute path and returns ``section_body`` as the
+        section's ``content_markdown``.
+        """
+        path = top_title.replace(" ", "_")
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        mock.search_zim_file_data.return_value = {
+            "results": [{"path": path, "title": top_title}],
+            "total": 1,
+        }
+        mock.get_zim_entry.return_value = "stub-body"
+        mock.find_entry_by_title_data.return_value = {
+            "results": [{"path": path, "title": top_title, "score": 1.0}],
+            "total": 1,
+        }
+        # Article structure for the section-resolution probe — the
+        # target H2 must be in the article and its id used downstream.
+        mock.get_article_structure_data.return_value = {
+            "headings": [
+                {"level": 2, "text": section_text, "id": section_id},
+            ],
+        }
+        # The section_data call returns the markdown that
+        # _maybe_render_subject_section then inspects for table-
+        # placeholder dominance.
+        mock.get_section_data.return_value = {
+            "content_markdown": section_body,
+        }
+        return SimpleToolsHandler(mock)
+
+    def test_table_dominated_section_falls_back_to_compact_false_pointer(
+        self,
+    ) -> None:
+        # Mimic Munich's Notable people section as it actually came
+        # back live: two H3 sub-tables that compact mode stripped to
+        # placeholders, with only the H3 headings as substantive
+        # text. Without the fix the LLM would get zero useful
+        # content. With the fix it gets a direct compact=False
+        # recovery pointer.
+        section_body = (
+            "### Born in Munich\n\n"
+            "[Table 8: 1 rows x 2 cols - pass compact=False to expand]\n\n"
+            "### Notable residents\n\n"
+            "[Table 9: 1 rows x 2 cols - pass compact=False to expand]\n"
+        )
+        handler = self._make_handler_for_subject_section(
+            topic="musicians from München",
+            top_title="Munich",
+            section_text="Notable people",
+            section_id="Notable_people",
+            section_body=section_body,
+        )
+        out = handler.handle_zim_query(
+            "tell me about musicians from München",
+            zim_file_path="/x.zim",
+            options={"compact": True},
+        )
+        # The fix surfaces a clear recovery message and DOES NOT
+        # embed the table placeholders in the response body. The
+        # subject_attribute_section telemetry marker should still
+        # fire so callers can distinguish this branch from the
+        # plain lead path.
+        assert "[Table" not in out, (
+            "table placeholders must be substituted by the "
+            "compact=False recovery pointer, not surfaced as data"
+        )
+        assert "compact=False" in out
+        assert "tell me about Munich" in out or "get section" in out
+        assert "intent=subject_attribute_section" in out
+
+    def test_section_with_real_prose_plus_one_table_still_returns_body(
+        self,
+    ) -> None:
+        # Regression guard: a section with ONE table placeholder but
+        # ALSO substantial prose (>= 100 chars of real content)
+        # should NOT trigger the recovery pointer. The fix is for
+        # sections where placeholders ARE the content.
+        prose = (
+            "Vienna's music tradition stretches from the Habsburg "
+            "court through Mozart and Beethoven to the Second "
+            "Viennese School. Today the city hosts the Vienna "
+            "Philharmonic and the Wiener Staatsoper, two of the "
+            "world's most prestigious music institutions, alongside "
+            "an annual New Year's concert broadcast globally."
+        )
+        section_body = (
+            f"{prose}\n\n" "[Table 3: 5 rows x 2 cols - pass compact=False to expand]\n"
+        )
+        handler = self._make_handler_for_subject_section(
+            topic="musicians from Vienna",
+            top_title="Vienna",
+            section_text="Music",
+            section_id="Music",
+            section_body=section_body,
+        )
+        out = handler.handle_zim_query(
+            "tell me about musicians from Vienna",
+            zim_file_path="/x.zim",
+            options={"compact": True},
+        )
+        # Body returned as-is (with placeholder pass-through). The
+        # caller sees the prose AND a hint that one table was
+        # stripped — that's the expected behaviour for a mixed
+        # section.
+        assert "Habsburg" in out
+        assert "intent=subject_attribute_section" in out
+
+    def test_section_with_zero_tables_unchanged(self) -> None:
+        # Regression guard: no placeholders at all → no fallback.
+        section_body = (
+            "Tokyo has produced major contemporary musicians "
+            "across genres including Ryuichi Sakamoto, Hikaru "
+            "Utada, and many J-pop / city-pop figures."
+        )
+        handler = self._make_handler_for_subject_section(
+            topic="musicians from Tokyo",
+            top_title="Tokyo",
+            section_text="Notable people",
+            section_id="Notable_people",
+            section_body=section_body,
+        )
+        out = handler.handle_zim_query(
+            "tell me about musicians from Tokyo",
+            zim_file_path="/x.zim",
+            options={"compact": True},
+        )
+        assert "Ryuichi Sakamoto" in out
+        assert "compact=False" not in out
+
+
+# ---------------------------------------------------------------------------
+# P3-D2: soft-connector recognises non-Latin halves via title-alias probe
+# ---------------------------------------------------------------------------
+
+
+class TestP3D2SoftConnectorAliasFallback:
+    """P3-D2: when both halves of a soft-connector topic fail the
+    substring-in-title check (typically because the resolved title
+    is an English-aliased form of a non-Latin half — München ->
+    Munich), fall back to title-alias probing. If a half's
+    title-index hit resolves to ``top_path``, treat that half as
+    "in title".
+    """
+
+    def _make_handler(
+        self,
+        *,
+        top_title: str,
+        alias_map: dict[str, str],
+    ) -> SimpleToolsHandler:
+        """Wire mocks so the search returns ``top_title`` for any
+        query and the title index resolves each key in
+        ``alias_map`` to the path value.
+        """
+        path = top_title.replace(" ", "_")
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        mock.search_zim_file_data.return_value = {
+            "results": [{"path": path, "title": top_title}],
+            "total": 1,
+        }
+        mock.get_zim_entry.return_value = "stub-body"
+
+        def find_by_title(
+            zim_file_path: str,
+            title: str,
+            *,
+            cross_file: bool = False,
+            limit: int = 3,
+        ) -> dict[str, Any]:
+            resolved_path = alias_map.get(title.lower())
+            if resolved_path is None:
+                return {"results": [], "total": 0}
+            return {
+                "results": [
+                    {
+                        "path": resolved_path,
+                        "title": resolved_path.replace("_", " "),
+                        "score": 1.0,
+                    }
+                ],
+                "total": 1,
+            }
+
+        mock.find_entry_by_title_data.side_effect = find_by_title
+        return SimpleToolsHandler(mock)
+
+    def test_non_latin_half_resolves_via_alias_and_footer_fires(self) -> None:
+        # ``Berlin and München`` resolved (via the Unicode tail probe
+        # landed in a18) to Munich. Substring check fails for both:
+        # ``berlin not in munich`` and ``münchen not in munich``.
+        # Pre-fix: ``left_in == right_in == False`` → suppress.
+        # User never learns Berlin was dropped. Post-fix: title
+        # index probe sees ``München -> Munich``, so right_in becomes
+        # True, footer fires correctly naming Berlin as the dropped
+        # half.
+        handler = self._make_handler(
+            top_title="Munich",
+            alias_map={"münchen": "Munich", "berlin": "Berlin"},
+        )
+        out = handler.handle_zim_query(
+            "tell me about Berlin and München",
+            zim_file_path="/x.zim",
+            options={"compact": False},
+        )
+        assert "query contained" in out, (
+            "soft-connector footer must fire when one half resolves "
+            "via title alias to the returned top_path"
+        )
+        assert "Berlin" in out
+        assert "tell me about Berlin" in out
+
+    def test_neither_half_resolves_via_alias_still_suppresses(self) -> None:
+        # Defensive: when neither half's title-alias resolves to
+        # ``top_path``, the fallback returns False for both and the
+        # legacy "neither in title — unclear which was picked"
+        # suppression still applies. No footer.
+        handler = self._make_handler(
+            top_title="Munich",
+            # Neither half resolves to "Munich" via the title index.
+            alias_map={
+                "berlin": "Berlin",
+                "lyon": "Lyon",
+            },
+        )
+        out = handler.handle_zim_query(
+            "tell me about Berlin and Lyon",
+            zim_file_path="/x.zim",
+            options={"compact": False},
+        )
+        assert "query contained" not in out
+
+    def test_legacy_substring_path_still_works_without_zim_kwargs(
+        self,
+    ) -> None:
+        # Defensive: when ``_soft_connector_footer`` is called via the
+        # legacy positional-only signature (no zim_file_path /
+        # top_path kwargs), the alias fallback can't run and the
+        # substring-only behaviour remains in effect. Existing call
+        # sites that didn't get migrated MUST not start crashing.
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        handler = SimpleToolsHandler(mock)
+        # Title contains both halves → suppressed by the original
+        # left_in == right_in == True branch.
+        result = handler._soft_connector_footer("Romeo and Juliet", "Romeo and Juliet")
+        assert result is None
+        # Right half matches via substring → footer fires.
+        result = handler._soft_connector_footer("Berlin and Paris", "Paris")
+        assert result is not None
+        assert "Berlin" in result
+
+
+# ---------------------------------------------------------------------------
+# P1-D4 (deferred from a17): cross-tool cursor reuse rejected at
+# simple-tools handler edge
+# ---------------------------------------------------------------------------
+
+
+class TestP1D4CrossToolCursorRejection:
+    """P1-D4 (deferred from post-a17 sweep): a cursor issued by
+    ``walk_namespace`` previously walked browse silently because the
+    simple-tools dispatcher decoded only ``s.o`` and ``s.ns`` from
+    the cursor; ``s.t`` (issuing tool) was ignored. The advanced
+    tools already enforce tool-binding via
+    ``Cursor.decode(expected_tool=...)``; this restores the check
+    at the simple-tools handler edge.
+    """
+
+    def _encode_walk_cursor(
+        self, *, offset: int, limit: int, namespace: str, ai: str
+    ) -> str:
+        state: dict[str, Any] = {
+            "o": offset,
+            "l": limit,
+            "ns": namespace,
+            "ai": ai,
+        }
+        return Cursor.encode(tool="walk_namespace", state=state)  # type: ignore[arg-type]
+
+    def _encode_browse_cursor(
+        self, *, offset: int, limit: int, namespace: str, ai: str
+    ) -> str:
+        state: dict[str, Any] = {
+            "o": offset,
+            "l": limit,
+            "ns": namespace,
+            "ai": ai,
+        }
+        return Cursor.encode(tool="browse_namespace", state=state)  # type: ignore[arg-type]
+
+    def test_walk_cursor_passed_to_browse_is_rejected(self) -> None:
+        # Pre-fix: silently walked browse from walk's offset (=3 for
+        # the canonical reproducer), returning entries 4-6 of the M
+        # namespace and emitting a fresh ``browse_namespace`` cursor
+        # as if nothing was wrong. Post-fix: the handler returns a
+        # structured Cursor / Tool Mismatch error before any
+        # backend call.
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        handler = SimpleToolsHandler(mock)
+        cursor_token = self._encode_walk_cursor(
+            offset=3, limit=3, namespace="M", ai="e048666a9e92"
+        )
+        out = handler.handle_zim_query(
+            "browse namespace M",
+            zim_file_path="/x.zim",
+            options={"compact": True, "cursor": cursor_token},
+        )
+        assert "Cursor / Tool Mismatch" in out
+        assert "walk_namespace" in out
+        assert "browse_namespace" in out
+        # The backend call must NOT have happened.
+        assert not mock.browse_namespace.called
+        assert not mock.browse_namespace_data.called
+
+    def test_browse_cursor_passed_to_walk_is_rejected(self) -> None:
+        # Defence-in-depth: walk's own handler rejects browse cursors
+        # too (same shape, opposite direction).
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        handler = SimpleToolsHandler(mock)
+        cursor_token = self._encode_browse_cursor(
+            offset=3, limit=3, namespace="M", ai="e048666a9e92"
+        )
+        out = handler.handle_zim_query(
+            "walk namespace M",
+            zim_file_path="/x.zim",
+            options={"compact": True, "cursor": cursor_token},
+        )
+        assert "Cursor / Tool Mismatch" in out
+        assert "browse_namespace" in out
+        assert "walk_namespace" in out
+        assert not mock.walk_namespace.called
+        assert not mock.walk_namespace_data.called
+
+    def test_same_tool_cursor_round_trip_still_works(self) -> None:
+        # Regression guard: a walk_namespace cursor passed back to
+        # walk_namespace must STILL round-trip cleanly (the P1-D3
+        # fix that landed in a18). The new tool-mismatch check
+        # should fire ONLY on cross-tool reuse.
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        captured: dict[str, Any] = {}
+
+        def fake_walk(
+            zim_file_path: str,
+            namespace: str,
+            *,
+            cursor_state: Any = None,
+            limit: int = 200,
+        ) -> dict[str, Any]:
+            captured["cursor_state"] = cursor_state
+            return {
+                "namespace": namespace,
+                "results": [],
+                "next_cursor": None,
+                "total": 12,
+                "done": True,
+                "page_info": {
+                    "offset": 3,
+                    "limit": limit,
+                    "returned_count": 0,
+                },
+                "discovery_method": "full_iteration",
+                "sampling_based": False,
+                "results_may_be_incomplete": False,
+            }
+
+        mock.walk_namespace_data.side_effect = fake_walk
+        handler = SimpleToolsHandler(mock)
+        cursor_token = self._encode_walk_cursor(
+            offset=3, limit=3, namespace="M", ai="e048666a9e92"
+        )
+        out = handler.handle_zim_query(
+            "walk namespace M",
+            zim_file_path="/x.zim",
+            options={"compact": True, "cursor": cursor_token},
+        )
+        # No tool-mismatch error; backend was called with the
+        # rebuilt cursor_state carrying ai/ns.
+        assert "Cursor / Tool Mismatch" not in out
+        assert captured.get("cursor_state") is not None
+        assert captured["cursor_state"]["ai"] == "e048666a9e92"


### PR DESCRIPTION
## Summary

Live-MCP beta sweep against `wikipedia_en_all_maxi_2026-02.zim` (~118 GB, ~27.2M entries) on the freshly-deployed `v2.0.0a18` build. Pass 1 confirmed the three a18 fixes (P1-D1 / P1-D2 / P1-D3) all work as designed, then surfaced three new defects. Pass 2 source-level self-audit found zero new defects.

## Defects (pass 1)

### P3-D1 — subject-attribute section dominated by table placeholders falls back to recovery pointer

**Query:** `musicians from München` (or any Unicode subject-attribute query that lands on a table-heavy section)

**Pre-fix output:**
```
# Munich

_Source: `Munich` (section: Notable people)_

_Showing **Notable people** section because your query asked about `musicians`. Use `tell me about Munich` for the full article._

### Born in Munich

[Table 8: 1 rows x 2 cols - pass compact=False to expand]

### Notable residents

[Table 9: 1 rows x 2 cols - pass compact=False to expand]
```

The LLM saw zero substantive content — exactly the content-less-response shape that wave 4's empty-lead fallback was originally designed to prevent. This defect was unreachable before a18 because the a17 tokenisation bug (`München → "m"/"nchen"` → `M` letter article) prevented the query from ever resolving to Munich.

**Root cause:** the bundle `get_section_data` reads is always built with `compact=True` (`openzim_mcp/bundle.py:307`), and `ContentProcessor.replace_oversized_tables` strips qualifying tables to `[Table N: M rows x P cols - pass compact=False to expand]` placeholders. Munich's Notable people section is two H3 sub-tables — after stripping, only ~40 chars of substantive content remain. `_maybe_render_subject_section` returned that body as if it were the answer.

**Fix:** detect placeholder dominance (≥1 placeholder AND <100 chars of substantive prose after stripping them) and substitute a `compact=False` recovery pointer that names the exact call to make. The `subject_attribute_section` intent marker still fires so callers can distinguish this branch from the plain-lead path. New telemetry counter `subject_attribute_table_dominated` for future tuning.

### P3-D2 — soft-connector footer recognises non-Latin halves via title-alias fallback

**Query:** `tell me about Berlin and München`

**Pre-fix:** resolved correctly to Munich (right-promote), but the soft-connector footer was silently suppressed — the user never learned Berlin was dropped. The substring check `"berlin" in "munich"` is False; `"münchen" in "munich"` is also False because the title-alias index crosses the Unicode + language boundary (München → Munich) and substring matching can't see through that. So `left_in == right_in == False` hit the "neither in title — unclear which was picked" suppression branch. This defect was also unreachable before a18 (München previously tokenised to noise).

**Fix:** when both halves fail substring, fall back to title-alias probing — probe the title index for each half, and if a half's top-scored hit resolves to `top_path`, treat that half as "in title" semantically. Cheap (in-memory title-index lookup) and only fires on the rare both-missed branch. The legacy positional-only call signature (without `zim_file_path` / `top_path` kwargs) continues to work — alias fallback is gated on those kwargs being passed.

### P1-D4 — cross-tool cursor reuse rejected at simple-tools handler edge (deferred from post-a17)

**Query:** `walk namespace M` → grab `next_cursor` → pass to `browse namespace M` with that cursor

**Pre-fix:** silently walked browse from walk's offset (=3 in the canonical reproducer), returning entries 4-6 and emitting a fresh `browse_namespace` cursor as if nothing was wrong. The advanced tools already enforce tool-binding via `Cursor.decode(expected_tool=...)`; the simple-tools layer decoded the cursor in-place earlier in the dispatcher and bypassed that check, reading only `s.o` and `s.ns`.

**Fix:** stash `decoded_payload.get("t")` (issuing tool) into `options["_cursor_t"]`; add the `_cursor_tool_mismatch` helper alongside the existing `_cursor_ns_mismatch`; fire it at the top of both `_handle_browse` and `_handle_walk_namespace` (defence-in-depth for the symmetric direction). User now sees a clear `Cursor / Tool Mismatch` rejection before any backend call.

## Pass-1 verification of a18 fixes (no regressions)

- ✓ **P1-D1** (post-a17): soft-connector title-spans suppression works for `notable people from Big Rapids, Michigan`, `musicians from Romeo and Juliet`. Legitimate two-entity footers still fire (`musicians from Berlin and Paris`).
- ✓ **P1-D2** (post-a17): Unicode tail tokenisation works across Latin-1 extended (`München → Munich`, `Zürich → Zurich`, `Köln → Cologne`, `São Paulo`) AND Cyrillic (`Москва → Moscow`), Greek (`Αθήνα → Athens`), CJK (`東京` resolves to an in-archive 東京 disambiguation article).
- ✓ **P1-D3** (post-a17): walk_namespace cursor round-trip works for multi-page paging (M page-1 → page-2 → page-3). Cross-archive `ai` mismatch now produces the proper "different archive" error instead of the misleading "missing archive-identity field" one (the pass-2 audit regression guard from a17 paid off here).

## Pass-2 source-level audit (zero new defects)

- **P3-D1 sibling grep:** the table-placeholder shape is unique to subject-attribute decomposition. Other content-fetch paths (`_lead_with_toc`, `_fetch_topic_article_body`, plain `tell me about`) surface tables embedded in a larger prose body, where placeholders aren't dominant. No siblings.
- **P3-D2 sibling grep:** `_soft_connector_footer` is the only substring-in-title site in the codebase. Other footers (disambig twin probe, related extends paths) use exact path/title matching from search results, not substring. No siblings.
- **P1-D4 sibling grep:** `_handle_search` / `_handle_links` / `_handle_filtered_search` also read `options["offset"]` from any decoded cursor, but they use search-tool offsets that aren't cross-tool meaningful in the same way as walk/browse's shared namespace-offset semantics. **Filed as a follow-up opportunity** to widen the tool-mismatch guard later if a live probe ever surfaces the issue.

## Tests

9 regression tests in `tests/test_post_a18_beta_fixes.py`:

- **P3-D1** (3): table-dominated falls back to recovery pointer; prose + 1 table returns body unchanged; zero tables unchanged.
- **P3-D2** (3): alias-resolved half makes the footer fire; neither-half-resolves still suppresses; legacy positional-only call signature still works.
- **P1-D4** (3): walk cursor passed to browse → rejected; browse cursor passed to walk → rejected; same-tool round-trip preserves the post-a17 P1-D3 fix.

Full test suite: **1823 passed, 50 skipped** (was 1814 pre-sweep).

## Methodology note

Both pass-1 defects (P3-D1 and P3-D2) are examples of a recurring pattern: fixes that unlock previously-broken code paths surface new defects in those paths. P3-D1 lives in the subject-attribute decomposition that wave 4 added; P3-D2 lives in the soft-connector footer post-a16 D1 (pass-2) added. Neither was reachable from the canonical reproducers before a18 because the a17 Unicode tokenisation defect intercepted every non-Latin topic earlier in the pipeline. The post-a16 methodology refinement (live-MCP catches a defect class unit tests structurally cannot) keeps paying off: this PR's two new defects are both live-only, surfaced only after the a18 deploy on `wikipedia_en_all_maxi_2026-02.zim`.

## Commits

- `7be575e` — pass-1 fixes (3 defects, 9 regression tests).

## Live-MCP probe set used

**Pass-1 (verification of a18 fixes + new angles):**

- `tell me about München` ✓ → Munich (cert 0.85) — smoke test
- `tell me about Zürich` ✓ → Zurich
- `tell me about Köln` ✓ → Cologne
- `tell me about São Paulo` ✓ → São Paulo (diacritic preserved in path)
- `tell me about Москва` ✓ → Moscow (Cyrillic)
- `tell me about Αθήνα` ✓ → Athens (Greek)
- `tell me about 東京` ✓ → 東京 (CJK; in-archive disambig)
- `notable people from Big Rapids, Michigan` ✓ — no false footer
- `musicians from Romeo and Juliet` ✓ — no false footer
- `walk namespace M` → cursor → replay ✓ (page-1 → page-2 → page-3)
- Cross-archive `ai` cursor ✓ → proper "different archive" error
- `musicians from München` ❌ **P3-D1** (Munich Notable people = tables)
- `tell me about Berlin and München` ❌ **P3-D2** (silent footer suppression)
- `browse namespace M` with walk cursor ❌ **P1-D4** (silent cross-tool accept)
- `musicians from München` with `compact=False` ✓ — bypasses subject-attribute, returns full article (existing design — confirms the fix's recovery hint is actionable)
- `tell me about Vienna, Austria` ✓ — soft-connector footer correctly fires (Austria title doesn't contain ",")
- `tell me about Tom and Jerry` ✓ — title-spans suppression still works
