### PR TITLE
fix(v2): post-a21 beta-test sweep — 11 defects across two passes

### DIFF
--- a/openzim_mcp/intent_parser.py
+++ b/openzim_mcp/intent_parser.py
@@ -730,9 +730,26 @@ class IntentParser:
     # after the close-quote is what gets stripped) are unaffected. Loop
     # the strip so combinations like ``biology, thanks please`` peel
     # cleanly.
+    # Post-a21 P1-D6 + P1-D7: widen the politeness token list to cover
+    # British/texting variants (``ta`` / ``cheers`` / ``thx`` / ``ty``
+    # / ``pls``) and the obvious multi-language tokens (``bitte`` /
+    # ``danke`` / ``merci`` / ``gracias`` / ``por favor``). Live
+    # transcripts show small models speculatively appending these
+    # too — same shape as the post-a20 PD2-1 ``please``/``thanks``
+    # leak. Several of the new tokens are short (``ta`` is 2 chars,
+    # ``ty`` is 2 chars) so the leading anchor must guarantee a
+    # word boundary or ``cantata`` / ``feta`` / ``Dante`` would get
+    # their last 2 chars eaten. Pre-extension, the leading anchor
+    # was ``\s*[,;.!?]?\s*`` — zero-or-more whitespace lets the
+    # regex match mid-word. The extension tightens to
+    # ``(?:^|\s+|[,;.!?]\s*)`` — start-of-string OR at least one
+    # whitespace OR punctuation + optional whitespace. Embedded
+    # ``ta`` / ``ty`` substrings inside other words no longer match.
     _TRAILING_POLITENESS_RE = (
-        r"\s*[,;.!?]?\s*"
-        r"(?:please|kindly|thanks(?:\s+a\s+lot)?|thank\s+(?:you|u))"
+        r"(?:^|\s+|[,;.!?]\s*)"
+        r"(?:please|kindly|thanks(?:\s+a\s+lot)?|thank\s+(?:you|u)|"
+        r"pls|thx|ty|ta|cheers|"
+        r"bitte|danke|merci|gracias|por\s+favor)"
         r"\s*[,;.!?]*\s*$"
     )
 

--- a/openzim_mcp/server.py
+++ b/openzim_mcp/server.py
@@ -267,7 +267,14 @@ class OpenZimMcpServer:
                     paths that don't match a loaded archive are silently
                     auto-corrected when only one archive is loaded, and
                     surface a path-listing error otherwise.
-                limit: Max search/browse results (default: 3).
+                limit: Max search/browse results (default: 3). Ignored
+                    for atomic intents that return a single item or a
+                    fixed-shape payload — `tell me about <topic>`,
+                    `get article <name>`, `show structure of <name>`,
+                    `links in <name>`, `articles related to <name>`,
+                    `show main page`, `list namespaces`, `metadata for
+                    <file>`, `list available ZIM files`. Setting it
+                    there has no effect; omit it on those calls.
                 offset: Pagination offset (default: 0).
                 max_content_length: Article body cap (default: 4000).
                 content_offset: Character offset to start reading the

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -1400,8 +1400,14 @@ class SimpleToolsHandler:
     # but the leftover is ``"and Bears"`` because the comma-pass split
     # eats the ``", "`` and leaves ``"and"`` as a leading-conjunction
     # prefix. Strip both shapes per-half so the final list is clean.
-    _LEADING_CONJUNCTION_RE = re.compile(r"^(?:and|or|vs\.?|&)\s+", re.IGNORECASE)
-    _TRAILING_CONJUNCTION_RE = re.compile(r"\s+(?:and|or|vs\.?|&)$", re.IGNORECASE)
+    #
+    # String-based (not regex) so SonarCloud's S5852 polynomial-
+    # backtracking flag stays quiet — alternation + ``\s+``/``$`` in
+    # one pattern keeps tripping the static analyzer despite the
+    # actual runtime being linear in the half length. Longest-first
+    # ordering so ``vs.`` matches before ``vs``.
+    _CONJUNCTION_SUFFIXES = (" and", " or", " vs.", " vs", " &")
+    _CONJUNCTION_PREFIXES = ("and ", "or ", "vs. ", "vs ", "& ")
 
     @classmethod
     def _split_multi_entity(cls, topic: str) -> Optional[List[str]]:
@@ -1449,8 +1455,23 @@ class SimpleToolsHandler:
             p = raw.strip(" \t,;.")
             if not p:
                 continue
-            p = cls._LEADING_CONJUNCTION_RE.sub("", p).strip()
-            p = cls._TRAILING_CONJUNCTION_RE.sub("", p).strip(" \t,;.")
+            # Strip leading conjunction word + whitespace
+            # (case-insensitive). String-prefix scan rather than
+            # regex so S5852 stays quiet.
+            lower_p = p.lower()
+            for prefix in cls._CONJUNCTION_PREFIXES:
+                if lower_p.startswith(prefix):
+                    p = p[len(prefix) :].lstrip()
+                    break
+            # Strip trailing conjunction word preceded by whitespace
+            # (case-insensitive); rstrip stray punctuation that
+            # follows.
+            p = p.rstrip(" \t,;.")
+            lower_p = p.lower()
+            for suffix in cls._CONJUNCTION_SUFFIXES:
+                if lower_p.endswith(suffix):
+                    p = p[: -len(suffix)].rstrip(" \t,;.")
+                    break
             if p:
                 cleaned.append(p)
         if len(cleaned) < 3:

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -548,6 +548,33 @@ class SimpleToolsHandler:
                     "\n<!-- intent=chained_intent_rejected cert=1.00 -->"
                 )
             intent, params, confidence = self.intent_parser.parse_intent(query)
+            # Post-a21 P1-D1: defence-in-depth strip of trailing
+            # politeness on user-supplied content fields in ``params``.
+            # Idempotent when ``parse_intent`` already cleaned them
+            # (the post-a20 PD2-1 strip lives there), and a belt-and-
+            # suspenders catch for any future regression that returns
+            # ``params`` with politeness still attached (the live a21
+            # sweep observed ``Found N matches for "biology please"``
+            # despite the source-side ``parse_intent`` strip working
+            # correctly under direct unit test — the most likely cause
+            # was an in-process module cache on the live server that
+            # loaded only part of PR #152, but the user-visible defect
+            # is the same shape regardless of root cause). Idempotent
+            # by construction — the strip's regex is end-anchored and
+            # leaves clean content untouched.
+            if isinstance(params, dict):
+                for _key in (
+                    "query",
+                    "topic",
+                    "title",
+                    "entry_path",
+                    "partial_query",
+                ):
+                    _v = params.get(_key)
+                    if isinstance(_v, str) and _v:
+                        _v_clean = IntentParser._strip_trailing_politeness(_v).strip()
+                        if _v_clean != _v:
+                            params[_key] = _v_clean
             # A11 B2: ``tell me about <empty>`` (trailing-space input,
             # punctuation-only topic) used to fall through to a topic
             # of ``"tell me about"`` and disambiguate to article titles
@@ -575,7 +602,20 @@ class SimpleToolsHandler:
                 # nothing followed "search for", the result equals the
                 # original query — accept that case only when there are
                 # ≥1 non-stopword content tokens. Otherwise reject.
+                #
+                # Post-a21 P1-D8: peel trailing politeness from the
+                # tail before the empty-check. Pre-fix, ``search for
+                # please`` (and ``search for ta`` after the P1-D6
+                # extension) returned tail=``"please"`` (non-empty),
+                # the guard didn't fire, ``_extract_search`` captured
+                # ``"for"`` as the search term and the user got a
+                # 200k-hit response dominated by the literal verb
+                # word. The strip is idempotent — when the tail
+                # carries real content the politeness substring is
+                # never trailing.
                 tail = self._search_query_tail(query)
+                if tail is not None:
+                    tail = IntentParser._strip_trailing_politeness(tail).strip()
                 if tail is not None and not tail:
                     return (
                         "**Search Terms Required**\n\n"
@@ -624,6 +664,23 @@ class SimpleToolsHandler:
             # the caller deliberately wrote (H14: explicit paths must reach
             # the backend and surface a clear error there, not a silent
             # auto-replacement).
+
+            # Post-a21 P1-D2 / P1-D3 / P1-D4: detect bare-topic chains
+            # of 3+ substantive proper-noun-shaped halves joined by soft
+            # connectors (``and`` / ``or`` / ``,`` / ``&`` / ``vs`` /
+            # ``/``). The post-a20 P1-D2 alias-fallback widening only
+            # addresses the 2-entity asymmetric case (``Köln or Cologne``).
+            # 3+ entity queries either silently dropped halves
+            # (``Berlin and München and Köln`` → Cologne, no footer
+            # about Berlin or München) or produced a footer suggesting
+            # a still-chained re-query (``Köln, München, and Berlin``
+            # → footer ``tell me about Köln, München,``).
+            multi_entity_warning = self._multi_entity_chain_guidance(
+                intent, params, zim_file_path
+            )
+            if multi_entity_warning is not None:
+                self._track("multi_entity_chain_rejected")
+                return multi_entity_warning
 
             handler = self._INTENT_HANDLERS.get(
                 intent, SimpleToolsHandler._handle_search
@@ -780,11 +837,27 @@ class SimpleToolsHandler:
             if looks_like_zim_path_error:
                 hint = self._zim_path_recovery_hint()
                 if hint is not None:
+                    # Post-a21 P1-D10: surface the original exception
+                    # message alongside the recovery hint. Pre-fix the
+                    # detector matched ``"access denied"`` substring,
+                    # which the security validator's
+                    # ``OpenZimMcpSecurityError`` ("Access denied -
+                    # Path is outside allowed directories") triggered
+                    # in addition to the intended file-not-found
+                    # ``OpenZimMcpValidationError``. The replacement
+                    # body dropped the security-specific reason on
+                    # the floor and emitted only the generic "doesn't
+                    # match any loaded archive" message — confusing
+                    # the caller about why their path actually failed
+                    # (path outside allowed tree vs typoed filename).
+                    # Including ``**Reason**`` keeps the diagnostic
+                    # context while still surfacing the recovery hint.
                     return (
                         f"**ZIM File Not Found**\n\n"
                         f"**Query**: {safe_query}\n"
                         f"**Issue**: the `zim_file_path` value passed "
-                        f"doesn't match any loaded archive.\n\n"
+                        f"doesn't match any loaded archive.\n"
+                        f"**Reason**: {safe_error}\n\n"
                         f"{hint}\n\n"
                         f"<!-- intent=zim_path_not_found cert=1.00 -->"
                     )
@@ -1315,6 +1388,143 @@ class SimpleToolsHandler:
                 f"with `tell me about {dropped}`._"
             )
         return None
+
+    # Post-a21 P1-D2/D3/D4: combined soft-connector pattern for
+    # multi-entity bare-topic chain detection. Same set as
+    # ``_SOFT_CHAIN_CONNECTOR_PATS`` but joined with alternation so a
+    # single ``re.split`` can chop a topic into ALL its halves in one
+    # pass (rather than the connector-by-connector loop in
+    # ``_soft_connector_footer``, which only ever splits on the FIRST
+    # match and leaves the rest of the chain stuffed into one half).
+    _COMBINED_SOFT_CONNECTOR_RE = re.compile(
+        r"\s+and\s+|\s+or\s+|\s+vs\.?\s+|\s*,\s+|\s+&\s+|\s*/\s*",
+        re.IGNORECASE,
+    )
+    # Post-a21 P1-D2/D3/D4: after a comma-split the next half can lead
+    # with a conjunction word (``, and Bears`` → comma-split eats
+    # ``", "`` but leaves ``"and Bears"`` because ``\s+and\s+`` requires
+    # leading whitespace and the half starts at the ``"a"``). Strip
+    # the leading conjunction post-split so ``Lions, Tigers, and Bears``
+    # → ``["Lions", "Tigers", "Bears"]`` rather than
+    # ``["Lions", "Tigers", "and Bears"]``.
+    _LEADING_CONJUNCTION_RE = re.compile(
+        r"^(?:and|or|vs\.?|&)\s+", re.IGNORECASE
+    )
+
+    @classmethod
+    def _split_multi_entity(cls, topic: str) -> Optional[List[str]]:
+        """Split ``topic`` into N substantive halves on any soft
+        connector. Returns the list iff N ≥ 3 AND every half passes
+        ``_is_substantive_topic``; otherwise None.
+
+        Used by ``_multi_entity_chain_guidance`` to decide whether a
+        topic deserves the structured ``Multi-Entity Chain Detected``
+        rejection. The 2-entity case stays with the existing
+        ``_soft_connector_footer`` post-resolution path (post-a18
+        P3-D2 + post-a20 P1-D2).
+        """
+        if not topic or not topic.strip():
+            return None
+        parts = cls._COMBINED_SOFT_CONNECTOR_RE.split(topic.strip())
+        cleaned: List[str] = []
+        for raw in parts:
+            p = raw.strip() if raw else ""
+            if not p:
+                continue
+            p = cls._LEADING_CONJUNCTION_RE.sub("", p).strip()
+            if p:
+                cleaned.append(p)
+        if len(cleaned) < 3:
+            return None
+        if not all(cls._is_substantive_topic(p) for p in cleaned):
+            return None
+        return cleaned
+
+    @staticmethod
+    def _path_matches_topic_loosely(path: str, topic: str) -> bool:
+        """True when an article-path (underscored, possibly punctuated)
+        normalises to the same word sequence as ``topic``. Used to
+        suppress the multi-entity chain warning for real multi-entity
+        article titles (``Earth, Wind & Fire`` /
+        ``Lions, Tigers, and Bears`` / etc.) — the title-index probe
+        returns a path that, once normalised, equals the topic.
+        """
+        if not path or not topic:
+            return False
+
+        def _norm(s: str) -> str:
+            s = s.lower().replace("_", " ")
+            # \w in Python re is Unicode by default; this keeps
+            # letters / digits / underscores → spaces and drops the
+            # rest (commas, ampersands, etc.).
+            s = re.sub(r"[^\w\s]+", " ", s, flags=re.UNICODE)
+            s = re.sub(r"\s+", " ", s).strip()
+            return s
+
+        return _norm(path) == _norm(topic)
+
+    def _multi_entity_chain_guidance(
+        self,
+        intent: str,
+        params: Dict[str, Any],
+        zim_file_path: str,
+    ) -> Optional[str]:
+        """Post-a21 P1-D2/D3/D4: return a structured chain rejection
+        when ``intent`` is ``tell_me_about`` and the topic names 3+
+        substantive entities joined by soft connectors, UNLESS the
+        whole-topic title-index probe resolves to a path that loosely
+        matches the topic (real multi-entity titles like
+        ``Earth, Wind & Fire``).
+
+        Returns None to fall through to normal resolution; returns a
+        structured Markdown body when the chain should be rejected.
+        """
+        if intent != "tell_me_about":
+            return None
+        topic = (params.get("topic") or "").strip() if isinstance(params, dict) else ""
+        if not topic:
+            return None
+        halves = self._split_multi_entity(topic)
+        if not halves:
+            return None
+        # Probe the title index for the whole topic — if it resolves
+        # cleanly to a single article whose path loosely matches the
+        # topic, the user meant a real multi-entity title (band name,
+        # movie title, idiom) and the chain warning would false-fire.
+        try:
+            data = self.zim_operations.find_entry_by_title_data(
+                zim_file_path, topic, cross_file=False, limit=1
+            )
+        except Exception:
+            data = None
+        if isinstance(data, dict):
+            results = data.get("results") or []
+            if results and isinstance(results[0], dict):
+                hit = results[0]
+                hit_path = str(hit.get("path") or "")
+                try:
+                    score = float(hit.get("score") or 0)
+                except (TypeError, ValueError):
+                    score = 0.0
+                # Score >= 1.0 from the title index means an exact
+                # canonical-title hit; loose-path match catches cases
+                # where the score is fuzzy but the path obviously
+                # spans every entity (``Earth,_Wind_&_Fire`` for
+                # ``Earth, Wind & Fire``).
+                if score >= 1.0 or self._path_matches_topic_loosely(hit_path, topic):
+                    return None
+        bullets = "\n".join(f"  - `tell me about {h}`" for h in halves)
+        return (
+            "**Multi-Entity Chain Detected**\n\n"
+            f"**Issue**: your query names {len(halves)} entities joined "
+            "by soft connectors (`and` / `or` / `,` / `&` / `vs` / `/`). "
+            "The intent parser returns one article at a time — silently "
+            f"dropping {len(halves) - 1} of them would be confusing.\n\n"
+            f"**Detected entities**:\n{bullets}\n\n"
+            "**Fix**: issue each as a separate `zim_query` call so "
+            "every entity gets its own response.\n\n"
+            "<!-- intent=multi_entity_chain_rejected cert=1.00 -->"
+        )
 
     def _half_resolves_to_top(
         self, zim_file_path: str, half: str, top_path: str

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -1389,25 +1389,19 @@ class SimpleToolsHandler:
             )
         return None
 
-    # Post-a21 P1-D2/D3/D4: combined soft-connector pattern for
-    # multi-entity bare-topic chain detection. Same set as
-    # ``_SOFT_CHAIN_CONNECTOR_PATS`` but joined with alternation so a
-    # single ``re.split`` can chop a topic into ALL its halves in one
-    # pass (rather than the connector-by-connector loop in
-    # ``_soft_connector_footer``, which only ever splits on the FIRST
-    # match and leaves the rest of the chain stuffed into one half).
-    _COMBINED_SOFT_CONNECTOR_RE = re.compile(
-        r"\s+and\s+|\s+or\s+|\s+vs\.?\s+|\s*,\s+|\s+&\s+|\s*/\s*",
-        re.IGNORECASE,
-    )
-    # Post-a21 P1-D2/D3/D4: after a comma-split the next half can lead
-    # with a conjunction word (``, and Bears`` → comma-split eats
-    # ``", "`` but leaves ``"and Bears"`` because ``\s+and\s+`` requires
-    # leading whitespace and the half starts at the ``"a"``). Strip
-    # the leading conjunction post-split so ``Lions, Tigers, and Bears``
-    # → ``["Lions", "Tigers", "Bears"]`` rather than
-    # ``["Lions", "Tigers", "and Bears"]``.
+    # Post-a21 P1-D2/D3/D4: when the iterative single-pattern split
+    # below applies one connector pattern before the next, a half can
+    # end up with a leftover leading conjunction OR a leftover trailing
+    # comma. ``Köln, München, and Berlin`` after the ``\s+and\s+`` pass
+    # is ``["Köln, München,", "Berlin"]``; the subsequent ``\s*,\s+``
+    # pass over ``"Köln, München,"`` yields ``["Köln", "München,"]``
+    # because the regex requires whitespace AFTER the comma and there's
+    # none at end-of-string. ``Lions, Tigers, and Bears`` — same shape
+    # but the leftover is ``"and Bears"`` because the comma-pass split
+    # eats the ``", "`` and leaves ``"and"`` as a leading-conjunction
+    # prefix. Strip both shapes per-half so the final list is clean.
     _LEADING_CONJUNCTION_RE = re.compile(r"^(?:and|or|vs\.?|&)\s+", re.IGNORECASE)
+    _TRAILING_CONJUNCTION_RE = re.compile(r"\s+(?:and|or|vs\.?|&)$", re.IGNORECASE)
 
     @classmethod
     def _split_multi_entity(cls, topic: str) -> Optional[List[str]]:
@@ -1420,16 +1414,43 @@ class SimpleToolsHandler:
         rejection. The 2-entity case stays with the existing
         ``_soft_connector_footer`` post-resolution path (post-a18
         P3-D2 + post-a20 P1-D2).
+
+        Implementation note: applies each entry of
+        ``_SOFT_CHAIN_CONNECTOR_PATS`` as a SEPARATE ``re.split``
+        pass over the running parts list, rather than joining them
+        into one alternation regex. The combined-alternation form
+        (``\\s+and\\s+|\\s*,\\s+|...``) trips SonarCloud's S5852
+        polynomial-backtracking flag because every alternative
+        starts with a ``\\s+`` or ``\\s*`` quantifier and the
+        engine could in principle try many overlapping prefixes at
+        each position. Iterative single-pattern splits match the
+        existing codebase convention (see ``_search_query_tail``'s
+        three-token decomposition for the same defensive shape) and
+        avoid the static-analysis flag entirely. Cost is O(N · P)
+        per topic where P ≤ 6 — a constant — so the runtime cost is
+        identical in practice.
         """
         if not topic or not topic.strip():
             return None
-        parts = cls._COMBINED_SOFT_CONNECTOR_RE.split(topic.strip())
+        parts: List[str] = [topic.strip()]
+        for pat in cls._SOFT_CHAIN_CONNECTOR_PATS:
+            next_parts: List[str] = []
+            for part in parts:
+                next_parts.extend(re.split(pat, part, flags=re.IGNORECASE))
+            parts = next_parts
         cleaned: List[str] = []
         for raw in parts:
-            p = raw.strip() if raw else ""
+            if not raw:
+                continue
+            # Strip whitespace + leftover punctuation that the
+            # iterative connector splits couldn't trim (trailing
+            # commas / semicolons / periods that end a half because
+            # the comma-pattern wanted a trailing ``\s+``).
+            p = raw.strip(" \t,;.")
             if not p:
                 continue
             p = cls._LEADING_CONJUNCTION_RE.sub("", p).strip()
+            p = cls._TRAILING_CONJUNCTION_RE.sub("", p).strip(" \t,;.")
             if p:
                 cleaned.append(p)
         if len(cleaned) < 3:

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -1407,9 +1407,7 @@ class SimpleToolsHandler:
     # the leading conjunction post-split so ``Lions, Tigers, and Bears``
     # → ``["Lions", "Tigers", "Bears"]`` rather than
     # ``["Lions", "Tigers", "and Bears"]``.
-    _LEADING_CONJUNCTION_RE = re.compile(
-        r"^(?:and|or|vs\.?|&)\s+", re.IGNORECASE
-    )
+    _LEADING_CONJUNCTION_RE = re.compile(r"^(?:and|or|vs\.?|&)\s+", re.IGNORECASE)
 
     @classmethod
     def _split_multi_entity(cls, topic: str) -> Optional[List[str]]:

--- a/openzim_mcp/tools/content_tools.py
+++ b/openzim_mcp/tools/content_tools.py
@@ -143,7 +143,9 @@ def _register_get_zim_entries(server: "OpenZimMcpServer") -> None:
         Two accepted shapes for ``entries``:
 
         1. **List of strings** — entry paths in ``zim_file_path`` (required).
-           Example: ``entries=["C/Foo", "C/Bar"], zim_file_path="/path/x.zim"``
+           Example: ``entries=["C/Foo", "C/Bar"], zim_file_path=<zim_path>``
+           (replace ``<zim_path>`` with the real path from
+           ``list_zim_files`` — never copy the placeholder verbatim).
         2. **List of dicts** — ``{"zim_file_path": "...", "entry_path": "..."}``
            per entry. Use this when batching across archives. ``zim_file_path``
            kwarg becomes the default for any dict that omits its own.

--- a/openzim_mcp/tools/structure_tools.py
+++ b/openzim_mcp/tools/structure_tools.py
@@ -237,10 +237,12 @@ def _register_get_entry_summary(server: "OpenZimMcpServer") -> None:
             returns a ``ToolErrorPayload`` envelope (see
             ``responses.tool_error``).
 
-        Examples:
-            - Quick overview: get_entry_summary("/path/to/wiki.zim", "Biology")
-            - Longer summary: get_entry_summary(..., "Evolution", max_words=500)
-            - Compact body: get_entry_summary(..., "Tiger", compact=True)
+        Examples (call ``list_zim_files`` first for the real ``zim_file_path``;
+        the placeholder ``<zim_path>`` below must be replaced with that
+        real path, never copied verbatim):
+            - Quick overview: get_entry_summary(<zim_path>, "Biology")
+            - Longer summary: get_entry_summary(<zim_path>, "Evolution", max_words=500)
+            - Compact body: get_entry_summary(<zim_path>, "Tiger", compact=True)
         """
         try:
             try:
@@ -333,8 +335,9 @@ def _register_get_table_of_contents(server: "OpenZimMcpServer") -> None:
               or ``"slug"`` (generated from heading text).
             - children: Nested subheadings
 
-        Examples:
-            - Get TOC: get_table_of_contents("/path/to/wiki.zim", "Biology")
+        Examples (replace ``<zim_path>`` with the real path returned by
+        ``list_zim_files`` — never copy the placeholder verbatim):
+            - Get TOC: get_table_of_contents(<zim_path>, "Biology")
         """
         try:
             try:
@@ -406,10 +409,11 @@ def _register_get_binary_entry(server: "OpenZimMcpServer") -> None:
             On failure, returns a ``{"error": True, ...}`` envelope (see
             ``responses.tool_error``).
 
-        Examples:
-            - Get a PDF: get_binary_entry("/path/file.zim", "I/document.pdf")
-            - Image metadata: get_binary_entry(..., "I/logo.png", include_data=False)
-            - Large video: get_binary_entry(..., "I/video.mp4", 100000000)
+        Examples (replace ``<zim_path>`` with the real path returned by
+        ``list_zim_files`` — never copy the placeholder verbatim):
+            - Get a PDF: get_binary_entry(<zim_path>, "I/document.pdf")
+            - Image metadata: get_binary_entry(<zim_path>, "I/logo.png", include_data=False)
+            - Large video: get_binary_entry(<zim_path>, "I/video.mp4", 100000000)
         """
         try:
             try:

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -654,6 +654,15 @@ class _SearchMixin:
         done = last_index >= total_results
         next_cursor: Optional[str] = None
         if not done:
+            # Post-a20 P1-D1 / post-a21 P1-D5 contract: any tool whose
+            # cursor state carries ``"q"`` must also appear in
+            # ``simple_tools.SimpleToolsHandler._Q_EMITTING_CURSOR_TOOLS``
+            # so the dispatcher's q-overlap guard knows to run for
+            # legitimate pagination AND to skip when a cursor's ``t``
+            # claims a non-q-emitting tool. Add a new ``Cursor.encode``
+            # callsite here? Update that set in lockstep — the post-a21
+            # ``TestP1D5QEmittingCursorToolsDrift`` regression pins the
+            # contract via a parametric scan of these encode sites.
             cursor_state: Dict[str, Any] = {
                 "o": last_index,
                 "l": limit,

--- a/tests/test_post_a21_beta_fixes.py
+++ b/tests/test_post_a21_beta_fixes.py
@@ -102,7 +102,6 @@ import pytest
 from openzim_mcp.intent_parser import IntentParser
 from openzim_mcp.simple_tools import SimpleToolsHandler
 
-
 # ===========================================================================
 # P1-D6 + P1-D7: trailing politeness regex extension
 # ===========================================================================
@@ -181,9 +180,9 @@ class TestP1D6P1D7TrailingPolitenessExtensions:
     )
     def test_extended_tokens_in_full_parse(self, raw: str, expected_query: str) -> None:
         intent, params, _conf = IntentParser.parse_intent(raw)
-        assert "ta" not in (params.get("query", "") + params.get("title", "")).lower(), (
-            f"Leftover token in params for {raw!r}: {params}"
-        )
+        assert (
+            "ta" not in (params.get("query", "") + params.get("title", "")).lower()
+        ), f"Leftover token in params for {raw!r}: {params}"
         v = params.get("query") or params.get("title") or ""
         assert v == expected_query, f"Expected {expected_query!r}, got {v!r}"
 
@@ -229,8 +228,7 @@ class TestP1D8SearchTermsRequiredAfterPolitenessStrip:
         handler, _mock = self._handler_single_archive()
         result = handler.handle_zim_query(query=query, zim_file_path="/x.zim")
         assert "Search Terms Required" in str(result), (
-            f"Expected the B4 guard to fire for {query!r}, got: "
-            f"{str(result)[:300]}"
+            f"Expected the B4 guard to fire for {query!r}, got: " f"{str(result)[:300]}"
         )
 
 
@@ -372,13 +370,13 @@ class TestMultiEntityChainGuidance:
             zim_file_path="/x.zim",
         )
         body = str(result)
-        assert "Multi-Entity Chain Detected" in body, (
-            f"Expected chain warning; got: {body[:400]}"
-        )
+        assert (
+            "Multi-Entity Chain Detected" in body
+        ), f"Expected chain warning; got: {body[:400]}"
         # Each entity should be enumerated in the warning.
-        assert "Köln" in body and "München" in body and "Berlin" in body, (
-            f"Entities not enumerated: {body[:400]}"
-        )
+        assert (
+            "Köln" in body and "München" in body and "Berlin" in body
+        ), f"Entities not enumerated: {body[:400]}"
 
     def test_three_entity_or_chain_with_non_latin_fires_warning(self) -> None:
         handler, _mock = self._handler(title_resolves={})
@@ -429,9 +427,9 @@ class TestMultiEntityChainGuidance:
             query="tell me about Earth, Wind & Fire", zim_file_path="/x.zim"
         )
         body = str(result)
-        assert "Multi-Entity Chain Detected" not in body, (
-            f"False-fire on real multi-entity title: {body[:400]}"
-        )
+        assert (
+            "Multi-Entity Chain Detected" not in body
+        ), f"False-fire on real multi-entity title: {body[:400]}"
 
     def test_lions_tigers_and_bears_suppressed_via_title_probe(self) -> None:
         # ``Lions, Tigers, and Bears`` is a real idiom / film
@@ -450,20 +448,20 @@ class TestMultiEntityChainGuidance:
             zim_file_path="/x.zim",
         )
         body = str(result)
-        assert "Multi-Entity Chain Detected" not in body, (
-            f"False-fire on real multi-entity idiom: {body[:400]}"
-        )
+        assert (
+            "Multi-Entity Chain Detected" not in body
+        ), f"False-fire on real multi-entity idiom: {body[:400]}"
 
     def test_comma_then_and_strips_leading_conjunction(self) -> None:
         # Regression: pre-strip-leading-conjunction the comma-split
         # left ``"and Berlin"`` as the third half. Verify the strip
         # collapses ``", and "`` to a clean entity boundary.
-        halves = SimpleToolsHandler._split_multi_entity(
-            "Köln, München, and Berlin"
-        )
-        assert halves == ["Köln", "München", "Berlin"], (
-            f"Leading conjunction not stripped: {halves}"
-        )
+        halves = SimpleToolsHandler._split_multi_entity("Köln, München, and Berlin")
+        assert halves == [
+            "Köln",
+            "München",
+            "Berlin",
+        ], f"Leading conjunction not stripped: {halves}"
 
     def test_search_intent_not_affected(self) -> None:
         # Multi-entity check is gated on tell_me_about — ``search for
@@ -655,8 +653,7 @@ class TestP1D10RecoveryHintMarkerDiscriminatesSecurityError:
         # floor. Either preserve the original message OR mention
         # "outside allowed directories".
         assert (
-            "outside allowed directories" in body.lower()
-            or "Path is outside" in body
+            "outside allowed directories" in body.lower() or "Path is outside" in body
         ), (
             f"P1-D10: security-specific error reason was dropped by the "
             f"PD2-4 recovery hint. Got: {body[:500]}"
@@ -690,9 +687,8 @@ class TestTD1LimitDocstringClarifiesAtomicIntents:
         # We can't grep for the exact wording (style choice) but the
         # docstring must say something about ``limit`` being ignored
         # or no-op for atomic intents.
-        assert (
-            "limit" in source.lower()
-            and ("ignored" in source.lower() or "atomic" in source.lower())
+        assert "limit" in source.lower() and (
+            "ignored" in source.lower() or "atomic" in source.lower()
         ), (
             "zim_query docstring should clarify that ``limit`` is "
             "ignored for atomic intents (tell_me_about / get article / "

--- a/tests/test_post_a21_beta_fixes.py
+++ b/tests/test_post_a21_beta_fixes.py
@@ -1,0 +1,701 @@
+"""Regression tests for the post-a21 beta-test sweep (a22 candidate fixes).
+
+The post-a21 live-MCP sweep against the 118 GB Wikipedia ZIM after
+v2.0.0a21 deployed surfaced ELEVEN user-facing defects in a single
+pass. Pass-1 probed the angles pass-2 of the post-a20 sweep didn't
+cover for each of the six a21 fix shapes (P1-D1 dispatcher q-gate,
+P1-D2 alias-fallback gate, PD2-1 politeness strip, PD2-2 docstring
+bait, PD2-3 single-archive auto-select, PD2-4 recovery hint), plus
+small-model transcript review for the weak-instruction-follower
+defect class.
+
+The defects span six surfaces:
+
+* **Politeness strip** — P1-D6/D7 cover British/texting and
+  multi-language trailing markers that the post-a20 regex didn't
+  enumerate (``ta`` / ``cheers`` / ``thx`` / ``ty`` / ``pls`` /
+  ``bitte`` / ``danke`` / ``gracias`` / ``por favor`` / ``merci``).
+  P1-D8 is the B4 ``search for <politeness>`` guard miss
+  (``_search_query_tail`` used the ORIGINAL query, so the trailing
+  politeness wasn't peeled before the empty-tail check and the search
+  silently dispatched with ``query="for"`` — the literal verb word).
+  P1-D1 is the same shape under defence-in-depth: even when
+  ``parse_intent`` doesn't strip for whatever reason (in-process
+  module cache, future regression, etc.), the dispatcher edge
+  re-applies the strip idempotently so the handler still sees a
+  cleaned ``params``.
+
+* **Soft-connector footer / multi-entity chain** — P1-D2/D3/D4 cover
+  3+ entity chains the post-a20 P1-D2 alias-fallback widening didn't
+  address. ``tell me about Köln, München, and Berlin`` produced a
+  footer suggesting ``tell me about Köln, München,`` (still-chained
+  recursive suggestion); ``tell me about Berlin or 東京 or Tokyo``
+  silently fell through to "No search results found" with no chain
+  signal; ``tell me about Berlin and München and Köln`` returned
+  Cologne with no footer about the dropped Berlin/München. Fix:
+  detect 3+ substantive proper-noun-shaped halves split by soft
+  connectors AND probe the title index for the whole topic — if no
+  clean single-title hit, fire a structured ``Multi-Entity Chain
+  Detected`` rejection (mirrors the existing
+  ``chained_intent_rejected`` shape). The title-index probe
+  suppresses false-fires on real multi-entity titles like
+  ``Earth, Wind & Fire`` / ``Romeo and Juliet`` (already 2-entity
+  case) / ``Lions, Tigers, and Bears``.
+
+* **Dispatcher q-gate drift** — P1-D5 pins the contract between
+  ``Cursor.encode(state={..., "q": ...})`` callsites and
+  ``_Q_EMITTING_CURSOR_TOOLS``. Pre-fix, a future contributor could
+  add a new q-emitting tool but forget to update the set; the
+  dispatcher q-overlap check would silently degrade to no-op for
+  that tool — paginating with the wrong query proceeds silently. The
+  test pins both sides of the contract: the set value AND a comment
+  hook in ``zim/search.py`` that mentions ``_Q_EMITTING_CURSOR_TOOLS``
+  so the right place to update is greppable from the encode callsite.
+
+* **Docstring path-bait siblings** — P1-D9 widens the post-a20 PD2-2
+  regression test to every LLM-facing tool docstring. PD2-2 only
+  pinned ``server.py``'s ``zim_query`` docstring; ``structure_tools``
+  (``get_entry_summary`` / ``get_table_of_contents`` /
+  ``get_binary_entry``) and ``content_tools`` (``get_zim_entries``)
+  carried sibling docstring path examples
+  (``/path/to/wiki.zim`` / ``/path/file.zim`` / ``/path/x.zim``) that
+  small models can copy verbatim. Fix: replace literal paths with
+  placeholders that don't look like valid filesystem paths (e.g.,
+  ``<zim_path>`` or omit and reference ``list_zim_files``).
+
+* **Recovery hint marker overlap** — P1-D10 tightens the PD2-4
+  detector to discriminate the security-specific
+  ``OpenZimMcpSecurityError`` (path outside allowed directories) from
+  the validation-specific ``OpenZimMcpValidationError`` (file does
+  not exist / not a zim file / not a file). Pre-fix, both fell into
+  the generic "doesn't match any loaded archive" hint, dropping the
+  security-relevant reason. The hint now surfaces the original error
+  message alongside the recovery instruction.
+
+* **Tool-self-described drift (weak-instruction-follower)** — T-D1
+  pins that the ``zim_query`` docstring's ``limit`` parameter
+  description explicitly says it's ignored for atomic intents
+  (``tell_me_about`` / ``get article`` / ``show structure``). Small
+  models (Qwen3-8B-Q4 in the live transcript) speculatively pass
+  ``limit=5`` on tell_me_about; the call wastes tokens but doesn't
+  fail visibly. The docstring nudge prevents future drift.
+
+Methodology note (post-a21): the recurring "fix unlocks new paths"
+cycle reproduced again. Post-a20's P1-D2 (alias-fallback widening to
+2-entity asymmetric chains) didn't address 3+ entity chains; this
+pass's P1-D2/D3/D4 catch them. Post-a20's PD2-1 (parse_intent strip)
+didn't widen the politeness token set; P1-D6/D7 add the
+British/texting/multi-language variants. Post-a20's PD2-2 (zim_query
+docstring de-bait) didn't sweep the sibling advanced-tool docstrings;
+P1-D9 widens the regression net. The fix-then-stress-test cycle
+keeps producing real defects at each new edge.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from openzim_mcp.intent_parser import IntentParser
+from openzim_mcp.simple_tools import SimpleToolsHandler
+
+
+# ===========================================================================
+# P1-D6 + P1-D7: trailing politeness regex extension
+# ===========================================================================
+
+
+class TestP1D6P1D7TrailingPolitenessExtensions:
+    """P1-D6 (British/texting) + P1-D7 (multilang). Pre-fix the
+    politeness regex only enumerated ``please`` / ``kindly`` /
+    ``thanks`` / ``thank you|u``. Common British/texting variants
+    (``ta`` / ``cheers`` / ``thx`` / ``ty`` / ``pls``) and the
+    obvious multi-language tokens (``bitte`` / ``danke`` / ``merci``
+    / ``gracias`` / ``por favor``) silently leaked into the search
+    query, title lookup, or topic. The fix adds the missing tokens
+    AND tightens the leading anchor to require a word boundary so
+    embedded substrings like ``cantata`` / ``dante`` don't get
+    falsely stripped at the tail.
+    """
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("search for biology ta", "search for biology"),
+            ("search for biology cheers", "search for biology"),
+            ("search for biology thx", "search for biology"),
+            ("search for biology ty", "search for biology"),
+            ("search for biology pls", "search for biology"),
+            ("search for biology bitte", "search for biology"),
+            ("search for biology danke", "search for biology"),
+            ("search for biology merci", "search for biology"),
+            ("search for biology gracias", "search for biology"),
+            ("search for biology por favor", "search for biology"),
+            # Case variants
+            ("search for biology Ta", "search for biology"),
+            ("search for biology CHEERS", "search for biology"),
+            # Comma / punctuation forms
+            ("search for biology, ta", "search for biology"),
+            ("search for biology, pls!", "search for biology"),
+            # Multi-token tail
+            ("search for biology please, ta", "search for biology"),
+            # Idempotence: already-stripped query unchanged
+            ("search for biology", "search for biology"),
+        ],
+    )
+    def test_extended_tokens_strip(self, raw: str, expected: str) -> None:
+        assert IntentParser._strip_trailing_politeness(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            # Word-boundary safety: politeness tokens embedded in other
+            # words must NOT be stripped. Pre-fix-extension, naive
+            # additions of short tokens (``ta``) would have stripped
+            # ``cantata`` → ``can``, ``vista`` → ``vis``.
+            "cantata",
+            "vista",
+            "feta",
+            "tomato",
+            "data",
+            "Dante",
+            "thanks giving",  # NB: trailing "giving" word — strip should not eat "thanks"
+        ],
+    )
+    def test_word_boundary_safety(self, raw: str) -> None:
+        assert IntentParser._strip_trailing_politeness(raw) == raw
+
+    @pytest.mark.parametrize(
+        "raw, expected_query",
+        [
+            ("search for biology ta", "biology"),
+            ("search for biology cheers", "biology"),
+            ("search for biology bitte", "biology"),
+            ("search for biology por favor", "biology"),
+            ("find article titled Berlin ta", "Berlin"),
+            ("find article titled Berlin merci", "Berlin"),
+        ],
+    )
+    def test_extended_tokens_in_full_parse(self, raw: str, expected_query: str) -> None:
+        intent, params, _conf = IntentParser.parse_intent(raw)
+        assert "ta" not in (params.get("query", "") + params.get("title", "")).lower(), (
+            f"Leftover token in params for {raw!r}: {params}"
+        )
+        v = params.get("query") or params.get("title") or ""
+        assert v == expected_query, f"Expected {expected_query!r}, got {v!r}"
+
+
+# ===========================================================================
+# P1-D8: B4 "Search Terms Required" guard miss with politeness tail
+# ===========================================================================
+
+
+class TestP1D8SearchTermsRequiredAfterPolitenessStrip:
+    """P1-D8: ``search for please`` after parse_intent's politeness
+    strip becomes ``search for`` (empty tail) — but the dispatcher's
+    B4 guard called ``_search_query_tail(query)`` with the ORIGINAL
+    query (still ``search for please``), so the tail returned was
+    ``please`` (non-empty), the guard didn't fire, and ``_extract_search``
+    captured the literal verb word ``for`` as the search term.
+    Result: ``Found N matches for "for"`` — 200k+ hits dominated by
+    stop-word collisions, no useful learning signal.
+
+    Fix: peel trailing politeness off the tail before the empty-tail
+    check so the guard fires for politeness-only search queries.
+    """
+
+    def _handler_single_archive(self) -> tuple[Any, MagicMock]:
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        return SimpleToolsHandler(mock), mock
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "search for please",
+            "search for thanks",
+            "search for kindly",
+            "search for please.",
+            "search for thank you",
+            "search for ta",
+            "search for cheers",
+            "search for pls",
+        ],
+    )
+    def test_politeness_only_search_fires_terms_required(self, query: str) -> None:
+        handler, _mock = self._handler_single_archive()
+        result = handler.handle_zim_query(query=query, zim_file_path="/x.zim")
+        assert "Search Terms Required" in str(result), (
+            f"Expected the B4 guard to fire for {query!r}, got: "
+            f"{str(result)[:300]}"
+        )
+
+
+# ===========================================================================
+# P1-D1: defense-in-depth — dispatcher-edge politeness strip on params
+# ===========================================================================
+
+
+class TestP1D1DispatcherEdgePolitenessStrip:
+    """P1-D1: the live-MCP sweep observed
+    ``Found 5000 matches for "biology please"`` for the query
+    ``search for biology please`` despite the post-a20 PD2-1 fix
+    that lifted the trailing-politeness strip to
+    ``IntentParser.parse_intent``. Source-side, the strip works
+    correctly; the most likely cause is an in-process module cache
+    on the live server that loaded only PART of the PR-#152 diff
+    (the rest of the a21 gates pass live). The user decided to log
+    this as a defect and land a defense-in-depth that re-applies
+    the strip at the dispatcher edge — idempotent when
+    ``parse_intent`` already stripped, and a belt-and-suspenders
+    catch for any future regression that bypasses
+    ``parse_intent``.
+
+    Fix: in ``handle_zim_query``, after the parse_intent call,
+    apply ``IntentParser._strip_trailing_politeness`` to each of
+    the user-supplied content fields in ``params``
+    (``query`` / ``topic`` / ``title`` / ``entry_path`` /
+    ``partial_query``). Strip is idempotent — no-op when
+    ``parse_intent`` already cleaned.
+    """
+
+    def _handler_single_archive(self) -> tuple[Any, MagicMock]:
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        # Search returns a structured payload that includes the
+        # ``query`` used. We assert the dispatcher passed the stripped
+        # form even if parse_intent didn't.
+        mock.search_zim_file.return_value = "search ok"
+        return SimpleToolsHandler(mock), mock
+
+    def test_dispatcher_strips_query_field_idempotently(self) -> None:
+        # Simulate a hypothetical case where ``parse_intent`` returns
+        # params with politeness still attached (e.g., a future
+        # regression). The dispatcher-edge strip must clean it.
+        from openzim_mcp.intent_parser import IntentParser as IP
+
+        original_parse = IP.parse_intent
+
+        def buggy_parse(query: str):
+            # Pretend parse_intent forgot to strip. Return the search
+            # extractor's output without the strip — params["query"]
+            # carries the trailing politeness.
+            return "search", {"query": "biology please"}, 0.75
+
+        IP.parse_intent = staticmethod(buggy_parse)  # type: ignore[method-assign]
+        try:
+            handler, mock = self._handler_single_archive()
+            handler.handle_zim_query(
+                query="search for biology please", zim_file_path="/x.zim"
+            )
+            # The dispatcher edge should have stripped "please" before
+            # dispatching to the search backend.
+            calls = mock.search_zim_file.call_args_list
+            assert calls, "Search backend was not called"
+            # Backend's second positional arg is the query.
+            args, kwargs = calls[0]
+            search_query = args[1] if len(args) > 1 else kwargs.get("query")
+            assert search_query == "biology", (
+                f"Dispatcher should have stripped politeness defence-in-depth; "
+                f"backend got {search_query!r}"
+            )
+        finally:
+            IP.parse_intent = original_parse  # type: ignore[method-assign]
+
+
+# ===========================================================================
+# P1-D2 + P1-D3 + P1-D4: multi-entity chain warning
+# ===========================================================================
+
+
+class TestMultiEntityChainGuidance:
+    """P1-D2/D3/D4: 3+ entity bare-topic chains joined by soft
+    connectors (``and`` / ``or`` / ``,`` / ``&`` / ``vs``) bypass
+    the existing 2-entity soft-connector footer's alias-fallback.
+    Pre-fix:
+
+    * ``tell me about Köln, München, and Berlin`` → returned Berlin
+      + footer suggesting ``tell me about Köln, München,`` (the
+      dropped half still contains a comma — re-running it would
+      re-trigger the same defect).
+
+    * ``tell me about Berlin or 東京 or Tokyo`` → silent "No search
+      results found" (the resolver couldn't title-index the literal
+      multi-entity string and the search fallback fired no signal
+      about the dropped halves).
+
+    * ``tell me about Berlin and München and Köln`` → returned
+      Cologne (Köln alias) with NO footer about Berlin / München.
+
+    Fix: at the dispatcher edge (for tell_me_about intent), detect
+    3+ substantive proper-noun-shaped halves split by combined soft
+    connectors AND probe the title index for the whole topic. If the
+    whole topic doesn't title-resolve cleanly to a single article,
+    fire a ``Multi-Entity Chain Detected`` rejection naming each
+    detected entity and instructing the caller to issue N separate
+    calls. The title-index probe suppresses false-fires on real
+    multi-entity titles (``Earth, Wind & Fire`` /
+    ``Lions, Tigers, and Bears``).
+    """
+
+    def _handler(
+        self,
+        title_resolves: dict[str, str] | None = None,
+    ) -> tuple[Any, MagicMock]:
+        """Build a handler with a stub title-index probe.
+
+        ``title_resolves`` maps query string (lowercased) → top-hit
+        path. If a query string isn't in the map, the probe returns
+        no results (simulating "title does not resolve cleanly").
+        """
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.list_zim_files.return_value = '[{"path": "/x.zim"}]'
+
+        def stub_find(zim_path, query, **kw):
+            key = (query or "").lower()
+            if title_resolves and key in title_resolves:
+                return {"results": [{"path": title_resolves[key], "score": 1.0}]}
+            return {"results": []}
+
+        mock.find_entry_by_title_data.side_effect = stub_find
+        return SimpleToolsHandler(mock), mock
+
+    def test_three_entity_and_chain_fires_warning(self) -> None:
+        # No title-index hit for the whole topic — chain warning fires.
+        handler, _mock = self._handler(title_resolves={})
+        result = handler.handle_zim_query(
+            query="tell me about Köln, München, and Berlin",
+            zim_file_path="/x.zim",
+        )
+        body = str(result)
+        assert "Multi-Entity Chain Detected" in body, (
+            f"Expected chain warning; got: {body[:400]}"
+        )
+        # Each entity should be enumerated in the warning.
+        assert "Köln" in body and "München" in body and "Berlin" in body, (
+            f"Entities not enumerated: {body[:400]}"
+        )
+
+    def test_three_entity_or_chain_with_non_latin_fires_warning(self) -> None:
+        handler, _mock = self._handler(title_resolves={})
+        result = handler.handle_zim_query(
+            query="tell me about Berlin or 東京 or Tokyo",
+            zim_file_path="/x.zim",
+        )
+        body = str(result)
+        assert "Multi-Entity Chain Detected" in body
+        assert "Berlin" in body and "東京" in body and "Tokyo" in body
+
+    def test_four_entity_chain_fires_warning(self) -> None:
+        handler, _mock = self._handler(title_resolves={})
+        result = handler.handle_zim_query(
+            query="tell me about Berlin and München and Köln and Hamburg",
+            zim_file_path="/x.zim",
+        )
+        body = str(result)
+        assert "Multi-Entity Chain Detected" in body
+
+    def test_two_entity_chain_does_not_fire(self) -> None:
+        # 2-entity case is already handled by the post-a20 P1-D2
+        # alias-fallback footer.
+        handler, _mock = self._handler(title_resolves={})
+        # The handler will try to resolve "Berlin or Köln" via the
+        # normal path; we only check that the multi-entity warning
+        # is NOT in the response (the existing soft-connector path
+        # can do whatever it does).
+        result = handler.handle_zim_query(
+            query="tell me about Berlin or Köln", zim_file_path="/x.zim"
+        )
+        body = str(result)
+        assert "Multi-Entity Chain Detected" not in body
+
+    def test_multi_entity_title_suppresses_warning(self) -> None:
+        # ``Earth, Wind & Fire`` is a real article title. Even
+        # without a title-index hit, the half "Wind" fails the
+        # ``_is_substantive_topic`` 5-ASCII-char floor (it's 4
+        # chars, single token, no digit, no non-ASCII letter), so
+        # the chain warning is suppressed before the title probe
+        # would even run. Defence-in-depth: when the substantive
+        # filter doesn't catch the real title, the title-index
+        # probe does.
+        handler, _mock = self._handler(
+            title_resolves={"earth, wind & fire": "Earth,_Wind_&_Fire"}
+        )
+        result = handler.handle_zim_query(
+            query="tell me about Earth, Wind & Fire", zim_file_path="/x.zim"
+        )
+        body = str(result)
+        assert "Multi-Entity Chain Detected" not in body, (
+            f"False-fire on real multi-entity title: {body[:400]}"
+        )
+
+    def test_lions_tigers_and_bears_suppressed_via_title_probe(self) -> None:
+        # ``Lions, Tigers, and Bears`` is a real idiom / film
+        # subtitle. Every half is substantive (Lions=5, Tigers=6,
+        # Bears=5), so the substantive filter doesn't catch it.
+        # Title-index probe finds a cleanly-matching article path,
+        # ``_path_matches_topic_loosely`` normalises both sides and
+        # suppresses the chain warning.
+        handler, _mock = self._handler(
+            title_resolves={
+                "lions, tigers, and bears": "Lions,_Tigers,_and_Bears",
+            }
+        )
+        result = handler.handle_zim_query(
+            query="tell me about Lions, Tigers, and Bears",
+            zim_file_path="/x.zim",
+        )
+        body = str(result)
+        assert "Multi-Entity Chain Detected" not in body, (
+            f"False-fire on real multi-entity idiom: {body[:400]}"
+        )
+
+    def test_comma_then_and_strips_leading_conjunction(self) -> None:
+        # Regression: pre-strip-leading-conjunction the comma-split
+        # left ``"and Berlin"`` as the third half. Verify the strip
+        # collapses ``", and "`` to a clean entity boundary.
+        halves = SimpleToolsHandler._split_multi_entity(
+            "Köln, München, and Berlin"
+        )
+        assert halves == ["Köln", "München", "Berlin"], (
+            f"Leading conjunction not stripped: {halves}"
+        )
+
+    def test_search_intent_not_affected(self) -> None:
+        # Multi-entity check is gated on tell_me_about — ``search for
+        # X and Y and Z`` is a legitimate multi-term BM25 query and
+        # must not fire the chain warning.
+        handler, _mock = self._handler(title_resolves={})
+        result = handler.handle_zim_query(
+            query="search for Berlin and München and Köln",
+            zim_file_path="/x.zim",
+        )
+        body = str(result)
+        assert "Multi-Entity Chain Detected" not in body
+
+
+# ===========================================================================
+# P1-D5: drift guard for _Q_EMITTING_CURSOR_TOOLS
+# ===========================================================================
+
+
+class TestP1D5QEmittingCursorToolsDrift:
+    """P1-D5: the post-a20 P1-D1 fix introduced
+    ``SimpleToolsHandler._Q_EMITTING_CURSOR_TOOLS`` as a hand-
+    maintained frozenset of tool names whose cursors legitimately
+    carry an ``s.q`` field. The dispatcher's q-overlap check skips
+    when the cursor's ``t`` claims a tool NOT in the set. If a
+    future contributor adds a new q-emitting tool (a new
+    ``Cursor.encode(state={..., "q": ...})`` callsite) but forgets
+    to update the set, the dispatcher's q-overlap guard silently
+    degrades to no-op for that tool — paginating with the wrong
+    query proceeds silently.
+
+    Pin both:
+      * the current set value (so accidental edits surface).
+      * a comment hook in ``zim/search.py`` that mentions
+        ``_Q_EMITTING_CURSOR_TOOLS`` so the right place to update
+        is greppable from the encode callsite.
+    """
+
+    def test_q_emitting_cursor_tools_pinned_value(self) -> None:
+        assert SimpleToolsHandler._Q_EMITTING_CURSOR_TOOLS == frozenset(
+            {"search_zim_file", "search_with_filters"}
+        )
+
+    def test_search_encode_callsite_references_set(self) -> None:
+        # Both encode callsites (search_zim_file at L664, search_with_
+        # filters at L1243) must reference the set by name in the
+        # surrounding comments so a contributor adding a new
+        # q-emitting tool sees the pointer.
+        import openzim_mcp.zim.search as search_mod
+
+        source = inspect.getsource(search_mod)
+        assert "_Q_EMITTING_CURSOR_TOOLS" in source, (
+            "zim/search.py must reference _Q_EMITTING_CURSOR_TOOLS so "
+            "future Cursor.encode(state={..., 'q': ...}) callsites are "
+            "wired to the dispatcher's q-overlap guard. Add a comment "
+            "near the encode callsites pointing at "
+            "simple_tools._Q_EMITTING_CURSOR_TOOLS."
+        )
+
+    def test_q_emitting_set_matches_search_encode_sites(self) -> None:
+        # Find every ``Cursor.encode(tool="X", state={..., "q":  ...})``
+        # site in zim/search.py and assert the tool names align with
+        # ``_Q_EMITTING_CURSOR_TOOLS``. Catches the case where a
+        # contributor adds a new encode site but forgets the set.
+        import re
+
+        import openzim_mcp.zim.search as search_mod
+
+        source = inspect.getsource(search_mod)
+        # Match ``Cursor.encode(tool="X"`` and remember X.
+        tool_names = set(re.findall(r"Cursor\.encode\(\s*tool=\"(\w+)\"", source))
+        # Each ``Cursor.encode`` callsite in zim/search.py emits a
+        # state with ``"q"`` (see the bodies); pinning the equality
+        # locks the contract.
+        assert tool_names == SimpleToolsHandler._Q_EMITTING_CURSOR_TOOLS, (
+            f"Drift detected: zim/search.py encodes cursors for {tool_names}, "
+            f"_Q_EMITTING_CURSOR_TOOLS lists "
+            f"{SimpleToolsHandler._Q_EMITTING_CURSOR_TOOLS}. Update the "
+            f"set so the dispatcher's q-overlap guard fires for the new "
+            f"tool too."
+        )
+
+
+# ===========================================================================
+# P1-D9: PD2-2 sibling docstring path-bait sweep
+# ===========================================================================
+
+
+class TestP1D9DocstringPathBaitSiblings:
+    """P1-D9: the post-a20 PD2-2 fix removed the literal-looking path
+    example (``/data/wikipedia_en_all_maxi.zim``) from the
+    ``zim_query`` tool docstring in ``server.py``. The advanced-
+    tool docstrings in ``tools/structure_tools.py`` and
+    ``tools/content_tools.py`` carried sibling docstring path
+    examples (``/path/to/wiki.zim`` / ``/path/file.zim`` /
+    ``/path/x.zim``) that the PD2-2 regression test didn't reach.
+    Small models copy these verbatim too — the canonical
+    weak-instruction-follower defect class — and drop into the same
+    "File does not exist" retry loop the PD2-3 auto-select +
+    PD2-4 recovery hint were designed to break.
+
+    Fix: replace literal ``/path/...`` strings in the docstring
+    Examples blocks with placeholders that won't validate as a real
+    filesystem path (e.g., ``<zim_path>``). The widened regression
+    test below scans every ``openzim_mcp/tools/*.py`` source file
+    for any string matching ``/path/...\\.zim`` or
+    ``/data/...\\.zim`` in a docstring context — anything new
+    fails the test.
+    """
+
+    def test_no_path_bait_in_tools_docstrings(self) -> None:
+        import re
+        from pathlib import Path
+
+        tools_dir = Path(__file__).resolve().parents[1] / "openzim_mcp" / "tools"
+        assert tools_dir.is_dir(), f"tools/ not found at {tools_dir}"
+
+        # Match ``/path/...\.zim`` or ``/data/...\.zim`` shapes.
+        # Conservative — only flags strings that look like fake
+        # filesystem paths a small model would copy. Real path
+        # references inside test setup or fixture data aren't in
+        # tools/ source.
+        bait_re = re.compile(r"/(?:path|data)/[\w/.-]*\.zim")
+        offenders: list[tuple[str, int, str]] = []
+        for py in sorted(tools_dir.glob("*.py")):
+            text = py.read_text(encoding="utf-8")
+            for line_no, line in enumerate(text.splitlines(), start=1):
+                m = bait_re.search(line)
+                if m:
+                    offenders.append((py.name, line_no, m.group(0)))
+
+        assert not offenders, (
+            "Found docstring path-bait in tools/ that small models can "
+            "copy verbatim — same defect class as post-a20 PD2-2. "
+            f"Sites: {offenders}. Replace literal paths with placeholders "
+            "like ``<zim_path>`` or omit and reference list_zim_files()."
+        )
+
+
+# ===========================================================================
+# P1-D10: PD2-4 recovery hint marker overlap with security errors
+# ===========================================================================
+
+
+class TestP1D10RecoveryHintMarkerDiscriminatesSecurityError:
+    """P1-D10: the post-a20 PD2-4 recovery-hint detector matches the
+    substring ``"access denied"`` in the exception message. The
+    ``OpenZimMcpSecurityError`` raised by ``security.py`` when the
+    path is outside the allowed directories formats its message as
+    ``"Access denied - Path is outside allowed directories: ..."``.
+    Pre-fix, the catch-all detected the substring, replaced the
+    security-specific reason with the generic "doesn't match any
+    loaded archive" hint, and the caller never saw the actual cause.
+
+    Fix: surface the original exception message alongside the
+    recovery hint so security-specific failures (path outside
+    allowed directories) keep their diagnostic context.
+    """
+
+    def _handler_multi_archive(self) -> tuple[Any, MagicMock]:
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [
+            {"path": "/var/lib/zim/wikipedia_en_all_maxi_2026-02.zim"},
+            {"path": "/var/lib/zim/wiktionary_en_all_maxi_2026-02.zim"},
+        ]
+        mock.list_zim_files.return_value = (
+            '[{"path": "/var/lib/zim/wikipedia_en_all_maxi_2026-02.zim"}, '
+            '{"path": "/var/lib/zim/wiktionary_en_all_maxi_2026-02.zim"}]'
+        )
+        return SimpleToolsHandler(mock), mock
+
+    def test_security_error_surfaces_original_reason(self) -> None:
+        from openzim_mcp.exceptions import OpenZimMcpSecurityError
+
+        handler, mock = self._handler_multi_archive()
+        # Stub get_main_page (or whatever the dispatcher routes to) to
+        # raise the security error so the catch-all hits.
+        mock.get_main_page.side_effect = OpenZimMcpSecurityError(
+            "Access denied - Path is outside allowed directories: /etc/x.zim"
+        )
+        # Use main_page intent so the dispatch is deterministic.
+        result = handler.handle_zim_query(
+            query="show main page",
+            zim_file_path="/etc/x.zim",
+        )
+        body = str(result)
+        # The recovery hint may still fire (it's useful — surfaces real
+        # archive paths) but MUST NOT drop the original reason on the
+        # floor. Either preserve the original message OR mention
+        # "outside allowed directories".
+        assert (
+            "outside allowed directories" in body.lower()
+            or "Path is outside" in body
+        ), (
+            f"P1-D10: security-specific error reason was dropped by the "
+            f"PD2-4 recovery hint. Got: {body[:500]}"
+        )
+
+
+# ===========================================================================
+# T-D1: zim_query docstring clarifies limit ignored for atomic intents
+# ===========================================================================
+
+
+class TestTD1LimitDocstringClarifiesAtomicIntents:
+    """T-D1: live small-model transcript (Qwen3-8B-Q4) showed the
+    model passing ``limit=5`` on a ``tell_me_about`` query. The
+    ``limit`` docstring said "Max search/browse results (default: 3)"
+    — silent about whether it applies to atomic intents. Small
+    models speculatively pass it; the call wastes tokens because the
+    handler ignores it.
+
+    Fix: docstring nudge — call out the atomic intents
+    (``tell_me_about`` / ``get article`` / ``show structure`` /
+    ``main_page`` / ``list_namespaces`` / ``list_files``) as
+    ignoring ``limit``.
+    """
+
+    def test_limit_docstring_mentions_atomic_intents(self) -> None:
+        import openzim_mcp.server as server_mod
+
+        source = inspect.getsource(server_mod)
+        # Look for an explicit mention near the ``limit`` Args block.
+        # We can't grep for the exact wording (style choice) but the
+        # docstring must say something about ``limit`` being ignored
+        # or no-op for atomic intents.
+        assert (
+            "limit" in source.lower()
+            and ("ignored" in source.lower() or "atomic" in source.lower())
+        ), (
+            "zim_query docstring should clarify that ``limit`` is "
+            "ignored for atomic intents (tell_me_about / get article / "
+            "show structure / main_page / list_namespaces / list_files). "
+            "Small models speculatively pass it otherwise."
+        )


### PR DESCRIPTION
Live-MCP beta sweep against `wikipedia_en_all_maxi_2026-02.zim` on the freshly-deployed `v2.0.0a21` build, plus small-model failure transcript review.

## Smoke gates (pre-fix state)

The four a21-specific smoke gates landed **3/4 green** before any code changed:

- ✓ Walk cursor with stuffed `s.q="biology"` passed to `search for photosynthesis` → correct `Cursor / Tool Mismatch` (a21 P1-D1 fix)
- ✓ `tell me about Köln or Cologne` → Cologne article, no false footer (a21 P1-D2 alias-fallback)
- ✗ `search for biology please` → live MCP returns `Found 5000 matches for "biology please"`. Source-side `IntentParser.parse_intent` strips correctly under direct unit test; the most likely cause is an in-process module cache on the live server that loaded only part of PR #152. The user-visible defect class is the same regardless of root cause, so a defence-in-depth dispatcher-edge strip lands here (P1-D1).
- ✓ Bogus slashed path with single archive → auto-selected (a21 PD2-3)

## Pass 1 — eleven defects (six surfaces)

### Multi-entity chain warning (P1-D2 / P1-D3 / P1-D4)

3+ entity bare-topic chains joined by soft connectors bypass the existing 2-entity `_soft_connector_footer` alias-fallback. Three observed shapes:

* `tell me about Köln, München, and Berlin` → returned Berlin + footer suggesting `tell me about Köln, München,` (still-chained recursive suggestion — re-running it re-triggers the same defect).
* `tell me about Berlin or 東京 or Tokyo` → silent `No search results found`.
* `tell me about Berlin and München and Köln` → returned Cologne with no footer about the dropped Berlin / München.

New `_multi_entity_chain_guidance` detects 3+ substantive halves split by combined soft connectors AND probes the title index for the whole topic — clean single-title hits (`Earth, Wind & Fire` band; `Lions, Tigers, and Bears` idiom) suppress the warning; no clean hit fires a structured `Multi-Entity Chain Detected` rejection naming each entity. Splitter strips leading conjunctions post-split so `Lions, Tigers, and Bears` decomposes cleanly into three entities (rather than `[Lions, Tigers, and Bears]`).

### Politeness regex extensions (P1-D6 + P1-D7 + P1-D8)

The post-a20 PD2-1 token list missed:

* **British/texting**: `ta` / `cheers` / `thx` / `ty` / `pls`
* **Multi-language**: `bitte` / `danke` / `merci` / `gracias` / `por favor`

All leaked into search query / topic / title silently. Several new tokens are short (`ta` / `ty` are 2 chars) so the leading anchor tightens from `\s*[,;.!?]?\s*` to `(?:^|\s+|[,;.!?]\s*)` — embedded substrings in longer words (`cantata` / `feta` / `Dante`) no longer get their last two chars eaten.

Separately, **P1-D8** is the `Search Terms Required` B4 guard miss: `_search_query_tail(query)` ran on the ORIGINAL query, so the trailing politeness wasn't peeled before the empty-tail check and `search for please` silently dispatched with `query="for"` (the literal verb word). Fix: peel trailing politeness off the tail before the guard fires.

### Defence-in-depth dispatcher-edge politeness strip (P1-D1)

See smoke-gate paragraph above. Idempotent when `parse_intent` already cleaned the params; belt-and-suspenders catch otherwise.

### Cursor q-emitting tool drift guard (P1-D5)

The post-a20 P1-D1 fix introduced `_Q_EMITTING_CURSOR_TOOLS` as a hand-maintained frozenset. If a future contributor adds a new q-emitting tool (a new `Cursor.encode(state={..., "q": ...})` callsite) without updating the set, the dispatcher's q-overlap guard silently degrades to no-op for that tool. Regression test scans every `Cursor.encode(tool=...)` callsite in `zim/search.py` and pins membership equality with the set. Comments at the encode callsites now name the set, so the cross-module link is greppable from either side.

### PD2-2 sibling docstring path-bait sweep (P1-D9)

The post-a20 PD2-2 regression test only pinned the `zim_query` docstring in `server.py`. Advanced tool docstrings carried sibling path examples:

* `structure_tools.py:241` `get_entry_summary("/path/to/wiki.zim", "Biology")`
* `structure_tools.py:337` `get_table_of_contents("/path/to/wiki.zim", "Biology")`
* `structure_tools.py:410` `get_binary_entry("/path/file.zim", "I/document.pdf")`
* `content_tools.py:146` `zim_file_path="/path/x.zim"` in `get_zim_entries`

Small models copy these verbatim too — the same weak-instruction-follower class PD2-2 was designed to break. Replaced with `<zim_path>` placeholders that don't validate as filesystem paths. New regression test scans every `openzim_mcp/tools/*.py` for `/path/...\.zim` or `/data/...\.zim` shapes.

### PD2-4 recovery hint marker overlap with security errors (P1-D10)

The PD2-4 detector substring-matched `"access denied"` and fired on `OpenZimMcpSecurityError`'s `"Access denied - Path is outside allowed directories"` message in addition to the intended `OpenZimMcpValidationError`. The replacement body dropped the security-specific reason; the caller saw only the generic "doesn't match any loaded archive" hint. Surface the original error message as a new `**Reason**` line so the security-specific context isn't lost.

### `limit` docstring nudge for atomic intents (T-D1)

Small-model transcript (Qwen3-8B-Q4) shows the model passing `limit=5` on `tell_me_about`. Live transcript:

```
{"query":"May Erlewine","limit":5,"compact":false}
```

The docstring didn't say `limit` is no-op for atomic intents. Added an explicit "Ignored for atomic intents" sentence enumerating `tell_me_about` / `get article` / `show structure` / `links` / `related` / `main_page` / `list_namespaces` / `list_files`.

## Pass 2 — source-level audit

Sibling sweep for each fix shape: zero new defects.

* Other politeness regex sites (`_extract_tell_me_about`'s own narrow strip; `_chained_intent_guidance`'s leading-politeness strip) are defence-in-depth and either redundant-but-harmless or correctly scoped to leading-politeness only.
* Other `access denied` substring detectors (`error_messages.py`'s `_get_error_config`) correctly route to `PERMISSION_ERROR_CONFIG` — not used by the PD2-4 catch-all.
* No further docstring path-bait in `openzim_mcp/` outside `security.py`'s internal `sanitize_path_for_error` example (not LLM-facing).

## Test surface

54 regression tests in `tests/test_post_a21_beta_fixes.py`:

* `TestP1D6P1D7TrailingPolitenessExtensions` — 29 parametric strip cases + word-boundary safety + full-parse integration.
* `TestP1D8SearchTermsRequiredAfterPolitenessStrip` — 8 parametric guard-fires cases.
* `TestP1D1DispatcherEdgePolitenessStrip` — buggy-parse-stub regression for the defence-in-depth strip.
* `TestMultiEntityChainGuidance` — 6 cases covering 3-entity AND chains, 3-entity OR chains with non-Latin, 4-entity chains, 2-entity guard, real-title suppression via title-index probe, search-intent isolation, leading-conjunction split, Lions/Tigers/Bears idiom suppression.
* `TestP1D5QEmittingCursorToolsDrift` — 3 cases: set value, search-encode comment hook, parametric scan against `Cursor.encode` callsites.
* `TestP1D9DocstringPathBaitSiblings` — directory-wide scan of `tools/*.py`.
* `TestP1D10RecoveryHintMarkerDiscriminatesSecurityError` — surfaces the original `OpenZimMcpSecurityError` reason.
* `TestTD1LimitDocstringClarifiesAtomicIntents` — docstring contract pin.

## Full suite

```
1954 passed, 50 skipped, 38 deselected in 27.39s
```

mypy clean across all 45 source files.

## Methodology note

Recurring "fix unlocks new paths" cycle reproduced again:
* Post-a20 P1-D2 (alias-fallback widening to 2-entity asymmetric chains) didn't address 3+ entity chains; this sweep's P1-D2/D3/D4 catch them.
* Post-a20 PD2-1 (parse_intent strip) didn't widen the politeness token set; P1-D6/D7 add British/texting/multi-language variants.
* Post-a20 PD2-2 (zim_query docstring de-bait) didn't sweep the sibling advanced-tool docstrings; P1-D9 widens the regression net.

Live-transcript review remains a distinct test surface from live-MCP probing (T-D1 came from the Qwen3-8B-Q4 transcript; not reachable via adversarial query probing alone).