### PR TITLE
fix(v2): post-a19 beta-test sweep — 3 defects across one pass

### DIFF
--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -1235,7 +1235,13 @@ class SimpleToolsHandler:
           * ≥2 tokens (multi-word proper nouns / titles),
           * ≥5 characters in the longest token (real proper nouns
             tend to be longer than short adverbials),
-          * contains a digit (``Apollo 12``, ``1969`` etc.).
+          * contains a digit (``Apollo 12``, ``1969`` etc.),
+          * contains a non-ASCII letter and length ≥2 (CJK ideograms,
+            German umlaut city names like ``Köln``, Greek toponyms
+            like ``Αθήνα`` — a single CJK ideogram or accented vowel
+            carries roughly a syllable of lexical weight, so the
+            5-ASCII-char threshold systematically over-rejects real
+            non-Latin proper nouns).
         """
         stripped = text.strip()
         if not stripped:
@@ -1245,7 +1251,21 @@ class SimpleToolsHandler:
             return True
         if any(ch.isdigit() for ch in stripped):
             return True
-        return len(stripped) >= 5
+        if len(stripped) >= 5:
+            return True
+        # Post-a19 P1-D3: the ASCII-length-5 threshold was tuned for
+        # English particles like ``Now`` / ``Both`` / ``Here``, but it
+        # also rejects real non-Latin proper nouns (``東京`` = 2 chars,
+        # ``Köln`` = 4 chars, ``北京`` = 2 chars). The post-a17 Unicode
+        # tail-tokenisation fix (a18) lets the resolver REACH these
+        # topics; this fix lets the chain detector + soft-connector
+        # footer recognise them as substantive. Restrict the relaxed
+        # threshold to strings carrying a non-ASCII *letter* so we
+        # don't accidentally accept ASCII abbreviations like ``Dr.`` or
+        # punctuation tokens like ``--``.
+        if any(not ch.isascii() and ch.isalpha() for ch in stripped):
+            return len(stripped) >= 2
+        return False
 
     @classmethod
     def _is_topic_shaped(cls, text: str) -> bool:
@@ -2466,6 +2486,17 @@ class SimpleToolsHandler:
                 "**Example**: 'links in Biology' or "
                 "'links from \"C/Evolution\"'"
             )
+        # Post-a19 P1-D2 (widened cross-tool guard): reject cursors
+        # issued by a different cursor-emitting tool. The current
+        # handler hardcodes offset=0 internally, but defending the
+        # boundary keeps the guard consistent with the sibling
+        # cursor-consuming handlers (``_handle_browse`` /
+        # ``_handle_walk_namespace`` / ``_handle_search`` /
+        # ``_handle_filtered_search``) so a future offset-reading
+        # change can't silently regress into a cross-tool walk.
+        tool_mismatch = self._cursor_tool_mismatch(options, "extract_article_links")
+        if tool_mismatch is not None:
+            return tool_mismatch
         entry_path = self._resolve_natural_language_path(zim_file_path, entry_path)
         try:
             if options.get("compact", False):
@@ -2574,6 +2605,18 @@ class SimpleToolsHandler:
                 "- `search Counter in namespace M` — archive metadata\n"
                 "<!-- intent=filtered_search cert=0.80 -->"
             )
+        # Post-a19 P1-D2: reject cursors issued by a different
+        # cursor-emitting tool. Pre-fix, a ``walk_namespace`` cursor
+        # passed to ``search foo in namespace C`` was silently
+        # decoded; ``options["offset"]`` got the walk cursor's
+        # ``s.o`` and filtered search returned page-2-of-walk-offset
+        # results instead of the search's page 1. The advanced
+        # ``search_with_filters`` tool enforces tool-binding via
+        # ``Cursor.decode(expected_tool=...)``; this restores it at
+        # the simple-tools handler edge.
+        tool_mismatch = self._cursor_tool_mismatch(options, "search_with_filters")
+        if tool_mismatch is not None:
+            return tool_mismatch
         # A11 post-a11 H2: route to the canonical-title-match-aware
         # variant so ``search for berlin in namespace C`` surfaces
         # the canonical ``Berlin`` article instead of dropping it
@@ -2662,6 +2705,19 @@ class SimpleToolsHandler:
         named after Albert Einstein`` instead of ``Albert_Einstein``).
         Only applied at ``offset=0`` so paged results stay stable.
         """
+        # Post-a19 P1-D1: reject cursors issued by a different
+        # cursor-emitting tool. Pre-fix, a ``walk_namespace`` /
+        # ``browse_namespace`` cursor passed to ``search for X`` was
+        # silently decoded; ``options["offset"]`` got the cursor's
+        # ``s.o`` and search returned page-2-of-cursor-offset results
+        # instead of page 1 of the search. The advanced
+        # ``search_zim_file`` tool enforces tool-binding via
+        # ``Cursor.decode(expected_tool=...)``; this restores it at
+        # the simple-tools handler edge. Same shape as the post-a18
+        # P1-D4 fix that landed for browse / walk_namespace.
+        tool_mismatch = self._cursor_tool_mismatch(options, "search_zim_file")
+        if tool_mismatch is not None:
+            return tool_mismatch
         search_query = params.get("query", query)
         limit = options.get("limit")
         offset = options.get("offset", 0)

--- a/tests/test_post_a19_beta_fixes.py
+++ b/tests/test_post_a19_beta_fixes.py
@@ -1,0 +1,402 @@
+"""Regression tests for the post-a19 beta-test sweep (a20 fixes).
+
+The post-a19 live-MCP sweep against the 118 GB Wikipedia ZIM after
+v2.0.0a19 deployed surfaced three new user-facing defects across one
+pass. Two were unlocked by a19's own fix shapes opening up code
+paths the pass-2 source-level audit didn't cover; one was the
+deferred-widening follow-up flagged in the post-a18 sweep.
+
+- P1-D1: ``search for X`` silently consumes the offset from a
+  cross-tool cursor. Pre-fix, a ``walk_namespace`` or
+  ``browse_namespace`` cursor passed to ``search for Photosynthesis``
+  decoded ``s.o=3`` into ``options["offset"]`` and search returned
+  ``showing 4-6 of 4237`` instead of ``showing 1-3``. The advanced
+  ``search_zim_file`` tool enforces tool-binding via
+  ``Cursor.decode(expected_tool=...)``; this defect is the
+  simple-tools-layer mirror of the post-a18 P1-D4 fix that landed
+  for ``_handle_browse`` / ``_handle_walk_namespace``. Fix: call
+  ``_cursor_tool_mismatch(options, "search_zim_file")`` at the top
+  of ``_handle_search``.
+
+- P1-D2: ``search X in namespace C`` silently consumes a cross-tool
+  cursor's offset (same shape, sibling handler). Fix: call
+  ``_cursor_tool_mismatch(options, "search_with_filters")`` at the
+  top of ``_handle_filtered_search``. Defence-in-depth: also guard
+  ``_handle_links`` (it hardcodes ``offset=0`` today so no live
+  defect, but it IS a cursor-emitting handler — defending the
+  boundary prevents a future offset-reading change from regressing
+  silently).
+
+- P1-D3: soft-connector footer silently suppressed when a half is a
+  short (<5 ASCII char) non-Latin proper noun. ``tell me about
+  Berlin and 東京`` resolved correctly to 東京 (right-promote), but
+  ``_is_substantive_topic("東京")`` returned False because the
+  ASCII-length-5 heuristic doesn't account for CJK ideograms
+  carrying syllable-level lexical weight per character. Same shape
+  for ``Köln`` (4 chars, has ö) and ``京都`` / ``北京`` / ``上海``.
+  The post-a17 → a18 Unicode tail-tokenisation fix made these
+  topics REACHABLE; this fix lets the chain detector + soft-
+  connector footer recognise them as substantive when they're 2+
+  chars and carry at least one non-ASCII letter.
+
+Each test pins one defect; failures here mean a regression on the
+specific bug.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from openzim_mcp.pagination import Cursor
+from openzim_mcp.simple_tools import SimpleToolsHandler
+
+# ---------------------------------------------------------------------------
+# P1-D1: search silently consumes cross-tool cursor's offset
+# ---------------------------------------------------------------------------
+
+
+class TestP1D1SearchCrossToolCursorRejection:
+    """P1-D1: a ``walk_namespace`` / ``browse_namespace`` cursor
+    passed to ``search for X`` previously decoded ``s.o`` silently
+    into ``options["offset"]`` and the search returned page-2-of-
+    cursor-offset results instead of its own page 1.
+    """
+
+    def _encode_walk_cursor(
+        self, *, offset: int, limit: int, namespace: str, ai: str
+    ) -> str:
+        state: dict[str, Any] = {
+            "o": offset,
+            "l": limit,
+            "ns": namespace,
+            "ai": ai,
+        }
+        return Cursor.encode(tool="walk_namespace", state=state)  # type: ignore[arg-type]
+
+    def _encode_browse_cursor(
+        self, *, offset: int, limit: int, namespace: str, ai: str
+    ) -> str:
+        state: dict[str, Any] = {
+            "o": offset,
+            "l": limit,
+            "ns": namespace,
+            "ai": ai,
+        }
+        return Cursor.encode(tool="browse_namespace", state=state)  # type: ignore[arg-type]
+
+    def _encode_search_cursor(
+        self, *, offset: int, ai: str, query: str = "photosynthesis"
+    ) -> str:
+        state: dict[str, Any] = {
+            "o": offset,
+            "q": query,
+            "ai": ai,
+        }
+        return Cursor.encode(tool="search_zim_file", state=state)  # type: ignore[arg-type]
+
+    def test_walk_cursor_passed_to_search_is_rejected(self) -> None:
+        # Pre-fix: silently applied walk's offset to the search;
+        # search backend returned results 4-6 instead of 1-3.
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        handler = SimpleToolsHandler(mock)
+        cursor_token = self._encode_walk_cursor(
+            offset=3, limit=3, namespace="M", ai="e048666a9e92"
+        )
+        out = handler.handle_zim_query(
+            "search for Photosynthesis",
+            zim_file_path="/x.zim",
+            options={"compact": True, "cursor": cursor_token},
+        )
+        assert "Cursor / Tool Mismatch" in out
+        assert "walk_namespace" in out
+        assert "search_zim_file" in out
+        # The backend call MUST NOT have happened — the guard fires
+        # before any search routing.
+        assert not mock.search_zim_file_data.called
+        assert not mock.search_zim_file.called
+
+    def test_browse_cursor_passed_to_search_is_rejected(self) -> None:
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        handler = SimpleToolsHandler(mock)
+        cursor_token = self._encode_browse_cursor(
+            offset=3, limit=3, namespace="M", ai="e048666a9e92"
+        )
+        out = handler.handle_zim_query(
+            "search for Berlin",
+            zim_file_path="/x.zim",
+            options={"compact": True, "cursor": cursor_token},
+        )
+        assert "Cursor / Tool Mismatch" in out
+        assert "browse_namespace" in out
+        assert "search_zim_file" in out
+        assert not mock.search_zim_file_data.called
+
+    def test_same_tool_search_cursor_round_trips(self) -> None:
+        # Regression guard: a ``search_zim_file`` cursor passed back
+        # to ``search`` MUST still apply offset normally — the new
+        # guard fires only on cross-tool reuse.
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+
+        def fake_search(
+            zim_file_path: str,
+            query: str,
+            limit: Any,
+            offset: int,
+        ) -> dict[str, Any]:
+            return {
+                "total": 100,
+                "results": [],
+                "page_info": {
+                    "offset": offset,
+                    "limit": limit or 5,
+                    "returned_count": 0,
+                },
+                "_meta": {},
+            }
+
+        mock.search_zim_file_data.side_effect = fake_search
+        handler = SimpleToolsHandler(mock)
+        cursor_token = self._encode_search_cursor(
+            offset=3, ai="e048666a9e92", query="photosynthesis"
+        )
+        out = handler.handle_zim_query(
+            "search for photosynthesis",
+            zim_file_path="/x.zim",
+            options={"compact": True, "cursor": cursor_token},
+        )
+        assert "Cursor / Tool Mismatch" not in out
+        # Backend WAS called.
+        assert mock.search_zim_file_data.called
+
+    def test_search_without_cursor_unaffected(self) -> None:
+        # Defence-in-depth: the guard MUST be a no-op when no cursor
+        # is passed (the canonical entry path for nearly all callers).
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        mock.search_zim_file_data.return_value = {
+            "total": 0,
+            "results": [],
+            "_meta": {},
+        }
+        handler = SimpleToolsHandler(mock)
+        out = handler.handle_zim_query(
+            "search for Photosynthesis",
+            zim_file_path="/x.zim",
+            options={"compact": True},
+        )
+        assert "Cursor / Tool Mismatch" not in out
+        assert mock.search_zim_file_data.called
+
+
+# ---------------------------------------------------------------------------
+# P1-D2: filtered_search + links silently consume cross-tool cursor
+# ---------------------------------------------------------------------------
+
+
+class TestP1D2FilteredSearchAndLinksCrossToolCursorRejection:
+    """P1-D2: the cross-tool cursor guard widens to the other two
+    cursor-emitting simple-tools handlers.
+
+    ``_handle_filtered_search`` had the same live defect as
+    ``_handle_search``: a walk cursor's offset bled into the
+    filtered-search call silently.
+
+    ``_handle_links`` hardcodes offset=0 today, so the live shape
+    didn't reproduce — but the guard is added for defence-in-depth
+    (consistency with the sibling handlers + future-proofing if
+    offset-reading is ever added).
+    """
+
+    def _encode_walk_cursor(
+        self, *, offset: int, limit: int, namespace: str, ai: str
+    ) -> str:
+        state: dict[str, Any] = {
+            "o": offset,
+            "l": limit,
+            "ns": namespace,
+            "ai": ai,
+        }
+        return Cursor.encode(tool="walk_namespace", state=state)  # type: ignore[arg-type]
+
+    def test_walk_cursor_passed_to_filtered_search_is_rejected(self) -> None:
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        handler = SimpleToolsHandler(mock)
+        cursor_token = self._encode_walk_cursor(
+            offset=3, limit=3, namespace="M", ai="e048666a9e92"
+        )
+        out = handler.handle_zim_query(
+            "search Berlin in namespace C",
+            zim_file_path="/x.zim",
+            options={"compact": True, "cursor": cursor_token},
+        )
+        assert "Cursor / Tool Mismatch" in out
+        assert "walk_namespace" in out
+        assert "search_with_filters" in out
+        # No backend call.
+        assert not mock.search_with_filters_with_canonical_splice.called
+
+    def test_walk_cursor_passed_to_links_is_rejected(self) -> None:
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        # Make natural-language path resolution a no-op.
+        mock.find_entry_by_title_data.return_value = {"hits": []}
+        handler = SimpleToolsHandler(mock)
+        cursor_token = self._encode_walk_cursor(
+            offset=3, limit=3, namespace="M", ai="e048666a9e92"
+        )
+        out = handler.handle_zim_query(
+            "links in Photosynthesis",
+            zim_file_path="/x.zim",
+            options={"compact": True, "cursor": cursor_token},
+        )
+        assert "Cursor / Tool Mismatch" in out
+        assert "walk_namespace" in out
+        assert "extract_article_links" in out
+        # No backend call.
+        assert not mock.extract_article_links_data.called
+        assert not mock.extract_article_links.called
+
+    def test_filtered_search_without_cursor_unaffected(self) -> None:
+        # Regression guard: the canonical entry path (no cursor)
+        # still routes to the backend.
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        mock.search_with_filters_with_canonical_splice.return_value = "ok"
+        handler = SimpleToolsHandler(mock)
+        out = handler.handle_zim_query(
+            "search Berlin in namespace C",
+            zim_file_path="/x.zim",
+            options={"compact": True},
+        )
+        assert "Cursor / Tool Mismatch" not in out
+        assert mock.search_with_filters_with_canonical_splice.called
+
+
+# ---------------------------------------------------------------------------
+# P1-D3: _is_substantive_topic now recognises short non-Latin proper nouns
+# ---------------------------------------------------------------------------
+
+
+class TestP1D3UnicodeSubstantiveTopic:
+    """P1-D3: pre-fix, ``_is_substantive_topic`` rejected ``東京``
+    (2 chars), ``Köln`` (4 chars), ``京都`` etc. because the ASCII-
+    length-5 heuristic ignored that non-Latin proper nouns pack
+    syllable-level lexical weight into each character. This
+    suppressed the soft-connector footer for ``Berlin and 東京`` /
+    ``Köln and Berlin`` even when the resolver picked the right
+    article.
+    """
+
+    def test_cjk_two_char_topic_is_substantive(self) -> None:
+        assert SimpleToolsHandler._is_substantive_topic("東京") is True
+        assert SimpleToolsHandler._is_substantive_topic("北京") is True
+        assert SimpleToolsHandler._is_substantive_topic("京都") is True
+        assert SimpleToolsHandler._is_substantive_topic("上海") is True
+
+    def test_umlaut_short_topic_is_substantive(self) -> None:
+        # 4-char German city names with umlauts: ``Köln``, ``Bonn`` is
+        # ASCII-only so passes the existing path; this targets the
+        # post-a19 non-ASCII branch.
+        assert SimpleToolsHandler._is_substantive_topic("Köln") is True
+        assert SimpleToolsHandler._is_substantive_topic("Ürüm") is True
+
+    def test_short_ascii_particles_still_rejected(self) -> None:
+        # Regression guard: the original a16 post-a16 D1 motivation
+        # was rejecting English particles like ``Then`` / ``Both`` /
+        # ``Here`` / ``Now``. Those must still be rejected.
+        assert SimpleToolsHandler._is_substantive_topic("Then") is False
+        assert SimpleToolsHandler._is_substantive_topic("Both") is False
+        assert SimpleToolsHandler._is_substantive_topic("Here") is False
+        assert SimpleToolsHandler._is_substantive_topic("Now") is False
+        assert SimpleToolsHandler._is_substantive_topic("This") is False
+
+    def test_abbreviations_still_rejected(self) -> None:
+        # The pass-2 self-audit motivation for the substantive check
+        # was protecting against abbreviation-then-capital false-
+        # positives in chain detection: ``Dr. Strange`` should NOT
+        # be treated as a chain. The ``Dr.`` half is ASCII-only and
+        # under 5 chars, so the relaxed non-ASCII branch must not
+        # activate.
+        assert SimpleToolsHandler._is_substantive_topic("Dr.") is False
+        assert SimpleToolsHandler._is_substantive_topic("St.") is False
+        assert SimpleToolsHandler._is_substantive_topic("Mt.") is False
+        assert SimpleToolsHandler._is_substantive_topic("Jr.") is False
+
+    def test_single_cjk_char_still_rejected(self) -> None:
+        # A single CJK character is too ambiguous (could be a particle,
+        # a one-character toponym is rare in actual usage). The
+        # length-≥2 minimum keeps the false-positive surface tight.
+        assert SimpleToolsHandler._is_substantive_topic("京") is False
+        assert SimpleToolsHandler._is_substantive_topic("北") is False
+
+    def test_existing_long_ascii_topics_unaffected(self) -> None:
+        # Regression guard: the original 5-char ASCII path still
+        # works for ASCII proper nouns.
+        assert SimpleToolsHandler._is_substantive_topic("Berlin") is True
+        assert SimpleToolsHandler._is_substantive_topic("Tokyo") is True
+        assert SimpleToolsHandler._is_substantive_topic("Apollo") is True
+
+    def test_multi_token_topics_unaffected(self) -> None:
+        # Regression guard: the ≥2-token path still wins.
+        assert SimpleToolsHandler._is_substantive_topic("Big Rapids") is True
+        assert SimpleToolsHandler._is_substantive_topic("Romeo and Juliet") is True
+
+    def test_digit_topics_unaffected(self) -> None:
+        # Regression guard: digit-containing short topics still pass.
+        assert SimpleToolsHandler._is_substantive_topic("Apollo 11") is True
+        assert SimpleToolsHandler._is_substantive_topic("1969") is True
+
+    def test_empty_and_whitespace_rejected(self) -> None:
+        assert SimpleToolsHandler._is_substantive_topic("") is False
+        assert SimpleToolsHandler._is_substantive_topic("   ") is False
+
+    def test_cyrillic_short_topic_via_existing_threshold(self) -> None:
+        # ``Москва`` is 6 chars — passes the existing 5-char ASCII
+        # threshold. Test included to document that Cyrillic 4-char
+        # names ALSO pass the new non-ASCII branch.
+        assert SimpleToolsHandler._is_substantive_topic("Москва") is True
+        # 3-char Cyrillic — uncommon as a real article title, but
+        # passes the relaxed non-ASCII branch (len≥2).
+        assert SimpleToolsHandler._is_substantive_topic("СПб") is True
+
+    def test_soft_connector_footer_fires_with_cjk_dropped_half(self) -> None:
+        # End-to-end via the soft-connector footer: pre-fix, "Berlin
+        # and 東京" returned 東京 silently; the footer was suppressed
+        # because 東京 failed the substantive check, dropping the
+        # chain through to the no-footer path. Post-fix, the footer
+        # fires naming Berlin as the dropped half.
+        handler = SimpleToolsHandler(MagicMock())
+        footer = handler._soft_connector_footer(
+            "Berlin and 東京",
+            "東京",
+            zim_file_path="/x.zim",
+            top_path="東京",
+        )
+        assert footer is not None
+        assert "Berlin" in footer
+        assert "東京" in footer
+
+    def test_soft_connector_footer_fires_with_umlaut_dropped_half(self) -> None:
+        # ``Köln and Berlin``: pre-fix, Köln failed substantive
+        # (4 chars), so the chain detector + footer were suppressed.
+        # Post-fix, the footer fires.
+        handler = SimpleToolsHandler(MagicMock())
+        footer = handler._soft_connector_footer(
+            "Köln and Berlin",
+            "Berlin",
+            zim_file_path="/x.zim",
+            top_path="Berlin",
+        )
+        assert footer is not None
+        assert "Köln" in footer
+        assert "Berlin" in footer

--- a/tests/test_post_a19_beta_fixes.py
+++ b/tests/test_post_a19_beta_fixes.py
@@ -49,6 +49,18 @@ from unittest.mock import MagicMock
 from openzim_mcp.pagination import Cursor
 from openzim_mcp.simple_tools import SimpleToolsHandler
 
+
+def _encode_cursor(tool: str, **state_fields: Any) -> str:
+    """Encode a v2 cursor for ``tool`` from arbitrary ``s.*`` fields.
+
+    A single parameterised helper keeps cursor-shape knowledge in one
+    place — the test surface mirrors the production encoder, where
+    every cursor-emitting tool calls ``Cursor.encode(tool=..., state=...)``
+    with its own ``s.*`` envelope.
+    """
+    return Cursor.encode(tool=tool, state=state_fields)  # type: ignore[arg-type]
+
+
 # ---------------------------------------------------------------------------
 # P1-D1: search silently consumes cross-tool cursor's offset
 # ---------------------------------------------------------------------------
@@ -61,38 +73,6 @@ class TestP1D1SearchCrossToolCursorRejection:
     cursor-offset results instead of its own page 1.
     """
 
-    def _encode_walk_cursor(
-        self, *, offset: int, limit: int, namespace: str, ai: str
-    ) -> str:
-        state: dict[str, Any] = {
-            "o": offset,
-            "l": limit,
-            "ns": namespace,
-            "ai": ai,
-        }
-        return Cursor.encode(tool="walk_namespace", state=state)  # type: ignore[arg-type]
-
-    def _encode_browse_cursor(
-        self, *, offset: int, limit: int, namespace: str, ai: str
-    ) -> str:
-        state: dict[str, Any] = {
-            "o": offset,
-            "l": limit,
-            "ns": namespace,
-            "ai": ai,
-        }
-        return Cursor.encode(tool="browse_namespace", state=state)  # type: ignore[arg-type]
-
-    def _encode_search_cursor(
-        self, *, offset: int, ai: str, query: str = "photosynthesis"
-    ) -> str:
-        state: dict[str, Any] = {
-            "o": offset,
-            "q": query,
-            "ai": ai,
-        }
-        return Cursor.encode(tool="search_zim_file", state=state)  # type: ignore[arg-type]
-
     def test_walk_cursor_passed_to_search_is_rejected(self) -> None:
         # Pre-fix: silently applied walk's offset to the search;
         # search backend returned results 4-6 instead of 1-3.
@@ -100,8 +80,8 @@ class TestP1D1SearchCrossToolCursorRejection:
         mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
         mock.config.meta.footer_enabled = False
         handler = SimpleToolsHandler(mock)
-        cursor_token = self._encode_walk_cursor(
-            offset=3, limit=3, namespace="M", ai="e048666a9e92"
+        cursor_token = _encode_cursor(
+            "walk_namespace", o=3, l=3, ns="M", ai="e048666a9e92"
         )
         out = handler.handle_zim_query(
             "search for Photosynthesis",
@@ -121,8 +101,8 @@ class TestP1D1SearchCrossToolCursorRejection:
         mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
         mock.config.meta.footer_enabled = False
         handler = SimpleToolsHandler(mock)
-        cursor_token = self._encode_browse_cursor(
-            offset=3, limit=3, namespace="M", ai="e048666a9e92"
+        cursor_token = _encode_cursor(
+            "browse_namespace", o=3, l=3, ns="M", ai="e048666a9e92"
         )
         out = handler.handle_zim_query(
             "search for Berlin",
@@ -161,8 +141,8 @@ class TestP1D1SearchCrossToolCursorRejection:
 
         mock.search_zim_file_data.side_effect = fake_search
         handler = SimpleToolsHandler(mock)
-        cursor_token = self._encode_search_cursor(
-            offset=3, ai="e048666a9e92", query="photosynthesis"
+        cursor_token = _encode_cursor(
+            "search_zim_file", o=3, q="photosynthesis", ai="e048666a9e92"
         )
         out = handler.handle_zim_query(
             "search for photosynthesis",
@@ -213,24 +193,13 @@ class TestP1D2FilteredSearchAndLinksCrossToolCursorRejection:
     offset-reading is ever added).
     """
 
-    def _encode_walk_cursor(
-        self, *, offset: int, limit: int, namespace: str, ai: str
-    ) -> str:
-        state: dict[str, Any] = {
-            "o": offset,
-            "l": limit,
-            "ns": namespace,
-            "ai": ai,
-        }
-        return Cursor.encode(tool="walk_namespace", state=state)  # type: ignore[arg-type]
-
     def test_walk_cursor_passed_to_filtered_search_is_rejected(self) -> None:
         mock = MagicMock()
         mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
         mock.config.meta.footer_enabled = False
         handler = SimpleToolsHandler(mock)
-        cursor_token = self._encode_walk_cursor(
-            offset=3, limit=3, namespace="M", ai="e048666a9e92"
+        cursor_token = _encode_cursor(
+            "walk_namespace", o=3, l=3, ns="M", ai="e048666a9e92"
         )
         out = handler.handle_zim_query(
             "search Berlin in namespace C",
@@ -250,8 +219,8 @@ class TestP1D2FilteredSearchAndLinksCrossToolCursorRejection:
         # Make natural-language path resolution a no-op.
         mock.find_entry_by_title_data.return_value = {"hits": []}
         handler = SimpleToolsHandler(mock)
-        cursor_token = self._encode_walk_cursor(
-            offset=3, limit=3, namespace="M", ai="e048666a9e92"
+        cursor_token = _encode_cursor(
+            "walk_namespace", o=3, l=3, ns="M", ai="e048666a9e92"
         )
         out = handler.handle_zim_query(
             "links in Photosynthesis",


### PR DESCRIPTION
## Summary

The post-a19 beta-test sweep against the 118 GB Wikipedia ZIM
(`wikipedia_en_all_maxi_2026-02.zim`) surfaced **3 user-facing
defects across one pass**:

- **P1-D1**: `_handle_search` silently consumes the offset from a
  cross-tool cursor — same shape as the post-a18 P1-D4 fix for
  `_handle_browse` / `_handle_walk_namespace`, but on the search
  side. A `walk_namespace` or `browse_namespace` cursor passed to
  `search for Photosynthesis` decoded `s.o=3` into
  `options["offset"]` and search returned `showing 4-6 of 4237`
  instead of `showing 1-3`.
- **P1-D2**: same shape in `_handle_filtered_search` (`search X in
  namespace C`). Defence-in-depth: `_handle_links` also gets the
  guard — it hardcodes `offset=0` today so the live shape didn't
  reproduce, but it IS a cursor-emitting handler and the guard keeps
  the boundary consistent with siblings.
- **P1-D3**: soft-connector footer silently suppressed for short
  (<5 ASCII char) non-Latin proper nouns. `tell me about Berlin and
  東京` resolved correctly to 東京 (right-promote via a18's Unicode
  tail-tokenisation fix), but `_is_substantive_topic("東京")`
  returned False because the ASCII-length-5 heuristic doesn't
  account for CJK ideograms carrying syllable-level lexical weight
  per character. Same shape for `Köln` (4 chars with umlaut), `京都`,
  `北京`, `上海`. The post-a17 → a18 Unicode tail fix made these
  topics REACHABLE; this fix lets the chain detector + soft-
  connector footer recognise them as substantive at 2+ chars when
  carrying at least one non-ASCII letter.

Pass-2 source-level sibling audits + new-angle live-MCP probes
came up clean: zero new defects.

## Live-MCP transcript highlights (pre-fix probes)

```
walk-cursor → search for Photosynthesis  ❌ silently applied offset=3 ("showing 4-6")
walk-cursor → search Berlin in namespace C  ❌ silently applied offset=3 ("showing 4-6")
browse-cursor → search for Berlin  ❌ silently applied offset=3 ("showing 4-6")
walk-cursor → links in Photosynthesis  ✓ ignored (hardcoded offset=0; guarded anyway)
typo cursor (t="walk_nsmespace") → walk  ✓ rejected with Cursor / Tool Mismatch
empty t cursor → walk  ✓ no-ops cleanly (per design)

tell me about Berlin and 東京  ❌ returned 東京, no soft-connector footer
tell me about Köln and Berlin  ❌ returned Berlin, no footer
tell me about 東京 and Berlin  ❌ returned Berlin, no footer
tell me about Москва and Berlin  ✓ footer fires (Москва ≥5 chars)
tell me about the and München  ✓ footer correctly suppressed ("the" not substantive)
tell me about Berlin vs München  ✓ "vs" connector footer fires
```

## Pass-2 audit summary

**Sibling audit (P1-D1 / P1-D2):** all 4 sites in `simple_tools.py`
that read `options.get("offset", 0)` now have the
`_cursor_tool_mismatch` guard (`_handle_browse`,
`_handle_walk_namespace` from the post-a18 sweep; `_handle_search`,
`_handle_filtered_search` from this sweep). `_handle_search_all`
and `_handle_related` don't read `options["offset"]` at all. No
siblings remaining.

**Sibling audit (P1-D3):** `_is_substantive_topic` is called from
two sites — the chain detector right-promote branch
(`simple_tools.py:983-984`) and `_soft_connector_footer`
(`simple_tools.py:1156`). Both benefit from the fix. Searched for
other `len(stripped) >= N` ASCII-length heuristics in
`simple_tools.py` / `intent_parser.py` / `title_promotion.py` /
`synthesize.py`; `intent_parser.py:1012` already has explicit
Unicode handling for the analogous `_looks_like_topic_ask` check,
no other ASCII-only thresholds on user-provided strings.

**Pass-3 live re-probe deferred** following the post-a17 sweep
methodology: the three fixes are narrow, well-characterised,
handler-edge guards / pure-function heuristic. No cross-module
contract changes, no cursor codec / serialization changes — the
mock-based regression tests catch the exact same surfaces a live
re-probe would. Live re-probe remains the right call when fixes
touch cross-module surfaces (post-a16 wave 3) or live-only cursor
shapes (post-a16 P3-D2); neither applies here.

## Regression tests

19 new tests in [tests/test_post_a19_beta_fixes.py](tests/test_post_a19_beta_fixes.py):

- **P1-D1** (4): walk-cursor-to-search rejected; browse-cursor-to-
  search rejected; same-tool search-cursor round-trips cleanly;
  no-cursor passthrough unaffected.
- **P1-D2** (3): walk-cursor-to-filtered-search rejected; walk-
  cursor-to-links rejected; filtered-search no-cursor passthrough
  unaffected.
- **P1-D3** (12): CJK 2-char accept (`東京` / `北京` / `京都` / `上海`);
  umlaut 4-char accept (`Köln`); ASCII particles still rejected
  (`Then` / `Both` / `Here` / `Now` / `This`); abbreviations still
  rejected (`Dr.` / `St.` / `Mt.` / `Jr.`); single CJK char still
  rejected (`京` / `北`); regression guards for ASCII long topics,
  multi-token, digit topics, empty / whitespace; Cyrillic short
  topic via existing 5-char path + relaxed branch; end-to-end soft-
  connector footer fires with CJK dropped half + umlaut dropped
  half.

**Full test suite: 1842 passed, 50 skipped.**

## Files changed

- [openzim_mcp/simple_tools.py](openzim_mcp/simple_tools.py) — 3 fix
  shapes:
  - `_is_substantive_topic`: relaxed non-ASCII branch (P1-D3).
  - `_handle_search`: `_cursor_tool_mismatch(options,
    "search_zim_file")` at top (P1-D1).
  - `_handle_filtered_search`: `_cursor_tool_mismatch(options,
    "search_with_filters")` at top (P1-D2).
  - `_handle_links`: `_cursor_tool_mismatch(options,
    "extract_article_links")` at top (defence-in-depth).
- [tests/test_post_a19_beta_fixes.py](tests/test_post_a19_beta_fixes.py)
  — new, 19 regression tests pinning each defect.

