### PR TITLE
chore(security): ignore PYSEC-2025-183 in pip-audit (disputed pyjwt CVE)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,18 @@ security:  ## Run security scans (fails on bandit/pip-audit findings)
 	# emits "Dependency not found on PyPI and could not be audited:
 	# openzim-mcp (X.Y.ZaN)" and exits 1, blocking the release. Only
 	# our project is editable; third-party deps still get audited.
-	uv run pip-audit --skip-editable
+	#
+	# --ignore-vuln PYSEC-2025-183 (CVE-2025-45768): disputed pyjwt
+	# advisory about "weak encryption" in HS256. pyjwt's maintainer
+	# disputes the claim — key length is chosen by the application
+	# that uses the library, not by pyjwt itself. No fix version is
+	# documented (2.12.1 is the latest as of 2026-05-20), and openzim-
+	# mcp pulls pyjwt only transitively via ``mcp``; the MCP server
+	# uses pyjwt for OAuth bearer-token validation where key length
+	# is controlled by the auth-provider configuration upstream, not
+	# by this codebase. Re-evaluate when pyjwt ships a fix release or
+	# the advisory database resolves the dispute.
+	uv run pip-audit --skip-editable --ignore-vuln PYSEC-2025-183
 
 download-test-data:  ## Download ZIM test data files
 	uv run python scripts/download_test_data.py --priority 1


### PR DESCRIPTION
The v2.0.0a24 release workflow (tag pushed at https://github.com/cameronrye/openzim-mcp/actions/runs/26168651073) failed at the `make security` → `pip-audit` step on a new disputed pyjwt CVE.

## Advisory
- **PYSEC-2025-183** (CVE-2025-45768) — pyjwt "weak encryption" in HS256
- **Severity**: CVSS 3.1 = 7.4 (High)
- **Status**: Disputed by pyjwt's maintainer — "the key length is chosen by the application that uses the library"
- **Fix version**: None documented; pyjwt 2.12.1 is the latest as of 2026-05-20

## Why ignore this one
- openzim-mcp pulls pyjwt only transitively via the `mcp` package; we don't call pyjwt directly.
- The MCP server uses pyjwt for OAuth bearer-token validation where key length is controlled by the auth-provider config upstream, not by this codebase.
- No fix version exists — there's nothing to bump to.
- Same defensive-ignore pattern the post-a20 sweep would have used if the idna CVE-2026-45409 had been disputed (that one had a fix version available, so we bumped instead — see #151).

## Fix
Add `--ignore-vuln PYSEC-2025-183` to the `pip-audit` invocation in the `security` make target, with inline comment documenting the dispute + rationale + re-evaluation trigger (pyjwt fix release or advisory dispute resolution).

## Verification
```
$ make security
...
uv run pip-audit --skip-editable --ignore-vuln PYSEC-2025-183
No known vulnerabilities found, 1 ignored
```

## Next steps after merge
The `v2.0.0a24` tag will be force-updated to point at the new HEAD on `main`, re-triggering the release workflow. Nothing was published from the first attempt (PyPI publish + GitHub release both gate on `make security` passing).
