### PR TITLE
chore(deps): bump idna 3.13 -> 3.15 (CVE-2026-45409)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -562,11 +562,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

pip-audit (run as part of the release workflow's pre-release test step) flagged idna 3.13 against [CVE-2026-45409](https://github.com/advisories/GHSA-?), blocking the v2.0.0a20 release at the `Test before release` step ([run 26114300537](https://github.com/cameronrye/openzim-mcp/actions/runs/26114300537)).

`idna` is a transitive dependency:

```
mcp[cli] → anyio → idna
mcp[cli] → httpx → httpcore → idna
```

Refreshed uv.lock with `uv lock --upgrade-package idna`. The diff is a single 3-line bump (sdist URL + wheel URL + version). Local `pip-audit --skip-editable` post-bump: **No known vulnerabilities found**.

## Release retry plan

After this merges, I'll delete the broken `v2.0.0a20` tag (the release workflow run failed at pre-release tests, so no PyPI artifact or GitHub release exists) and re-tag the new main HEAD.