### PR TITLE
fix(v2): post-a20 beta-test sweep — 6 defects across three passes

### DIFF
--- a/openzim_mcp/intent_parser.py
+++ b/openzim_mcp/intent_parser.py
@@ -704,6 +704,57 @@ class IntentParser:
         ),
     ]
 
+    # Post-a20 PD2-1: trailing politeness markers ("please", "thanks",
+    # "thank you", "kindly") were stripped only by
+    # ``_extract_tell_me_about``. Every other extractor that captures
+    # the topic / search-terms with a greedy tail
+    # ((``_extract_search``, ``_extract_search_all``, ``_extract_find_by_title``,
+    # ``_extract_related``, ``_extract_suggestions``,
+    # ``_extract_entry_path_keyworded`` — feeding get_article / links /
+    # structure / toc / summary, ``_extract_get_zim_entries``,
+    # ``_extract_get_section``) silently swallowed the politeness as
+    # part of the captured value:
+    #
+    #   * ``search for biology please`` → ``query="biology please"`` →
+    #     ranks ``Thanks Maa`` etc. above ``Biology``.
+    #   * ``find article titled Berlin please`` → looks up
+    #     ``Berlin please`` (not found).
+    #   * ``links in Photosynthesis please`` → tries to fetch
+    #     ``Photosynthesis please`` (not found).
+    #
+    # Strip universally at the top of ``parse_intent`` so every
+    # extractor sees the cleaned query. The strip is end-anchored
+    # (``\s*$``), so legitimate uses of the politeness word as content
+    # (``search for "Please Understand Me"`` — song title; the quoted
+    # form fully encloses the content phrase, and the trailing ``please``
+    # after the close-quote is what gets stripped) are unaffected. Loop
+    # the strip so combinations like ``biology, thanks please`` peel
+    # cleanly.
+    _TRAILING_POLITENESS_RE = (
+        r"\s*[,;.!?]?\s*"
+        r"(?:please|kindly|thanks(?:\s+a\s+lot)?|thank\s+(?:you|u))"
+        r"\s*[,;.!?]*\s*$"
+    )
+
+    @classmethod
+    def _strip_trailing_politeness(cls, query: str) -> str:
+        """Peel trailing politeness tokens (``please`` / ``thanks`` /
+        ``thank you`` / ``kindly``) off ``query``. Idempotent; loops
+        until a pass produces no change so combinations like
+        ``biology, thanks please`` strip in one call.
+        """
+        for _ in range(4):
+            before = query
+            query = safe_regex_sub(
+                cls._TRAILING_POLITENESS_RE,
+                "",
+                query,
+                flags=re.IGNORECASE,
+            ).strip()
+            if query == before:
+                break
+        return query
+
     @classmethod
     def parse_intent(cls, query: str) -> Tuple[str, Dict[str, Any], float]:
         """Parse a natural language query to determine intent.
@@ -718,6 +769,11 @@ class IntentParser:
         Returns:
             Tuple of (intent_type, extracted_params, confidence_score)
         """
+        # Post-a20 PD2-1: peel trailing politeness BEFORE pattern
+        # matching + extraction so every extractor sees the cleaned
+        # query. See ``_TRAILING_POLITENESS_RE`` above for rationale +
+        # sibling-defect enumeration.
+        query = cls._strip_trailing_politeness(query)
         query_lower = query.lower()
 
         # Collect all matching patterns

--- a/openzim_mcp/server.py
+++ b/openzim_mcp/server.py
@@ -256,12 +256,17 @@ class OpenZimMcpServer:
             Args:
                 query: REQUIRED. Translated from user intent — never the
                     user's raw message.
-                zim_file_path: Optional. The on-disk path of a .zim file
-                    (e.g. `/data/wikipedia_en_all_maxi.zim`) — NOT an
-                    article title, topic, or made-up filename. Omit
-                    entirely and the tool auto-selects the one loaded
-                    archive (or opens all of them when `synthesize=True`).
-                    Use `list available ZIM files` to see real paths.
+                zim_file_path: Optional. **Omit entirely (recommended)** —
+                    the tool auto-selects the loaded archive (or opens
+                    all of them when `synthesize=True`). Pass a real
+                    path ONLY when multiple archives are loaded and you
+                    need to target a specific one; call `list available
+                    ZIM files` first to see the real paths. NEVER pass
+                    an article title, topic, or made-up filename here,
+                    and do NOT invent a path from this docstring —
+                    paths that don't match a loaded archive are silently
+                    auto-corrected when only one archive is loaded, and
+                    surface a path-listing error otherwise.
                 limit: Max search/browse results (default: 3).
                 offset: Pagination offset (default: 0).
                 max_content_length: Article body cap (default: 4000).

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -362,7 +362,37 @@ class SimpleToolsHandler:
                     # has no ≥3-char tokens fall back to a bidirectional
                     # substring check.
                     cursor_q = state.get("q")
-                    if isinstance(cursor_q, str) and cursor_q.strip():
+                    # Post-a20 P1-D1: only ``search_zim_file`` /
+                    # ``search_with_filters`` legitimately emit ``s.q``
+                    # in their cursors (see ``Cursor.encode`` callsites
+                    # in zim/search.py). When ``_cursor_t`` claims a
+                    # non-q-emitting tool (``walk_namespace`` /
+                    # ``browse_namespace`` / ``extract_article_links``)
+                    # but the payload still carries ``s.q``, the field
+                    # is adversarial or vestigial — skipping the
+                    # dispatcher q-overlap check here lets the
+                    # handler-level ``_cursor_tool_mismatch`` fire
+                    # with the correct ``Cursor / Tool Mismatch``
+                    # diagnosis instead of the misleading
+                    # ``Cursor was issued for query X; current request
+                    # shares no terms`` shape (which advises starting
+                    # the search over — useless when the real fault
+                    # is cross-tool reuse).
+                    cursor_t_for_q = (
+                        decoded_payload.get("t")
+                        if isinstance(decoded_payload, dict)
+                        else None
+                    )
+                    cursor_t_emits_q = (
+                        not isinstance(cursor_t_for_q, str)
+                        or not cursor_t_for_q
+                        or cursor_t_for_q in self._Q_EMITTING_CURSOR_TOOLS
+                    )
+                    if (
+                        isinstance(cursor_q, str)
+                        and cursor_q.strip()
+                        and cursor_t_emits_q
+                    ):
                         import re as _re
 
                         cursor_tokens = {
@@ -1160,17 +1190,44 @@ class SimpleToolsHandler:
             title_lower = top_title.lower()
             left_in = left.lower() in title_lower
             right_in = right.lower() in title_lower
-            if not left_in and not right_in and zim_file_path and top_path:
+            if not (left_in and right_in) and zim_file_path and top_path:
                 # Post-a18 P3-D2: substring check fails when the
                 # resolved title is an English-aliased form of a
                 # non-Latin half (München → Munich). Fall back to
                 # title-alias resolution: probe the title index for
                 # each half and treat any half whose top-scored hit
                 # equals ``top_path`` as "in title". Cheap (in-memory
-                # title-index hit) and only fires on the rare
-                # both-missed branch.
-                left_in = self._half_resolves_to_top(zim_file_path, left, top_path)
-                right_in = self._half_resolves_to_top(zim_file_path, right, top_path)
+                # title-index hit).
+                #
+                # Post-a20 P1-D2: previously gated on
+                # ``not left_in and not right_in`` (only ran when BOTH
+                # halves missed the substring check), which left the
+                # asymmetric alias case unsuppressed —
+                # ``tell me about Köln or Cologne`` returned the
+                # Cologne article with a footer suggesting
+                # ``tell me about Köln`` even though Köln's title-index
+                # entry redirects right back to Cologne, sending the
+                # user on a 2-hop journey. Same shape for
+                # ``京都 or Kyoto``, ``上海 or Shanghai``,
+                # ``München or Munich`` (and the reverse-order forms).
+                # Widen the gate to ``not (left_in and right_in)`` so
+                # the alias probe runs whenever EITHER half is missing
+                # in substring; the probe still only upgrades a half's
+                # ``_in`` to True when its top-scored title-index hit
+                # equals ``top_path`` (so unrelated halves like
+                # ``Berlin and 東京`` still drop correctly — Berlin
+                # resolves to Berlin, not to 東京). The irreducible
+                # ``東京 or Tokyo`` case stays unfixed because 東京
+                # title-resolves to its own disambig article, not to
+                # Tokyo.
+                if not left_in:
+                    left_in = self._half_resolves_to_top(
+                        zim_file_path, left, top_path
+                    )
+                if not right_in:
+                    right_in = self._half_resolves_to_top(
+                        zim_file_path, right, top_path
+                    )
             if left_in == right_in:
                 # Both in title → returned article is the full
                 # phrase (``Romeo and Juliet``); neither in title →
@@ -1570,6 +1627,19 @@ class SimpleToolsHandler:
     # search-fallback path (when no strong title match).
     _SEARCH_RENDER_INTENTS = frozenset(
         {"search", "filtered_search", "search_all", "tell_me_about"}
+    )
+
+    # Post-a20 P1-D1: the set of cursor-emitting tools that legitimately
+    # carry an ``s.q`` field in their cursor payload (``search_zim_file``
+    # / ``search_with_filters`` — see ``Cursor.encode`` callsites in
+    # ``zim/search.py``). Other cursor-emitting tools (``walk_namespace``
+    # / ``browse_namespace`` / ``extract_article_links``) never emit
+    # ``s.q``; if a cursor claims one of those tools but still carries
+    # ``s.q``, the field is adversarial or vestigial. The dispatcher's
+    # q-overlap check skips that case so the handler-level
+    # ``_cursor_tool_mismatch`` can fire with the correct diagnosis.
+    _Q_EMITTING_CURSOR_TOOLS = frozenset(
+        {"search_zim_file", "search_with_filters"}
     )
 
     @staticmethod

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -1294,9 +1294,7 @@ class SimpleToolsHandler:
                 # title-resolves to its own disambig article, not to
                 # Tokyo.
                 if not left_in:
-                    left_in = self._half_resolves_to_top(
-                        zim_file_path, left, top_path
-                    )
+                    left_in = self._half_resolves_to_top(zim_file_path, left, top_path)
                 if not right_in:
                     right_in = self._half_resolves_to_top(
                         zim_file_path, right, top_path
@@ -1711,9 +1709,7 @@ class SimpleToolsHandler:
     # ``s.q``, the field is adversarial or vestigial. The dispatcher's
     # q-overlap check skips that case so the handler-level
     # ``_cursor_tool_mismatch`` can fire with the correct diagnosis.
-    _Q_EMITTING_CURSOR_TOOLS = frozenset(
-        {"search_zim_file", "search_with_filters"}
-    )
+    _Q_EMITTING_CURSOR_TOOLS = frozenset({"search_zim_file", "search_with_filters"})
 
     @staticmethod
     def _cursor_tool_mismatch(

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -756,16 +756,89 @@ class SimpleToolsHandler:
                     message=f"Synthesize pipeline failed: {safe_error}",
                     context=f"Query: {safe_query}",
                 )
+            # Post-a20 PD2-4: when ``validate_zim_file`` raises (file
+            # does not exist / not a file / wrong extension), the
+            # generic four-step "Troubleshooting" block gives small
+            # models no learning signal — they just retry the same
+            # call. Replace with a targeted recovery hint that lists
+            # the actual loaded archive paths and points at the
+            # canonical fix ("omit `zim_file_path` to auto-select" or
+            # "use one of these paths verbatim"). PD2-3's auto-select
+            # already handles single-archive setups silently; this
+            # branch is the multi-archive recovery surface (and
+            # defence-in-depth if PD2-3's backend listing ever fails).
+            error_lower = str(e).lower()
+            looks_like_zim_path_error = any(
+                marker in error_lower
+                for marker in (
+                    "file does not exist",
+                    "path is not a file",
+                    "is not a zim file",
+                    "access denied",
+                )
+            )
+            if looks_like_zim_path_error:
+                hint = self._zim_path_recovery_hint()
+                if hint is not None:
+                    return (
+                        f"**ZIM File Not Found**\n\n"
+                        f"**Query**: {safe_query}\n"
+                        f"**Issue**: the `zim_file_path` value passed "
+                        f"doesn't match any loaded archive.\n\n"
+                        f"{hint}\n\n"
+                        f"<!-- intent=zim_path_not_found cert=1.00 -->"
+                    )
             return (
                 f"**Error Processing Query**\n\n"
                 f"**Query**: {safe_query}\n"
                 f"**Error**: {safe_error}\n\n"
                 f"**Troubleshooting**:\n"
-                f"1. Check that the ZIM file path is correct\n"
+                f"1. Omit `zim_file_path` to auto-select the loaded "
+                f"archive (single-archive setups), or call "
+                f"`list available ZIM files` to see real paths\n"
                 f"2. Verify the query format\n"
                 f"3. Try a simpler query\n"
                 f"4. Check server logs for details"
             )
+
+    def _zim_path_recovery_hint(self) -> Optional[str]:
+        """Post-a20 PD2-4: render the recovery hint surfaced by the
+        catch-all when ``validate_zim_file`` raises. Returns a
+        Markdown fragment listing real archive paths plus the
+        canonical "omit to auto-select" fix, or ``None`` if the
+        backend listing can't be fetched (caller falls back to the
+        generic troubleshooting block).
+
+        Defensive against backend failures: ``list_zim_files_data``
+        going sideways should never block the error path itself.
+        """
+        try:
+            files = self.zim_operations.list_zim_files_data()
+        except Exception:
+            return None
+        if not isinstance(files, list) or not files:
+            return None
+        paths: List[str] = []
+        for entry in files:
+            if isinstance(entry, dict):
+                p = entry.get("path")
+                if isinstance(p, str) and p:
+                    paths.append(p)
+        if not paths:
+            return None
+        if len(paths) == 1:
+            return (
+                "**Recovery**: this archive is the only one loaded — "
+                "omit the `zim_file_path` parameter entirely and the "
+                "tool will auto-select it.\n\n"
+                f"**Loaded archive**: `{paths[0]}`"
+            )
+        bullets = "\n".join(f"  - `{p}`" for p in paths)
+        return (
+            "**Recovery**: pass one of the paths below verbatim, or "
+            "use `list available ZIM files` for the same listing.\n\n"
+            f"**Loaded archives**:\n{bullets}"
+        )
 
     # A11 B1: connector tokens that split a chained query into two
     # halves. Each connector is a whole-word match (surrounded by
@@ -4375,22 +4448,34 @@ class SimpleToolsHandler:
     def _normalize_zim_file_path(self, candidate: str) -> str:
         """Resolve hallucinated ZIM file paths or fall back to auto-select.
 
-        Returns the (possibly rewritten) path. Three cases — matches the
-        policy that previously lived inline in ``handle_zim_query`` for
-        the intent-classification branch only:
+        Returns the (possibly rewritten) path. Resolution policy:
 
           1. ``candidate`` matches a real ZIM file's full path or basename:
              return the real path. Basename-only matches normalize bare-
              filename hallucinations like ``"wikipedia.zim"`` to whatever
              directory the file actually lives in.
 
-          2. ``candidate`` is a bare filename (no path separator) and
-             matches nothing: treat it as a hallucination and substitute
-             the auto-selected archive when exactly one is loaded.
+          2. ``candidate`` doesn't match anything AND exactly one ZIM
+             file is loaded: auto-select that one. Catches bare-filename
+             hallucinations (``"wikipedia.zim"``) and — post-a20 PD2-3
+             — also fully-qualified path hallucinations like
+             ``/data/wikipedia_en_all_maxi.zim`` (small models routinely
+             copy this literally from the tool's own docstring example;
+             the real archive is date-suffixed and won't match by
+             basename either). In single-archive setups the explicit
+             path is functionally redundant — there is no second
+             archive to disambiguate against — so silent substitution
+             is the right UX and unlocks small-model recovery instead
+             of dropping them into a "File does not exist" loop.
 
-          3. ``candidate`` has a path separator and matches nothing: trust
-             it (H14: explicit paths must reach the backend, which will
-             surface a clearer error than silent replacement).
+          3. ``candidate`` doesn't match anything AND multiple archives
+             are loaded: trust the candidate. The backend surfaces a
+             clean ``File does not exist`` error which
+             ``handle_zim_query``'s catch-all then enriches with the
+             list of real archive paths (post-a20 PD2-4). H14's rule
+             that "explicit paths must reach the backend" only matters
+             when there's genuine ambiguity about which archive the
+             caller wanted — single-archive setups have none.
         """
         resolved = self._resolve_zim_path(candidate)
         if resolved is not None:
@@ -4401,15 +4486,20 @@ class SimpleToolsHandler:
                     f"'{candidate}' to '{resolved}' via basename match."
                 )
             return resolved
-        if "/" not in candidate and "\\" not in candidate:
-            auto_selected = self._auto_select_zim_file()
-            if auto_selected:
-                self._track("zim_path_replaced_with_auto_select")
-                logger.info(
-                    f"Discarded hallucinated zim_file_path "
-                    f"'{candidate}'; auto-selected '{auto_selected}'."
-                )
-                return auto_selected
+        auto_selected = self._auto_select_zim_file()
+        if auto_selected:
+            has_separator = "/" in candidate or "\\" in candidate
+            self._track(
+                "zim_path_replaced_with_auto_select_separator"
+                if has_separator
+                else "zim_path_replaced_with_auto_select"
+            )
+            logger.info(
+                f"Discarded hallucinated zim_file_path "
+                f"'{candidate}' (no match, single archive loaded); "
+                f"auto-selected '{auto_selected}'."
+            )
+            return auto_selected
         return candidate
 
     def _resolve_zim_path(self, candidate: str) -> Optional[str]:

--- a/tests/test_post_a16_beta_fixes.py
+++ b/tests/test_post_a16_beta_fixes.py
@@ -218,6 +218,17 @@ class TestD1SoftFooter:
         path. Title-promotion needs a score-1.0 title-index hit so
         ``_promote_topic_via_title_index`` succeeds when the search's
         top hit isn't a strong token-match for the topic.
+
+        Post-a20 P1-D2: the alias-fallback in ``_soft_connector_footer``
+        now also calls ``find_entry_by_title_data`` to check whether a
+        connector half title-resolves to ``top_path``. A blanket
+        ``return_value`` would falsely report that every half (incl.
+        ``Berlin`` / ``Mozart``) resolves to ``top_path``, silently
+        suppressing footers that real archives would still emit. Use
+        a ``side_effect`` that only returns the score-1.0 hit when
+        the queried title case-insensitively contains ``top_title``
+        (covers the title-promotion path for the original chained
+        topic) and falls back to empty for unrelated half-lookups.
         """
         path = top_path or top_title
         mock = MagicMock()
@@ -229,14 +240,31 @@ class TestD1SoftFooter:
         }
         mock.get_zim_entry.return_value = "stub-body"
         # Title-promotion + disambig-twin probe both call this. Returning
-        # a score-1.0 hit for the title-promotion path lets the handler
-        # reach the article-fetch + footer-append code. The disambig
-        # twin probe rejects the same path because it doesn't end with
-        # ``_(disambiguation)``.
-        mock.find_entry_by_title_data.return_value = {
-            "results": [{"path": path, "title": top_title, "score": 1.0}],
-            "total": 1,
-        }
+        # a score-1.0 hit when the queried title is ``top_title`` (or
+        # the full chained topic that the title-promotion path probes)
+        # lets the handler reach the article-fetch + footer-append code.
+        # Unrelated half-lookups (Berlin / Mozart / etc.) get an empty
+        # result so the alias-fallback doesn't falsely upgrade them.
+        top_title_lower = top_title.lower()
+
+        def _title_lookup(
+            _zim: str,
+            title: str,
+            *,
+            cross_file: bool = False,
+            limit: int = 1,
+        ) -> dict[str, Any]:
+            q = (title or "").lower()
+            if q == top_title_lower or top_title_lower in q:
+                return {
+                    "results": [
+                        {"path": path, "title": top_title, "score": 1.0}
+                    ],
+                    "total": 1,
+                }
+            return {"results": [], "total": 0}
+
+        mock.find_entry_by_title_data.side_effect = _title_lookup
         return SimpleToolsHandler(mock)
 
     def test_one_half_in_title_emits_footer(self) -> None:

--- a/tests/test_post_a16_beta_fixes.py
+++ b/tests/test_post_a16_beta_fixes.py
@@ -257,9 +257,7 @@ class TestD1SoftFooter:
             q = (title or "").lower()
             if q == top_title_lower or top_title_lower in q:
                 return {
-                    "results": [
-                        {"path": path, "title": top_title, "score": 1.0}
-                    ],
+                    "results": [{"path": path, "title": top_title, "score": 1.0}],
                     "total": 1,
                 }
             return {"results": [], "total": 0}

--- a/tests/test_post_a17_beta_fixes.py
+++ b/tests/test_post_a17_beta_fixes.py
@@ -100,9 +100,7 @@ class TestP1D1TitleSpansConnectorSuppression:
             q = (title or "").lower()
             if q == top_title_lower or top_title_lower in q:
                 return {
-                    "results": [
-                        {"path": path, "title": top_title, "score": 1.0}
-                    ],
+                    "results": [{"path": path, "title": top_title, "score": 1.0}],
                     "total": 1,
                 }
             return {"results": [], "total": 0}

--- a/tests/test_post_a17_beta_fixes.py
+++ b/tests/test_post_a17_beta_fixes.py
@@ -69,6 +69,16 @@ class TestP1D1TitleSpansConnectorSuppression:
     """
 
     def _make_handler(self, top_title: str) -> SimpleToolsHandler:
+        """Post-a20 P1-D2: the alias-fallback in
+        ``_soft_connector_footer`` now also calls
+        ``find_entry_by_title_data`` to check whether a connector half
+        title-resolves to ``top_path``. A blanket ``return_value`` would
+        falsely report that every half (incl. ``Berlin``, ``Mozart``)
+        resolves to ``top_path``, silently suppressing footers that real
+        archives would still emit. Use a ``side_effect`` so only lookups
+        for ``top_title`` (or the full chained topic) hit the score-1.0
+        path — unrelated half-lookups fall back to empty.
+        """
         path = top_title.replace(" ", "_")
         mock = MagicMock()
         mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
@@ -78,10 +88,26 @@ class TestP1D1TitleSpansConnectorSuppression:
             "total": 1,
         }
         mock.get_zim_entry.return_value = "stub-body"
-        mock.find_entry_by_title_data.return_value = {
-            "results": [{"path": path, "title": top_title, "score": 1.0}],
-            "total": 1,
-        }
+        top_title_lower = top_title.lower()
+
+        def _title_lookup(
+            _zim: str,
+            title: str,
+            *,
+            cross_file: bool = False,
+            limit: int = 1,
+        ) -> dict[str, Any]:
+            q = (title or "").lower()
+            if q == top_title_lower or top_title_lower in q:
+                return {
+                    "results": [
+                        {"path": path, "title": top_title, "score": 1.0}
+                    ],
+                    "total": 1,
+                }
+            return {"results": [], "total": 0}
+
+        mock.find_entry_by_title_data.side_effect = _title_lookup
         return SimpleToolsHandler(mock)
 
     def test_comma_title_with_subject_attribute_prefix_suppresses(self) -> None:

--- a/tests/test_post_a20_beta_fixes.py
+++ b/tests/test_post_a20_beta_fixes.py
@@ -152,7 +152,9 @@ class TestP1D1DispatcherQMismatchSkipsNonQEmittingTools:
             options={"compact": True, "cursor": cursor_token},
         )
         # Must NOT route through the misleading q-mismatch shape.
-        assert not (isinstance(out, dict) and out.get("operation") == "cursor_decode"), (
+        assert not (
+            isinstance(out, dict) and out.get("operation") == "cursor_decode"
+        ), (
             f"dispatcher fired q-mismatch when handler tool-mismatch was correct: "
             f"{out!r}"
         )
@@ -601,18 +603,14 @@ class TestPD21TrailingPolitenessStrip:
     def test_search_strips_trailing_please(self) -> None:
         from openzim_mcp.intent_parser import IntentParser
 
-        intent, params, _conf = IntentParser.parse_intent(
-            "search for biology please"
-        )
+        intent, params, _conf = IntentParser.parse_intent("search for biology please")
         assert intent == "search"
         assert params.get("query") == "biology"
 
     def test_search_strips_trailing_thanks(self) -> None:
         from openzim_mcp.intent_parser import IntentParser
 
-        intent, params, _conf = IntentParser.parse_intent(
-            "search for biology thanks"
-        )
+        intent, params, _conf = IntentParser.parse_intent("search for biology thanks")
         assert intent == "search"
         assert params.get("query") == "biology"
 
@@ -628,9 +626,7 @@ class TestPD21TrailingPolitenessStrip:
     def test_search_strips_trailing_kindly(self) -> None:
         from openzim_mcp.intent_parser import IntentParser
 
-        intent, params, _conf = IntentParser.parse_intent(
-            "search for biology kindly"
-        )
+        intent, params, _conf = IntentParser.parse_intent("search for biology kindly")
         assert intent == "search"
         assert params.get("query") == "biology"
 
@@ -638,9 +634,7 @@ class TestPD21TrailingPolitenessStrip:
         # ``biology, please`` — comma-then-politeness shape.
         from openzim_mcp.intent_parser import IntentParser
 
-        intent, params, _conf = IntentParser.parse_intent(
-            "search for biology, please"
-        )
+        intent, params, _conf = IntentParser.parse_intent("search for biology, please")
         assert intent == "search"
         assert params.get("query") == "biology"
 
@@ -693,18 +687,14 @@ class TestPD21TrailingPolitenessStrip:
     def test_get_article_strips_trailing_please(self) -> None:
         from openzim_mcp.intent_parser import IntentParser
 
-        intent, params, _conf = IntentParser.parse_intent(
-            "get article Berlin please"
-        )
+        intent, params, _conf = IntentParser.parse_intent("get article Berlin please")
         assert intent == "get_article"
         assert params.get("entry_path") == "Berlin"
 
     def test_suggestions_strips_trailing_please(self) -> None:
         from openzim_mcp.intent_parser import IntentParser
 
-        intent, params, _conf = IntentParser.parse_intent(
-            "suggestions for ber please"
-        )
+        intent, params, _conf = IntentParser.parse_intent("suggestions for ber please")
         assert intent == "suggestions"
         assert params.get("partial_query") == "ber"
 
@@ -714,9 +704,7 @@ class TestPD21TrailingPolitenessStrip:
         # idempotent).
         from openzim_mcp.intent_parser import IntentParser
 
-        intent, params, _conf = IntentParser.parse_intent(
-            "tell me about Berlin please"
-        )
+        intent, params, _conf = IntentParser.parse_intent("tell me about Berlin please")
         assert intent == "tell_me_about"
         assert params.get("topic") == "Berlin"
 
@@ -726,9 +714,7 @@ class TestPD21TrailingPolitenessStrip:
         # must not change this behaviour.
         from openzim_mcp.intent_parser import IntentParser
 
-        intent, params, _conf = IntentParser.parse_intent(
-            "walk namespace M please"
-        )
+        intent, params, _conf = IntentParser.parse_intent("walk namespace M please")
         assert intent == "walk_namespace"
         assert params.get("namespace") == "M"
 
@@ -797,14 +783,8 @@ class TestPD21TrailingPolitenessStrip:
             IntentParser._strip_trailing_politeness("biology, please, thanks")
             == "biology"
         )
-        assert (
-            IntentParser._strip_trailing_politeness("biology")
-            == "biology"
-        )
-        assert (
-            IntentParser._strip_trailing_politeness("")
-            == ""
-        )
+        assert IntentParser._strip_trailing_politeness("biology") == "biology"
+        assert IntentParser._strip_trailing_politeness("") == ""
 
     def test_helper_does_not_swallow_legitimate_content(self) -> None:
         # ``Photosynthesis`` ends in nothing that resembles politeness;
@@ -825,22 +805,10 @@ class TestPD21TrailingPolitenessStrip:
         # ``please!`` / ``please.``) should still strip cleanly.
         from openzim_mcp.intent_parser import IntentParser
 
-        assert (
-            IntentParser._strip_trailing_politeness("biology please.")
-            == "biology"
-        )
-        assert (
-            IntentParser._strip_trailing_politeness("biology please!")
-            == "biology"
-        )
-        assert (
-            IntentParser._strip_trailing_politeness("biology please?")
-            == "biology"
-        )
-        assert (
-            IntentParser._strip_trailing_politeness("biology, please.")
-            == "biology"
-        )
+        assert IntentParser._strip_trailing_politeness("biology please.") == "biology"
+        assert IntentParser._strip_trailing_politeness("biology please!") == "biology"
+        assert IntentParser._strip_trailing_politeness("biology please?") == "biology"
+        assert IntentParser._strip_trailing_politeness("biology, please.") == "biology"
 
     def test_helper_mid_query_politeness_word_unaffected(self) -> None:
         # ``thanks giving`` mid-phrase is content (Thanksgiving holiday).
@@ -890,6 +858,7 @@ class TestPD22DocstringExampleNoLongerBait:
         # ``server.py``; we extract it from the source rather than
         # standing up a live server.
         import inspect
+
         import openzim_mcp.server as server_mod
 
         source = inspect.getsource(server_mod)
@@ -903,6 +872,7 @@ class TestPD22DocstringExampleNoLongerBait:
         self,
     ) -> None:
         import inspect
+
         import openzim_mcp.server as server_mod
 
         source = inspect.getsource(server_mod)
@@ -959,9 +929,7 @@ class TestPD23NormalizerSingleArchiveAutoSelect:
         # The canonical small-model hallucination — the literal example
         # path from the (pre-PD2-2) tool docstring.
         handler, mock = self._handler_single_archive()
-        result = handler._normalize_zim_file_path(
-            "/data/wikipedia_en_all_maxi.zim"
-        )
+        result = handler._normalize_zim_file_path("/data/wikipedia_en_all_maxi.zim")
         assert result == "/var/lib/zim/wikipedia_en_all_maxi_2026-02.zim"
 
     def test_arbitrary_slashed_hallucination_auto_selects_single_archive(
@@ -981,9 +949,7 @@ class TestPD23NormalizerSingleArchiveAutoSelect:
         # Regression guard: a bare filename matching the real basename
         # still resolves through the existing case-1 path.
         handler, mock = self._handler_single_archive()
-        result = handler._normalize_zim_file_path(
-            "wikipedia_en_all_maxi_2026-02.zim"
-        )
+        result = handler._normalize_zim_file_path("wikipedia_en_all_maxi_2026-02.zim")
         assert result == "/var/lib/zim/wikipedia_en_all_maxi_2026-02.zim"
 
     def test_real_full_path_passes_through(self) -> None:
@@ -1131,9 +1097,7 @@ class TestPD24FileNotFoundRecoveryHint:
         mock.list_zim_files_data.return_value = [
             {"path": "/var/lib/zim/the-only-one.zim"},
         ]
-        mock.list_zim_files.return_value = (
-            '[{"path": "/var/lib/zim/the-only-one.zim"}]'
-        )
+        mock.list_zim_files.return_value = '[{"path": "/var/lib/zim/the-only-one.zim"}]'
         mock.get_main_page.return_value = "main page text"
         mock.config.meta.footer_enabled = False
         handler = SimpleToolsHandler(mock)

--- a/tests/test_post_a20_beta_fixes.py
+++ b/tests/test_post_a20_beta_fixes.py
@@ -1,10 +1,14 @@
 """Regression tests for the post-a20 beta-test sweep (a21 candidate fixes).
 
 The post-a20 live-MCP sweep against the 118 GB Wikipedia ZIM after
-v2.0.0a20 deployed surfaced two new user-facing defects, both shaped
-by the recurring "fix unlocks new paths" pattern that has held
-across a17 → a18 → a19 → a20: each release's fixes reach code paths
-earlier defects had intercepted, exposing the NEXT layer's bugs.
+v2.0.0a20 deployed surfaced three user-facing defects across two
+passes. Pass-1 caught P1-D1 + P1-D2 (the "fix unlocks new paths"
+shape: a20's three landed fixes opened up the surfaces probed). Pass-2
+caught PD2-1 by widening probe coverage to politeness wrappers across
+all simple-mode intents — only ``tell_me_about`` was stripping
+trailing politeness; every other extractor with a greedy
+end-anchored capture was silently swallowing ``please`` / ``thanks``
+/ ``thank you`` into the search term, title lookup, or entry path.
 
 - P1-D1: the dispatcher's cursor-decode block (simple_tools.py
   ``handle_zim_query``) runs the cursor's ``s.q`` overlap check
@@ -54,6 +58,39 @@ earlier defects had intercepted, exposing the NEXT layer's bugs.
   irreducible ``東京 or Tokyo`` case stays unfixed because 東京
   title-resolves to its own disambig article path, not to Tokyo;
   the fallback correctly leaves it alone.
+
+- PD2-1: trailing politeness markers (``please``, ``kindly``,
+  ``thanks``, ``thank you``) leaked into every simple-mode intent
+  EXCEPT ``tell_me_about`` and a few that capture by a tight tail
+  token (filtered_search ends at the namespace letter; walk/browse
+  capture only the letter). Only ``_extract_tell_me_about`` had a
+  trailing-politeness strip (post-a11 B3); the sibling extractors
+  (``_extract_search``, ``_extract_search_all``,
+  ``_extract_find_by_title``, ``_extract_related``,
+  ``_extract_suggestions``, ``_extract_entry_path_keyworded`` —
+  feeding get_article / links / structure / toc / summary, plus
+  ``_extract_get_zim_entries`` / ``_extract_get_section``) capture
+  with greedy patterns terminated only by end-of-string and
+  silently swallowed the politeness into the captured value:
+
+    * ``search for biology please`` → query ``"biology please"``,
+      ranks ``Thanks Maa`` etc. above the canonical ``Biology``.
+    * ``find article titled Berlin please`` → ``"Berlin please"``,
+      not found.
+    * ``links in Photosynthesis please`` → tries to fetch
+      ``"Photosynthesis please"``, not found.
+    * Comma forms (``"biology, please"``) and other tail words
+      (``thanks``, ``thank you``) showed the same shape.
+
+  Fix: lift the trailing-politeness strip into
+  ``IntentParser.parse_intent`` at the entry point — a single
+  end-anchored strip on the query string, looped so combinations
+  (``biology, thanks please``) peel cleanly, runs before pattern
+  matching + extractor dispatch. Every extractor now sees the
+  cleaned query. Legitimate content uses
+  (``search for "Please Understand Me"`` — song title) are
+  unaffected: the strip is end-anchored, so it only peels tokens
+  appearing after the close-quote at end-of-string.
 
 Each test pins one defect; failures here mean a regression on the
 specific bug.
@@ -540,3 +577,282 @@ class TestEndToEndA20Gates:
         # (extract_article_links is non-q-emitting). The handler
         # then walks normally (offset=0 hardcoded).
         assert "Cursor / Tool Mismatch" not in out
+
+
+# ---------------------------------------------------------------------------
+# PD2-1: trailing politeness leaks into intents other than tell_me_about
+# ---------------------------------------------------------------------------
+
+
+class TestPD21TrailingPolitenessStrip:
+    """PD2-1: every extractor with a greedy end-anchored capture
+    silently swallowed trailing politeness (``please`` / ``kindly`` /
+    ``thanks`` / ``thank you``) into the captured value. Only
+    ``_extract_tell_me_about`` had a strip. Fix lifts the strip into
+    ``IntentParser.parse_intent`` so every extractor sees a cleaned
+    query.
+
+    These tests assert at the parsed-params level (the contract
+    extractors expose), not at the end-to-end response level — that
+    isolates the fix to the intent parser and keeps the tests fast
+    regardless of which backend each intent then routes to.
+    """
+
+    def test_search_strips_trailing_please(self) -> None:
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            "search for biology please"
+        )
+        assert intent == "search"
+        assert params.get("query") == "biology"
+
+    def test_search_strips_trailing_thanks(self) -> None:
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            "search for biology thanks"
+        )
+        assert intent == "search"
+        assert params.get("query") == "biology"
+
+    def test_search_strips_trailing_thank_you(self) -> None:
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            "search for biology thank you"
+        )
+        assert intent == "search"
+        assert params.get("query") == "biology"
+
+    def test_search_strips_trailing_kindly(self) -> None:
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            "search for biology kindly"
+        )
+        assert intent == "search"
+        assert params.get("query") == "biology"
+
+    def test_search_strips_comma_please(self) -> None:
+        # ``biology, please`` — comma-then-politeness shape.
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            "search for biology, please"
+        )
+        assert intent == "search"
+        assert params.get("query") == "biology"
+
+    def test_search_strips_combined_thanks_please(self) -> None:
+        # Loop pass: ``biology thanks please`` peels both tails.
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            "search for biology thanks please"
+        )
+        assert intent == "search"
+        assert params.get("query") == "biology"
+
+    def test_find_by_title_strips_trailing_please(self) -> None:
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            "find article titled Berlin please"
+        )
+        assert intent == "find_by_title"
+        assert params.get("title") == "Berlin"
+
+    def test_find_by_title_strips_trailing_thanks(self) -> None:
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            "find article titled Photosynthesis thanks"
+        )
+        assert intent == "find_by_title"
+        assert params.get("title") == "Photosynthesis"
+
+    def test_links_strips_trailing_please(self) -> None:
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            "links in Photosynthesis please"
+        )
+        assert intent == "links"
+        assert params.get("entry_path") == "Photosynthesis"
+
+    def test_structure_strips_trailing_please(self) -> None:
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            "show structure of Photosynthesis please"
+        )
+        assert intent == "structure"
+        assert params.get("entry_path") == "Photosynthesis"
+
+    def test_get_article_strips_trailing_please(self) -> None:
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            "get article Berlin please"
+        )
+        assert intent == "get_article"
+        assert params.get("entry_path") == "Berlin"
+
+    def test_suggestions_strips_trailing_please(self) -> None:
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            "suggestions for ber please"
+        )
+        assert intent == "suggestions"
+        assert params.get("partial_query") == "ber"
+
+    def test_tell_me_about_already_stripped_still_works(self) -> None:
+        # Regression guard: the original tell_me_about strip continues
+        # to work (the lifted strip is upstream, so this should be
+        # idempotent).
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            "tell me about Berlin please"
+        )
+        assert intent == "tell_me_about"
+        assert params.get("topic") == "Berlin"
+
+    def test_walk_namespace_unaffected_by_trailing_please(self) -> None:
+        # Walk's extractor captures only the namespace letter, so
+        # trailing politeness never affected it pre-fix. The strip
+        # must not change this behaviour.
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            "walk namespace M please"
+        )
+        assert intent == "walk_namespace"
+        assert params.get("namespace") == "M"
+
+    def test_filtered_search_unaffected_by_trailing_please(self) -> None:
+        # Filtered search's regex ends at the namespace letter, so
+        # the trailing politeness was already harmless. Defence-in-
+        # depth: the strip must not break this case either.
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            "search Berlin in namespace C please"
+        )
+        assert intent == "filtered_search"
+        assert params.get("query") == "Berlin"
+        assert (params.get("namespace") or "").upper() == "C"
+
+    def test_quoted_inner_please_not_stripped(self) -> None:
+        # Legitimate content uses with ``please`` as a query word
+        # MUST not be touched. Quoted form encloses the content; the
+        # strip is end-anchored after the close-quote.
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            'search for "Please Understand Me"'
+        )
+        assert intent == "search"
+        # The quoted phrase remains intact (with or without enclosing
+        # quotes is up to the extractor — what matters is "Please" is
+        # still present as a content token).
+        captured = (params.get("query") or "").lower()
+        assert "please understand me" in captured
+
+    def test_search_quoted_inner_please_with_outer_please_strip(self) -> None:
+        # Hybrid: quoted content uses "please" AND trailing politeness
+        # appears outside the quotes. Only the outside ``please`` peels.
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            'search for "Please Understand Me" please'
+        )
+        assert intent == "search"
+        captured = (params.get("query") or "").lower()
+        assert "please understand me" in captured
+        # The trailing ``please`` outside the quotes is gone.
+        assert not captured.rstrip().endswith("please")
+
+    def test_no_politeness_unchanged(self) -> None:
+        # Regression guard: queries without any politeness tail must
+        # parse exactly as before (the strip is a no-op).
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent("search for biology")
+        assert intent == "search"
+        assert params.get("query") == "biology"
+
+    def test_helper_idempotent(self) -> None:
+        # _strip_trailing_politeness is exposed for unit testing the
+        # loop behaviour directly.
+        from openzim_mcp.intent_parser import IntentParser
+
+        assert (
+            IntentParser._strip_trailing_politeness("biology please thanks")
+            == "biology"
+        )
+        assert (
+            IntentParser._strip_trailing_politeness("biology, please, thanks")
+            == "biology"
+        )
+        assert (
+            IntentParser._strip_trailing_politeness("biology")
+            == "biology"
+        )
+        assert (
+            IntentParser._strip_trailing_politeness("")
+            == ""
+        )
+
+    def test_helper_does_not_swallow_legitimate_content(self) -> None:
+        # ``Photosynthesis`` ends in nothing that resembles politeness;
+        # ``please`` inside a quoted phrase is content and must stay.
+        from openzim_mcp.intent_parser import IntentParser
+
+        assert (
+            IntentParser._strip_trailing_politeness("Photosynthesis")
+            == "Photosynthesis"
+        )
+        assert (
+            IntentParser._strip_trailing_politeness('"Please Understand Me"')
+            == '"Please Understand Me"'
+        )
+
+    def test_helper_handles_trailing_punctuation(self) -> None:
+        # Trailing punctuation after the politeness (``please?`` /
+        # ``please!`` / ``please.``) should still strip cleanly.
+        from openzim_mcp.intent_parser import IntentParser
+
+        assert (
+            IntentParser._strip_trailing_politeness("biology please.")
+            == "biology"
+        )
+        assert (
+            IntentParser._strip_trailing_politeness("biology please!")
+            == "biology"
+        )
+        assert (
+            IntentParser._strip_trailing_politeness("biology please?")
+            == "biology"
+        )
+        assert (
+            IntentParser._strip_trailing_politeness("biology, please.")
+            == "biology"
+        )
+
+    def test_helper_mid_query_politeness_word_unaffected(self) -> None:
+        # ``thanks giving`` mid-phrase is content (Thanksgiving holiday).
+        # ``kindly remind me`` mid-phrase is content. Strip is
+        # end-anchored, so neither matches.
+        from openzim_mcp.intent_parser import IntentParser
+
+        assert (
+            IntentParser._strip_trailing_politeness("biology thanks giving")
+            == "biology thanks giving"
+        )
+        assert (
+            IntentParser._strip_trailing_politeness("biology kindly remind me")
+            == "biology kindly remind me"
+        )

--- a/tests/test_post_a20_beta_fixes.py
+++ b/tests/test_post_a20_beta_fixes.py
@@ -1,0 +1,542 @@
+"""Regression tests for the post-a20 beta-test sweep (a21 candidate fixes).
+
+The post-a20 live-MCP sweep against the 118 GB Wikipedia ZIM after
+v2.0.0a20 deployed surfaced two new user-facing defects, both shaped
+by the recurring "fix unlocks new paths" pattern that has held
+across a17 → a18 → a19 → a20: each release's fixes reach code paths
+earlier defects had intercepted, exposing the NEXT layer's bugs.
+
+- P1-D1: the dispatcher's cursor-decode block (simple_tools.py
+  ``handle_zim_query``) runs the cursor's ``s.q`` overlap check
+  BEFORE any handler-level ``_cursor_tool_mismatch`` guard fires.
+  When a cross-tool cursor carries an ``s.q`` field (a hand-stuffed
+  walk_namespace cursor with ``s.q="biology"`` passed to ``search
+  for photosynthesis``, or a real search cursor reused with a
+  different tool), the dispatcher emits the "Cursor was issued for
+  query X; current request shares no terms" message — naming the
+  wrong fault shape. The user is advised to "start the search over
+  for the new query" even though the cursor is from a different
+  tool entirely. Post-a19's P1-D1/D2 made cross-tool reuse LOUD via
+  the handler-edge guard; this defect is the surface of the
+  dispatcher-vs-handler ordering issue pass-2 of the post-a19
+  sweep flagged but did not address.
+
+  Fix (scoped): the dispatcher's q-overlap check now skips when the
+  cursor's ``t`` field claims a tool that does NOT legitimately
+  emit ``s.q`` in its cursors (walk_namespace, browse_namespace,
+  extract_article_links). Only ``search_zim_file`` and
+  ``search_with_filters`` emit ``s.q`` (per the ``Cursor.encode``
+  callsites in zim/search.py); any ``s.q`` riding a non-q-emitting
+  ``t`` is adversarial or vestigial — letting the dispatcher
+  short-circuit on it produces a misleading error. The handler's
+  ``_cursor_tool_mismatch`` then fires with the correct
+  ``Cursor / Tool Mismatch`` diagnosis.
+
+- P1-D2: ``_soft_connector_footer``'s alias-fallback branch
+  (post-a18 P3-D2) was gated on ``not left_in and not right_in``
+  (both halves missing in substring). When one half matches the
+  resolved title via substring (``Cologne`` ⊂ ``Cologne``) and the
+  other matches only via title-alias (``Köln`` → ``Cologne``), the
+  gate was False and the alias probe never ran. The footer
+  surfaced "For Köln, query separately with tell me about Köln"
+  for queries like
+  ``tell me about Köln or Cologne`` — sending the caller on a
+  two-hop journey to an article that just redirects back to the
+  one already returned. Same shape for ``京都 or Kyoto`` /
+  ``上海 or Shanghai`` / ``München or Munich`` (and the reverse-
+  order variants).
+
+  Fix: widen the gate to ``not (left_in and right_in)`` so the
+  alias probe runs whenever EITHER half is missing in substring
+  (only upgrades a False → True; unrelated halves like ``Berlin``
+  in ``Berlin and 東京`` still resolve to themselves, so the gate
+  semantics for the "real chain" case are unchanged). The
+  irreducible ``東京 or Tokyo`` case stays unfixed because 東京
+  title-resolves to its own disambig article path, not to Tokyo;
+  the fallback correctly leaves it alone.
+
+Each test pins one defect; failures here mean a regression on the
+specific bug.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from openzim_mcp.pagination import Cursor
+from openzim_mcp.simple_tools import SimpleToolsHandler
+
+
+def _encode_cursor(tool: str, **state_fields: Any) -> str:
+    """Encode a v2 cursor for ``tool`` from arbitrary ``s.*`` fields.
+
+    Mirrors the helper used in the post-a19 fixes test file — the
+    test surface mirrors production, where every cursor-emitting tool
+    calls ``Cursor.encode(tool=..., state=...)`` with its own ``s.*``
+    envelope. We can also pass adversarial ``s.q`` values on tools
+    that don't normally emit ``q`` to verify the dispatcher's new
+    skip behaviour.
+    """
+    return Cursor.encode(tool=tool, state=state_fields)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# P1-D1: dispatcher q-mismatch fires before handler tool-mismatch
+# ---------------------------------------------------------------------------
+
+
+class TestP1D1DispatcherQMismatchSkipsNonQEmittingTools:
+    """P1-D1: cross-tool cursors that carry an adversarial ``s.q``
+    must NOT trigger the dispatcher's q-overlap rejection — the
+    correct diagnosis is tool-mismatch, fired by the handler-edge
+    guard. The dispatcher now skips its q-check when the cursor's
+    ``t`` field claims a non-q-emitting tool.
+    """
+
+    def _handler(self) -> tuple[SimpleToolsHandler, MagicMock]:
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        return SimpleToolsHandler(mock), mock
+
+    def test_walk_cursor_with_stuffed_q_routes_to_tool_mismatch(self) -> None:
+        # Pre-fix: dispatcher saw cursor.q='biology', current query
+        # tokens = {'search','for','photosynthesis'}, no overlap,
+        # returned 'Cursor was issued for query "biology"; current
+        # request shares no terms'. Post-fix: dispatcher sees
+        # cursor.t='walk_namespace' is NOT q-emitting, skips q-check,
+        # handler's tool-mismatch fires with the right diagnosis.
+        handler, mock = self._handler()
+        cursor_token = _encode_cursor(
+            "walk_namespace", o=5, l=3, ns="M", ai="e048666a9e92", q="biology"
+        )
+        out = handler.handle_zim_query(
+            "search for photosynthesis",
+            zim_file_path="/x.zim",
+            options={"compact": True, "cursor": cursor_token},
+        )
+        # Must NOT route through the misleading q-mismatch shape.
+        assert not (isinstance(out, dict) and out.get("operation") == "cursor_decode"), (
+            f"dispatcher fired q-mismatch when handler tool-mismatch was correct: "
+            f"{out!r}"
+        )
+        # Handler-level tool-mismatch markdown shape.
+        assert isinstance(out, str)
+        assert "Cursor / Tool Mismatch" in out
+        assert "walk_namespace" in out
+        assert "search_zim_file" in out
+        # Backend not called.
+        assert not mock.search_zim_file_data.called
+        assert not mock.search_zim_file.called
+
+    def test_browse_cursor_with_stuffed_q_routes_to_tool_mismatch(self) -> None:
+        # Same shape with a different non-q-emitting source tool.
+        handler, mock = self._handler()
+        cursor_token = _encode_cursor(
+            "browse_namespace",
+            o=5,
+            l=3,
+            ns="M",
+            ai="e048666a9e92",
+            q="completely-unrelated",
+        )
+        out = handler.handle_zim_query(
+            "search for Berlin",
+            zim_file_path="/x.zim",
+            options={"compact": True, "cursor": cursor_token},
+        )
+        assert not (isinstance(out, dict) and out.get("operation") == "cursor_decode")
+        assert isinstance(out, str)
+        assert "Cursor / Tool Mismatch" in out
+        assert "browse_namespace" in out
+        assert "search_zim_file" in out
+
+    def test_links_cursor_with_stuffed_q_routes_to_tool_mismatch(self) -> None:
+        # ``extract_article_links`` also never emits ``s.q`` — any
+        # ``s.q`` on its cursors is adversarial.
+        handler, mock = self._handler()
+        cursor_token = _encode_cursor(
+            "extract_article_links",
+            o=3,
+            ai="e048666a9e92",
+            q="vestigial",
+        )
+        out = handler.handle_zim_query(
+            "search for Photosynthesis",
+            zim_file_path="/x.zim",
+            options={"compact": True, "cursor": cursor_token},
+        )
+        assert not (isinstance(out, dict) and out.get("operation") == "cursor_decode")
+        assert isinstance(out, str)
+        assert "Cursor / Tool Mismatch" in out
+        assert "extract_article_links" in out
+        assert "search_zim_file" in out
+
+    def test_walk_cursor_stuffed_q_to_filtered_search_routes_to_tool_mismatch(
+        self,
+    ) -> None:
+        # Same shape with the filtered-search handler edge.
+        handler, mock = self._handler()
+        cursor_token = _encode_cursor(
+            "walk_namespace",
+            o=3,
+            l=3,
+            ns="M",
+            ai="e048666a9e92",
+            q="cooking",
+        )
+        out = handler.handle_zim_query(
+            "search Berlin in namespace C",
+            zim_file_path="/x.zim",
+            options={"compact": True, "cursor": cursor_token},
+        )
+        assert not (isinstance(out, dict) and out.get("operation") == "cursor_decode")
+        assert isinstance(out, str)
+        assert "Cursor / Tool Mismatch" in out
+        assert "walk_namespace" in out
+        assert "search_with_filters" in out
+
+    def test_real_search_cursor_unrelated_query_still_q_mismatches(self) -> None:
+        # Regression guard: the dispatcher's q-mismatch logic MUST
+        # still fire for real ``search_zim_file`` cursors whose
+        # stored ``s.q`` shares no terms with the current request.
+        # This is the original D9 (beta) intent — pagination state
+        # coupled to a different query. The fix only skips the check
+        # for cursors from tools that don't normally emit ``s.q``;
+        # real search cursors still go through.
+        handler, mock = self._handler()
+        cursor_token = _encode_cursor(
+            "search_zim_file", o=5, q="algebra", ai="e048666a9e92"
+        )
+        out = handler.handle_zim_query(
+            "search for photosynthesis",
+            zim_file_path="/x.zim",
+            options={"compact": True, "cursor": cursor_token},
+        )
+        # Existing q-mismatch shape (JSON tool_error dict).
+        assert isinstance(out, dict)
+        assert out.get("operation") == "cursor_decode"
+        assert "shares no terms" in (out.get("message") or "")
+
+    def test_real_search_cursor_overlapping_query_routes_to_backend(self) -> None:
+        # Regression guard: a real search cursor whose stored ``s.q``
+        # overlaps the current query MUST still route through to the
+        # backend (the canonical pagination path). The fix does not
+        # touch this case.
+        handler, mock = self._handler()
+        mock.search_zim_file_data.return_value = {
+            "total": 100,
+            "results": [],
+            "page_info": {"offset": 5, "limit": 5, "returned_count": 0},
+            "_meta": {},
+        }
+        cursor_token = _encode_cursor(
+            "search_zim_file", o=5, q="biology evolution", ai="e048666a9e92"
+        )
+        out = handler.handle_zim_query(
+            "search for biology",
+            zim_file_path="/x.zim",
+            options={"compact": True, "cursor": cursor_token},
+        )
+        # No cursor_decode error — backend was invoked.
+        assert not (isinstance(out, dict) and out.get("operation") == "cursor_decode")
+        assert mock.search_zim_file_data.called
+
+    def test_walk_cursor_stuffed_q_to_walk_handler_routes_normally(self) -> None:
+        # When the cursor's ``t`` matches the actual routing target
+        # (walk -> walk), the dispatcher's q-skip does NOT alter
+        # normal cursor consumption — the walk handler ignores the
+        # stuffed ``q`` field (which doesn't appear in walk's data
+        # path at all) and pages forward from the cursor's offset.
+        # This pins the skip's blast radius to cross-tool reuse only.
+        handler, mock = self._handler()
+        mock.walk_namespace_data.return_value = {
+            "results": [],
+            "total": 100,
+            "page_info": {"offset": 5, "limit": 3, "returned_count": 0},
+            "_meta": {},
+        }
+        cursor_token = _encode_cursor(
+            "walk_namespace",
+            o=5,
+            l=3,
+            ns="M",
+            ai="e048666a9e92",
+            q="vestigial",
+        )
+        out = handler.handle_zim_query(
+            "walk namespace M",
+            zim_file_path="/x.zim",
+            options={"compact": True, "cursor": cursor_token},
+        )
+        # No tool-mismatch (same tool), no q-mismatch (skipped).
+        assert not (isinstance(out, dict) and out.get("operation") == "cursor_decode")
+        assert "Cursor / Tool Mismatch" not in (out if isinstance(out, str) else "")
+        assert mock.walk_namespace_data.called
+
+
+# ---------------------------------------------------------------------------
+# P1-D2: soft-connector footer's alias-fallback gate was too narrow
+# ---------------------------------------------------------------------------
+
+
+class TestP1D2SoftConnectorFooterAsymmetricAliasSuppression:
+    """P1-D2: the alias-fallback in ``_soft_connector_footer`` was
+    gated on ``not left_in and not right_in`` — both halves missing
+    in substring. The asymmetric case (one half matches substring,
+    the other matches only via title alias) slipped through,
+    producing footers that sent the user to a 2-hop article that
+    just redirects back to the picked article (``Köln`` →
+    ``Cologne``, ``京都`` → ``Kyoto``, ``上海`` → ``Shanghai``,
+    ``München`` → ``Munich``).
+
+    The fix widens the gate to ``not (left_in and right_in)`` so
+    the alias probe runs whenever either half is missing in
+    substring. The probe only upgrades a half whose top-scored
+    title-index hit equals ``top_path``, so unrelated chain
+    halves (``Berlin and 東京``) still drop correctly.
+    """
+
+    def _handler(
+        self,
+        alias_map: dict[str, str] | None = None,
+    ) -> tuple[SimpleToolsHandler, MagicMock]:
+        # Build a mock whose ``find_entry_by_title_data`` returns
+        # the supplied alias mapping. The footer's alias probe calls
+        # this backend; we drive deterministic responses to pin the
+        # gate's behaviour without hitting a real archive.
+        mock = MagicMock()
+
+        def lookup(
+            zim_file_path: str,
+            title: str,
+            *,
+            cross_file: bool = False,
+            limit: int = 1,
+        ) -> dict[str, Any]:
+            target = (alias_map or {}).get(title)
+            if target is None:
+                return {"results": []}
+            return {"results": [{"path": target}]}
+
+        mock.find_entry_by_title_data.side_effect = lookup
+        return SimpleToolsHandler(mock), mock
+
+    def test_koln_or_cologne_suppresses_footer(self) -> None:
+        # Köln title-resolves to Cologne — same article via the
+        # German-name alias. The footer must NOT direct the user to
+        # ``tell me about Köln`` (which round-trips back to Cologne).
+        handler, mock = self._handler(alias_map={"Köln": "Cologne"})
+        out = handler._soft_connector_footer(
+            topic="Köln or Cologne",
+            top_title="Cologne",
+            zim_file_path="/x.zim",
+            top_path="Cologne",
+        )
+        assert out is None, f"footer should suppress alias-edge case, got: {out!r}"
+
+    def test_cologne_or_koln_suppresses_footer(self) -> None:
+        # Reverse order — same asymmetric alias case, picked half
+        # on the left this time.
+        handler, mock = self._handler(alias_map={"Köln": "Cologne"})
+        out = handler._soft_connector_footer(
+            topic="Cologne or Köln",
+            top_title="Cologne",
+            zim_file_path="/x.zim",
+            top_path="Cologne",
+        )
+        assert out is None
+
+    def test_kyoto_japanese_or_english_suppresses_footer(self) -> None:
+        # CJK ideogram half (京都) aliases to the English title (Kyoto).
+        handler, mock = self._handler(alias_map={"京都": "Kyoto"})
+        out = handler._soft_connector_footer(
+            topic="京都 or Kyoto",
+            top_title="Kyoto",
+            zim_file_path="/x.zim",
+            top_path="Kyoto",
+        )
+        assert out is None
+
+    def test_shanghai_or_chinese_suppresses_footer(self) -> None:
+        handler, mock = self._handler(alias_map={"上海": "Shanghai"})
+        out = handler._soft_connector_footer(
+            topic="Shanghai or 上海",
+            top_title="Shanghai",
+            zim_file_path="/x.zim",
+            top_path="Shanghai",
+        )
+        assert out is None
+
+    def test_munich_german_alias_suppresses_footer(self) -> None:
+        handler, mock = self._handler(alias_map={"München": "Munich"})
+        out = handler._soft_connector_footer(
+            topic="Munich or München",
+            top_title="Munich",
+            zim_file_path="/x.zim",
+            top_path="Munich",
+        )
+        assert out is None
+
+    def test_genuinely_different_halves_still_footer(self) -> None:
+        # Regression guard: ``Berlin and München`` — different
+        # cities, München aliases to Munich, but the resolver
+        # picked one of them (München in the live probe). When
+        # picked is München and dropped is Berlin, the alias probe
+        # for Berlin returns Berlin's own path (NOT Munich) so the
+        # dropped-half remains genuinely dropped — footer must fire.
+        handler, mock = self._handler(
+            alias_map={"München": "Munich", "Berlin": "Berlin"}
+        )
+        out = handler._soft_connector_footer(
+            topic="Berlin and München",
+            top_title="München",
+            zim_file_path="/x.zim",
+            top_path="Munich",
+        )
+        assert out is not None
+        assert "Berlin" in out
+        # Probe was run on both halves (Berlin AND München) — the
+        # widened gate runs the fallback on the missing-substring
+        # half(es), so München's alias matches → left_in=True,
+        # Berlin's alias misses → right_in=False (or vice versa
+        # depending on connector position).
+        assert mock.find_entry_by_title_data.called
+
+    def test_tokyo_has_own_disambig_still_fires_footer(self) -> None:
+        # The irreducible edge: 東京 has its own disambig article at
+        # path ``東京`` — not an alias to Tokyo. The fallback for 東京
+        # returns its own path which differs from ``Tokyo``, so the
+        # footer correctly fires (the user genuinely needs the
+        # disambig page to choose between Tokyo / Tonkin / Đông Kinh).
+        # This was flagged in the post-a20 brief as a known
+        # not-in-scope edge case.
+        handler, mock = self._handler(alias_map={"東京": "東京"})
+        out = handler._soft_connector_footer(
+            topic="東京 or Tokyo",
+            top_title="Tokyo",
+            zim_file_path="/x.zim",
+            top_path="Tokyo",
+        )
+        assert out is not None
+        assert "東京" in out
+
+    def test_both_halves_already_in_title_no_alias_probe(self) -> None:
+        # Regression guard: ``Romeo and Juliet`` with top_title
+        # ``Romeo and Juliet`` — both halves match by substring,
+        # widened gate evaluates to False, alias probe doesn't run,
+        # footer suppresses (returned article IS the full phrase).
+        handler, mock = self._handler()
+        out = handler._soft_connector_footer(
+            topic="Romeo and Juliet",
+            top_title="Romeo and Juliet",
+            zim_file_path="/x.zim",
+            top_path="Romeo_and_Juliet",
+        )
+        # Suppressed via the structural-connector branch
+        # (top_title contains "and" connector pattern) — kept here
+        # to defence-in-depth check both branches reject this shape.
+        assert out is None
+        # No alias probe needed — the top-title-contains-connector
+        # branch suppresses without reaching the alias fallback.
+        assert not mock.find_entry_by_title_data.called
+
+    def test_both_halves_missing_in_substring_alias_runs_for_both(self) -> None:
+        # Regression guard for the original post-a18 P3-D2 motivation:
+        # both halves miss substring, alias probe runs on both,
+        # one alias matches → footer fires for the genuinely
+        # dropped half. The post-a20 widening must preserve this.
+        handler, mock = self._handler(
+            alias_map={"München": "Munich", "Berlin": "Berlin"}
+        )
+        out = handler._soft_connector_footer(
+            topic="Berlin and München",
+            top_title="Munich",
+            zim_file_path="/x.zim",
+            top_path="Munich",
+        )
+        # München aliases to Munich (left_in upgrades), Berlin doesn't
+        # (right_in stays False) — footer fires naming Berlin.
+        assert out is not None
+        assert "Berlin" in out
+
+
+# ---------------------------------------------------------------------------
+# End-to-end smoke gates
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndA20Gates:
+    """End-to-end gates that confirm both P1-D1 and P1-D2 hold at the
+    user-facing surface — not just at the helper layer. These mirror
+    the live-MCP smoke gates from the post-a20 sweep brief.
+    """
+
+    def _handler(self) -> tuple[SimpleToolsHandler, MagicMock]:
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        return SimpleToolsHandler(mock), mock
+
+    def test_walk_cursor_stuffed_q_search_intent_yields_tool_mismatch(self) -> None:
+        # Cross-tool with stuffed q — must yield the markdown
+        # tool-mismatch shape, not the JSON q-mismatch.
+        handler, mock = self._handler()
+        cursor_token = _encode_cursor(
+            "walk_namespace",
+            o=5,
+            l=3,
+            ns="M",
+            ai="e048666a9e92",
+            q="biology",
+        )
+        out = handler.handle_zim_query(
+            "search for photosynthesis",
+            zim_file_path="/x.zim",
+            options={"compact": True, "cursor": cursor_token},
+        )
+        assert isinstance(out, str), f"expected markdown, got {type(out)!r}: {out!r}"
+        assert "Cursor / Tool Mismatch" in out
+
+    def test_walk_cursor_stuffed_q_filtered_search_yields_tool_mismatch(
+        self,
+    ) -> None:
+        handler, mock = self._handler()
+        cursor_token = _encode_cursor(
+            "walk_namespace",
+            o=5,
+            l=3,
+            ns="C",
+            ai="e048666a9e92",
+            q="cooking",
+        )
+        out = handler.handle_zim_query(
+            "search Berlin in namespace C",
+            zim_file_path="/x.zim",
+            options={"compact": True, "cursor": cursor_token},
+        )
+        assert isinstance(out, str)
+        assert "Cursor / Tool Mismatch" in out
+
+    def test_walk_cursor_stuffed_q_links_yields_tool_mismatch(self) -> None:
+        handler, mock = self._handler()
+        # Make path resolution a no-op (returns nothing).
+        mock.find_entry_by_title_data.return_value = {"results": []}
+        cursor_token = _encode_cursor(
+            "extract_article_links",
+            o=3,
+            ai="e048666a9e92",
+            q="biology",
+        )
+        out = handler.handle_zim_query(
+            "links in Photosynthesis",
+            zim_file_path="/x.zim",
+            options={"compact": True, "cursor": cursor_token},
+        )
+        assert isinstance(out, str)
+        # The cursor's ``t`` is extract_article_links, which IS
+        # what the routing target is, so this case is same-tool
+        # cursor reuse. Tool-mismatch must NOT fire here — the
+        # ``q`` is vestigial and the dispatcher skips its q-check
+        # (extract_article_links is non-q-emitting). The handler
+        # then walks normally (offset=0 hardcoded).
+        assert "Cursor / Tool Mismatch" not in out

--- a/tests/test_post_a20_beta_fixes.py
+++ b/tests/test_post_a20_beta_fixes.py
@@ -856,3 +856,293 @@ class TestPD21TrailingPolitenessStrip:
             IntentParser._strip_trailing_politeness("biology kindly remind me")
             == "biology kindly remind me"
         )
+
+
+# ---------------------------------------------------------------------------
+# PD2-2 / PD2-3 / PD2-4: small-model hallucinated zim_file_path recovery
+# ---------------------------------------------------------------------------
+
+
+class TestPD22DocstringExampleNoLongerBait:
+    """PD2-2: the ``zim_query`` tool docstring used to contain a
+    literal-looking example path (``/data/wikipedia_en_all_maxi.zim``).
+    Small models with weak instruction-following parse "e.g." as
+    illustrative inconsistently and frequently copy the example as
+    the actual ``zim_file_path`` value. Real archives in production
+    are date-suffixed (``wikipedia_en_all_maxi_2026-02.zim``) so the
+    basename doesn't match either, and the previous "trust slashed
+    paths" branch dropped the model into a ``File does not exist``
+    retry loop with no recovery signal.
+
+    The docstring no longer contains a literal-looking path example;
+    the description leads with "Omit entirely (recommended)" so
+    auto-select is the natural choice the model latches onto.
+    """
+
+    def test_zim_query_docstring_does_not_contain_literal_path_example(
+        self,
+    ) -> None:
+        # The bait was the literal example ``/data/wikipedia_en_all_maxi.zim``
+        # appearing in the docstring. Pin its removal — any reappearance
+        # should fail this test and remind future maintainers that
+        # docstring example paths get copied by small models.
+        # The tool docstring lives on ``zim_query`` registered in
+        # ``server.py``; we extract it from the source rather than
+        # standing up a live server.
+        import inspect
+        import openzim_mcp.server as server_mod
+
+        source = inspect.getsource(server_mod)
+        assert "/data/wikipedia_en_all_maxi.zim" not in source, (
+            "Docstring example reintroduced the literal-looking path "
+            "small models copy verbatim. Use a generic placeholder or "
+            "drop the example entirely."
+        )
+
+    def test_zim_query_docstring_emphasises_omit_to_auto_select(
+        self,
+    ) -> None:
+        import inspect
+        import openzim_mcp.server as server_mod
+
+        source = inspect.getsource(server_mod)
+        # Match phrasing that primes the model toward the canonical
+        # omit-to-auto-select default rather than path invention.
+        assert "Omit entirely" in source, (
+            "Docstring should lead with 'Omit entirely' for the "
+            "zim_file_path parameter to nudge small models toward the "
+            "canonical default."
+        )
+
+
+class TestPD23NormalizerSingleArchiveAutoSelect:
+    """PD2-3: ``_normalize_zim_file_path`` auto-selects when exactly
+    one archive is loaded — even when the candidate has a path
+    separator. Pre-fix, slashed paths fell through "trust it" (H14)
+    and reached the backend, which errored. In single-archive setups
+    there is no ambiguity to surface; silent substitution is the
+    right UX. Multi-archive setups still trust the candidate and let
+    the backend error surface with PD2-4's recovery hint.
+    """
+
+    def _handler_single_archive(self) -> tuple[Any, MagicMock]:
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [
+            {
+                "path": "/var/lib/zim/wikipedia_en_all_maxi_2026-02.zim",
+                "name": "wikipedia_en_all_maxi_2026-02.zim",
+            },
+        ]
+        mock.list_zim_files.return_value = (
+            '[{"path": "/var/lib/zim/wikipedia_en_all_maxi_2026-02.zim"}]'
+        )
+        mock.get_main_page.return_value = "main page text"
+        return SimpleToolsHandler(mock), mock
+
+    def _handler_multi_archive(self) -> tuple[Any, MagicMock]:
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [
+            {"path": "/var/lib/zim/wikipedia_en_all_maxi_2026-02.zim"},
+            {"path": "/var/lib/zim/wiktionary_en_all_maxi_2026-02.zim"},
+        ]
+        mock.list_zim_files.return_value = (
+            '[{"path": "/var/lib/zim/wikipedia_en_all_maxi_2026-02.zim"}, '
+            '{"path": "/var/lib/zim/wiktionary_en_all_maxi_2026-02.zim"}]'
+        )
+        return SimpleToolsHandler(mock), mock
+
+    def test_docstring_example_path_auto_selects_single_archive(self) -> None:
+        # The canonical small-model hallucination — the literal example
+        # path from the (pre-PD2-2) tool docstring.
+        handler, mock = self._handler_single_archive()
+        result = handler._normalize_zim_file_path(
+            "/data/wikipedia_en_all_maxi.zim"
+        )
+        assert result == "/var/lib/zim/wikipedia_en_all_maxi_2026-02.zim"
+
+    def test_arbitrary_slashed_hallucination_auto_selects_single_archive(
+        self,
+    ) -> None:
+        handler, mock = self._handler_single_archive()
+        result = handler._normalize_zim_file_path("/totally/made/up.zim")
+        assert result == "/var/lib/zim/wikipedia_en_all_maxi_2026-02.zim"
+
+    def test_bare_filename_hallucination_still_auto_selects(self) -> None:
+        # Regression guard for the original bare-filename auto-select.
+        handler, mock = self._handler_single_archive()
+        result = handler._normalize_zim_file_path("wikipedia.zim")
+        assert result == "/var/lib/zim/wikipedia_en_all_maxi_2026-02.zim"
+
+    def test_basename_match_still_resolves(self) -> None:
+        # Regression guard: a bare filename matching the real basename
+        # still resolves through the existing case-1 path.
+        handler, mock = self._handler_single_archive()
+        result = handler._normalize_zim_file_path(
+            "wikipedia_en_all_maxi_2026-02.zim"
+        )
+        assert result == "/var/lib/zim/wikipedia_en_all_maxi_2026-02.zim"
+
+    def test_real_full_path_passes_through(self) -> None:
+        # Regression guard: the real full path matches case 1 and is
+        # returned verbatim.
+        handler, mock = self._handler_single_archive()
+        real = "/var/lib/zim/wikipedia_en_all_maxi_2026-02.zim"
+        assert handler._normalize_zim_file_path(real) == real
+
+    def test_multi_archive_slashed_path_no_match_preserves_h14(self) -> None:
+        # H14 narrowed: with multiple archives loaded, we can't
+        # silently pick one — preserve the candidate so the backend
+        # error surfaces and PD2-4 enriches it with the actual listing.
+        handler, mock = self._handler_multi_archive()
+        candidate = "/totally/made/up.zim"
+        assert handler._normalize_zim_file_path(candidate) == candidate
+
+    def test_multi_archive_bare_filename_no_match_preserves_h14(
+        self,
+    ) -> None:
+        # Same shape for bare filenames in multi-archive setups: the
+        # ambiguity blocks auto-select.
+        handler, mock = self._handler_multi_archive()
+        candidate = "totally-fake.zim"
+        assert handler._normalize_zim_file_path(candidate) == candidate
+
+    def test_zero_archives_loaded_returns_candidate_unchanged(self) -> None:
+        # Edge case: no archives loaded → auto-select returns None →
+        # we return the candidate, backend errors, error handler
+        # surfaces "no archives loaded".
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = []
+        mock.list_zim_files.return_value = "[]"
+        handler = SimpleToolsHandler(mock)
+        candidate = "/whatever.zim"
+        assert handler._normalize_zim_file_path(candidate) == candidate
+
+
+class TestPD24FileNotFoundRecoveryHint:
+    """PD2-4: when ``validate_zim_file`` raises a path-error, the
+    catch-all in ``handle_zim_query`` now emits a targeted recovery
+    hint listing real archive paths and the canonical "omit to
+    auto-select" fix. Pre-fix, the generic 4-step "Troubleshooting"
+    template gave no learning signal.
+    """
+
+    def test_recovery_hint_single_archive_says_omit(self) -> None:
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [
+            {"path": "/var/lib/zim/wikipedia_en_all_maxi_2026-02.zim"},
+        ]
+        handler = SimpleToolsHandler(mock)
+        hint = handler._zim_path_recovery_hint()
+        assert hint is not None
+        assert "Omit" in hint or "omit" in hint
+        assert "/var/lib/zim/wikipedia_en_all_maxi_2026-02.zim" in hint
+
+    def test_recovery_hint_multi_archive_lists_paths(self) -> None:
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [
+            {"path": "/var/lib/zim/wikipedia.zim"},
+            {"path": "/var/lib/zim/wiktionary.zim"},
+        ]
+        handler = SimpleToolsHandler(mock)
+        hint = handler._zim_path_recovery_hint()
+        assert hint is not None
+        assert "/var/lib/zim/wikipedia.zim" in hint
+        assert "/var/lib/zim/wiktionary.zim" in hint
+        assert "verbatim" in hint or "Loaded archives" in hint
+
+    def test_recovery_hint_zero_archives_returns_none(self) -> None:
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = []
+        handler = SimpleToolsHandler(mock)
+        assert handler._zim_path_recovery_hint() is None
+
+    def test_recovery_hint_backend_failure_returns_none(self) -> None:
+        # Defensive: backend listing failure must not block the error
+        # path. Returning None makes the caller fall back to the
+        # generic troubleshooting block.
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        mock = MagicMock()
+        mock.list_zim_files_data.side_effect = RuntimeError("listing failed")
+        handler = SimpleToolsHandler(mock)
+        assert handler._zim_path_recovery_hint() is None
+
+    def test_recovery_hint_malformed_listing_returns_none(self) -> None:
+        # Defensive: listing returns something other than a list of
+        # dicts with path strings (e.g. None / wrong shape).
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = "not-a-list"
+        handler = SimpleToolsHandler(mock)
+        assert handler._zim_path_recovery_hint() is None
+
+    def test_multi_archive_path_error_surfaces_hint_end_to_end(self) -> None:
+        # End-to-end: multi-archive setup, bogus slashed path passed,
+        # backend raises ``File does not exist``, catch-all wraps it
+        # in the PD2-4 recovery markdown with the actual paths listed.
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [
+            {"path": "/var/lib/zim/wikipedia.zim"},
+            {"path": "/var/lib/zim/wiktionary.zim"},
+        ]
+        # Make the backend raise to drive the catch-all.
+        mock.get_main_page.side_effect = Exception(
+            "File does not exist: /totally/fake.zim"
+        )
+        mock.config.meta.footer_enabled = False
+        handler = SimpleToolsHandler(mock)
+        out = handler.handle_zim_query(
+            "show main page",
+            zim_file_path="/totally/fake.zim",
+        )
+        assert isinstance(out, str)
+        # New error shape.
+        assert "**ZIM File Not Found**" in out
+        # Real paths surfaced.
+        assert "/var/lib/zim/wikipedia.zim" in out
+        assert "/var/lib/zim/wiktionary.zim" in out
+        # Generic troubleshooting block is replaced.
+        assert "Check server logs" not in out
+
+    def test_single_archive_path_error_falls_through_to_pd23_auto_select(
+        self,
+    ) -> None:
+        # End-to-end: single-archive setup MUST never reach the
+        # catch-all for a bogus zim_file_path — PD2-3 auto-selects
+        # before the backend sees it. Pin this contract.
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [
+            {"path": "/var/lib/zim/the-only-one.zim"},
+        ]
+        mock.list_zim_files.return_value = (
+            '[{"path": "/var/lib/zim/the-only-one.zim"}]'
+        )
+        mock.get_main_page.return_value = "main page text"
+        mock.config.meta.footer_enabled = False
+        handler = SimpleToolsHandler(mock)
+        handler.handle_zim_query(
+            "show main page",
+            zim_file_path="/some/other/fake.zim",
+        )
+        # Backend was invoked with the auto-selected path, not the
+        # hallucinated one.
+        mock.get_main_page.assert_called_once_with(
+            "/var/lib/zim/the-only-one.zim", compact=False
+        )

--- a/tests/test_simple_tools.py
+++ b/tests/test_simple_tools.py
@@ -963,20 +963,36 @@ class TestGetZimEntriesDispatch:
 
 
 class TestExplicitZimPathHonored:
-    """Regression: H14 - explicit zim_file_path must not be overwritten."""
+    """Regression: H14 (narrowed post-a20) - explicit zim_file_path must
+    not be overwritten when multiple archives are loaded.
+
+    The original H14 contract was "any explicit slashed path reaches the
+    backend verbatim". Post-a20 PD2-3 narrowed this: single-archive
+    setups auto-select even for slashed paths (no ambiguity to surface),
+    but multi-archive setups still preserve the explicit path so the
+    backend can produce a clean error pointing at the right path. This
+    fixture loads two archives so the H14 preservation case fires for
+    every parameterised intent.
+    """
 
     @pytest.fixture
     def mock_zim_operations(self):
-        """Create mock ZimOperations that records the zim path it receives."""
+        """Create mock ZimOperations that records the zim path it receives.
+
+        Multi-archive setup: with PD2-3, auto-select only kicks in when
+        exactly one archive is loaded, so we need ≥2 to exercise the
+        H14 preservation branch.
+        """
         mock = Mock()
-        # Auto-select would return a different path; if the fix is wrong and
-        # the intent branch calls _auto_select_zim_file, this is what would
-        # be passed through to the backend.
+        # Two loaded archives: auto-select returns None (ambiguous),
+        # so the normalizer falls through to "trust the candidate".
         mock.list_zim_files_data.return_value = [
-            {"path": "/auto/selected.zim", "name": "selected.zim"}
+            {"path": "/auto/selected.zim", "name": "selected.zim"},
+            {"path": "/auto/secondary.zim", "name": "secondary.zim"},
         ]
         mock.list_zim_files.return_value = (
-            '[{"path": "/auto/selected.zim", "name": "selected.zim"}]'
+            '[{"path": "/auto/selected.zim", "name": "selected.zim"}, '
+            '{"path": "/auto/secondary.zim", "name": "secondary.zim"}]'
         )
         mock.walk_namespace.return_value = "{}"
         mock.find_entry_by_title.return_value = "{}"
@@ -2188,18 +2204,45 @@ class TestZimPathHallucinationHandling:
             "/var/lib/zim/wikipedia_en_all_maxi.zim", compact=False
         )
 
-    def test_slashed_path_is_trusted_even_when_unknown(
+    def test_slashed_path_no_match_single_archive_auto_selects(
         self, handler, mock_zim_operations
     ):
-        """A slashed path that doesn't match the listing is trusted —
-        the caller knew enough to write a path, so we let it reach the
-        backend (which has its own validation and clearer error
-        messages than silent auto-replacement). H14 regression.
+        """Post-a20 PD2-3: a slashed path that doesn't match the listing
+        auto-selects when exactly one archive is loaded. Small models
+        routinely copy the docstring example
+        (``/data/wikipedia_en_all_maxi.zim``) verbatim — that path
+        won't match a date-suffixed real archive by basename either,
+        so the previous "trust the candidate" branch dropped them into
+        a ``File does not exist`` retry loop with no recovery signal.
+        In single-archive setups there's nothing to disambiguate against,
+        so silent substitution is the right UX.
         """
         explicit = "/some/other/wikipedia.zim"
         handler.handle_zim_query("show main page", zim_file_path=explicit)
+        # The hallucinated slashed path was discarded; auto-select
+        # supplied the real path.
         mock_zim_operations.get_main_page.assert_called_once_with(
-            explicit, compact=False
+            "/var/lib/zim/wikipedia_en_all_maxi.zim", compact=False
+        )
+
+    def test_slashed_path_docstring_example_auto_selects(
+        self, handler, mock_zim_operations
+    ):
+        """Post-a20 PD2-3: the exact docstring example
+        ``/data/wikipedia_en_all_maxi.zim`` is the canonical small-model
+        hallucination — it appears literally in the tool description
+        and weak instruction-followers copy it verbatim. The basename
+        ``wikipedia_en_all_maxi.zim`` won't match the real archive
+        (date-suffixed in production), so without auto-select the model
+        gets dropped into a ``File does not exist`` loop. With
+        single-archive auto-select on, it just works.
+        """
+        # The docstring's example path — copied verbatim from the
+        # tool's own description in server.py.
+        explicit = "/data/wikipedia_en_all_maxi.zim"
+        handler.handle_zim_query("show main page", zim_file_path=explicit)
+        mock_zim_operations.get_main_page.assert_called_once_with(
+            "/var/lib/zim/wikipedia_en_all_maxi.zim", compact=False
         )
 
     def test_slashed_path_matching_full_path_is_used_verbatim(
@@ -2316,14 +2359,27 @@ class TestZimPathHallucinationHandling:
             compact=False,
         )
 
-    def test_synthesize_slashed_unmatched_path_passed_through(
-        self, handler, mock_zim_operations
-    ):
-        """A14: a deliberate slashed path that doesn't match the listing
-        must still reach the synthesize pipeline verbatim — same H14
-        rule as the intent branch. The backend path validator can then
-        surface a clearer error than silent replacement.
+    def test_synthesize_slashed_unmatched_path_single_archive_auto_selects(
+        self,
+    ) -> None:
+        """Post-a20 PD2-3: a slashed path that doesn't match the listing
+        auto-selects when only one archive is loaded — same rule for
+        the synthesize branch as the intent branch. Pre-PD2-3 (legacy
+        H14 contract on this single-archive fixture), the slashed path
+        reached synthesize verbatim and the backend errored. Now the
+        normalizer substitutes the only loaded archive before the
+        synthesize dispatcher sees the path.
         """
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        mock = Mock()
+        mock.list_zim_files_data.return_value = [
+            {"path": "/var/lib/zim/wikipedia_en_all_maxi.zim"},
+        ]
+        mock.list_zim_files.return_value = (
+            '[{"path": "/var/lib/zim/wikipedia_en_all_maxi.zim"}]'
+        )
+        handler = SimpleToolsHandler(mock)
         explicit = "/some/other/wikipedia.zim"
         with patch.object(handler, "_handle_synthesize_query") as mock_synth:
             mock_synth.return_value = {
@@ -2337,7 +2393,55 @@ class TestZimPathHallucinationHandling:
                 zim_file_path=explicit,
                 options={"synthesize": True},
             )
-        mock_synth.assert_called_once_with("berlin", explicit, compact=False)
+        # The synthesize dispatcher receives the auto-selected real
+        # path, not the hallucinated slashed candidate.
+        mock_synth.assert_called_once_with(
+            "berlin",
+            "/var/lib/zim/wikipedia_en_all_maxi.zim",
+            compact=False,
+        )
+
+    def test_synthesize_slashed_unmatched_path_multi_archive_preserved(
+        self,
+    ) -> None:
+        """Post-a20 PD2-3 H14 narrowing: multi-archive setups still
+        preserve the explicit slashed path verbatim — the synthesize
+        dispatcher gets to surface its own error about the path.
+        """
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        mock = Mock()
+        mock.list_zim_files_data.return_value = [
+            {"path": "/var/lib/zim/wikipedia.zim"},
+            {"path": "/var/lib/zim/wiktionary.zim"},
+        ]
+        mock.list_zim_files.return_value = (
+            '[{"path": "/var/lib/zim/wikipedia.zim"}, '
+            '{"path": "/var/lib/zim/wiktionary.zim"}]'
+        )
+        handler = SimpleToolsHandler(mock)
+        # Basename ``ghost.zim`` doesn't match either loaded archive,
+        # so case 1 (basename match) doesn't fire. With two archives
+        # loaded, auto-select returns None → candidate preserved.
+        explicit = "/some/other/ghost.zim"
+        with patch.object(handler, "_handle_synthesize_query") as mock_synth:
+            mock_synth.return_value = {
+                "answer_markdown": "ok",
+                "passages": [],
+                "citations": [],
+                "archives_searched": [],
+            }
+            handler.handle_zim_query(
+                "berlin",
+                zim_file_path=explicit,
+                options={"synthesize": True},
+            )
+        # Multi-archive: auto-select returns None (ambiguous) →
+        # candidate preserved. H14 still holds when there's something
+        # to disambiguate against.
+        mock_synth.assert_called_once_with(
+            "berlin", "/some/other/ghost.zim", compact=False
+        )
 
     def test_synthesize_no_path_skips_resolver(self, handler, mock_zim_operations):
         """A14: when ``zim_file_path`` is None, the resolver is


### PR DESCRIPTION
## Summary

Post-a20 live-MCP sweep against the 118 GB Wikipedia ZIM + a live small-model failure transcript. Six user-facing defects across three passes:

- **Pass 1 (live-MCP)** — P1-D1 + P1-D2: cross-tool cursor q/tool-mismatch ordering + soft-connector alias-fallback gate too narrow.
- **Pass 2 — wave 1 (live-MCP, widened probes)** — PD2-1: trailing politeness (`please` / `thanks` / `thank you` / `kindly`) leaked into 8+ intent handlers.
- **Pass 2 — wave 2 (live transcript review)** — PD2-2 + PD2-3 + PD2-4: a small-model failure shape where the tool's own docstring example path was copied verbatim, the normalizer's H14 "trust slashed paths" branch dropped the model into a retry loop, and the generic catch-all error gave no recovery signal.
- **Pass 3 (source-level audit)** — zero new defects across all six fix-sites.

## Pass-1 defects

### P1-D1 — Dispatcher q-mismatch fires before handler tool-mismatch
Cross-tool cursors carrying an \`s.q\` field tripped the dispatcher's q-overlap check before the handler-edge \`_cursor_tool_mismatch\` could fire. User saw a misleading "shares no terms" error instead of "Cursor / Tool Mismatch". Fix scopes the dispatcher check to cursors claiming \`search_zim_file\` / \`search_with_filters\` (the only \`Cursor.encode\` callsites that emit \`s.q\`); other tool cursors route to the handler-edge guard.

### P1-D2 — Soft-connector footer alias-fallback gate too narrow
\`_soft_connector_footer\`'s post-a18 alias-fallback ran only when both halves missed substring. The asymmetric case (Köln → Cologne, 京都 → Kyoto, 上海 → Shanghai, München → Munich, Москва → Moscow, Αθήνα → Athens) slipped through, sending users on 2-hop journeys. Widened the gate to \`not (left_in and right_in)\`. The irreducible \`東京 or Tokyo\` case stays correctly unsuppressed.

## Pass-2 defects

### PD2-1 — Trailing politeness leaks into multiple intent params
Every simple-mode intent except \`tell_me_about\` and a few that capture by a tight tail token silently swallowed \`please\` / \`thanks\` / \`thank you\` / \`kindly\` into the captured value (\`search for biology please\` → query \`"biology please"\`, etc.). Lifted the trailing-politeness strip into \`IntentParser.parse_intent\` at the entry point — single end-anchored regex, looped for combinations, runs before pattern matching + extractor dispatch.

### PD2-2 — Tool docstring example IS the hallucination source
Live transcript showed Qwen3-8B-Q4 passing \`zim_file_path: "/data/wikipedia_en_all_maxi.zim"\` — copied verbatim from the docstring's "e.g." example. Small models with weak instruction-following parse "e.g." inconsistently and copy literal-looking paths as actual arguments. Real archives are date-suffixed in production, so the basename doesn't match either. Rewrote the parameter description to lead with **Omit entirely (recommended)**, dropped the literal path example, added an explicit "do NOT invent a path from this docstring" line. Regression test pins the absence of the bait string.

### PD2-3 — Normalizer's "trust slashed paths" was the wrong default for single-archive setups
H14's rule ("explicit paths must reach the backend") only matters when there's genuine ambiguity about which archive the caller wanted. Single-archive setups have none, so silent substitution is the correct UX. Widened \`_normalize_zim_file_path\` to auto-select when the candidate doesn't match anything AND exactly one archive is loaded — regardless of whether the candidate has a path separator. Multi-archive setups still preserve the candidate (H14 narrowed but intact where it actually applies).

### PD2-4 — Catch-all error gave small models no learning signal
The generic four-step "Troubleshooting" template doesn't tell the model *what to do differently* on retry. Added a targeted path-error detector that fires for the \`validate_zim_file\` exception family (\`File does not exist\` / \`Path is not a file\` / \`is not a zim file\` / \`Access denied\`) and replaces the template with a **ZIM File Not Found** shape:
  * Single archive loaded → "Omit the parameter — only one archive loaded" + the actual path (defence-in-depth; PD2-3 already prevents this branch from firing in single-archive setups).
  * Multiple archives → bulleted listing of real archive paths with "pass one verbatim" guidance.
  
Generic template's step 1 also rewritten to suggest "omit \`zim_file_path\`" as the canonical fix.

Combined effect on the reported transcript: the model would have either (a) succeeded silently on the first call via PD2-3's auto-select (single-archive), or (b) received an actionable error listing real paths (multi-archive) instead of looping.

## Source-level audits (zero new defects)

- **P1-D1 sibling check** — all 7 \`Cursor.encode\` callsites enumerated: \`_Q_EMITTING_CURSOR_TOOLS\` closed against the full encoder surface.
- **P1-D2 sibling check** — \`_half_resolves_to_top\` has exactly one caller; no other gate sites in the codebase.
- **PD2-1 sibling check** — all extractors flow through \`parse_intent\`; strip lands at single entry point.
- **PD2-2 sibling check** — \`tools/structure_tools.py\` uses \`/path/to/wiki.zim\` (obvious placeholder), \`tools/resource_tools.py\` mentions \`wikipedia.zim\` in internal helper docs only (not LLM-facing); simple-mode \`zim_query\` was the only bait site surfaced to small models.
- **PD2-3/4 sibling check** — synthesize branch also calls \`_normalize_zim_file_path\` so the fix applies uniformly; catch-all enrichment is the single chokepoint for path errors out of \`handle_zim_query\`.

## Tests

65 new tests in \`tests/test_post_a20_beta_fixes.py\`:
  * 7 for P1-D1 (cross-tool cursor with stuffed \`s.q\` → tool-mismatch; q-mismatch regression guards; same-tool round-trip).
  * 9 for P1-D2 (alias-edge suppression for Köln / 京都 / 上海 / München, reverse-order variants, irreducible Tokyo edge, structural-suppression regression guards).
  * 3 end-to-end markdown-shape gates.
  * 22 for PD2-1 (all affected intents × politeness variants + edge cases).
  * 2 for PD2-2 (docstring bait removal + "Omit entirely" emphasis).
  * 8 for PD2-3 (docstring example path, arbitrary slashed hallucination, bare filename, basename match, real full path, multi-archive H14 preservation, zero archives edge case).
  * 7 for PD2-4 (helper output single/multi/zero, defensive returns, end-to-end multi-archive enrichment, end-to-end single-archive PD2-3 passthrough).

Plus 4 existing H14 tests updated for the narrowed contract:
  * \`TestExplicitZimPathHonored\` fixture now multi-archive.
  * \`TestZimPathHallucinationHandling\` slashed-unmatched test split into single-archive (auto-select) + multi-archive (preserve).
  * Two mock-realism updates in \`tests/test_post_a16_beta_fixes.py\` and \`tests/test_post_a17_beta_fixes.py\` (per-title \`side_effect\` so P1-D2's widened alias-fallback doesn't falsely suppress legitimate footers in the test fixtures).

Full suite: **1902 passed, 50 skipped**.

## Methodology

Per the post-a17 refinement: source-level audit suffices when fixes are narrow handler-edge guards + pure-function heuristic widening with no cross-module contract changes. All six defects meet these criteria. Live re-probe is deferred until the next deploy of the build.

The sweep evolved across three rounds of probe coverage:
  1. Pass-1: probe a20's three new fix shapes from angles its own pass-2 didn't cover (recurring "fix unlocks new paths" pattern).
  2. Pass-2 wave 1: widen to politeness wrappers across all intents (PD2-1 sibling-defect class).
  3. Pass-2 wave 2: live transcript review surfaced PD2-2/3/4 as a single docstring-bait → hallucinated-path → no-recovery loop.

Base: \`60b2107\` (CVE-driven idna lockfile bump on top of v2.0.0a20).