### PR TITLE
feat(v2): Phase D sub-D-1 — cross-encoder reranker behind [reranker] extra

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,36 @@ jobs:
           echo "3. Add it as CODECOV_TOKEN in GitHub repository secrets"
           echo "4. Re-run this workflow to upload coverage reports"
 
+  test-reranker:
+    name: Test [reranker] extra on Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install dependencies with [reranker] extra
+        run: |
+          uv sync --extra reranker
+
+      - name: Run ml tests including requires_reranker marker
+        run: |
+          uv run pytest tests/ml/ -v
+
   security:
     name: Security Scanning
     runs-on: ubuntu-latest

--- a/docs/superpowers/plans/2026-05-20-v2-phase-d-sub-d-1-reranker.md
+++ b/docs/superpowers/plans/2026-05-20-v2-phase-d-sub-d-1-reranker.md
@@ -1,0 +1,2035 @@
+# v2 Phase D sub-D-1 — Cross-Encoder Reranker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a cross-encoder reranker behind the `[reranker]` opt-in extra that silently improves search + synthesize relevance when installed, falls back cleanly to Xapian-only ranking when absent, and never hangs the first query on an offline deployment.
+
+**Architecture:** New `openzim_mcp/ml/` submodule with three small files (feature-detection registry, fallback decorator, BGEReranker class). Reranker plugs into existing `_handle_search` / `_handle_filtered_search` / `_handle_search_all` in `simple_tools.py` and `_collect_passages` in `synthesize.py`. Optional FastEmbed dependency via `[reranker]` extra; lazy import + lazy model load; 5-second timeout on first-call fetch with structured fallback. Telemetry via the existing `_track()` path.
+
+**Tech Stack:** Python 3.12+, FastEmbed (ONNX-backed, no torch), Pydantic v2 for config, pytest, argparse for CLI dispatch, uv for dependency management.
+
+**Spec:** [`docs/superpowers/specs/2026-05-20-v2-phase-d-ml-accelerators-design.md`](../specs/2026-05-20-v2-phase-d-ml-accelerators-design.md), § sub-D-1.
+
+---
+
+## File Structure
+
+**New files:**
+- `openzim_mcp/ml/__init__.py` — `MLFeatures` dataclass + `detect()` registry function
+- `openzim_mcp/ml/fallback.py` — shared `ml_fallback` decorator
+- `openzim_mcp/ml/reranker.py` — `BGEReranker` class (lazy singleton, score_pairs, rerank)
+- `openzim_mcp/ml/cli/__init__.py` — empty package marker
+- `openzim_mcp/ml/cli/download.py` — `openzim-mcp download-models` entrypoint
+- `tests/ml/__init__.py` — empty package marker
+- `tests/ml/conftest.py` — `requires_reranker` marker registration + shared fixtures
+- `tests/ml/test_ml_registry.py` — tests for `MLFeatures.detect()`
+- `tests/ml/test_fallback.py` — tests for `ml_fallback` decorator
+- `tests/ml/test_reranker_unit.py` — unit tests for `BGEReranker` (mocked FastEmbed)
+- `tests/ml/test_reranker_integration.py` — integration tests against real FastEmbed
+- `tests/ml/test_download_cli.py` — CLI smoke test
+- `docs/v2/extras-reranker.md` — user-facing documentation
+
+**Modified files:**
+- `pyproject.toml` — add `[project.optional-dependencies]` with `reranker = ["fastembed>=0.4.0,<1.0"]`
+- `openzim_mcp/config.py` — add `MLConfig` + `RerankerConfig`; compose onto `OpenZimMcpConfig`
+- `openzim_mcp/main.py` — early-detect `sys.argv[1] == "download-models"` to dispatch the new CLI without breaking the existing `openzim-mcp <dirs>` invocation
+- `openzim_mcp/simple_tools.py` — call `BGEReranker.rerank()` in `_handle_search`, `_handle_filtered_search`, `_handle_search_all`; emit `_meta.reranked` flag
+- `openzim_mcp/synthesize.py` — call `BGEReranker.rerank()` in `_collect_passages` before citation assembly
+- `.github/workflows/test.yml` — add a separate `test-reranker` job that installs `[reranker]` and runs the integration tests on ubuntu-latest only (cost-controlled)
+
+**Test boundaries:**
+- Default `make test` runs on no-extras install. Integration tests skip via `@pytest.mark.requires_reranker` keyed on `importlib.util.find_spec("fastembed")`.
+- The new `test-reranker` CI job runs the integration tests with FastEmbed installed.
+
+---
+
+### Task 1: Feature-detection registry — `MLFeatures.detect()`
+
+**Files:**
+- Create: `openzim_mcp/ml/__init__.py`
+- Create: `tests/ml/__init__.py`
+- Create: `tests/ml/test_ml_registry.py`
+
+- [ ] **Step 1: Create the empty test package marker**
+
+Create `tests/ml/__init__.py` as an empty file:
+
+```python
+"""ML accelerator tests. Lives in its own package to keep the
+default `make test` run unchanged when no extras are installed."""
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/ml/test_ml_registry.py`:
+
+```python
+"""Unit tests for openzim_mcp.ml.__init__'s feature-detection registry."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from openzim_mcp.ml import MLFeatures, detect
+
+
+class TestDetectRegistry:
+    def setup_method(self) -> None:
+        # Clear the lru_cache between tests so each test gets a fresh detect()
+        detect.cache_clear()
+
+    def test_returns_frozen_dataclass(self) -> None:
+        features = detect()
+        assert isinstance(features, MLFeatures)
+        # frozen dataclass: mutation should raise
+        with pytest.raises(Exception):
+            features.reranker = not features.reranker  # type: ignore[misc]
+
+    def test_reranker_true_when_fastembed_importable(self) -> None:
+        with patch("openzim_mcp.ml.importlib.util.find_spec") as mock_spec:
+            mock_spec.return_value = object()  # truthy: package found
+            features = detect()
+            assert features.reranker is True
+        # Verify find_spec was called with the expected argument
+        mock_spec.assert_called_with("fastembed")
+
+    def test_reranker_false_when_fastembed_missing(self) -> None:
+        with patch("openzim_mcp.ml.importlib.util.find_spec") as mock_spec:
+            mock_spec.return_value = None  # falsy: package not found
+            features = detect()
+            assert features.reranker is False
+
+    def test_detect_is_cached(self) -> None:
+        # Two calls should hit find_spec only once
+        with patch("openzim_mcp.ml.importlib.util.find_spec") as mock_spec:
+            mock_spec.return_value = object()
+            detect()
+            detect()
+            assert mock_spec.call_count == 1
+```
+
+- [ ] **Step 3: Run the failing test**
+
+```bash
+uv run pytest tests/ml/test_ml_registry.py -v
+```
+
+Expected: `ImportError: No module named 'openzim_mcp.ml'`
+
+- [ ] **Step 4: Create `openzim_mcp/ml/__init__.py`**
+
+```python
+"""ML accelerator subsystem for openzim-mcp v2 Phase D.
+
+Three opt-in capabilities (only one shipping in sub-D-1):
+  * [reranker] — cross-encoder relevance ranker via FastEmbed
+
+Feature-detection happens here; consumers check `detect()` before
+touching any ML code. Lazy-import + lazy-load are enforced by the
+per-feature module (e.g., ml.reranker imports `fastembed` inside
+`BGEReranker.get()`, not at module level).
+"""
+
+from __future__ import annotations
+
+import functools
+import importlib.util
+from dataclasses import dataclass
+
+__all__ = ["MLFeatures", "detect"]
+
+
+@dataclass(frozen=True)
+class MLFeatures:
+    """Snapshot of which ML extras are installed in this process.
+
+    Sized to today's scope. New fields added when their sub-Ds ship —
+    no pre-commitment to deferred items (#12, #15)."""
+
+    reranker: bool
+
+
+@functools.lru_cache(maxsize=1)
+def detect() -> MLFeatures:
+    """Single source of truth for installed ML extras.
+
+    Cached per process; uses `importlib.util.find_spec` only — no
+    imports, no side effects, no model loads."""
+    return MLFeatures(
+        reranker=importlib.util.find_spec("fastembed") is not None,
+    )
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+uv run pytest tests/ml/test_ml_registry.py -v
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 6: Run lint + type-check**
+
+```bash
+make lint && make type-check
+```
+
+Expected: both clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add openzim_mcp/ml/__init__.py tests/ml/__init__.py tests/ml/test_ml_registry.py
+git commit -m "feat(ml): add MLFeatures feature-detection registry"
+```
+
+---
+
+### Task 2: Shared fallback decorator — `ml_fallback`
+
+**Files:**
+- Create: `openzim_mcp/ml/fallback.py`
+- Create: `tests/ml/test_fallback.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/ml/test_fallback.py`:
+
+```python
+"""Unit tests for ml_fallback decorator."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from openzim_mcp.ml.fallback import ml_fallback, reset_kill_switches
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> None:
+    """Each test starts with empty kill-switch state."""
+    reset_kill_switches()
+
+
+def _fallback(*args: Any, **kwargs: Any) -> str:
+    return "fallback"
+
+
+class TestMlFallback:
+    def test_success_path_returns_inner_result(self) -> None:
+        @ml_fallback(feature="reranker", on_failure=_fallback)
+        def inner() -> str:
+            return "inner"
+
+        assert inner() == "inner"
+
+    def test_first_exception_logs_warning_and_returns_fallback(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.WARNING)
+
+        @ml_fallback(feature="reranker", on_failure=_fallback)
+        def inner() -> str:
+            raise RuntimeError("boom")
+
+        result = inner()
+        assert result == "fallback"
+        warnings = [
+            r for r in caplog.records if r.levelname == "WARNING"
+        ]
+        assert len(warnings) == 1
+        assert "reranker" in warnings[0].message.lower()
+
+    def test_subsequent_calls_after_failure_skip_inner(self) -> None:
+        call_count = 0
+
+        @ml_fallback(feature="reranker", on_failure=_fallback)
+        def inner() -> str:
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("boom")
+
+        inner()  # triggers kill switch
+        inner()  # should NOT call inner again
+        inner()
+        assert call_count == 1  # only the first call entered the wrapped function
+
+    def test_subsequent_failures_log_debug_only(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.DEBUG)
+
+        @ml_fallback(feature="reranker", on_failure=_fallback)
+        def inner() -> str:
+            raise RuntimeError("boom")
+
+        inner()  # WARNING
+        inner()  # DEBUG (kill-switch path)
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        debugs = [r for r in caplog.records if r.levelname == "DEBUG"]
+        assert len(warnings) == 1
+        assert any("reranker" in d.message.lower() for d in debugs)
+
+    def test_kill_switch_is_per_feature(self) -> None:
+        """A failure on reranker doesn't disable a hypothetical other feature."""
+
+        @ml_fallback(feature="reranker", on_failure=_fallback)
+        def reranker_inner() -> str:
+            raise RuntimeError("boom")
+
+        @ml_fallback(feature="other", on_failure=_fallback)
+        def other_inner() -> str:
+            return "other_ok"
+
+        reranker_inner()
+        assert other_inner() == "other_ok"
+```
+
+- [ ] **Step 2: Run the failing test**
+
+```bash
+uv run pytest tests/ml/test_fallback.py -v
+```
+
+Expected: `ImportError: No module named 'openzim_mcp.ml.fallback'`
+
+- [ ] **Step 3: Create `openzim_mcp/ml/fallback.py`**
+
+```python
+"""Shared fallback decorator for ML entry points.
+
+When an ML call raises, the decorator logs a WARNING (once per feature),
+sets a per-process kill switch for that feature, and routes all future
+calls through `on_failure`. Idempotent — second failure for the same
+feature logs at DEBUG level only."""
+
+from __future__ import annotations
+
+import functools
+import logging
+from typing import Any, Callable, Set, TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+_disabled_features: Set[str] = set()
+
+
+def reset_kill_switches() -> None:
+    """Clear all kill switches. For tests only."""
+    _disabled_features.clear()
+
+
+def ml_fallback(
+    *,
+    feature: str,
+    on_failure: Callable[..., T],
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """Decorator: wrap an ML call so failure routes to a pure-Python fallback.
+
+    On the FIRST exception for `feature`:
+      * log a structured WARNING naming the feature and the underlying error,
+      * set a process-wide kill switch,
+      * return `on_failure(*args, **kwargs)`.
+
+    On SUBSEQUENT calls after the kill switch is set:
+      * `on_failure(*args, **kwargs)` is called WITHOUT entering the wrapped
+        function.
+
+    On SUBSEQUENT exceptions (if a fresh kill-switch had been cleared):
+      * log at DEBUG only to avoid log spam.
+    """
+
+    def decorator(fn: Callable[..., T]) -> Callable[..., T]:
+        @functools.wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            if feature in _disabled_features:
+                logger.debug(
+                    "ml feature %s kill-switched; routing to fallback", feature
+                )
+                return on_failure(*args, **kwargs)
+            try:
+                return fn(*args, **kwargs)
+            except Exception as exc:  # noqa: BLE001 — intentional broad catch
+                if feature in _disabled_features:
+                    logger.debug(
+                        "ml feature %s re-failure suppressed: %s", feature, exc
+                    )
+                else:
+                    logger.warning(
+                        "ml feature %s failed (%s); disabling for this process",
+                        feature,
+                        exc,
+                    )
+                    _disabled_features.add(feature)
+                return on_failure(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+uv run pytest tests/ml/test_fallback.py -v
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 5: Run lint + type-check**
+
+```bash
+make lint && make type-check
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add openzim_mcp/ml/fallback.py tests/ml/test_fallback.py
+git commit -m "feat(ml): add ml_fallback decorator for graceful ML failure"
+```
+
+---
+
+### Task 3: `RerankerConfig` + `MLConfig` on `OpenZimMcpConfig`
+
+**Files:**
+- Modify: `openzim_mcp/config.py:153-170` (`OpenZimMcpConfig` field block, line numbers approximate — find by searching for the `cache: CacheConfig = Field(...)` line)
+- Modify: `openzim_mcp/config.py` (just above `class OpenZimMcpConfig(BaseSettings):`)
+- Test: extend `tests/test_config.py` if it exists, otherwise create `tests/ml/test_ml_config.py`
+
+- [ ] **Step 1: Locate existing config tests**
+
+```bash
+find tests -name "test_config*.py" -not -path "*/ml/*"
+```
+
+If a file exists, extend it; otherwise we add a new test file under `tests/ml/`.
+
+- [ ] **Step 2: Write the failing test**
+
+Create or extend `tests/ml/test_ml_config.py`:
+
+```python
+"""Tests for MLConfig + RerankerConfig wiring on OpenZimMcpConfig."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openzim_mcp.config import MLConfig, OpenZimMcpConfig, RerankerConfig
+
+
+class TestRerankerConfig:
+    def test_defaults(self) -> None:
+        cfg = RerankerConfig()
+        assert cfg.enabled is True
+        assert cfg.model_id == "Xenova/bge-reranker-base-onnx"
+        assert cfg.candidate_pool_size == 50
+        assert cfg.final_top_k == 10
+        assert cfg.max_query_length == 256
+        assert cfg.max_passage_length == 512
+        assert cfg.min_query_tokens == 4
+        assert cfg.first_call_timeout_seconds == 5.0
+        assert cfg.cache_dir is None
+
+    def test_pool_size_bounds(self) -> None:
+        # Pydantic v2 validation: pool size must be positive
+        with pytest.raises(Exception):
+            RerankerConfig(candidate_pool_size=0)
+        # Reasonable upper bound prevents runaway memory
+        with pytest.raises(Exception):
+            RerankerConfig(candidate_pool_size=10000)
+
+    def test_min_query_tokens_bounds(self) -> None:
+        # 0 disables the skip gate; that's allowed.
+        RerankerConfig(min_query_tokens=0)
+        # Negative is not.
+        with pytest.raises(Exception):
+            RerankerConfig(min_query_tokens=-1)
+
+
+class TestMLConfig:
+    def test_defaults(self) -> None:
+        cfg = MLConfig()
+        assert isinstance(cfg.reranker, RerankerConfig)
+        assert cfg.reranker.enabled is True
+
+    def test_attaches_to_openzim_config(self, tmp_path: Path) -> None:
+        zim_dir = tmp_path / "zim"
+        zim_dir.mkdir()
+        cfg = OpenZimMcpConfig(allowed_directories=[str(zim_dir)])
+        assert isinstance(cfg.ml, MLConfig)
+        assert isinstance(cfg.ml.reranker, RerankerConfig)
+```
+
+- [ ] **Step 3: Run the failing test**
+
+```bash
+uv run pytest tests/ml/test_ml_config.py -v
+```
+
+Expected: `ImportError: cannot import name 'MLConfig'`
+
+- [ ] **Step 4: Add `RerankerConfig` + `MLConfig` to `openzim_mcp/config.py`**
+
+In `openzim_mcp/config.py`, add the new classes after the existing `SynthesizeConfig` class (around line 135, before `class LoggingConfig`):
+
+```python
+class RerankerConfig(BaseModel):
+    """Phase D sub-D-1: cross-encoder reranker config.
+
+    Only applies when the `[reranker]` optional extra is installed.
+    All knobs respect the kill switch in `ml_fallback` — if the model
+    fails to load once, every subsequent search bypasses rerank for
+    the rest of the process."""
+
+    enabled: bool = Field(
+        default=True,
+        description=(
+            "Master kill switch. Set False (or env OPENZIM_RERANKER_DISABLE=1) "
+            "to skip rerank even when the [reranker] extra is importable."
+        ),
+    )
+    model_id: str = Field(
+        default="Xenova/bge-reranker-base-onnx",
+        description=(
+            "FastEmbed model identifier. Default targets English-first "
+            "archives. Multilingual archives can override via "
+            "OPENZIM_RERANKER_MODEL env var (e.g., jina-reranker-v3)."
+        ),
+    )
+    candidate_pool_size: int = Field(
+        default=50,
+        ge=1,
+        le=500,
+        description=(
+            "Xapian top-N to rerank. Larger pool = more recall, more "
+            "rerank cost. 50 is the sweet spot per FastEmbed benchmarks."
+        ),
+    )
+    final_top_k: int = Field(
+        default=10,
+        ge=1,
+        le=100,
+        description=(
+            "Default response cap after rerank. Caller-supplied `limit` "
+            "overrides this when smaller."
+        ),
+    )
+    max_query_length: int = Field(default=256, ge=1, le=4096)
+    max_passage_length: int = Field(default=512, ge=1, le=8192)
+    min_query_tokens: int = Field(
+        default=4,
+        ge=0,
+        le=64,
+        description=(
+            "Skip-on-short-query gate: queries with fewer than this many "
+            "word tokens bypass rerank. Single-word entity queries (e.g., "
+            "`Berlin`) already get a Xapian-score-1.0 canonical-title hit; "
+            "the cross-encoder adds cost without value there. Set 0 to "
+            "disable the gate."
+        ),
+    )
+    first_call_timeout_seconds: float = Field(
+        default=5.0,
+        ge=0.1,
+        le=120.0,
+        description=(
+            "Timeout for the first model load (covers HuggingFace download). "
+            "When exceeded, the kill switch fires and search falls back to "
+            "Xapian-only. Pre-stage with `openzim-mcp download-models` to "
+            "avoid this path."
+        ),
+    )
+    cache_dir: Path | None = Field(
+        default=None,
+        description=(
+            "Override the FastEmbed model cache directory. None → "
+            "$OPENZIM_MODEL_CACHE_DIR/fastembed, fallback "
+            "~/.cache/openzim-mcp/models/fastembed."
+        ),
+    )
+
+
+class MLConfig(BaseModel):
+    """Phase D umbrella config. Sized to today's scope (sub-D-1 only);
+    deferred sub-Ds add their sub-configs when they ship."""
+
+    reranker: RerankerConfig = Field(default_factory=RerankerConfig)
+```
+
+In the `OpenZimMcpConfig` class (search for `cache: CacheConfig = Field(...)` and add this line in the same block):
+
+```python
+    ml: MLConfig = Field(default_factory=MLConfig)
+```
+
+Also add `MLConfig`, `RerankerConfig` to the `__all__` list (search for `"OpenZimMcpConfig"` in `__all__`).
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+uv run pytest tests/ml/test_ml_config.py -v
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 6: Run lint + type-check**
+
+```bash
+make lint && make type-check
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add openzim_mcp/config.py tests/ml/test_ml_config.py
+git commit -m "feat(ml): add RerankerConfig + MLConfig to OpenZimMcpConfig"
+```
+
+---
+
+### Task 4: `BGEReranker.get()` lazy singleton
+
+**Files:**
+- Create: `openzim_mcp/ml/reranker.py`
+- Create: `tests/ml/test_reranker_unit.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/ml/test_reranker_unit.py`:
+
+```python
+"""Unit tests for BGEReranker (mocked FastEmbed)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openzim_mcp.config import RerankerConfig
+from openzim_mcp.ml import detect
+from openzim_mcp.ml.fallback import reset_kill_switches
+from openzim_mcp.ml.reranker import BGEReranker
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> None:
+    BGEReranker.reset_instance()
+    reset_kill_switches()
+    detect.cache_clear()
+
+
+class TestBGEGet:
+    def test_returns_none_when_extra_absent(self) -> None:
+        with patch("openzim_mcp.ml.importlib.util.find_spec") as mock_spec:
+            mock_spec.return_value = None
+            assert BGEReranker.get() is None
+
+    def test_returns_none_when_disabled_via_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENZIM_RERANKER_DISABLE", "1")
+        # Even if the extra is "installed", env disable wins.
+        with patch("openzim_mcp.ml.importlib.util.find_spec") as mock_spec:
+            mock_spec.return_value = object()
+            assert BGEReranker.get() is None
+
+    def test_returns_singleton_when_extra_present(self) -> None:
+        with patch("openzim_mcp.ml.importlib.util.find_spec") as mock_spec, patch(
+            "openzim_mcp.ml.reranker._load_model"
+        ) as mock_load:
+            mock_spec.return_value = object()
+            mock_load.return_value = MagicMock(name="fastembed_reranker")
+            a = BGEReranker.get()
+            b = BGEReranker.get()
+            assert a is not None
+            assert a is b  # same singleton
+            assert mock_load.call_count == 1
+```
+
+- [ ] **Step 2: Run the failing test**
+
+```bash
+uv run pytest tests/ml/test_reranker_unit.py -v
+```
+
+Expected: `ImportError: No module named 'openzim_mcp.ml.reranker'`
+
+- [ ] **Step 3: Create `openzim_mcp/ml/reranker.py` skeleton**
+
+```python
+"""Cross-encoder reranker (Phase D sub-D-1).
+
+Lazy singleton wrapping FastEmbed's TextCrossEncoder. The whole module
+imports cheaply (no `import fastembed` at top level); the actual library
+import lives inside `_load_model`, which only runs when the
+`[reranker]` extra is installed AND the user actually hits a rerank
+code path."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeout
+from pathlib import Path
+from typing import Any, List, Optional, Sequence, Tuple
+
+from openzim_mcp.config import RerankerConfig
+from openzim_mcp.ml import detect
+from openzim_mcp.ml.fallback import ml_fallback
+
+logger = logging.getLogger(__name__)
+
+
+def _load_model(model_id: str, cache_dir: Optional[Path]) -> Any:
+    """Lazy import + load. Called inside BGEReranker.get(). Kept as a
+    module-level function so tests can mock it cleanly."""
+    from fastembed.rerank.cross_encoder import TextCrossEncoder  # type: ignore[import-untyped]
+
+    kwargs: dict[str, Any] = {"model_name": model_id}
+    if cache_dir is not None:
+        kwargs["cache_dir"] = str(cache_dir)
+    return TextCrossEncoder(**kwargs)
+
+
+class BGEReranker:
+    """Singleton wrapper around FastEmbed's cross-encoder reranker.
+
+    Use `BGEReranker.get(config)` to fetch an instance — returns None
+    when the `[reranker]` extra is missing or the kill switch fired.
+    Subsequent calls hit the cached instance."""
+
+    _instance: Optional["BGEReranker"] = None
+    _instance_lock: threading.Lock = threading.Lock()
+
+    def __init__(self, model: Any, config: RerankerConfig) -> None:
+        self._model = model
+        self._config = config
+
+    @classmethod
+    def reset_instance(cls) -> None:
+        """For tests only."""
+        with cls._instance_lock:
+            cls._instance = None
+
+    @classmethod
+    def get(
+        cls, config: Optional[RerankerConfig] = None
+    ) -> Optional["BGEReranker"]:
+        """Return the singleton, or None if unavailable.
+
+        The first call attempts to import FastEmbed + load the model
+        with a `first_call_timeout_seconds` wall-clock cap. On timeout
+        or failure, logs a structured WARNING and returns None for
+        every subsequent call this process makes."""
+        # 1. Extra installed?
+        if not detect().reranker:
+            return None
+        # 2. Disabled via env?
+        if os.environ.get("OPENZIM_RERANKER_DISABLE") == "1":
+            logger.debug("reranker disabled via OPENZIM_RERANKER_DISABLE=1")
+            return None
+        # 3. Disabled via config?
+        cfg = config or RerankerConfig()
+        if not cfg.enabled:
+            return None
+        # 4. Cached instance?
+        if cls._instance is not None:
+            return cls._instance
+        # 5. Load with timeout.
+        with cls._instance_lock:
+            if cls._instance is not None:
+                return cls._instance
+            try:
+                cls._instance = cls._load_with_timeout(cfg)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    (
+                        "reranker model load failed: %s. "
+                        "Falling back to Xapian-only ranking for this "
+                        "process. Run `openzim-mcp download-models` to "
+                        "pre-stage the model offline."
+                    ),
+                    exc,
+                )
+                return None
+            return cls._instance
+
+    @classmethod
+    def _load_with_timeout(cls, cfg: RerankerConfig) -> "BGEReranker":
+        timeout = cfg.first_call_timeout_seconds
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(_load_model, cfg.model_id, cfg.cache_dir)
+            try:
+                model = future.result(timeout=timeout)
+            except FuturesTimeout:
+                future.cancel()
+                raise TimeoutError(
+                    f"reranker model load exceeded {timeout}s timeout. "
+                    f"Run `openzim-mcp download-models` to pre-stage."
+                )
+        # First-load audit log: model id + library version.
+        try:
+            import fastembed  # type: ignore[import-untyped]
+
+            logger.info(
+                "reranker loaded: model_id=%s fastembed=%s",
+                cfg.model_id,
+                getattr(fastembed, "__version__", "unknown"),
+            )
+        except Exception:  # pragma: no cover — diagnostic-only path
+            pass
+        return cls(model=model, config=cfg)
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+uv run pytest tests/ml/test_reranker_unit.py::TestBGEGet -v
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Run lint + type-check**
+
+```bash
+make lint && make type-check
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add openzim_mcp/ml/reranker.py tests/ml/test_reranker_unit.py
+git commit -m "feat(ml): BGEReranker singleton with timeout-gated lazy load"
+```
+
+---
+
+### Task 5: `BGEReranker.score_pairs()` + `rerank()` + skip-gate
+
+**Files:**
+- Modify: `openzim_mcp/ml/reranker.py` (add methods + module-level helper)
+- Modify: `tests/ml/test_reranker_unit.py` (add test classes)
+
+- [ ] **Step 1: Extend the test file**
+
+Append to `tests/ml/test_reranker_unit.py`:
+
+```python
+class TestScorePairs:
+    def _make_reranker_with_scores(self, scores: List[float]) -> BGEReranker:
+        mock_model = MagicMock()
+        mock_model.rerank = MagicMock(return_value=iter(scores))
+        # Bypass BGEReranker.get() and inject a pre-built reranker
+        return BGEReranker(model=mock_model, config=RerankerConfig())
+
+    def test_empty_pairs_returns_empty(self) -> None:
+        r = self._make_reranker_with_scores([])
+        assert r.score_pairs([]) == []
+
+    def test_returns_one_score_per_pair(self) -> None:
+        r = self._make_reranker_with_scores([0.9, 0.5, 0.1])
+        scores = r.score_pairs(
+            [("q", "d1"), ("q", "d2"), ("q", "d3")]
+        )
+        assert scores == [0.9, 0.5, 0.1]
+
+    def test_truncates_query_at_max_length(self) -> None:
+        cfg = RerankerConfig(max_query_length=5)
+        mock_model = MagicMock()
+        mock_model.rerank = MagicMock(return_value=iter([0.5]))
+        r = BGEReranker(model=mock_model, config=cfg)
+        r.score_pairs([("abcdefghijklmnop", "doc")])
+        # Verify the query passed to fastembed was truncated
+        call_args = mock_model.rerank.call_args
+        # FastEmbed's rerank signature: rerank(query: str, documents: List[str])
+        passed_query = call_args[0][0]
+        assert len(passed_query) <= 5
+
+
+class TestRerank:
+    def _make_reranker_with_scores(self, scores: List[float]) -> BGEReranker:
+        mock_model = MagicMock()
+        mock_model.rerank = MagicMock(return_value=iter(scores))
+        return BGEReranker(model=mock_model, config=RerankerConfig())
+
+    def test_short_query_skips_rerank(self) -> None:
+        r = self._make_reranker_with_scores([0.5, 0.5, 0.5])
+        # "Berlin" is 1 token, well below min_query_tokens=4
+        candidates = [
+            {"path": "A", "snippet": "...", "xapian_score": 1.0},
+            {"path": "B", "snippet": "...", "xapian_score": 0.9},
+        ]
+        result = r.rerank("Berlin", candidates, top_k=2)
+        # Returns input order unchanged (no rerank fired)
+        assert [c["path"] for c in result] == ["A", "B"]
+        # And no rerank_score field added
+        assert all("rerank_score" not in c for c in result)
+
+    def test_long_query_reranks(self) -> None:
+        # Scores ordered to invert Xapian's ordering
+        r = self._make_reranker_with_scores([0.1, 0.9])
+        candidates = [
+            {"path": "A", "snippet": "...", "xapian_score": 1.0},
+            {"path": "B", "snippet": "...", "xapian_score": 0.5},
+        ]
+        result = r.rerank(
+            "what year did Marie Curie discover radium",
+            candidates,
+            top_k=2,
+        )
+        # B now wins (rerank_score=0.9 > 0.1)
+        assert [c["path"] for c in result] == ["B", "A"]
+        assert result[0]["rerank_score"] == 0.9
+        assert result[1]["rerank_score"] == 0.1
+
+    def test_top_k_slices_result(self) -> None:
+        r = self._make_reranker_with_scores([0.9, 0.5, 0.1])
+        candidates = [
+            {"path": "A", "snippet": "...", "xapian_score": 0.5},
+            {"path": "B", "snippet": "...", "xapian_score": 0.5},
+            {"path": "C", "snippet": "...", "xapian_score": 0.5},
+        ]
+        result = r.rerank(
+            "what year did Marie Curie discover radium",
+            candidates,
+            top_k=2,
+        )
+        assert len(result) == 2
+        assert [c["path"] for c in result] == ["A", "B"]
+
+    def test_empty_candidates_returns_empty(self) -> None:
+        r = self._make_reranker_with_scores([])
+        assert r.rerank("any long enough query string", [], top_k=10) == []
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+```bash
+uv run pytest tests/ml/test_reranker_unit.py::TestScorePairs tests/ml/test_reranker_unit.py::TestRerank -v
+```
+
+Expected: `AttributeError: 'BGEReranker' object has no attribute 'score_pairs'`
+
+- [ ] **Step 3: Add the methods to `openzim_mcp/ml/reranker.py`**
+
+Append to the `BGEReranker` class (before the `_load_with_timeout` classmethod):
+
+```python
+    def score_pairs(self, pairs: Sequence[Tuple[str, str]]) -> List[float]:
+        """Batch-score (query, passage) pairs.
+
+        Empty input → empty output. Query and passage are truncated at
+        the configured max lengths before being passed to FastEmbed."""
+        if not pairs:
+            return []
+        # Group by query so we make one rerank call per distinct query.
+        # In practice all pairs share the same query (rerank is called
+        # per search), so this collapses to a single batch.
+        by_query: dict[str, List[int]] = {}
+        truncated_passages: List[str] = []
+        for idx, (q, p) in enumerate(pairs):
+            q_trim = q[: self._config.max_query_length]
+            p_trim = p[: self._config.max_passage_length]
+            by_query.setdefault(q_trim, []).append(idx)
+            truncated_passages.append(p_trim)
+        scores: List[float] = [0.0] * len(pairs)
+        for q, idxs in by_query.items():
+            passages = [truncated_passages[i] for i in idxs]
+            batch_scores = list(self._model.rerank(q, passages))
+            for i, s in zip(idxs, batch_scores):
+                scores[i] = float(s)
+        return scores
+
+    def rerank(
+        self,
+        query: str,
+        candidates: List[dict[str, Any]],
+        top_k: int,
+    ) -> List[dict[str, Any]]:
+        """Rerank candidate envelopes against `query`, slice top_k.
+
+        Skip rules:
+          * Query has fewer than `min_query_tokens` whitespace-separated
+            tokens → return candidates unchanged (input order preserved),
+            no `rerank_score` added.
+          * Empty candidates → empty result.
+
+        On rerank, each candidate gains a `rerank_score: float` field.
+        The original `xapian_score` (if present) is preserved."""
+        if not candidates:
+            return []
+        # Skip-on-short-query gate.
+        if self._config.min_query_tokens > 0:
+            token_count = len(query.split())
+            if token_count < self._config.min_query_tokens:
+                logger.debug(
+                    "reranker skipped: query has %d tokens (min %d)",
+                    token_count,
+                    self._config.min_query_tokens,
+                )
+                return candidates[:top_k]
+        # Build pairs.
+        pairs: List[Tuple[str, str]] = []
+        for c in candidates:
+            passage = c.get("snippet") or c.get("path", "")
+            pairs.append((query, str(passage)))
+        scores = self.score_pairs(pairs)
+        # Decorate + sort.
+        decorated = list(zip(candidates, scores))
+        decorated.sort(key=lambda x: x[1], reverse=True)
+        result: List[dict[str, Any]] = []
+        for cand, score in decorated[:top_k]:
+            new_cand = dict(cand)  # shallow copy preserves original envelope
+            new_cand["rerank_score"] = float(score)
+            result.append(new_cand)
+        return result
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+uv run pytest tests/ml/test_reranker_unit.py -v
+```
+
+Expected: all tests pass (10 total).
+
+- [ ] **Step 5: Run lint + type-check**
+
+```bash
+make lint && make type-check
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add openzim_mcp/ml/reranker.py tests/ml/test_reranker_unit.py
+git commit -m "feat(ml): BGEReranker.score_pairs + rerank with skip-on-short-query gate"
+```
+
+---
+
+### Task 6: Pyproject `[reranker]` extra
+
+**Files:**
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Locate the dependencies block**
+
+```bash
+grep -n "^dependencies\|optional-dependencies\|project.urls" pyproject.toml
+```
+
+Expected output shows `dependencies = [` at one line and `[project.urls]` shortly after. The new `[project.optional-dependencies]` section goes between them.
+
+- [ ] **Step 2: Add the `[reranker]` extra**
+
+Edit `pyproject.toml`. After the closing `]` of the existing `dependencies = [...]` list and before `[project.urls]`, add:
+
+```toml
+[project.optional-dependencies]
+# Phase D sub-D-1: cross-encoder reranker via FastEmbed (ONNX-backed,
+# no torch dependency). Adds ~150 MB install footprint. Lazy-imported
+# inside openzim_mcp.ml.reranker; default install is unaffected.
+reranker = [
+    "fastembed>=0.4.0,<1.0",
+]
+```
+
+- [ ] **Step 3: Verify wheel builds cleanly (no extras)**
+
+```bash
+uv sync && make test 2>&1 | tail -3
+```
+
+Expected: existing tests still pass; no new failures.
+
+- [ ] **Step 4: Verify install with `[reranker]` works**
+
+```bash
+uv sync --extra reranker
+uv run python -c "import fastembed; print('fastembed OK:', fastembed.__version__)"
+```
+
+Expected: prints `fastembed OK: <version>` (no ImportError). Then revert:
+
+```bash
+uv sync  # back to no-extras state
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "feat(ml): add [reranker] optional extra (FastEmbed)"
+```
+
+---
+
+### Task 7: Wire reranker into `simple_tools.py:_handle_search`
+
+**Files:**
+- Modify: `openzim_mcp/simple_tools.py` (in `_handle_search`)
+- Test: extend `tests/ml/test_reranker_unit.py` with integration-shaped tests
+
+- [ ] **Step 1: Locate `_handle_search` and identify where Xapian results are returned**
+
+```bash
+grep -n "_handle_search\|search_results\|search_zim_file" /Volumes/rye/Developer/openzim-mcp/openzim_mcp/simple_tools.py | head -10
+```
+
+Find the function signature and the line where the search-results list is assembled into the final response.
+
+- [ ] **Step 2: Write the failing integration test**
+
+Append to `tests/ml/test_reranker_unit.py`:
+
+```python
+class TestRerankerWiredToSimpleTools:
+    """Smoke test the activation surface: when BGEReranker.get() returns
+    a reranker, _handle_search uses it; when it returns None, the path
+    falls through to the existing Xapian ordering."""
+
+    def test_handle_search_passes_through_when_reranker_absent(
+        self, tmp_path: Path
+    ) -> None:
+        # When BGEReranker.get() returns None, _handle_search returns
+        # the same shape as before (no _meta.reranked field, or
+        # _meta.reranked = False).
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        # The test only needs to verify the wiring exists, not full
+        # search behaviour. Use a mocked-zim handler.
+        with patch(
+            "openzim_mcp.ml.reranker.BGEReranker.get", return_value=None
+        ):
+            # The actual handler call requires a configured archive;
+            # we mock the inner search to isolate the rerank wiring.
+            handler = MagicMock(spec=SimpleToolsHandler)
+            handler._handle_search = SimpleToolsHandler._handle_search.__get__(
+                handler, SimpleToolsHandler
+            )
+            # Asserting: no exceptions, no rerank call. Detailed
+            # behaviour is covered by the existing simple_tools tests.
+            assert True  # placeholder — full integration is in test_reranker_integration
+
+    def test_handle_search_reranks_when_reranker_present(self) -> None:
+        # Symmetric: when a reranker is available, search results carry
+        # rerank_score and _meta.reranked=True.
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        mock_reranker = MagicMock()
+        mock_reranker.rerank = MagicMock(
+            side_effect=lambda q, c, top_k: [
+                {**cand, "rerank_score": 0.5} for cand in c[:top_k]
+            ]
+        )
+        with patch(
+            "openzim_mcp.ml.reranker.BGEReranker.get",
+            return_value=mock_reranker,
+        ):
+            # Same placeholder shape — actual behaviour validated
+            # through the existing search test suite once wired.
+            assert True
+```
+
+These tests are scaffolding for the wiring; full integration is exercised by `test_reranker_integration.py` in Task 11.
+
+- [ ] **Step 3: Read the existing `_handle_search` to find the return point**
+
+```bash
+sed -n '/_handle_search/,/return\|_meta/p' /Volumes/rye/Developer/openzim-mcp/openzim_mcp/simple_tools.py | head -80
+```
+
+Identify:
+  * Where the `results` list of dicts is finalized.
+  * Where `_meta` is constructed.
+  * The function's return statement.
+
+- [ ] **Step 4: Inject reranker call before the response is assembled**
+
+In `simple_tools.py`, locate `_handle_search` (and the parallel `_handle_filtered_search`, `_handle_search_all`). Just BEFORE the final `_meta` construction / return statement, insert:
+
+```python
+            # Phase D sub-D-1: cross-encoder rerank if available.
+            from openzim_mcp.ml.reranker import BGEReranker
+
+            reranker = BGEReranker.get(self.config.ml.reranker)
+            reranked = False
+            if reranker is not None and results:
+                results = reranker.rerank(
+                    query=query,
+                    candidates=results,
+                    top_k=self.config.ml.reranker.final_top_k,
+                )
+                reranked = True
+                self._track("reranker_engaged")
+            else:
+                self._track(
+                    "reranker_skipped",
+                    {"reason": "not_installed" if reranker is None else "no_results"},
+                )
+```
+
+Then in the `_meta` construction, add:
+
+```python
+                "reranked": reranked,
+```
+
+Notes for the implementer:
+- The exact variable names (`results`, `query`) depend on the actual existing code. Match the existing naming.
+- The `_track()` method takes either a single string or `(event, details_dict)` — verify by searching for existing `_track(` calls in the file.
+- If `_track()` doesn't accept a details argument today, file a follow-up task (out of scope for sub-D-1) or pass the structured event as `f"reranker_skipped:{reason}"`.
+
+- [ ] **Step 5: Run the full test suite to verify no existing tests regress**
+
+```bash
+make test
+```
+
+Expected: all existing tests pass (no regressions from the rerank wiring).
+
+- [ ] **Step 6: Run lint + type-check**
+
+```bash
+make lint && make type-check
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add openzim_mcp/simple_tools.py tests/ml/test_reranker_unit.py
+git commit -m "feat(ml): wire BGEReranker into _handle_search + telemetry"
+```
+
+---
+
+### Task 8: Wire reranker into `_handle_filtered_search` + `_handle_search_all`
+
+**Files:**
+- Modify: `openzim_mcp/simple_tools.py` (two more handlers)
+
+- [ ] **Step 1: Locate both handlers**
+
+```bash
+grep -n "_handle_filtered_search\|_handle_search_all\|def _handle" /Volumes/rye/Developer/openzim-mcp/openzim_mcp/simple_tools.py | head -10
+```
+
+- [ ] **Step 2: Repeat the Task 7 injection pattern in both handlers**
+
+In `_handle_filtered_search`, just before the response is finalized, insert the same rerank block from Task 7 Step 4.
+
+In `_handle_search_all`, same pattern.
+
+Verify each insertion site keeps the same variable names (`results`, `query`) as the surrounding code.
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+make test
+```
+
+Expected: all existing tests pass.
+
+- [ ] **Step 4: Run lint + type-check**
+
+```bash
+make lint && make type-check
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add openzim_mcp/simple_tools.py
+git commit -m "feat(ml): wire BGEReranker into _handle_filtered_search + _handle_search_all"
+```
+
+---
+
+### Task 9: Wire reranker into `synthesize.py:_collect_passages`
+
+**Files:**
+- Modify: `openzim_mcp/synthesize.py`
+
+- [ ] **Step 1: Locate `_collect_passages`**
+
+```bash
+grep -n "_collect_passages\|def _collect\|passage_candidates" /Volumes/rye/Developer/openzim-mcp/openzim_mcp/synthesize.py | head -10
+```
+
+Identify:
+  * Where passage candidates are assembled (Phase C top-N retrieval).
+  * Where they're handed to the citation block builder.
+
+- [ ] **Step 2: Inject the rerank call between collection and assembly**
+
+In `synthesize.py:_collect_passages` (or the function that calls it just before citation assembly), insert:
+
+```python
+        # Phase D sub-D-1: rerank passage candidates before citation
+        # assembly. Synthesize is the primary content-fragment-query
+        # surface; reranker pays off most here.
+        from openzim_mcp.ml.reranker import BGEReranker
+
+        reranker = BGEReranker.get(self.config.ml.reranker)
+        if reranker is not None and passages:
+            # Convert passage objects to dict envelopes for the reranker
+            # (it works on `path` + `snippet` shapes). Adjust the
+            # exact attribute names to match the existing Passage
+            # type — likely Passage.path / Passage.text.
+            envelopes = [
+                {
+                    "path": p.path,
+                    "snippet": p.text[: self.config.ml.reranker.max_passage_length],
+                    "xapian_score": getattr(p, "score", 0.0),
+                }
+                for p in passages
+            ]
+            reranked_envelopes = reranker.rerank(
+                query=query,
+                candidates=envelopes,
+                top_k=len(passages),  # rerank ALL passages, top-K trim happens later
+            )
+            # Map back to Passage objects, preserving the new ordering.
+            envelope_by_path = {e["path"]: e for e in reranked_envelopes}
+            passages = [p for p in passages if p.path in envelope_by_path]
+            passages.sort(
+                key=lambda p: envelope_by_path[p.path]["rerank_score"],
+                reverse=True,
+            )
+            self._track("reranker_engaged", {"surface": "synthesize"})
+```
+
+Notes for the implementer:
+- The `Passage` envelope's attribute names (`path`, `text`, `score`) need verification against the actual Phase C implementation. Search for `class Passage` or `@dataclass` definitions in `synthesize.py`.
+- If the existing code uses a list of dicts already, skip the envelope conversion.
+
+- [ ] **Step 3: Run the synthesize tests**
+
+```bash
+uv run pytest tests/test_synthesize* -v
+```
+
+Expected: all existing synthesize tests pass.
+
+- [ ] **Step 4: Run the full test suite**
+
+```bash
+make test
+```
+
+- [ ] **Step 5: Run lint + type-check**
+
+```bash
+make lint && make type-check
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add openzim_mcp/synthesize.py
+git commit -m "feat(ml): wire BGEReranker into synthesize._collect_passages"
+```
+
+---
+
+### Task 10: `openzim-mcp download-models` CLI
+
+**Files:**
+- Create: `openzim_mcp/ml/cli/__init__.py`
+- Create: `openzim_mcp/ml/cli/download.py`
+- Modify: `openzim_mcp/main.py` (early-dispatch on `sys.argv[1] == "download-models"`)
+- Create: `tests/ml/test_download_cli.py`
+
+- [ ] **Step 1: Create the cli package marker**
+
+Create `openzim_mcp/ml/cli/__init__.py`:
+
+```python
+"""CLI subcommands for the ml subsystem."""
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/ml/test_download_cli.py`:
+
+```python
+"""Tests for the `openzim-mcp download-models` CLI."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openzim_mcp.ml.cli.download import download_models_main
+
+
+class TestDownloadModelsCli:
+    def test_reports_when_no_extras_installed(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with patch("openzim_mcp.ml.cli.download.detect") as mock_detect:
+            mock_detect.return_value = MagicMock(reranker=False)
+            rc = download_models_main(argv=[])
+            captured = capsys.readouterr()
+            assert rc == 0
+            assert "no ml extras installed" in captured.out.lower()
+
+    def test_downloads_reranker_when_extra_present(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with patch("openzim_mcp.ml.cli.download.detect") as mock_detect, patch(
+            "openzim_mcp.ml.cli.download._stage_reranker"
+        ) as mock_stage:
+            mock_detect.return_value = MagicMock(reranker=True)
+            mock_stage.return_value = None  # success
+            rc = download_models_main(argv=[])
+            captured = capsys.readouterr()
+            assert rc == 0
+            assert "reranker" in captured.out.lower()
+            mock_stage.assert_called_once()
+
+    def test_returns_nonzero_on_stage_failure(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with patch("openzim_mcp.ml.cli.download.detect") as mock_detect, patch(
+            "openzim_mcp.ml.cli.download._stage_reranker"
+        ) as mock_stage:
+            mock_detect.return_value = MagicMock(reranker=True)
+            mock_stage.side_effect = RuntimeError("network error")
+            rc = download_models_main(argv=[])
+            captured = capsys.readouterr()
+            assert rc == 1
+            assert "failed" in captured.out.lower()
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+uv run pytest tests/ml/test_download_cli.py -v
+```
+
+Expected: `ImportError: No module named 'openzim_mcp.ml.cli.download'`
+
+- [ ] **Step 4: Create `openzim_mcp/ml/cli/download.py`**
+
+```python
+"""`openzim-mcp download-models` — pre-stage ML model files.
+
+Run once after `pip install openzim-mcp[reranker]` (or any other ML
+extra) so the first MCP query doesn't hit a network call. Idempotent —
+re-running checks the cache and only fetches missing files."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from typing import List, Optional
+
+from openzim_mcp.config import RerankerConfig
+from openzim_mcp.ml import detect
+
+logger = logging.getLogger(__name__)
+
+
+def _stage_reranker(cfg: RerankerConfig) -> None:
+    """Force-load the reranker model so FastEmbed's HuggingFace cache
+    is populated. Raises on failure."""
+    from openzim_mcp.ml.reranker import _load_model
+
+    _load_model(cfg.model_id, cfg.cache_dir)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="openzim-mcp download-models",
+        description=(
+            "Pre-stage ML model files for installed extras. Run this once "
+            "after installing an extra (e.g., `pip install "
+            "openzim-mcp[reranker]`) on a machine with network access; "
+            "the MCP server can then run offline without first-call "
+            "download delays."
+        ),
+    )
+    parser.add_argument(
+        "--reranker-model-id",
+        default=None,
+        help=(
+            "Override the reranker model id (default: "
+            "Xenova/bge-reranker-base-onnx)."
+        ),
+    )
+    return parser
+
+
+def download_models_main(argv: Optional[List[str]] = None) -> int:
+    """Entry point. Returns process exit code (0 success, 1 failure)."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    features = detect()
+    if not features.reranker:
+        print(
+            "No ml extras installed. Re-run after `pip install "
+            "openzim-mcp[reranker]` to pre-stage the reranker model.",
+        )
+        return 0
+
+    print("Staging reranker model... ", end="", flush=True)
+    cfg = RerankerConfig()
+    if args.reranker_model_id:
+        cfg = cfg.model_copy(update={"model_id": args.reranker_model_id})
+    try:
+        _stage_reranker(cfg)
+        print("done.")
+        return 0
+    except Exception as exc:  # noqa: BLE001 — surface any underlying error
+        print(f"failed: {exc}")
+        return 1
+```
+
+- [ ] **Step 5: Wire the subcommand dispatch into `main.py`**
+
+In `openzim_mcp/main.py`, locate the `def main() -> None:` function (around line 107) and add a subcommand-style early-dispatch at the very top:
+
+```python
+def main() -> None:
+    """CLI entry point."""
+    # Phase D sub-D-1: subcommand-style dispatch for `openzim-mcp
+    # download-models`. Early-checks sys.argv to preserve the existing
+    # `openzim-mcp <directories>` invocation shape without restructuring
+    # the argparse subparser tree.
+    if len(sys.argv) >= 2 and sys.argv[1] == "download-models":
+        from openzim_mcp.ml.cli.download import download_models_main
+
+        sys.exit(download_models_main(argv=sys.argv[2:]))
+    # ...existing main() body unchanged from this point on...
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+```bash
+uv run pytest tests/ml/test_download_cli.py -v
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 7: Smoke test the CLI dispatch (no extras)**
+
+```bash
+uv run openzim-mcp download-models
+```
+
+Expected output: `No ml extras installed. Re-run after \`pip install openzim-mcp[reranker]\` to pre-stage the reranker model.`
+
+- [ ] **Step 8: Run lint + type-check**
+
+```bash
+make lint && make type-check
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add openzim_mcp/ml/cli/ openzim_mcp/main.py tests/ml/test_download_cli.py
+git commit -m "feat(ml): openzim-mcp download-models CLI for pre-staging"
+```
+
+---
+
+### Task 11: Live FastEmbed integration test fixture
+
+**Files:**
+- Create: `tests/ml/conftest.py`
+- Create: `tests/ml/test_reranker_integration.py`
+
+- [ ] **Step 1: Create the conftest with the requires_reranker marker**
+
+Create `tests/ml/conftest.py`:
+
+```python
+"""Shared fixtures + marker registration for ml tests."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "requires_reranker: test requires the [reranker] extra to be installed",
+    )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """Skip @requires_reranker tests when fastembed is not importable."""
+    if importlib.util.find_spec("fastembed") is not None:
+        return
+    skip_marker = pytest.mark.skip(reason="requires [reranker] extra")
+    for item in items:
+        if item.get_closest_marker("requires_reranker") is not None:
+            item.add_marker(skip_marker)
+```
+
+- [ ] **Step 2: Write the integration test**
+
+Create `tests/ml/test_reranker_integration.py`:
+
+```python
+"""End-to-end tests against the real FastEmbed reranker.
+
+These tests SKIP when the [reranker] extra is not installed. CI runs
+them in a dedicated job (see .github/workflows/test.yml). They confirm
+the FastEmbed API surface matches our wrapper and that the reranker
+actually reorders results in a predictable way."""
+
+from __future__ import annotations
+
+import pytest
+
+from openzim_mcp.config import RerankerConfig
+from openzim_mcp.ml.fallback import reset_kill_switches
+from openzim_mcp.ml.reranker import BGEReranker
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> None:
+    BGEReranker.reset_instance()
+    reset_kill_switches()
+
+
+@pytest.mark.requires_reranker
+class TestRerankerIntegration:
+    def test_get_loads_model_on_first_call(self) -> None:
+        # Generous timeout for cold-cache CI runs.
+        cfg = RerankerConfig(first_call_timeout_seconds=120.0)
+        reranker = BGEReranker.get(cfg)
+        assert reranker is not None
+
+    def test_reranks_known_corpus_correctly(self) -> None:
+        cfg = RerankerConfig(first_call_timeout_seconds=120.0)
+        reranker = BGEReranker.get(cfg)
+        assert reranker is not None
+
+        # Query is content-fragment shaped — semantic relevance should
+        # win over surface keyword overlap.
+        query = "what biological pigment makes plants appear green"
+        candidates = [
+            {
+                "path": "Chlorophyll",
+                "snippet": (
+                    "Chlorophyll is the green pigment in plants that absorbs "
+                    "light for photosynthesis."
+                ),
+                "xapian_score": 0.3,  # intentionally low — Xapian misses it
+            },
+            {
+                "path": "Green",
+                "snippet": (
+                    "Green is the color between blue and yellow on the visible "
+                    "spectrum."
+                ),
+                "xapian_score": 0.9,  # Xapian's top hit (keyword overlap)
+            },
+            {
+                "path": "Plant",
+                "snippet": (
+                    "Plants are mainly multicellular eukaryotes in the kingdom "
+                    "Plantae."
+                ),
+                "xapian_score": 0.5,
+            },
+        ]
+        result = reranker.rerank(query, candidates, top_k=3)
+        # Chlorophyll should win on semantic match despite low Xapian score.
+        assert result[0]["path"] == "Chlorophyll"
+        assert all("rerank_score" in c for c in result)
+
+    def test_score_pairs_returns_one_per_pair(self) -> None:
+        cfg = RerankerConfig(first_call_timeout_seconds=120.0)
+        reranker = BGEReranker.get(cfg)
+        assert reranker is not None
+        pairs = [
+            ("query about cats", "Cats are small carnivorous mammals."),
+            ("query about cats", "The sun is the star at the center of the solar system."),
+        ]
+        scores = reranker.score_pairs(pairs)
+        assert len(scores) == 2
+        # First pair (relevant) should score higher than second (irrelevant).
+        assert scores[0] > scores[1]
+```
+
+- [ ] **Step 3: Verify the tests SKIP on no-extras install**
+
+```bash
+uv run pytest tests/ml/test_reranker_integration.py -v
+```
+
+Expected: all tests reported as SKIPPED with reason "requires [reranker] extra".
+
+- [ ] **Step 4: Install [reranker] and verify the tests run + pass**
+
+```bash
+uv sync --extra reranker
+uv run pytest tests/ml/test_reranker_integration.py -v
+```
+
+Expected: 3 tests pass (slower run; first call downloads the model — set `--timeout=300` if needed).
+
+- [ ] **Step 5: Revert to no-extras**
+
+```bash
+uv sync
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/ml/conftest.py tests/ml/test_reranker_integration.py
+git commit -m "test(ml): live FastEmbed integration tests + requires_reranker marker"
+```
+
+---
+
+### Task 12: CI matrix — add `test-reranker` job
+
+**Files:**
+- Modify: `.github/workflows/test.yml`
+
+- [ ] **Step 1: Add a separate test job for the `[reranker]` extra**
+
+Edit `.github/workflows/test.yml`. After the existing `test` job, add:
+
+```yaml
+  test-reranker:
+    name: Test [reranker] extra on Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install dependencies with [reranker] extra
+        run: |
+          uv sync --extra reranker
+
+      - name: Run ml tests including requires_reranker marker
+        run: |
+          uv run pytest tests/ml/ -v --timeout=300
+```
+
+Notes for the implementer:
+- The job runs ubuntu-latest only to control CI minutes; the unit tests still run on the full matrix in the existing `test` job.
+- `--timeout=300` covers the first-call model download (~80 MB from HuggingFace).
+- Add this job in parallel with the existing `test` job (not as a dependency).
+
+- [ ] **Step 2: Verify the workflow file parses cleanly**
+
+```bash
+# If yamllint is installed:
+yamllint .github/workflows/test.yml || true
+# Otherwise just sanity-check with python's yaml parser:
+uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"
+```
+
+Expected: no parse errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/test.yml
+git commit -m "ci(ml): add test-reranker job for [reranker] extra"
+```
+
+---
+
+### Task 13: User-facing documentation — `docs/v2/extras-reranker.md`
+
+**Files:**
+- Create: `docs/v2/extras-reranker.md`
+
+- [ ] **Step 1: Write the docs page**
+
+Create `docs/v2/extras-reranker.md`:
+
+```markdown
+# [reranker] Extra — Cross-Encoder Search Reranking
+
+The `[reranker]` extra adds cross-encoder relevance reranking on top of
+Xapian's BM25 results. When installed, search-shaped tools and
+`synthesize` mode silently produce more relevant top-K results on
+content-fragment queries. Caller surface is unchanged.
+
+## Install
+
+```bash
+pip install openzim-mcp[reranker]
+```
+
+Install footprint: ~150 MB (FastEmbed + onnxruntime + tokenizers +
+huggingface_hub).
+
+## Supported platforms
+
+The `[reranker]` extra is tested on:
+- Linux glibc x86_64 and ARM64
+- macOS x86_64 and ARM64
+- Windows x86_64
+
+Edge platforms (Alpine, FreeBSD, ARM32) are not part of the supported
+matrix; FastEmbed wheels may not be available there. The base install
+(`pip install openzim-mcp`) is unaffected.
+
+## Pre-staging models for offline deployment
+
+By default, the first call after install downloads the
+`Xenova/bge-reranker-base-onnx` model (~80 MB) from HuggingFace.
+Operators running in air-gapped environments should pre-stage:
+
+```bash
+openzim-mcp download-models
+```
+
+Idempotent — safe to re-run. Without pre-staging, the first MCP query
+that triggers rerank has a 5-second timeout; on timeout the reranker
+falls back to Xapian-only ranking for the rest of the process and logs
+a structured warning.
+
+## Verifying it's active
+
+After installing the extra, the MCP server log emits a one-line INFO
+record on first rerank:
+
+```
+reranker loaded: model_id=Xenova/bge-reranker-base-onnx fastembed=0.4.x
+```
+
+Response objects also gain `_meta.reranked: true` when rerank fires.
+
+## Disabling rerank without uninstalling
+
+Three knobs, listed in priority order:
+
+1. Environment variable: `OPENZIM_RERANKER_DISABLE=1`
+2. Config: `ml.reranker.enabled = false`
+3. Uninstall the extra: `pip uninstall fastembed`
+
+The skip-on-short-query gate (`ml.reranker.min_query_tokens`) bypasses
+rerank for queries with fewer than 4 word tokens — entity queries like
+`Berlin` or `Photosynthesis` get the canonical-title hit from Xapian
+directly without rerank cost. Set `min_query_tokens = 0` to disable
+the gate.
+
+## Configuration
+
+All knobs documented in `RerankerConfig` (see `openzim_mcp/config.py`).
+View effective config:
+
+```bash
+openzim-mcp config show
+```
+
+## Telemetry
+
+Reranker activity flows through the existing `_track()` path with
+these event names:
+
+- `reranker_engaged` — fired once per qualifying search.
+- `reranker_skipped` — fired when bypass conditions hit. The `reason`
+  detail distinguishes `short_query` / `disabled` / `not_installed` /
+  `no_results`.
+- `reranker_failed` — fired when a per-call inference raises.
+- `ml_feature_disabled` — fired once when the kill switch trips
+  (model-load failure, timeout, etc.).
+
+## Troubleshooting
+
+**"reranker model load failed: timeout"**
+The first-call download exceeded the configured
+`first_call_timeout_seconds` (default 5s). Run
+`openzim-mcp download-models` once to pre-stage, then the next server
+start will use the cached model.
+
+**Install fails with "no wheel for fastembed"**
+The platform isn't in the supported matrix (see above). Use the base
+install without the extra; the server still works, just without rerank.
+
+**Rerank doesn't seem to fire**
+Check the `min_query_tokens` gate (default 4 word tokens) and the
+`OPENZIM_RERANKER_DISABLE` environment variable. The
+`reranker_skipped` telemetry event's `reason` field tells you which
+gate fired.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/v2/extras-reranker.md
+git commit -m "docs(ml): user-facing docs for [reranker] extra"
+```
+
+---
+
+### Task 14: Final smoke pass + PR prep
+
+**Files:**
+- No code changes; final verification.
+
+- [ ] **Step 1: Run the full test suite (no extras)**
+
+```bash
+make test
+```
+
+Expected: 2143+ passing, 50 skipped (including the new `requires_reranker` tests skipping on no-extras).
+
+- [ ] **Step 2: Run lint + type-check**
+
+```bash
+make lint && make type-check
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Verify integration tests pass with the extra installed**
+
+```bash
+uv sync --extra reranker
+uv run pytest tests/ml/ -v --timeout=300
+uv sync  # revert
+```
+
+Expected: all 3 integration tests pass; unit tests pass; full ml suite ~15 tests.
+
+- [ ] **Step 4: Confirm git history is clean**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected: 13 commits, one per task, each commit message describes the change.
+
+- [ ] **Step 5: Push and open PR**
+
+```bash
+git push -u origin v2-phase-d-sub-d-1-reranker
+gh pr create \
+  --title "feat(v2): Phase D sub-D-1 — cross-encoder reranker behind [reranker] extra" \
+  --base main \
+  --body "$(cat <<EOF
+Implements sub-D-1 of [v2 Phase D](docs/superpowers/specs/2026-05-20-v2-phase-d-ml-accelerators-design.md).
+
+## What's new
+
+Optional [reranker] extra (install with \`pip install openzim-mcp[reranker]\`) adds cross-encoder rerank on top of Xapian's BM25 results. When the extra is absent, all behavior is unchanged.
+
+* New module \`openzim_mcp/ml/\` (feature-detection registry, fallback decorator, BGEReranker class)
+* New \`openzim-mcp download-models\` CLI for air-gapped pre-staging
+* Wired into \`_handle_search\`, \`_handle_filtered_search\`, \`_handle_search_all\`, \`synthesize._collect_passages\`
+* Telemetry events: \`reranker_engaged\`, \`reranker_skipped\`, \`reranker_failed\`, \`ml_feature_disabled\`
+* Skip-on-short-query gate (\`min_query_tokens=4\`) bypasses rerank for entity queries
+
+## Risk mitigations baked in
+
+* **5-second timeout on first-call model load** — no 30-second hangs on offline deployments
+* **Pinned model_id with audit-log hash on first load** — operators can verify model identity
+* **Per-process kill switch via ml_fallback** — one load failure disables rerank for the rest of the process, no retry storms
+* **Supported platforms list in docs** — Linux/macOS/Windows x86_64+ARM64; edge platforms explicitly out of scope
+
+## Telemetry review
+
+Per the spec's 2-week telemetry review gate: after this ships, we measure \`reranker_engaged\` fire rate, \`reranker_skipped\` reason distribution, and \`reranker_failed\` occurrence before committing sub-D-2 to writing-plans.
+
+## Tests
+
+* ~15 new tests in \`tests/ml/\` (unit + integration, marker-gated)
+* Full suite: 2143+ passing, 50 skipped (no-extras path unchanged)
+* New CI job \`test-reranker\` runs integration tests with the extra installed on ubuntu-latest, Python 3.12 + 3.13
+EOF
+)"
+```
+
+- [ ] **Step 6: Watch CI**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: all jobs pass, including the new `test-reranker` matrix.
+
+- [ ] **Step 7: After CI green, check SonarCloud findings**
+
+```bash
+PR_NUM=$(gh pr view --json number -q .number)
+curl -s "https://sonarcloud.io/api/issues/search?componentKeys=cameronrye_openzim-mcp&pullRequest=${PR_NUM}&resolved=false&ps=20" \
+  | python3 -m json.tool
+```
+
+Expected: 0 open issues. If any surface, address them (matches the pattern from the post-a24 sweep follow-up commit).
+
+---
+
+## Self-Review Notes
+
+**Spec coverage check** — every section of the spec's sub-D-1 design maps to a task:
+
+| Spec section | Task(s) |
+|--------------|---------|
+| Activation surface (search + synthesize) | 7, 8, 9 |
+| Module structure (`ml/__init__.py`, `reranker.py`, `fallback.py`, `cli/download.py`) | 1, 2, 4, 5, 10 |
+| FastEmbed library + lazy import | 4, 5, 6 |
+| Risk mitigation: 5s first-call timeout + structured warning | 4 |
+| Risk mitigation: pinned model_id + first-load hash log | 4 |
+| Risk mitigation: edge-platform wheel availability | 12, 13 (CI matrix + docs) |
+| Fallback contract via `ml_fallback` | 2, 4 |
+| Response shape (`_meta.reranked`, `rerank_score`) | 7, 8, 9 |
+| RerankerConfig defaults | 3 |
+| Skip-on-short-query gate | 5 |
+| Telemetry events | 7, 8, 9 (live wiring) |
+| Performance budget | implicit; verified by integration tests (Task 11) |
+| Testing (unit + integration + skip-decorator) | 1, 2, 4, 5, 11 |
+| `openzim-mcp download-models` CLI | 10 |
+| Documentation | 13 |
+| CI matrix `test-reranker` job | 12 |
+
+**Placeholder scan** — every code step shows actual code or actual commands. The few "find the exact line / variable name" steps in Tasks 7/8/9 are unavoidable because they require reading existing code; the surrounding pattern is fully specified.
+
+**Type consistency check** — `BGEReranker.get(config)` signature stays consistent across Tasks 4, 5, 7, 8, 9, 10. `RerankerConfig` field names stay consistent across Tasks 3, 4, 5, 10. `MLFeatures.reranker: bool` consistent across Tasks 1, 10.
+
+**Order check** — each task builds on the previous: registry → fallback → config → reranker class → wiring → CLI → integration tests → CI → docs. No forward references.

--- a/docs/superpowers/specs/2026-05-20-v2-phase-d-ml-accelerators-design.md
+++ b/docs/superpowers/specs/2026-05-20-v2-phase-d-ml-accelerators-design.md
@@ -1,0 +1,595 @@
+# v2 Phase D — Optional ML Accelerators (Design Spec)
+
+**Status:** Draft
+**Phase:** D of 6 ([tracking doc](../../v2/README.md))
+**Items in scope:** #6 (cross-encoder reranker), #8 (server-side query rewriting / decomposition), #12 (hybrid intent parser), #15 (sentence-embedding sidecar)
+**Target:** Four `v2.0.0bN` pre-releases (one per sub-D milestone). Final tag `v2.0.0b4`.
+**Date:** 2026-05-20
+
+---
+
+## Goal
+
+Make every model — especially Haiku-class, Llama-3-8B, Mistral-7B, Phi-class — find what it needs in a multi-million-article ZIM archive without burning context on retry loops. Phase D adds four optional ML capabilities behind opt-in extras. Each falls back gracefully to the existing pure-Python path when its extra is missing, and none becomes the default install.
+
+The four items decompose into one coordinated design but ship as four independent sub-D milestones (`v2.0.0b1` → `b4`). Each sub-D is independently shippable and reviewable; the entire spec is one design because the four items share infrastructure (model lifecycle, fallback decorator, telemetry, config, testing patterns).
+
+## Non-goals
+
+- **No required ML at install.** The default `pip install openzim-mcp` install stays lean. Every ML capability is behind one of three extras: `[reranker]`, `[planner]`, `[embeddings]`.
+- **No GPU requirement.** Every model targets CPU-fast (<150 ms p95 hot-path). GPU support is not designed for in v2.
+- **No HyDE.** Per the v2 README's research findings, hypothetical-document expansion hurts small models. Explicit non-goal — the design must not introduce a HyDE path even as a future-extension hook.
+- **No network at runtime.** Models download once at install (or via `openzim-mcp download-models` for air-gapped pre-stage) and load from disk thereafter. Sidecars build offline via the explicit `openzim-mcp build embeddings` CLI.
+- **No new ZIM archive format.** Sidecars live next to `.zim` files; the archive itself is read-only and unchanged.
+- **No model-trained-on-prod-data.** All bundled models (fastText `.ftz` files) train from the open-source sweep transcripts already in repo. The training data and training script ship in the repo for reproducibility.
+- **No multilingual default.** Default model picks (`bge-reranker-base`, `bge-small-en-v1.5`) target English-first archives. Multilingual archives override via env vars; this design documents the override surface but does not ship multilingual defaults.
+
+## Non-goals carried forward from earlier phases
+
+- **No new tool surface.** Tool collapse is Phase F. Phase D plugs into existing tools (`search_zim_file`, `synthesize` mode of `zim_query`, `parse_intent`).
+- **No response-contract changes.** Phase B already standardized response shapes. Phase D only adds metadata fields (`_meta.reranked`, `_meta.intent_source`, `_meta.decomposed`).
+- **No replacing libzim or Xapian.** Reranker reranks Xapian results; embeddings sidecar fuses semantic results with Xapian results via RRF; both treat Xapian as the canonical source.
+
+---
+
+## Foundational decisions
+
+These apply across all four sub-Ds.
+
+- **Three opt-in extras.** `[reranker]`, `[planner]`, `[embeddings]`. Plus convenience meta-extra `[ml-all]` = all three.
+- **Lazy import + lazy load.** No top-level imports of optional libraries. Every ML capability uses `importlib.util.find_spec(...)` for detection and imports the library only inside the function that needs it. Model load is deferred to first use.
+- **Graceful fallback contract.** When a model fails to load or a per-call inference fails, the code path logs a `WARNING`, sets a per-process kill switch for that feature, and falls back to the pre-ML behavior. The caller sees no exception.
+- **Telemetry by additive event names.** All ML events flow through the existing `_track("<event_name>")` path in `simple_tools.py` (next to `_track("chained_intent_rejected")` at line 541). No new telemetry infrastructure.
+- **Single shared model cache.** `~/.cache/openzim-mcp/models/` by default, overridable via `OPENZIM_MODEL_CACHE_DIR`. FastEmbed and any future model store share this root.
+- **Air-gapped support via explicit CLI.** A new `openzim-mcp download-models` command pre-stages every model the installed extras need. Idempotent; safe to re-run.
+- **Configuration via `MLConfig` composing four sub-configs.** Discoverable via the existing `openzim-mcp config show` CLI.
+
+---
+
+## Sub-D milestones
+
+| Milestone | Items | Extra | Tag | Why this order |
+|-----------|-------|-------|-----|----------------|
+| **sub-D-1** | #6 cross-encoder reranker | `[reranker]` | `v2.0.0b1` | Smallest scope, biggest immediate relevance win, establishes the lazy-ML + fallback patterns the other items inherit |
+| **sub-D-2** | #8 Tier 1 query rewriting (rules-based) | (none — base install) | `v2.0.0b2` | Zero deps; every downstream item benefits from a cleaner query upstream. Lift the floor for free. |
+| **sub-D-3** | #8 Tier 2 + #12 hybrid intent parser | `[planner]` | `v2.0.0b3` | Tier-2 + classifier share a model; ship together. Live evidence from sub-D-2 informs what the rules-based pass misses. |
+| **sub-D-4** | #15 embeddings sidecar + hybrid retrieval | `[embeddings]` | `v2.0.0b4` | Heaviest scope (build CLI, sidecar format, RRF plumbing). Plugs into a stable reranker (sub-D-1) and classifier (sub-D-3). |
+
+Each milestone ships with its own live-MCP smoke pass before its release PR merges. No mass-release at the end of Phase D — discover regressions early.
+
+---
+
+## Sub-D-1 — Cross-encoder reranker (#6)
+
+### What it does
+
+When `[reranker]` is installed, search-shaped tools (`search_zim_file`, `search_with_filters`, `search_all`) and `synthesize` mode silently rerank Xapian top-N results using a cross-encoder model. Caller surface unchanged; relevance improves ~30 pp on content-fragment queries.
+
+### Activation surface
+
+- `simple_tools.py:_handle_search` — Xapian returns top-N (default N=50), `BGEReranker.rerank(query, results, top_k=requested_limit)` produces the final order. When `BGEReranker.get()` returns None (extra absent or kill-switched), skip cleanly.
+- `simple_tools.py:_handle_filtered_search` + `_handle_search_all` — same shape.
+- `synthesize.py:_collect_passages` — rerank passage candidates before the citation block is assembled. Phase C #10 explicitly anticipates this hook.
+- `simple_tools.py:_handle_tell_me_about` — NOT reranked. Entity-driven queries are already canonical-title resolved; rerank adds cost without value.
+- **Skip-on-short-query gate:** when query has <4 word tokens, skip rerank. Single-word entity queries dominate the Xapian-score-1.0 canonical-title hit; the cross-encoder is wasted there. Cheap gate; avoids ~40% of needless rerank calls per the live-MCP sweep traffic patterns.
+
+### Module structure
+
+```
+openzim_mcp/ml/reranker.py    # ~250 LOC
+    class BGEReranker:
+        - get() classmethod, lazy singleton, thread-safe init
+        - score_pairs(pairs) -> List[float], batch-score (query, passage) pairs
+        - rerank(query, candidates, top_k) -> List[Candidate]
+```
+
+### Library: FastEmbed
+
+- `fastembed>=0.4.0,<1.0`. ONNX-backed, ~150 MB total install. No torch dependency.
+- CPU benchmark: ~50 ms for batch=50 of `bge-reranker-base` ONNX. Well under the 150 ms p95 budget.
+- Default model: `Xenova/bge-reranker-base-onnx` (~80 MB), download-on-first-use, cached in `~/.cache/openzim-mcp/models/fastembed`.
+- Overrides via env: `OPENZIM_RERANKER_MODEL`, `OPENZIM_RERANKER_CACHE_DIR`, `OPENZIM_RERANKER_DISABLE=1` (kill switch when extra is installed but we don't want it).
+
+### Fallback contract
+
+- Model load fails (corrupt cache, OOM, ImportError) → log `WARNING`, set process-local `_reranker_disabled = True`, every future `get()` returns None. Search continues on Xapian.
+- Per-call exception (tokenizer overflow, model crash) → log `WARNING` once per process, return input candidates in their Xapian order. Never raise to caller.
+- Telemetry: `_track("reranker_engaged" | "reranker_skipped" | "reranker_failed")`.
+
+### Response shape
+
+- Each result envelope gains `rerank_score: float | None` (None when not reranked).
+- Response object gains `_meta.reranked: bool` for branch-on-augmented-ranking detection.
+- No tool signature changes; additive metadata only.
+
+### Configuration
+
+```python
+class RerankerConfig(BaseModel):
+    enabled: bool = True               # only checked when extra importable
+    model_id: str = "Xenova/bge-reranker-base-onnx"
+    candidate_pool_size: int = 50      # Xapian top-N to rerank
+    final_top_k: int = 10              # default response cap; caller override wins
+    max_query_length: int = 256
+    max_passage_length: int = 512
+    min_query_tokens: int = 4          # skip-on-short-query gate
+    cache_dir: Path | None = None      # None → FastEmbed default
+```
+
+### Testing
+
+- Unit: mock `TextRerank.rerank()` and assert candidate ordering + envelope shape.
+- Integration: `tests/ml/test_reranker_integration.py` builds an in-process reranker against a 3-doc test corpus; asserts predictable reorder. `@pytest.mark.requires_reranker` keyed off `importlib.util.find_spec("fastembed")`.
+- Telemetry assertion: `_reranker_engaged` counter increments once per search hit.
+- Performance test: rerank batch of 50 in <150 ms p95 on the CI runner.
+
+### Performance budget
+
+- p95 added latency per search query: ≤120 ms on a modern CPU.
+- First-call cold start: ≤2 s (one-time model download or `openzim-mcp download-models` pre-stage).
+
+---
+
+## Sub-D-2 — Tier 1 query rewriting (#8 partial)
+
+### What it does
+
+Every query, before any pattern matching, runs through five rules-based rewrite passes. Zero extras, zero models, zero ML dependencies. Lands in the BASE install so all downstream items inherit a cleaner query. Lift the floor for every model immediately.
+
+### Five rule families
+
+Each idempotent, each loop-safe (same shape as existing `_strip_param_leaks` / `_strip_trailing_politeness` patterns in `intent_parser.py`):
+
+1. **Lowercase-entity normalization.** Pulls scattered `.lower()` calls in the `_tokenize_for_relevance` path into a named pass. Title-promotion's case-preserving path is untouched.
+2. **Common-misspelling map.** Ship `openzim_mcp/data/misspellings.txt` — ~200 entries seeded from Wikipedia's "List of common misspellings." Loaded once at module init; the map is `dict[str, str]` keyed on lowercase word; whole-word substitution (word-boundary anchors). Cap at ~500 entries to keep the lookup cheap.
+3. **Stopword-aware phrase detection.** When the topic carries `the / a / an / of` as leading or interleaved token, use the title index as the oracle: if the leading-stopword form has a canonical hit (`The Beatles`, `Of Mice and Men`), keep it; otherwise strip. One extra title-index probe per ambiguous query.
+4. **Simple "X of Y" decomposition.** `population of Berlin` → `(entity=Berlin, attribute=population)`. Routes to the existing subject-attribute extraction in `simple_tools.py:_handle_tell_me_about` (the post-a16 P4-D1/P6-D1 hardened path). Two regex shapes:
+   - `<attribute_word> of <entity>`
+   - `<entity>'s <attribute>` (genitive)
+   - **NOT in Tier-1:** multi-hop questions ("what year did the inventor of X die"). Tier-2 + classifier in sub-D-3.
+5. **Explicit HyDE skip.** No hypothetical-document synthesis; documented in the spec as a locked-in non-goal.
+
+### Module structure
+
+```
+openzim_mcp/intent_parser.py (existing, 1345 lines)
+    Extends the existing strip chain. Add four new methods following the
+    same idempotent-loop shape:
+        - _normalize_topic_case(query)
+        - _apply_misspelling_map(query)
+        - _detect_stopword_phrase(query, title_index)  # optional title_index
+        - _decompose_x_of_y(query)
+    All called from parse_intent BEFORE pattern matching.
+
+openzim_mcp/data/misspellings.txt   # new, ~200 lines
+```
+
+The stopword-phrase pass requires a title-index handle when called from the live path. Pass it in optionally; when unavailable (unit tests without an archive), the rule degrades cleanly to a no-op.
+
+### Configuration
+
+```python
+class QueryRewriteConfig(BaseModel):
+    enabled: bool = True
+    misspelling_map_path: Path | None = None  # None → bundled default
+    stopword_phrase_probe: bool = True
+```
+
+### Telemetry
+
+`_track("query_rewritten", details={"rules_applied": [...]})` — observability without printing rewritten text (PII-safe).
+
+### Testing
+
+- Unit: parametrized test cases per rule family — fix side, no-op side (already-correct), embedding-safety side (don't eat substrings).
+- Regression guards: pin the misspelling-map row count + sample entries so future contributors can't silently delete entries.
+- Live-MCP integration: extend the existing `tests/test_post_a*_beta_fixes.py` regression set with Tier-1 expected outputs.
+
+### Why route decomposition through existing `_handle_tell_me_about`
+
+The subject-attribute extraction path in `simple_tools.py:_handle_tell_me_about` is mature (a17 P1-D1 + post-a15 P4-D1 hardening). Tier-1 reuses it rather than introducing a parallel surface. Sub-D-3's classifier expands this into a true multi-hop decomposer.
+
+---
+
+## Sub-D-3 — Tier 2 query rewriting + hybrid intent parser (#8 + #12)
+
+### What it does
+
+When Tier-1 + regex aren't enough, fall back to a tiny ML classifier — without bloating the default install. Both items share one model and ship together behind a single `[planner]` extra.
+
+### Why ship #8 Tier-2 and #12 together
+
+They fire on the same trigger (low-confidence query shapes) and benefit from sharing a model. Splitting would mean two model loads, two `[planner-X]` extras, and duplicate failure-handling code.
+
+### Classifier: fastText
+
+- `fasttext-wheel>=0.9.2,<1.0`. ~50 MB installed. No torch dependency. CPU-fast (~0.1 ms per classification). Trains in minutes on the existing sweep transcripts.
+- Three trained models bundled inside `openzim_mcp/ml/data/`:
+  - `intent_classifier.ftz` (~5 MB, quantized): 19-class classifier matching `INTENT_PATTERNS` labels.
+  - `decomposition_classifier.ftz` (~3 MB): binary "needs decomposition?" classifier.
+  - `decomposition_extractor.ftz` (~5 MB): token-level sequence labeler producing `(entity_span, attribute_span, modifier_span)`.
+- Bundled in the wheel, not downloaded at runtime — adds ~15 MB to `[planner]` install. Offline-first; no network at runtime.
+
+### Hybrid intent parser flow (#12)
+
+```
+parse_intent(query):
+    1. apply Tier-1 rewrites               # sub-D-2
+    2. run INTENT_PATTERNS regex match     # existing
+    3. if confidence >= 0.7:               # existing
+         return regex result               # fast path, ~99% of traffic
+    4. else if [planner] installed:
+         classifier.predict(query)
+         if classifier.confidence >= 0.7:
+             return classifier result with rank_origin="classifier"
+    5. else:
+         existing low-confidence behavior (current footer)
+```
+
+### Tier-2 decomposition flow (#8)
+
+```
+after intent classification:
+    if intent == "tell_me_about" AND query is multi-hop-shaped:
+        decomposition_classifier.predict(query)
+        if "needs decomposition":
+            extractor.predict(query) -> (entity, attribute, modifier)
+            issue internal entity-lookup + attribute-lookup chain
+            assemble combined response with cite markers
+        else:
+            fall through to standard tell_me_about
+```
+
+### Training data: sweep transcripts already in repo
+
+- `tests/test_post_a*_beta_fixes.py` carries ~1000+ labeled `(query, expected_intent)` pairs from the live MCP sweeps a8 → a25 (estimate based on parametrized test counts; exact yield depends on dedup). Extract into a JSONL dataset (`openzim_mcp/ml/data/training/intent.jsonl`). Quality bar: a per-intent minimum of 30 examples; under-represented intents get synthetic seed examples generated from the regex patterns themselves.
+- For decomposition: synthetic dataset generated by templating `(attribute) of (entity)` / `(entity)'s (attribute)` over Wikipedia's category trees. Ship a 5000-row seed set without category-tree dependency.
+- Training script (`scripts/train_planner.py`) is reproducible — ships in the repo but NOT in the wheel. CI verifies bundled models are checksum-pinned.
+
+### Module structure
+
+```
+openzim_mcp/ml/planner.py             # ~250 LOC
+openzim_mcp/ml/intent_classifier.py   # ~150 LOC
+openzim_mcp/ml/data/                  # bundled .ftz files
+openzim_mcp/ml/data/training/         # JSONL datasets (training reproducibility)
+scripts/train_planner.py              # not in wheel
+```
+
+### Configuration
+
+```python
+class PlannerConfig(BaseModel):
+    enabled: bool = True
+    intent_model_path: Path | None = None         # None → bundled .ftz
+    decomposition_model_path: Path | None = None
+    extractor_model_path: Path | None = None
+    classifier_confidence_threshold: float = 0.7  # match regex threshold
+    decomposition_enabled: bool = True            # finer kill switch
+```
+
+### Response shape
+
+- Optional `_meta.intent_source: "regex" | "classifier"` field.
+- Optional `_meta.decomposed: bool` when Tier-2 decomposition fired.
+- No tool signature changes; additive metadata only.
+- Raw classifier scores not exposed to callers — confidence is internal.
+
+### Fallback contract (same shape as sub-D-1)
+
+- Classifier load fails → log WARNING, set `_planner_disabled`, every future `get()` returns None, parse_intent falls back to existing low-confidence footer.
+- Classifier prediction returns confidence < 0.7 → treated as if it never ran.
+- Telemetry: `_track("intent_classifier_engaged" | "decomposition_engaged" | "planner_failed")`.
+
+### Testing
+
+- Unit: parametrized tests with mocked `fastText.predict()` covering each of 19 intents + binary decomposition gate.
+- Integration: `tests/ml/test_planner_integration.py` loads bundled `.ftz` files (only when fasttext importable, skip otherwise); asserts known live-MCP queries route correctly.
+- Quality gate: held-out test set (10% of JSONL) achieves ≥90% intent classification accuracy. CI fails if retrain regresses below threshold.
+
+### Why fastText over distilled sentence-transformer
+
+README permits fastText / distilled sentence-transformer / lightweight rules-tree. fastText wins on:
+- **Size:** 50 MB vs ~500 MB for sentence-transformers.
+- **Speed:** 0.1 ms vs ~10 ms per classification.
+- **Dependency surface:** no torch, no transformers.
+
+Sentence-transformer reranking already lives in sub-D-1; sharing torch there doesn't make the planner cheaper.
+
+---
+
+## Sub-D-4 — Embeddings sidecar + hybrid retrieval (#15)
+
+### What it does
+
+True semantic retrieval. Find articles by meaning, not just keyword overlap. Heaviest scope in Phase D because it adds a build-time CLI, a sidecar file format, and hybrid-retrieval plumbing. Ships last so it can plug into a stable reranker (sub-D-1) and a stable classifier-aware intent parser (sub-D-3).
+
+### Sidecar file format: `<archive>.zim.semantic.hnsw`
+
+- Single binary, lives next to the `.zim` file.
+- Wraps two artifacts: HNSW index (via `hnswlib`) + parallel `path_id ↔ entry_path` mapping (`<archive>.zim.semantic.paths.sqlite`).
+- Header carries: `model_id`, `embedding_dim`, `vector_count`, ZIM archive UUID (for cross-archive safety), HNSW params (`M`, `ef_construction`), schema version.
+- Cross-archive safety: load-time UUID check. Sidecar built for archive A won't load against archive B; logs a WARNING and silently disables semantic retrieval for that archive.
+
+### Encoder: `bge-small-en-v1.5` via FastEmbed
+
+- 33 MB. 384-dim. CPU-fast (~5 ms per sentence on modern CPU).
+- Already in FastEmbed's first-class registry — shares the model cache + lifecycle code with sub-D-1's reranker. **No new ML library dependency.**
+- Configurable via `OPENZIM_EMBEDDING_MODEL` env var. Multilingual archives can opt into `paraphrase-multilingual-MiniLM-L12-v2` or `bge-m3`.
+
+### Build CLI: `openzim-mcp build embeddings <archive.zim>`
+
+```
+$ openzim-mcp build embeddings /data/wikipedia_en_all_maxi_2026-02.zim
+  Reading archive metadata... 27,200,000 entries, est. embedding budget 2.1 GB
+  Embedding entries [████████░░░░░░░] 42% — 3h 12m remaining
+  Writing HNSW index... done (1.8 GB)
+  Writing paths sqlite... done (480 MB)
+  Verifying sidecar... ✓
+  Sidecar written to /data/wikipedia_en_all_maxi_2026-02.zim.semantic.hnsw
+```
+
+CLI flags:
+- `--model <hf_id>` (default: `bge-small-en-v1.5`)
+- `--namespace <letter>` (default: `C` — content; can be repeated)
+- `--chunk-mode {title,summary,full}` (default: `summary` — embed first 200 tokens of body; cheaper, equally effective per RAG benchmarks)
+- `--workers <N>` (default: cpu_count())
+- `--resume` (idempotent — picks up from last completed batch)
+- `--verify` (load-test the sidecar without writing)
+
+Build time: ~3-4 hours on Wikipedia full archive on a modern CPU. **Build is one-time and idempotent**; rebuild only when the archive changes.
+
+### Runtime hybrid retrieval
+
+```
+hybrid_search(query, archive):
+    1. Xapian top-K   (default K=50)
+    2. if sidecar_loaded(archive):
+         encode(query) -> query_vec
+         HNSW top-K of query_vec
+         RRF fuse (k=60) the two ranked lists
+    3. else:
+         skip step 2, use Xapian list as-is
+    4. if reranker_available:
+         rerank top-K -> top-N
+    5. return top-N
+```
+
+**Reciprocal Rank Fusion** (`RRF score = Σ 1/(k + rank_i)` for k=60 across both lists) — battle-tested, requires no score calibration between Xapian's BM25 and cosine similarity.
+
+### Sidecar discovery
+
+- On archive open in `zim_operations.py`, probe for `<archive>.zim.semantic.hnsw` + `.semantic.paths.sqlite`.
+- Both present → lazy-load on first hybrid query.
+- One missing or version-mismatched → log INFO, mark archive as "semantic unavailable", continue Xapian-only.
+- Per-archive state (not global) — mixed-archive deployments can have some archives with sidecars and some without.
+
+### Storage cost
+
+- Wikipedia full archive (27M entries × 384-dim × float16) ≈ 21 GB raw embeddings.
+- HNSW with M=16 adds ~50% overhead → ~32 GB on-disk sidecar.
+- For deployments where 32 GB is too much: `--chunk-mode title` produces ~5 GB sidecar (titles only, no body); trade recall for footprint.
+
+### Module structure
+
+```
+openzim_mcp/ml/embeddings.py      # ~250 LOC: encoder + HNSW reader
+openzim_mcp/ml/sidecar.py         # ~150 LOC: sidecar discovery + load + UUID check
+openzim_mcp/ml/cli/build_index.py # ~200 LOC: `openzim-mcp build embeddings` CLI
+openzim_mcp/ml/fusion.py          # ~50 LOC: RRF implementation
+```
+
+### Configuration
+
+```python
+class EmbeddingsConfig(BaseModel):
+    enabled: bool = True                   # checked when extra importable
+    model_id: str = "bge-small-en-v1.5"
+    sidecar_search_paths: List[Path] = []  # extras beyond archive dir
+    xapian_top_k: int = 50
+    semantic_top_k: int = 50
+    rrf_k: int = 60
+    require_sidecar: bool = False          # True → error if missing, False → fall back
+```
+
+### Fallback contract
+
+- Sidecar missing → semantic retrieval skipped silently, Xapian-only.
+- Encoder load fails → log WARNING once, disable for the rest of the process, Xapian-only.
+- HNSW query exception → log WARNING, fall back to Xapian-only for that query.
+- **Never** fails search outright when a sidecar is unavailable.
+
+### Telemetry
+
+`_track("hybrid_retrieval_engaged" | "hybrid_retrieval_xapian_only" | "sidecar_missing" | "sidecar_version_mismatch")`. Build CLI emits structured progress logs (lines/sec, ETA) for piping into CI dashboards.
+
+### Testing
+
+- Unit: HNSW index round-trip on a 1000-doc synthetic corpus. RRF fusion math against hand-computed expected ranks.
+- Integration: `tests/ml/test_hybrid_retrieval.py` with a tiny ZIM + pre-built sidecar fixture asserts known semantic-vs-Xapian divergence (e.g., query "the chemical that makes leaves green" → semantic finds `Chlorophyll`, Xapian misses it).
+- Build CLI: smoke test in `tests/ml/test_build_cli.py` — build sidecar for a 10-entry test ZIM, assert byte-for-byte determinism (pin output hash).
+- Skip marker `@pytest.mark.requires_embeddings` keyed on `importlib.util.find_spec("hnswlib")`.
+
+### Why HNSW over FAISS
+
+`hnswlib` is a single 2 MB wheel with no transitive deps; FAISS pulls in numpy and sometimes BLAS. Both implement the same HNSW algorithm; at our scale (≤100M vectors per sidecar) hnswlib's perf is competitive.
+
+### Why `bge-small-en-v1.5` over `bge-base`
+
+Small produces 384-dim (vs base's 768), halving storage. Quality difference on Wikipedia-style content is <2 pp; small wins on size by ~50%.
+
+### Why per-archive sidecar, not global
+
+Lets deployments add semantic retrieval to high-value archives (Wikipedia) without paying the build cost on low-traffic ones (Wiktionary, niche StackExchange dumps).
+
+---
+
+## Cross-cutting infrastructure
+
+These touch every sub-D and live in `openzim_mcp/ml/__init__.py` + a few shared modules.
+
+### Feature-detection registry
+
+```python
+# openzim_mcp/ml/__init__.py
+@dataclass(frozen=True)
+class MLFeatures:
+    reranker:   bool   # fastembed importable
+    planner:    bool   # fasttext importable
+    embeddings: bool   # hnswlib importable
+
+@functools.cache
+def detect() -> MLFeatures:
+    """Single source of truth for which extras are installed. Cached per
+    process; importlib.util.find_spec — no side effects, no model loads."""
+```
+
+Every ML-aware code path checks `detect()` first. Tests parametrize over synthetic `MLFeatures` to exercise both "extra installed" and "extra missing" branches without touching the import system.
+
+### Shared fallback decorator
+
+```python
+# openzim_mcp/ml/fallback.py
+def ml_fallback(*, feature: str, on_failure: Callable[..., T]) -> Callable:
+    """Wrap an ML call: on first exception, log WARNING with stack,
+    set a per-process kill switch for that feature, route all future
+    calls to `on_failure`. Idempotent — second failure logs DEBUG only."""
+```
+
+Every reranker/classifier/encoder entry point wraps through this. Guarantees the "graceful fallback when a model is missing" contract is implemented exactly once.
+
+### Telemetry events (new, additive)
+
+```
+reranker_engaged / reranker_skipped / reranker_failed
+query_rewritten (rules_applied=[...])
+intent_classifier_engaged / decomposition_engaged
+planner_failed
+hybrid_retrieval_engaged / hybrid_retrieval_xapian_only
+sidecar_missing / sidecar_version_mismatch
+ml_feature_disabled (feature=<name>, reason=<load_error|kill_switch|env>)
+```
+
+All flow through the existing `_track("<event>")` path in `simple_tools.py:541`. No new telemetry infrastructure.
+
+### Model cache directory
+
+`~/.cache/openzim-mcp/models/` by default. Overridable via `OPENZIM_MODEL_CACHE_DIR` (env) or `model_cache_dir` in `Config`. FastEmbed gets `Path(OPENZIM_MODEL_CACHE_DIR) / "fastembed"`. fastText `.ftz` files live next to the package (bundled, no cache). Sidecars stay next to their `.zim` files.
+
+### Air-gapped deployments
+
+`openzim-mcp download-models` CLI command pre-stages every model the installed extras need. Idempotent — re-running checks cache and only fetches missing files. For `[embeddings]`, also useful before running `openzim-mcp build embeddings` on a no-internet build host.
+
+### Configuration top-level
+
+```python
+class MLConfig(BaseModel):
+    reranker: RerankerConfig = RerankerConfig()
+    query_rewrite: QueryRewriteConfig = QueryRewriteConfig()
+    planner: PlannerConfig = PlannerConfig()
+    embeddings: EmbeddingsConfig = EmbeddingsConfig()
+
+# Config (existing) gains:
+class Config(BaseModel):
+    ...existing fields...
+    ml: MLConfig = MLConfig()
+```
+
+Discoverable via existing `openzim-mcp config show` CLI; each field documented in `config.py` docstrings.
+
+### Testing infrastructure
+
+```
+tests/ml/                              # all ML tests live here
+    conftest.py                        # shared fixtures, requires_* markers
+    test_reranker_unit.py
+    test_reranker_integration.py       # @pytest.mark.requires_reranker
+    test_query_rewrite_tier1.py        # no marker — base install
+    test_planner_unit.py
+    test_planner_integration.py        # @pytest.mark.requires_planner
+    test_hybrid_retrieval.py           # @pytest.mark.requires_embeddings
+    test_build_cli.py
+    test_ml_registry.py                # MLFeatures + ml_fallback
+```
+
+CI matrix adds two new jobs per Python version: `extras-none` (current behavior, default) and `extras-all` (install `[reranker,planner,embeddings]` and run the integration tests). The existing test surface stays untouched on the no-extras path.
+
+### Pyproject extras structure
+
+```toml
+[project.optional-dependencies]
+reranker = [
+    "fastembed>=0.4.0,<1.0",
+]
+planner = [
+    "fasttext-wheel>=0.9.2,<1.0",
+]
+embeddings = [
+    "fastembed>=0.4.0,<1.0",   # shared with [reranker]
+    "hnswlib>=0.8.0,<1.0",
+]
+ml-all = [
+    "openzim-mcp[reranker,planner,embeddings]",
+]
+```
+
+Install footprints:
+- `pip install openzim-mcp[reranker]` → ~150 MB
+- `pip install openzim-mcp[planner]` → ~50 MB
+- `pip install openzim-mcp[embeddings]` → ~150 MB (shared FastEmbed, only HNSW adds ~2 MB on top)
+- `pip install openzim-mcp[ml-all]` → ~200 MB total
+
+### Documentation
+
+Every extra gets a `docs/v2/extras-<name>.md` page covering: what it does, install command, expected memory/disk/latency cost, how to verify it's active, how to disable it, sample observability-output snippet. README's Phase D section will link to these.
+
+### Release pacing
+
+Four sub-Ds → four `v2.0.0bN` releases. Per the existing sweep cadence, **each sub-D ships with its own live-MCP smoke pass before merging the release PR.** No mass-release at the end — discover failures early.
+
+---
+
+## Release plan
+
+| Sub-D | Tag | Owns | Spec link | Plan link |
+|-------|-----|------|-----------|-----------|
+| sub-D-1 | `v2.0.0b1` | #6 reranker | This doc § sub-D-1 | _TBD by writing-plans_ |
+| sub-D-2 | `v2.0.0b2` | #8 Tier 1 | This doc § sub-D-2 | _TBD_ |
+| sub-D-3 | `v2.0.0b3` | #8 Tier 2 + #12 | This doc § sub-D-3 | _TBD_ |
+| sub-D-4 | `v2.0.0b4` | #15 embeddings + hybrid | This doc § sub-D-4 | _TBD_ |
+
+After all four sub-Ds ship, the Phase D row in [`docs/v2/README.md`](../../v2/README.md) flips to **Shipped (v2.0.0b4)**.
+
+## Per-sub-D PR shape
+
+Each sub-D follows the existing release-PR shape:
+
+1. `feat(v2): Phase D sub-N — <topic>` PR off `main` (matching the `v2-phase-c` precedent).
+2. Implementation + tests in one bundle.
+3. Live-MCP smoke pass against the deployed prior alpha/beta.
+4. Release PR `chore(release): v2.0.0bN — Phase D sub-N shipped`.
+5. Tag `v2.0.0bN` pushed to `main` triggers `.github/workflows/release.yml`.
+
+## Open questions deferred to per-plan time
+
+These are NOT spec-level blockers; they'll be settled in the implementation plan for the relevant sub-D:
+
+- Concrete API for the `Candidate` envelope flowing into `rerank()` (existing search result shape vs new wrapper). Sub-D-1 plan.
+- Whether `_track()` should grow a structured-fields kwarg or stay string-keyed. Sub-D-1 plan.
+- Exact `.ftz` training hyperparameters (epochs, lr, ngram window). Sub-D-3 plan.
+- Whether the build CLI uses `click` or `argparse`. Sub-D-4 plan. Probably `click` — already a tested ecosystem.
+- HNSW `M` / `ef_construction` defaults — start with hnswlib's recommendations, tune in sub-D-4 plan if needed.
+
+---
+
+## Why this design
+
+**It matches v2's foundational decisions.** The v2 tracking doc commits to "ML accelerators are opt-in via extras." Phase D ships three of them. The doc commits to "offline-first" — bundled fastText models, lazy-load FastEmbed, explicit `build embeddings` CLI, optional `download-models` pre-stage all satisfy that.
+
+**It builds on what's already mature.** Sub-D-1 reranker plugs into search + synthesize, both well-tested through Phase C and the post-a15 → a25 sweeps. Sub-D-2 Tier 1 extends the existing `_strip_*` chain in `intent_parser.py` that's been hardened across 11 sweep cycles. Sub-D-3 classifier trains on the labeled sweep transcripts already in repo. Sub-D-4 sidecar reuses sub-D-1's FastEmbed install for the encoder.
+
+**It's incrementally shippable.** Each sub-D is a separate release. A user who installs only `[reranker]` gets meaningful relevance lift without paying for the other two extras. A deployment that doesn't want any ML stays on the base install indefinitely with no behavior change.
+
+**It defers the hardest scope to last.** Sub-D-4 (embeddings) carries a build CLI, a sidecar format, hybrid retrieval, and the most storage. By the time it ships, the lazy-load patterns from sub-D-1, the model-cache layout from cross-cutting, and the fallback contract from sub-D-1/sub-D-3 are all proven on simpler surfaces.
+
+**It locks in YAGNI on multilingual.** Multilingual archive support is documented as an override surface but not designed for. If real demand surfaces during sub-D-1/sub-D-4 live testing, the spec for sub-D-5 (multilingual) can be cut as a separate phase. Until then, English-first defaults keep the design surface tight.

--- a/docs/superpowers/specs/2026-05-20-v2-phase-d-ml-accelerators-design.md
+++ b/docs/superpowers/specs/2026-05-20-v2-phase-d-ml-accelerators-design.md
@@ -1,48 +1,50 @@
-# v2 Phase D — Optional ML Accelerators (Design Spec)
+# v2 Phase D (trimmed) — Optional ML Accelerators (Design Spec)
 
 **Status:** Draft
 **Phase:** D of 6 ([tracking doc](../../v2/README.md))
-**Items in scope:** #6 (cross-encoder reranker), #8 (server-side query rewriting / decomposition), #12 (hybrid intent parser), #15 (sentence-embedding sidecar)
-**Target:** Four `v2.0.0bN` pre-releases (one per sub-D milestone). Final tag `v2.0.0b4`.
+**Items in scope:** #6 (cross-encoder reranker), #8 Tier 1 (rules-based query rewriting)
+**Deferred from this spec:** #8 Tier 2, #12 (hybrid intent parser), #15 (embeddings sidecar). See "Deferred to follow-up specs" below for measurable triggers.
+**Target:** Two `v2.0.0bN` pre-releases (one per sub-D milestone). Final tag `v2.0.0b2`.
 **Date:** 2026-05-20
 
 ---
 
 ## Goal
 
-Make every model — especially Haiku-class, Llama-3-8B, Mistral-7B, Phi-class — find what it needs in a multi-million-article ZIM archive without burning context on retry loops. Phase D adds four optional ML capabilities behind opt-in extras. Each falls back gracefully to the existing pure-Python path when its extra is missing, and none becomes the default install.
+Make every model — especially Haiku-class, Llama-3-8B, Mistral-7B, Phi-class — find what it needs in a multi-million-article ZIM archive without burning context on retry loops. Phase D adds two ML-adjacent capabilities, ships them, then measures real-world impact before designing the more speculative items.
 
-The four items decompose into one coordinated design but ship as four independent sub-D milestones (`v2.0.0b1` → `b4`). Each sub-D is independently shippable and reviewable; the entire spec is one design because the four items share infrastructure (model lifecycle, fallback decorator, telemetry, config, testing patterns).
+The trim is deliberate: the post-a17 → a25 sweep cycles drove the regex path to roughly 99% accuracy on labeled queries, and live traffic is dominated by entity queries where Xapian's canonical-title-match already returns score 1.0. The full Phase D (#6/#8/#12/#15) was designed to address relevance gaps we *expect* but don't yet *measure*. Ship the two items that pay off regardless (#6 + #8 Tier 1), instrument them, then decide what's actually missing.
 
 ## Non-goals
 
-- **No required ML at install.** The default `pip install openzim-mcp` install stays lean. Every ML capability is behind one of three extras: `[reranker]`, `[planner]`, `[embeddings]`.
-- **No GPU requirement.** Every model targets CPU-fast (<150 ms p95 hot-path). GPU support is not designed for in v2.
-- **No HyDE.** Per the v2 README's research findings, hypothetical-document expansion hurts small models. Explicit non-goal — the design must not introduce a HyDE path even as a future-extension hook.
-- **No network at runtime.** Models download once at install (or via `openzim-mcp download-models` for air-gapped pre-stage) and load from disk thereafter. Sidecars build offline via the explicit `openzim-mcp build embeddings` CLI.
-- **No new ZIM archive format.** Sidecars live next to `.zim` files; the archive itself is read-only and unchanged.
-- **No model-trained-on-prod-data.** All bundled models (fastText `.ftz` files) train from the open-source sweep transcripts already in repo. The training data and training script ship in the repo for reproducibility.
-- **No multilingual default.** Default model picks (`bge-reranker-base`, `bge-small-en-v1.5`) target English-first archives. Multilingual archives override via env vars; this design documents the override surface but does not ship multilingual defaults.
+- **No required ML at install.** The default `pip install openzim-mcp` stays lean. Reranker capability is behind one opt-in extra: `[reranker]`. Tier 1 query rewriting is in the base install but rules-based — no model, no extra.
+- **No GPU requirement.** Target CPU-fast (<150 ms p95 hot-path). GPU is not designed for.
+- **No HyDE.** Per the v2 README's research, hypothetical-document expansion hurts small models. Explicit non-goal — the design must not introduce a HyDE path even as a future-extension hook.
+- **No network at runtime.** The reranker model downloads once at install (or via `openzim-mcp download-models` for air-gapped pre-stage) and loads from disk thereafter.
+- **No bundled ML models.** With sub-D-3 deferred, no fastText `.ftz` files ship in the wheel.
+- **No new ZIM archive format.** No sidecars in this spec (sidecar work moves to sub-D-4's deferred follow-up spec).
+- **No multilingual default.** Default reranker (`bge-reranker-base`) targets English-first archives. Multilingual archives override via env var; this design documents the override surface but does not ship a multilingual default.
 
 ## Non-goals carried forward from earlier phases
 
 - **No new tool surface.** Tool collapse is Phase F. Phase D plugs into existing tools (`search_zim_file`, `synthesize` mode of `zim_query`, `parse_intent`).
-- **No response-contract changes.** Phase B already standardized response shapes. Phase D only adds metadata fields (`_meta.reranked`, `_meta.intent_source`, `_meta.decomposed`).
-- **No replacing libzim or Xapian.** Reranker reranks Xapian results; embeddings sidecar fuses semantic results with Xapian results via RRF; both treat Xapian as the canonical source.
+- **No response-contract changes.** Phase B already standardized response shapes. Phase D only adds metadata fields (`_meta.reranked`).
+- **No replacing libzim or Xapian.** Reranker reranks Xapian results; Xapian remains the canonical source.
 
 ---
 
 ## Foundational decisions
 
-These apply across all four sub-Ds.
+These apply across both sub-Ds.
 
-- **Three opt-in extras.** `[reranker]`, `[planner]`, `[embeddings]`. Plus convenience meta-extra `[ml-all]` = all three.
-- **Lazy import + lazy load.** No top-level imports of optional libraries. Every ML capability uses `importlib.util.find_spec(...)` for detection and imports the library only inside the function that needs it. Model load is deferred to first use.
-- **Graceful fallback contract.** When a model fails to load or a per-call inference fails, the code path logs a `WARNING`, sets a per-process kill switch for that feature, and falls back to the pre-ML behavior. The caller sees no exception.
-- **Telemetry by additive event names.** All ML events flow through the existing `_track("<event_name>")` path in `simple_tools.py` (next to `_track("chained_intent_rejected")` at line 541). No new telemetry infrastructure.
-- **Single shared model cache.** `~/.cache/openzim-mcp/models/` by default, overridable via `OPENZIM_MODEL_CACHE_DIR`. FastEmbed and any future model store share this root.
+- **One opt-in extra (`[reranker]`).** sub-D-2 lives in the base install (rules-based, no model).
+- **Lazy import + lazy load.** No top-level imports of optional libraries. The reranker path uses `importlib.util.find_spec(...)` for detection and imports FastEmbed only inside the function that needs it. Model load is deferred to first use.
+- **Graceful fallback contract.** When the reranker model fails to load or a per-call inference fails, the code path logs a `WARNING`, sets a per-process kill switch for that feature, and falls back to Xapian-only ranking. The caller sees no exception.
+- **First-call model fetch has an aggressive timeout.** Default 5 s. If the timeout fires, log a one-line "model not staged; run `openzim-mcp download-models` to pre-stage" message and disable the reranker for the rest of the process. **No 30-second hangs on the first query in an offline deployment.**
+- **Telemetry by additive event names.** ML events flow through the existing `_track("<event>")` path in `simple_tools.py` (next to `_track("chained_intent_rejected")` at line 541). No new telemetry infrastructure.
+- **Shared model cache.** `~/.cache/openzim-mcp/models/fastembed/` by default, overridable via `OPENZIM_MODEL_CACHE_DIR`. The cache layout supports future extras without churn.
 - **Air-gapped support via explicit CLI.** A new `openzim-mcp download-models` command pre-stages every model the installed extras need. Idempotent; safe to re-run.
-- **Configuration via `MLConfig` composing four sub-configs.** Discoverable via the existing `openzim-mcp config show` CLI.
+- **Configuration via `MLConfig` composing two sub-configs.** Discoverable via the existing `openzim-mcp config show` CLI. The schema is sized to today's scope; deferred sub-Ds add their sub-configs when they ship.
 
 ---
 
@@ -50,12 +52,10 @@ These apply across all four sub-Ds.
 
 | Milestone | Items | Extra | Tag | Why this order |
 |-----------|-------|-------|-----|----------------|
-| **sub-D-1** | #6 cross-encoder reranker | `[reranker]` | `v2.0.0b1` | Smallest scope, biggest immediate relevance win, establishes the lazy-ML + fallback patterns the other items inherit |
-| **sub-D-2** | #8 Tier 1 query rewriting (rules-based) | (none — base install) | `v2.0.0b2` | Zero deps; every downstream item benefits from a cleaner query upstream. Lift the floor for free. |
-| **sub-D-3** | #8 Tier 2 + #12 hybrid intent parser | `[planner]` | `v2.0.0b3` | Tier-2 + classifier share a model; ship together. Live evidence from sub-D-2 informs what the rules-based pass misses. |
-| **sub-D-4** | #15 embeddings sidecar + hybrid retrieval | `[embeddings]` | `v2.0.0b4` | Heaviest scope (build CLI, sidecar format, RRF plumbing). Plugs into a stable reranker (sub-D-1) and classifier (sub-D-3). |
+| **sub-D-1** | #6 cross-encoder reranker | `[reranker]` | `v2.0.0b1` | Smallest scope, biggest immediate relevance win on the queries that benefit, establishes lazy-ML + fallback patterns for any future ML extras |
+| **sub-D-2** | #8 Tier 1 query rewriting (rules-based) | (none — base install) | `v2.0.0b2` | Zero deps; every model benefits from a cleaner query upstream. Lift the floor for free. |
 
-Each milestone ships with its own live-MCP smoke pass before its release PR merges. No mass-release at the end of Phase D — discover regressions early.
+Each milestone ships with its own live-MCP smoke pass before its release PR merges. **Sub-D-1 deploy gates a 2-week telemetry review** before sub-D-2 enters writing-plans — telemetry should confirm the reranker fires at a useful rate (target: ≥15% of search-tool calls past the skip-on-short-query gate, with measurable rerank-score divergence from Xapian ordering) and surface unexpected operator-side failures (model download timeouts, FastEmbed wheel-build issues on niche platforms).
 
 ---
 
@@ -63,38 +63,62 @@ Each milestone ships with its own live-MCP smoke pass before its release PR merg
 
 ### What it does
 
-When `[reranker]` is installed, search-shaped tools (`search_zim_file`, `search_with_filters`, `search_all`) and `synthesize` mode silently rerank Xapian top-N results using a cross-encoder model. Caller surface unchanged; relevance improves ~30 pp on content-fragment queries.
+When `[reranker]` is installed, search-shaped tools (`search_zim_file`, `search_with_filters`, `search_all`) and `synthesize` mode silently rerank Xapian top-N results using a cross-encoder model. Caller surface unchanged; relevance improves on content-fragment queries.
 
 ### Activation surface
 
 - `simple_tools.py:_handle_search` — Xapian returns top-N (default N=50), `BGEReranker.rerank(query, results, top_k=requested_limit)` produces the final order. When `BGEReranker.get()` returns None (extra absent or kill-switched), skip cleanly.
 - `simple_tools.py:_handle_filtered_search` + `_handle_search_all` — same shape.
-- `synthesize.py:_collect_passages` — rerank passage candidates before the citation block is assembled. Phase C #10 explicitly anticipates this hook.
-- `simple_tools.py:_handle_tell_me_about` — NOT reranked. Entity-driven queries are already canonical-title resolved; rerank adds cost without value.
-- **Skip-on-short-query gate:** when query has <4 word tokens, skip rerank. Single-word entity queries dominate the Xapian-score-1.0 canonical-title hit; the cross-encoder is wasted there. Cheap gate; avoids ~40% of needless rerank calls per the live-MCP sweep traffic patterns.
+- `synthesize.py:_collect_passages` — rerank passage candidates before the citation block is assembled. Phase C #10 explicitly anticipates this hook. Adds ~50 ms per synthesize call; within Phase C's latency budget.
+- `simple_tools.py:_handle_tell_me_about` — **not reranked.** Entity-driven queries are already canonical-title resolved; rerank adds cost without value.
+- **Skip-on-short-query gate:** when query has fewer than `min_query_tokens` (default 4) word tokens, skip rerank. Single-word entity queries dominate the Xapian-score-1.0 canonical-title hit; the cross-encoder is wasted there. Cheap gate; expected to short-circuit a large share of live-MCP traffic.
 
 ### Module structure
 
 ```
+openzim_mcp/ml/__init__.py    # feature-detection registry (sized for future extras)
 openzim_mcp/ml/reranker.py    # ~250 LOC
     class BGEReranker:
         - get() classmethod, lazy singleton, thread-safe init
         - score_pairs(pairs) -> List[float], batch-score (query, passage) pairs
         - rerank(query, candidates, top_k) -> List[Candidate]
+openzim_mcp/ml/fallback.py    # shared ml_fallback decorator
+openzim_mcp/ml/cli/download.py  # `openzim-mcp download-models` entrypoint
 ```
 
 ### Library: FastEmbed
 
-- `fastembed>=0.4.0,<1.0`. ONNX-backed, ~150 MB total install. No torch dependency.
+- `fastembed>=0.4.0,<1.0`. ONNX-backed. No torch dependency.
+- Install footprint: ~150 MB total (`fastembed` + transitive `onnxruntime` + `tokenizers` + `huggingface_hub`).
 - CPU benchmark: ~50 ms for batch=50 of `bge-reranker-base` ONNX. Well under the 150 ms p95 budget.
 - Default model: `Xenova/bge-reranker-base-onnx` (~80 MB), download-on-first-use, cached in `~/.cache/openzim-mcp/models/fastembed`.
-- Overrides via env: `OPENZIM_RERANKER_MODEL`, `OPENZIM_RERANKER_CACHE_DIR`, `OPENZIM_RERANKER_DISABLE=1` (kill switch when extra is installed but we don't want it).
+
+### Risk mitigations baked into the design
+
+**1. First-call model download UX (risk: 30 s hang on offline deployments).**
+
+- `BGEReranker.get()` wraps the model fetch in a 5-second timeout (configurable via `RerankerConfig.first_call_timeout_seconds`).
+- On timeout, log exactly: `WARNING: reranker model not staged; run \`openzim-mcp download-models\` to pre-stage. Falling back to Xapian-only ranking for this process.`
+- Kill-switch sets `_reranker_disabled = True`; no retries.
+- The `openzim-mcp download-models` CLI exists at GA. Documented in install instructions and in the warning message above.
+
+**2. Edge-platform wheel availability (risk: FastEmbed wheels missing on Alpine / ARM32 / FreeBSD).**
+
+- The `[reranker]` extra stays optional. Base install is unaffected.
+- CI tests `pip install openzim-mcp[reranker]` on the supported matrix (Linux glibc x86_64 + ARM64, macOS x86_64 + ARM64, Windows x86_64). Edge platforms are explicitly out of scope.
+- Documented as a "supported platforms for `[reranker]`" section in `docs/v2/extras-reranker.md`.
+
+**3. Model identity drift (risk: HuggingFace updates the model; reproducibility breaks).**
+
+- Pin model id in `RerankerConfig.model_id`; treat config bumps as the only knob.
+- Log model id + file hash on first load (one-time INFO log) so operators can audit.
+- A future `openzim-mcp ml status` CLI (out of scope for sub-D-1) would surface the loaded model's checksum.
 
 ### Fallback contract
 
-- Model load fails (corrupt cache, OOM, ImportError) → log `WARNING`, set process-local `_reranker_disabled = True`, every future `get()` returns None. Search continues on Xapian.
-- Per-call exception (tokenizer overflow, model crash) → log `WARNING` once per process, return input candidates in their Xapian order. Never raise to caller.
-- Telemetry: `_track("reranker_engaged" | "reranker_skipped" | "reranker_failed")`.
+- Model load fails (corrupt cache, OOM, ImportError, network timeout) → kill switch + structured WARNING + Xapian-only for the rest of the process.
+- Per-call exception (tokenizer overflow, model crash) → log WARNING once per process, return input candidates in their Xapian order. Never raise to caller.
+- Telemetry: `_track("reranker_engaged" | "reranker_skipped" | "reranker_failed")`. The `reranker_skipped` event distinguishes the short-query gate from disabled state via a `reason` field: `short_query | disabled | not_installed`.
 
 ### Response shape
 
@@ -113,20 +137,23 @@ class RerankerConfig(BaseModel):
     max_query_length: int = 256
     max_passage_length: int = 512
     min_query_tokens: int = 4          # skip-on-short-query gate
-    cache_dir: Path | None = None      # None → FastEmbed default
+    first_call_timeout_seconds: float = 5.0
+    cache_dir: Path | None = None      # None → FastEmbed default under model_cache_dir
 ```
 
 ### Testing
 
-- Unit: mock `TextRerank.rerank()` and assert candidate ordering + envelope shape.
+- Unit: mock `TextRerank.rerank()` and assert candidate ordering + envelope shape. Mock the timeout behavior to assert the kill-switch fires correctly.
 - Integration: `tests/ml/test_reranker_integration.py` builds an in-process reranker against a 3-doc test corpus; asserts predictable reorder. `@pytest.mark.requires_reranker` keyed off `importlib.util.find_spec("fastembed")`.
-- Telemetry assertion: `_reranker_engaged` counter increments once per search hit.
+- Telemetry assertion: `_reranker_engaged` counter increments once per qualifying search hit; `_reranker_skipped` increments on short queries.
 - Performance test: rerank batch of 50 in <150 ms p95 on the CI runner.
+- Edge-platform test: `pip install openzim-mcp[reranker]` smoke job in CI for each supported platform/Python combination. Failure on an unsupported platform is documented, not fixed.
 
 ### Performance budget
 
-- p95 added latency per search query: ≤120 ms on a modern CPU.
-- First-call cold start: ≤2 s (one-time model download or `openzim-mcp download-models` pre-stage).
+- p95 added latency per search query (when reranker fires): ≤120 ms on a modern CPU.
+- p95 added latency per search query (when skip-on-short-query gate fires): ≤1 ms (cheap token-count check).
+- First-call cold start: ≤2 s (model already on disk). First call without pre-stage: 5 s timeout → fallback.
 
 ---
 
@@ -134,20 +161,32 @@ class RerankerConfig(BaseModel):
 
 ### What it does
 
-Every query, before any pattern matching, runs through five rules-based rewrite passes. Zero extras, zero models, zero ML dependencies. Lands in the BASE install so all downstream items inherit a cleaner query. Lift the floor for every model immediately.
+Every query, before any pattern matching, runs through four rules-based rewrite passes. Zero extras, zero models, zero ML dependencies. Lands in the BASE install so all downstream items inherit a cleaner query. Lift the floor for every model immediately.
 
-### Five rule families
+### Four rule families
 
 Each idempotent, each loop-safe (same shape as existing `_strip_param_leaks` / `_strip_trailing_politeness` patterns in `intent_parser.py`):
 
-1. **Lowercase-entity normalization.** Pulls scattered `.lower()` calls in the `_tokenize_for_relevance` path into a named pass. Title-promotion's case-preserving path is untouched.
-2. **Common-misspelling map.** Ship `openzim_mcp/data/misspellings.txt` — ~200 entries seeded from Wikipedia's "List of common misspellings." Loaded once at module init; the map is `dict[str, str]` keyed on lowercase word; whole-word substitution (word-boundary anchors). Cap at ~500 entries to keep the lookup cheap.
-3. **Stopword-aware phrase detection.** When the topic carries `the / a / an / of` as leading or interleaved token, use the title index as the oracle: if the leading-stopword form has a canonical hit (`The Beatles`, `Of Mice and Men`), keep it; otherwise strip. One extra title-index probe per ambiguous query.
-4. **Simple "X of Y" decomposition.** `population of Berlin` → `(entity=Berlin, attribute=population)`. Routes to the existing subject-attribute extraction in `simple_tools.py:_handle_tell_me_about` (the post-a16 P4-D1/P6-D1 hardened path). Two regex shapes:
-   - `<attribute_word> of <entity>`
-   - `<entity>'s <attribute>` (genitive)
-   - **NOT in Tier-1:** multi-hop questions ("what year did the inventor of X die"). Tier-2 + classifier in sub-D-3.
-5. **Explicit HyDE skip.** No hypothetical-document synthesis; documented in the spec as a locked-in non-goal.
+**1. Lowercase-entity normalization.** Pulls scattered `.lower()` calls in the `_tokenize_for_relevance` path into a named pass. Title-promotion's case-preserving path is untouched.
+
+**2. Common-misspelling map (title-index-first lookup).**
+
+Ship `openzim_mcp/data/misspellings.txt` — ~200 entries seeded from Wikipedia's "List of common misspellings." Loaded once at module init; the map is `dict[str, str]` keyed on lowercase word.
+
+**Risk mitigation baked in:** before substituting, probe the title index for the original token. If the original has a canonical hit (score ≥ 0.95), skip the rewrite. This eliminates the false-positive class where a user types a real proper noun that happens to look like a misspelling (`Bilogy` as a surname, `Photosythesis` as an obscure band name, etc.). The probe is ~1 ms and cached.
+
+Cap at ~500 entries to keep the lookup cheap. Annotate the file with the upstream Wikipedia revision timestamp so maintenance is auditable.
+
+**3. Stopword-aware phrase detection.** When the topic carries `the / a / an / of` as leading or interleaved token, use the title index as the oracle: if the leading-stopword form has a canonical hit (`The Beatles`, `Of Mice and Men`), keep it; otherwise strip the leading article. One title-index probe per ambiguous query (~1 ms; piggybacks on the existing title-index cache where possible).
+
+**4. Simple "X of Y" decomposition.** `population of Berlin` → `(entity=Berlin, attribute=population)`. Routes to the existing subject-attribute extraction in `simple_tools.py:_handle_tell_me_about` (the post-a16 P4-D1/P6-D1 hardened path). Two regex shapes:
+
+- `<attribute_word> of <entity>`
+- `<entity>'s <attribute>` (genitive)
+
+**NOT in Tier 1:** multi-hop questions ("what year did the inventor of X die"). Those are deferred to a future sub-D-3 spec if live evidence warrants.
+
+**Explicit non-rule:** HyDE. No hypothetical-document synthesis. Documented as a locked-in non-goal.
 
 ### Module structure
 
@@ -156,15 +195,39 @@ openzim_mcp/intent_parser.py (existing, 1345 lines)
     Extends the existing strip chain. Add four new methods following the
     same idempotent-loop shape:
         - _normalize_topic_case(query)
-        - _apply_misspelling_map(query)
-        - _detect_stopword_phrase(query, title_index)  # optional title_index
+        - _apply_misspelling_map(query, title_index)
+        - _detect_stopword_phrase(query, title_index)
         - _decompose_x_of_y(query)
     All called from parse_intent BEFORE pattern matching.
 
-openzim_mcp/data/misspellings.txt   # new, ~200 lines
+openzim_mcp/data/misspellings.txt   # new, ~200 lines + upstream-revision header
 ```
 
-The stopword-phrase pass requires a title-index handle when called from the live path. Pass it in optionally; when unavailable (unit tests without an archive), the rule degrades cleanly to a no-op.
+The misspelling and stopword-phrase rules need a title-index handle for the false-positive-mitigation probe. Pass it in optionally; when unavailable (unit tests without an archive), those rules degrade to no-ops — the rest of Tier 1 still runs.
+
+### Risk mitigations baked into the design
+
+**1. Behavior changes on upgrade for every user (risk: silent regressions).**
+
+- Run the existing `tests/test_post_a*_beta_fixes.py` regression suite as a pinned baseline before merge.
+- Add a Tier-1 regression suite (`tests/test_query_rewrite_tier1.py`) with per-rule positive AND no-op cases — explicit assertions that already-correct queries pass through unchanged.
+- Live MCP smoke pass before merging the release PR (already in methodology).
+
+**2. Misspelling-map false positives (risk: silent rewrite of real proper nouns to wrong articles).**
+
+- Title-index-first lookup, as documented in rule #2.
+- Pin a "do not rewrite" exclusion list in the same data file for words confirmed to be real proper nouns (e.g., `Bilogy → SKIP`).
+- The exclusion list grows over time; sub-D-2's plan documents the process.
+
+**3. Rule-order interactions (risk: subtle bugs from composed rules).**
+
+- Idempotent loop pattern: each rule runs until its output stops changing, then the next rule runs. Already proven in the `_strip_*` chain.
+- Unit tests cover per-rule and per-rule-pair compositions.
+
+**4. Stopword-phrase probe latency on every query (risk: throughput regressions on high-volume deployments).**
+
+- Cache hits piggyback on the existing title-index cache.
+- `QueryRewriteConfig.stopword_phrase_probe = False` is an operator-side kill switch.
 
 ### Configuration
 
@@ -172,261 +235,26 @@ The stopword-phrase pass requires a title-index handle when called from the live
 class QueryRewriteConfig(BaseModel):
     enabled: bool = True
     misspelling_map_path: Path | None = None  # None → bundled default
+    misspelling_exclusion_path: Path | None = None  # None → bundled default
     stopword_phrase_probe: bool = True
 ```
 
 ### Telemetry
 
-`_track("query_rewritten", details={"rules_applied": [...]})` — observability without printing rewritten text (PII-safe).
+`_track("query_rewritten", details={"rules_applied": [...]})` — observability without printing rewritten text (PII-safe). The `rules_applied` list lets operators see which rules fire most.
 
 ### Testing
 
 - Unit: parametrized test cases per rule family — fix side, no-op side (already-correct), embedding-safety side (don't eat substrings).
-- Regression guards: pin the misspelling-map row count + sample entries so future contributors can't silently delete entries.
+- Title-index-first lookup: parametrized tests with a mocked title-index returning hits/no-hits for known queries to verify the false-positive mitigation fires correctly.
+- Regression guards: pin the misspelling-map row count + sample entries so future contributors can't silently delete entries; pin the upstream revision timestamp in the file header.
 - Live-MCP integration: extend the existing `tests/test_post_a*_beta_fixes.py` regression set with Tier-1 expected outputs.
-
-### Why route decomposition through existing `_handle_tell_me_about`
-
-The subject-attribute extraction path in `simple_tools.py:_handle_tell_me_about` is mature (a17 P1-D1 + post-a15 P4-D1 hardening). Tier-1 reuses it rather than introducing a parallel surface. Sub-D-3's classifier expands this into a true multi-hop decomposer.
-
----
-
-## Sub-D-3 — Tier 2 query rewriting + hybrid intent parser (#8 + #12)
-
-### What it does
-
-When Tier-1 + regex aren't enough, fall back to a tiny ML classifier — without bloating the default install. Both items share one model and ship together behind a single `[planner]` extra.
-
-### Why ship #8 Tier-2 and #12 together
-
-They fire on the same trigger (low-confidence query shapes) and benefit from sharing a model. Splitting would mean two model loads, two `[planner-X]` extras, and duplicate failure-handling code.
-
-### Classifier: fastText
-
-- `fasttext-wheel>=0.9.2,<1.0`. ~50 MB installed. No torch dependency. CPU-fast (~0.1 ms per classification). Trains in minutes on the existing sweep transcripts.
-- Three trained models bundled inside `openzim_mcp/ml/data/`:
-  - `intent_classifier.ftz` (~5 MB, quantized): 19-class classifier matching `INTENT_PATTERNS` labels.
-  - `decomposition_classifier.ftz` (~3 MB): binary "needs decomposition?" classifier.
-  - `decomposition_extractor.ftz` (~5 MB): token-level sequence labeler producing `(entity_span, attribute_span, modifier_span)`.
-- Bundled in the wheel, not downloaded at runtime — adds ~15 MB to `[planner]` install. Offline-first; no network at runtime.
-
-### Hybrid intent parser flow (#12)
-
-```
-parse_intent(query):
-    1. apply Tier-1 rewrites               # sub-D-2
-    2. run INTENT_PATTERNS regex match     # existing
-    3. if confidence >= 0.7:               # existing
-         return regex result               # fast path, ~99% of traffic
-    4. else if [planner] installed:
-         classifier.predict(query)
-         if classifier.confidence >= 0.7:
-             return classifier result with rank_origin="classifier"
-    5. else:
-         existing low-confidence behavior (current footer)
-```
-
-### Tier-2 decomposition flow (#8)
-
-```
-after intent classification:
-    if intent == "tell_me_about" AND query is multi-hop-shaped:
-        decomposition_classifier.predict(query)
-        if "needs decomposition":
-            extractor.predict(query) -> (entity, attribute, modifier)
-            issue internal entity-lookup + attribute-lookup chain
-            assemble combined response with cite markers
-        else:
-            fall through to standard tell_me_about
-```
-
-### Training data: sweep transcripts already in repo
-
-- `tests/test_post_a*_beta_fixes.py` carries ~1000+ labeled `(query, expected_intent)` pairs from the live MCP sweeps a8 → a25 (estimate based on parametrized test counts; exact yield depends on dedup). Extract into a JSONL dataset (`openzim_mcp/ml/data/training/intent.jsonl`). Quality bar: a per-intent minimum of 30 examples; under-represented intents get synthetic seed examples generated from the regex patterns themselves.
-- For decomposition: synthetic dataset generated by templating `(attribute) of (entity)` / `(entity)'s (attribute)` over Wikipedia's category trees. Ship a 5000-row seed set without category-tree dependency.
-- Training script (`scripts/train_planner.py`) is reproducible — ships in the repo but NOT in the wheel. CI verifies bundled models are checksum-pinned.
-
-### Module structure
-
-```
-openzim_mcp/ml/planner.py             # ~250 LOC
-openzim_mcp/ml/intent_classifier.py   # ~150 LOC
-openzim_mcp/ml/data/                  # bundled .ftz files
-openzim_mcp/ml/data/training/         # JSONL datasets (training reproducibility)
-scripts/train_planner.py              # not in wheel
-```
-
-### Configuration
-
-```python
-class PlannerConfig(BaseModel):
-    enabled: bool = True
-    intent_model_path: Path | None = None         # None → bundled .ftz
-    decomposition_model_path: Path | None = None
-    extractor_model_path: Path | None = None
-    classifier_confidence_threshold: float = 0.7  # match regex threshold
-    decomposition_enabled: bool = True            # finer kill switch
-```
-
-### Response shape
-
-- Optional `_meta.intent_source: "regex" | "classifier"` field.
-- Optional `_meta.decomposed: bool` when Tier-2 decomposition fired.
-- No tool signature changes; additive metadata only.
-- Raw classifier scores not exposed to callers — confidence is internal.
-
-### Fallback contract (same shape as sub-D-1)
-
-- Classifier load fails → log WARNING, set `_planner_disabled`, every future `get()` returns None, parse_intent falls back to existing low-confidence footer.
-- Classifier prediction returns confidence < 0.7 → treated as if it never ran.
-- Telemetry: `_track("intent_classifier_engaged" | "decomposition_engaged" | "planner_failed")`.
-
-### Testing
-
-- Unit: parametrized tests with mocked `fastText.predict()` covering each of 19 intents + binary decomposition gate.
-- Integration: `tests/ml/test_planner_integration.py` loads bundled `.ftz` files (only when fasttext importable, skip otherwise); asserts known live-MCP queries route correctly.
-- Quality gate: held-out test set (10% of JSONL) achieves ≥90% intent classification accuracy. CI fails if retrain regresses below threshold.
-
-### Why fastText over distilled sentence-transformer
-
-README permits fastText / distilled sentence-transformer / lightweight rules-tree. fastText wins on:
-- **Size:** 50 MB vs ~500 MB for sentence-transformers.
-- **Speed:** 0.1 ms vs ~10 ms per classification.
-- **Dependency surface:** no torch, no transformers.
-
-Sentence-transformer reranking already lives in sub-D-1; sharing torch there doesn't make the planner cheaper.
-
----
-
-## Sub-D-4 — Embeddings sidecar + hybrid retrieval (#15)
-
-### What it does
-
-True semantic retrieval. Find articles by meaning, not just keyword overlap. Heaviest scope in Phase D because it adds a build-time CLI, a sidecar file format, and hybrid-retrieval plumbing. Ships last so it can plug into a stable reranker (sub-D-1) and a stable classifier-aware intent parser (sub-D-3).
-
-### Sidecar file format: `<archive>.zim.semantic.hnsw`
-
-- Single binary, lives next to the `.zim` file.
-- Wraps two artifacts: HNSW index (via `hnswlib`) + parallel `path_id ↔ entry_path` mapping (`<archive>.zim.semantic.paths.sqlite`).
-- Header carries: `model_id`, `embedding_dim`, `vector_count`, ZIM archive UUID (for cross-archive safety), HNSW params (`M`, `ef_construction`), schema version.
-- Cross-archive safety: load-time UUID check. Sidecar built for archive A won't load against archive B; logs a WARNING and silently disables semantic retrieval for that archive.
-
-### Encoder: `bge-small-en-v1.5` via FastEmbed
-
-- 33 MB. 384-dim. CPU-fast (~5 ms per sentence on modern CPU).
-- Already in FastEmbed's first-class registry — shares the model cache + lifecycle code with sub-D-1's reranker. **No new ML library dependency.**
-- Configurable via `OPENZIM_EMBEDDING_MODEL` env var. Multilingual archives can opt into `paraphrase-multilingual-MiniLM-L12-v2` or `bge-m3`.
-
-### Build CLI: `openzim-mcp build embeddings <archive.zim>`
-
-```
-$ openzim-mcp build embeddings /data/wikipedia_en_all_maxi_2026-02.zim
-  Reading archive metadata... 27,200,000 entries, est. embedding budget 2.1 GB
-  Embedding entries [████████░░░░░░░] 42% — 3h 12m remaining
-  Writing HNSW index... done (1.8 GB)
-  Writing paths sqlite... done (480 MB)
-  Verifying sidecar... ✓
-  Sidecar written to /data/wikipedia_en_all_maxi_2026-02.zim.semantic.hnsw
-```
-
-CLI flags:
-- `--model <hf_id>` (default: `bge-small-en-v1.5`)
-- `--namespace <letter>` (default: `C` — content; can be repeated)
-- `--chunk-mode {title,summary,full}` (default: `summary` — embed first 200 tokens of body; cheaper, equally effective per RAG benchmarks)
-- `--workers <N>` (default: cpu_count())
-- `--resume` (idempotent — picks up from last completed batch)
-- `--verify` (load-test the sidecar without writing)
-
-Build time: ~3-4 hours on Wikipedia full archive on a modern CPU. **Build is one-time and idempotent**; rebuild only when the archive changes.
-
-### Runtime hybrid retrieval
-
-```
-hybrid_search(query, archive):
-    1. Xapian top-K   (default K=50)
-    2. if sidecar_loaded(archive):
-         encode(query) -> query_vec
-         HNSW top-K of query_vec
-         RRF fuse (k=60) the two ranked lists
-    3. else:
-         skip step 2, use Xapian list as-is
-    4. if reranker_available:
-         rerank top-K -> top-N
-    5. return top-N
-```
-
-**Reciprocal Rank Fusion** (`RRF score = Σ 1/(k + rank_i)` for k=60 across both lists) — battle-tested, requires no score calibration between Xapian's BM25 and cosine similarity.
-
-### Sidecar discovery
-
-- On archive open in `zim_operations.py`, probe for `<archive>.zim.semantic.hnsw` + `.semantic.paths.sqlite`.
-- Both present → lazy-load on first hybrid query.
-- One missing or version-mismatched → log INFO, mark archive as "semantic unavailable", continue Xapian-only.
-- Per-archive state (not global) — mixed-archive deployments can have some archives with sidecars and some without.
-
-### Storage cost
-
-- Wikipedia full archive (27M entries × 384-dim × float16) ≈ 21 GB raw embeddings.
-- HNSW with M=16 adds ~50% overhead → ~32 GB on-disk sidecar.
-- For deployments where 32 GB is too much: `--chunk-mode title` produces ~5 GB sidecar (titles only, no body); trade recall for footprint.
-
-### Module structure
-
-```
-openzim_mcp/ml/embeddings.py      # ~250 LOC: encoder + HNSW reader
-openzim_mcp/ml/sidecar.py         # ~150 LOC: sidecar discovery + load + UUID check
-openzim_mcp/ml/cli/build_index.py # ~200 LOC: `openzim-mcp build embeddings` CLI
-openzim_mcp/ml/fusion.py          # ~50 LOC: RRF implementation
-```
-
-### Configuration
-
-```python
-class EmbeddingsConfig(BaseModel):
-    enabled: bool = True                   # checked when extra importable
-    model_id: str = "bge-small-en-v1.5"
-    sidecar_search_paths: List[Path] = []  # extras beyond archive dir
-    xapian_top_k: int = 50
-    semantic_top_k: int = 50
-    rrf_k: int = 60
-    require_sidecar: bool = False          # True → error if missing, False → fall back
-```
-
-### Fallback contract
-
-- Sidecar missing → semantic retrieval skipped silently, Xapian-only.
-- Encoder load fails → log WARNING once, disable for the rest of the process, Xapian-only.
-- HNSW query exception → log WARNING, fall back to Xapian-only for that query.
-- **Never** fails search outright when a sidecar is unavailable.
-
-### Telemetry
-
-`_track("hybrid_retrieval_engaged" | "hybrid_retrieval_xapian_only" | "sidecar_missing" | "sidecar_version_mismatch")`. Build CLI emits structured progress logs (lines/sec, ETA) for piping into CI dashboards.
-
-### Testing
-
-- Unit: HNSW index round-trip on a 1000-doc synthetic corpus. RRF fusion math against hand-computed expected ranks.
-- Integration: `tests/ml/test_hybrid_retrieval.py` with a tiny ZIM + pre-built sidecar fixture asserts known semantic-vs-Xapian divergence (e.g., query "the chemical that makes leaves green" → semantic finds `Chlorophyll`, Xapian misses it).
-- Build CLI: smoke test in `tests/ml/test_build_cli.py` — build sidecar for a 10-entry test ZIM, assert byte-for-byte determinism (pin output hash).
-- Skip marker `@pytest.mark.requires_embeddings` keyed on `importlib.util.find_spec("hnswlib")`.
-
-### Why HNSW over FAISS
-
-`hnswlib` is a single 2 MB wheel with no transitive deps; FAISS pulls in numpy and sometimes BLAS. Both implement the same HNSW algorithm; at our scale (≤100M vectors per sidecar) hnswlib's perf is competitive.
-
-### Why `bge-small-en-v1.5` over `bge-base`
-
-Small produces 384-dim (vs base's 768), halving storage. Quality difference on Wikipedia-style content is <2 pp; small wins on size by ~50%.
-
-### Why per-archive sidecar, not global
-
-Lets deployments add semantic retrieval to high-value archives (Wikipedia) without paying the build cost on low-traffic ones (Wiktionary, niche StackExchange dumps).
 
 ---
 
 ## Cross-cutting infrastructure
 
-These touch every sub-D and live in `openzim_mcp/ml/__init__.py` + a few shared modules.
+These touch sub-D-1 and are designed to be reused by future ML extras without churn.
 
 ### Feature-detection registry
 
@@ -434,17 +262,15 @@ These touch every sub-D and live in `openzim_mcp/ml/__init__.py` + a few shared 
 # openzim_mcp/ml/__init__.py
 @dataclass(frozen=True)
 class MLFeatures:
-    reranker:   bool   # fastembed importable
-    planner:    bool   # fasttext importable
-    embeddings: bool   # hnswlib importable
+    reranker: bool   # fastembed importable
 
 @functools.cache
 def detect() -> MLFeatures:
     """Single source of truth for which extras are installed. Cached per
-    process; importlib.util.find_spec — no side effects, no model loads."""
+    process; uses importlib.util.find_spec — no side effects, no model
+    loads. Sized for today's scope; new fields added when their sub-Ds
+    ship."""
 ```
-
-Every ML-aware code path checks `detect()` first. Tests parametrize over synthetic `MLFeatures` to exercise both "extra installed" and "extra missing" branches without touching the import system.
 
 ### Shared fallback decorator
 
@@ -456,29 +282,27 @@ def ml_fallback(*, feature: str, on_failure: Callable[..., T]) -> Callable:
     calls to `on_failure`. Idempotent — second failure logs DEBUG only."""
 ```
 
-Every reranker/classifier/encoder entry point wraps through this. Guarantees the "graceful fallback when a model is missing" contract is implemented exactly once.
+Used by `BGEReranker.rerank()`. Pattern is shared across any future ML entry points.
 
 ### Telemetry events (new, additive)
 
 ```
-reranker_engaged / reranker_skipped / reranker_failed
+reranker_engaged
+reranker_skipped (reason=short_query | disabled | not_installed)
+reranker_failed
 query_rewritten (rules_applied=[...])
-intent_classifier_engaged / decomposition_engaged
-planner_failed
-hybrid_retrieval_engaged / hybrid_retrieval_xapian_only
-sidecar_missing / sidecar_version_mismatch
-ml_feature_disabled (feature=<name>, reason=<load_error|kill_switch|env>)
+ml_feature_disabled (feature=reranker, reason=load_error | timeout | kill_switch | env)
 ```
 
-All flow through the existing `_track("<event>")` path in `simple_tools.py:541`. No new telemetry infrastructure.
+All flow through the existing `_track("<event>")` path. No new telemetry infrastructure.
 
 ### Model cache directory
 
-`~/.cache/openzim-mcp/models/` by default. Overridable via `OPENZIM_MODEL_CACHE_DIR` (env) or `model_cache_dir` in `Config`. FastEmbed gets `Path(OPENZIM_MODEL_CACHE_DIR) / "fastembed"`. fastText `.ftz` files live next to the package (bundled, no cache). Sidecars stay next to their `.zim` files.
+`~/.cache/openzim-mcp/models/` by default. Overridable via `OPENZIM_MODEL_CACHE_DIR` (env) or `model_cache_dir` in `Config`. FastEmbed gets `Path(OPENZIM_MODEL_CACHE_DIR) / "fastembed"`.
 
 ### Air-gapped deployments
 
-`openzim-mcp download-models` CLI command pre-stages every model the installed extras need. Idempotent — re-running checks cache and only fetches missing files. For `[embeddings]`, also useful before running `openzim-mcp build embeddings` on a no-internet build host.
+`openzim-mcp download-models` CLI command pre-stages every model the installed extras need. Today: only the reranker model. Idempotent — re-running checks the cache and only fetches missing files.
 
 ### Configuration top-level
 
@@ -486,8 +310,6 @@ All flow through the existing `_track("<event>")` path in `simple_tools.py:541`.
 class MLConfig(BaseModel):
     reranker: RerankerConfig = RerankerConfig()
     query_rewrite: QueryRewriteConfig = QueryRewriteConfig()
-    planner: PlannerConfig = PlannerConfig()
-    embeddings: EmbeddingsConfig = EmbeddingsConfig()
 
 # Config (existing) gains:
 class Config(BaseModel):
@@ -495,24 +317,20 @@ class Config(BaseModel):
     ml: MLConfig = MLConfig()
 ```
 
-Discoverable via existing `openzim-mcp config show` CLI; each field documented in `config.py` docstrings.
+The schema is sized to today's scope. Deferred sub-Ds add their sub-configs when they ship — no pre-commitment.
 
 ### Testing infrastructure
 
 ```
-tests/ml/                              # all ML tests live here
+tests/ml/                              # ML tests live here
     conftest.py                        # shared fixtures, requires_* markers
     test_reranker_unit.py
     test_reranker_integration.py       # @pytest.mark.requires_reranker
     test_query_rewrite_tier1.py        # no marker — base install
-    test_planner_unit.py
-    test_planner_integration.py        # @pytest.mark.requires_planner
-    test_hybrid_retrieval.py           # @pytest.mark.requires_embeddings
-    test_build_cli.py
     test_ml_registry.py                # MLFeatures + ml_fallback
 ```
 
-CI matrix adds two new jobs per Python version: `extras-none` (current behavior, default) and `extras-all` (install `[reranker,planner,embeddings]` and run the integration tests). The existing test surface stays untouched on the no-extras path.
+CI matrix adds one new job per supported Python version: `extras-reranker` (install `[reranker]`, run integration tests). The `extras-none` path is the default existing CI. Total CI runtime impact: ~1.1x baseline (the integration tests are small).
 
 ### Pyproject extras structure
 
@@ -521,44 +339,58 @@ CI matrix adds two new jobs per Python version: `extras-none` (current behavior,
 reranker = [
     "fastembed>=0.4.0,<1.0",
 ]
-planner = [
-    "fasttext-wheel>=0.9.2,<1.0",
-]
-embeddings = [
-    "fastembed>=0.4.0,<1.0",   # shared with [reranker]
-    "hnswlib>=0.8.0,<1.0",
-]
-ml-all = [
-    "openzim-mcp[reranker,planner,embeddings]",
-]
 ```
 
-Install footprints:
-- `pip install openzim-mcp[reranker]` → ~150 MB
-- `pip install openzim-mcp[planner]` → ~50 MB
-- `pip install openzim-mcp[embeddings]` → ~150 MB (shared FastEmbed, only HNSW adds ~2 MB on top)
-- `pip install openzim-mcp[ml-all]` → ~200 MB total
+Install footprint: `pip install openzim-mcp[reranker]` → ~150 MB.
+
+When sub-D-3 or sub-D-4 enter design, their extras will be added without restructuring.
 
 ### Documentation
 
-Every extra gets a `docs/v2/extras-<name>.md` page covering: what it does, install command, expected memory/disk/latency cost, how to verify it's active, how to disable it, sample observability-output snippet. README's Phase D section will link to these.
+`docs/v2/extras-reranker.md` covers: what `[reranker]` does, install command, expected memory/disk/latency cost, supported platforms list, how to verify it's active, how to disable it (`OPENZIM_RERANKER_DISABLE=1`), sample observability-output snippet, troubleshooting (model-not-staged, timeout-on-first-call).
 
 ### Release pacing
 
-Four sub-Ds → four `v2.0.0bN` releases. Per the existing sweep cadence, **each sub-D ships with its own live-MCP smoke pass before merging the release PR.** No mass-release at the end — discover failures early.
+Two sub-Ds → two `v2.0.0bN` releases. Each ships with its own live-MCP smoke pass before merging. **2-week telemetry review gates sub-D-2's writing-plans:** sub-D-1 deploys, we collect `reranker_engaged` / `reranker_skipped` / `reranker_failed` event distributions for two weeks, then decide whether sub-D-2 still makes sense and whether deferred sub-Ds need follow-up specs.
+
+---
+
+## Deferred to follow-up specs
+
+The original Phase D design included two more items. Both are deferred from this spec pending live evidence. Each has a measurable trigger that would justify cutting a follow-up spec.
+
+### Deferred sub-D-3 — Hybrid intent parser + Tier 2 decomposition (#8 Tier 2 + #12)
+
+**Trigger to design:** after sub-D-1 + sub-D-2 ship and two weeks of live telemetry shows:
+
+- ≥5% of `parse_intent` calls land in the existing low-confidence path (regex confidence < 0.7), OR
+- Small-model transcript review surfaces multi-hop queries (`what year did the inventor of X die`) that the regex path fails on at a rate of ≥1 per 100 queries.
+
+If the trigger fires, cut a `sub-D-3-design.md` spec covering the fastText classifier path (already designed in the previous draft of this spec — preserved in git history at commit `a92d04e`). If the trigger does NOT fire within 8 weeks of sub-D-2 deploy, formally close sub-D-3 as "not justified by live evidence."
+
+### Deferred sub-D-4 — Embeddings sidecar + hybrid retrieval (#15)
+
+**Trigger to design:** after sub-D-1 ships and four weeks of live telemetry shows:
+
+- Reranker hit rate is meaningful (≥15% of search-tool calls past the skip-on-short-query gate) AND
+- Operators or end-users report that semantic-divergent queries ("the chemical that makes leaves green") consistently miss in Xapian-only search even with the reranker active.
+
+The sub-D-4 follow-up spec would cover the sidecar file format, build CLI, hybrid retrieval, RRF fusion (designed in the previous draft, preserved at commit `a92d04e`). The 32 GB sidecar cost and 3-4 hour build time mean this is a deliberate operator commitment; live evidence is necessary to justify the design effort.
+
+### Why these triggers, not "always build"
+
+The post-a17 → a25 sweep cycles taught us that the regex path is more capable than expected and that live traffic is more entity-dominated than the v2 README anticipated. Building #12 and #15 ahead of evidence ships complexity that may not be exercised. The triggers above turn "we think this would help" into "the data shows this is needed."
 
 ---
 
 ## Release plan
 
-| Sub-D | Tag | Owns | Spec link | Plan link |
-|-------|-----|------|-----------|-----------|
-| sub-D-1 | `v2.0.0b1` | #6 reranker | This doc § sub-D-1 | _TBD by writing-plans_ |
-| sub-D-2 | `v2.0.0b2` | #8 Tier 1 | This doc § sub-D-2 | _TBD_ |
-| sub-D-3 | `v2.0.0b3` | #8 Tier 2 + #12 | This doc § sub-D-3 | _TBD_ |
-| sub-D-4 | `v2.0.0b4` | #15 embeddings + hybrid | This doc § sub-D-4 | _TBD_ |
+| Sub-D | Tag | Owns | Spec link |
+|-------|-----|------|-----------|
+| sub-D-1 | `v2.0.0b1` | #6 reranker | This doc § sub-D-1 |
+| sub-D-2 | `v2.0.0b2` | #8 Tier 1 | This doc § sub-D-2 |
 
-After all four sub-Ds ship, the Phase D row in [`docs/v2/README.md`](../../v2/README.md) flips to **Shipped (v2.0.0b4)**.
+After both sub-Ds ship, the Phase D row in [`docs/v2/README.md`](../../v2/README.md) flips to **Shipped (trimmed; v2.0.0b2)**. Deferred items move to a separate "Deferred from Phase D" row with their trigger conditions documented.
 
 ## Per-sub-D PR shape
 
@@ -576,20 +408,21 @@ These are NOT spec-level blockers; they'll be settled in the implementation plan
 
 - Concrete API for the `Candidate` envelope flowing into `rerank()` (existing search result shape vs new wrapper). Sub-D-1 plan.
 - Whether `_track()` should grow a structured-fields kwarg or stay string-keyed. Sub-D-1 plan.
-- Exact `.ftz` training hyperparameters (epochs, lr, ngram window). Sub-D-3 plan.
-- Whether the build CLI uses `click` or `argparse`. Sub-D-4 plan. Probably `click` — already a tested ecosystem.
-- HNSW `M` / `ef_construction` defaults — start with hnswlib's recommendations, tune in sub-D-4 plan if needed.
+- Exact rule-order test matrix for Tier 1. Sub-D-2 plan.
+- Whether the `openzim-mcp download-models` CLI uses `click` or `argparse`. Sub-D-1 plan. (Probably `click` — already a tested ecosystem in similar projects.)
 
 ---
 
 ## Why this design
 
-**It matches v2's foundational decisions.** The v2 tracking doc commits to "ML accelerators are opt-in via extras." Phase D ships three of them. The doc commits to "offline-first" — bundled fastText models, lazy-load FastEmbed, explicit `build embeddings` CLI, optional `download-models` pre-stage all satisfy that.
+**It matches v2's foundational decisions.** The v2 tracking doc commits to "ML accelerators are opt-in via extras." Sub-D-1 ships one. The doc commits to "offline-first" — lazy-load FastEmbed, explicit `download-models` pre-stage, aggressive first-call timeout all satisfy that.
 
-**It builds on what's already mature.** Sub-D-1 reranker plugs into search + synthesize, both well-tested through Phase C and the post-a15 → a25 sweeps. Sub-D-2 Tier 1 extends the existing `_strip_*` chain in `intent_parser.py` that's been hardened across 11 sweep cycles. Sub-D-3 classifier trains on the labeled sweep transcripts already in repo. Sub-D-4 sidecar reuses sub-D-1's FastEmbed install for the encoder.
+**It builds on what's already mature.** Sub-D-1 reranker plugs into search + synthesize, both well-tested through Phase C and the post-a15 → a25 sweeps. Sub-D-2 Tier 1 extends the existing `_strip_*` chain in `intent_parser.py` that's been hardened across 11 sweep cycles.
 
-**It's incrementally shippable.** Each sub-D is a separate release. A user who installs only `[reranker]` gets meaningful relevance lift without paying for the other two extras. A deployment that doesn't want any ML stays on the base install indefinitely with no behavior change.
+**It's incrementally shippable.** Each sub-D is a separate release. A user who installs only `[reranker]` gets meaningful relevance lift on the queries that benefit. A deployment that doesn't want any ML stays on the base install with sub-D-2's rule-based lift only.
 
-**It defers the hardest scope to last.** Sub-D-4 (embeddings) carries a build CLI, a sidecar format, hybrid retrieval, and the most storage. By the time it ships, the lazy-load patterns from sub-D-1, the model-cache layout from cross-cutting, and the fallback contract from sub-D-1/sub-D-3 are all proven on simpler surfaces.
+**It defers speculation until evidence.** The sub-D-3 (#12) and sub-D-4 (#15) items in the original Phase D plan were designed against expected — not measured — relevance gaps. The trimmed spec ships what's clearly valuable, instruments it, then decides what else is actually needed. This is the same "narrow scope, widen on evidence" pattern the post-a15 → a25 beta sweeps have validated 11 times.
 
-**It locks in YAGNI on multilingual.** Multilingual archive support is documented as an override surface but not designed for. If real demand surfaces during sub-D-1/sub-D-4 live testing, the spec for sub-D-5 (multilingual) can be cut as a separate phase. Until then, English-first defaults keep the design surface tight.
+**The infrastructure pays for itself with one extra.** Feature-detection registry, fallback decorator, telemetry events, model cache layout — all designed to support future ML extras without churn. With only `[reranker]` shipping, the marginal cost of "designed for many" vs "designed for one" is small.
+
+**It locks in YAGNI on multilingual, HyDE, and on-the-fly model upgrades.** Three speculative paths that would have bloated the spec. All documented as explicit non-goals.

--- a/docs/v2/README.md
+++ b/docs/v2/README.md
@@ -31,7 +31,7 @@ These apply across all phases; per-phase specs do not re-litigate them.
 | **A** | Quality wins, non-breaking | #1, #2, #4, #5, #14 | **Shipped (v2.0.0a1)** | [2026-05-08-v2-phase-a-quality-wins-design.md](../superpowers/specs/2026-05-08-v2-phase-a-quality-wins-design.md) |
 | **B** | Response contract | #3, #13 | **Shipped (v2.0.0a2)** | [2026-05-08-v2-phase-b-response-contract-design.md](../superpowers/specs/2026-05-08-v2-phase-b-response-contract-design.md) |
 | **C** | New retrieval primitives | #7, #10, #11 | **Shipped (v2.0.0a4)** | [2026-05-09-v2-phase-c-retrieval-primitives-design.md](../superpowers/specs/2026-05-09-v2-phase-c-retrieval-primitives-design.md) |
-| **D** | Optional ML accelerators | #6, #8, #12, #15 | Planned | _TBD_ |
+| **D** (trimmed) | Optional ML accelerators | #6, #8 Tier 1 (others deferred) | In Design | [2026-05-20-v2-phase-d-ml-accelerators-design.md](../superpowers/specs/2026-05-20-v2-phase-d-ml-accelerators-design.md) |
 | **E** | Offline build artifacts | #16, #17 | Planned | _TBD_ |
 | **F** | Tool surface v2 | #9 | Planned | _TBD_ |
 

--- a/docs/v2/extras-reranker.md
+++ b/docs/v2/extras-reranker.md
@@ -1,0 +1,125 @@
+# [reranker] Extra — Cross-Encoder Search Reranking
+
+The `[reranker]` extra adds cross-encoder relevance reranking on top of
+Xapian's BM25 results. When installed, search-shaped tools and
+`synthesize` mode silently produce more relevant top-K results on
+content-fragment queries. Caller surface is unchanged.
+
+## Install
+
+```bash
+pip install openzim-mcp[reranker]
+```
+
+Install footprint: roughly 200 MB of Python packages (FastEmbed +
+onnxruntime + tokenizers + huggingface_hub). The cross-encoder model
+itself is downloaded lazily on first use (~1.1 GB for the default
+`BAAI/bge-reranker-base`) and cached in your HuggingFace home.
+
+## Supported platforms
+
+The `[reranker]` extra is tested on:
+- Linux glibc x86_64 and ARM64
+- macOS x86_64 and ARM64
+- Windows x86_64
+
+Edge platforms (Alpine, FreeBSD, ARM32) are not part of the supported
+matrix; FastEmbed wheels may not be available there. The base install
+(`pip install openzim-mcp`) is unaffected.
+
+## Pre-staging models for offline deployment
+
+By default, the first call after install downloads `BAAI/bge-reranker-base`
+(~1.1 GB) from HuggingFace. Operators running in air-gapped environments
+should pre-stage:
+
+```bash
+openzim-mcp download-models
+```
+
+Idempotent — safe to re-run. Without pre-staging, the first MCP query
+that triggers rerank has a 5-second timeout; on timeout the reranker
+falls back to Xapian-only ranking for the rest of the process and logs
+a structured warning.
+
+## Verifying it's active
+
+After installing the extra, the MCP server log emits a one-line INFO
+record on first rerank:
+
+```
+reranker loaded: model_id=BAAI/bge-reranker-base fastembed=0.x.y
+```
+
+Telemetry events also fire (see below) — `reranker_engaged` counts
+indicate the reranker is doing real work; `reranker_skipped.*` counts
+indicate the various bypass paths.
+
+## Disabling rerank without uninstalling
+
+Three knobs, listed in priority order:
+
+1. Environment variable: `OPENZIM_RERANKER_DISABLE=1`
+2. Config: `ml.reranker.enabled = false`
+3. Uninstall the extra: `pip uninstall fastembed`
+
+The skip-on-short-query gate (`ml.reranker.min_query_tokens`, default 4)
+bypasses rerank for queries with fewer than 4 word tokens — entity
+queries like `Berlin` or `Photosynthesis` get the canonical-title hit
+from Xapian directly without rerank cost. Set `min_query_tokens = 0` to
+disable the gate.
+
+## Configuration
+
+All knobs documented in `RerankerConfig` (see `openzim_mcp/config.py`).
+Set via environment variables with the `OPENZIM_MCP_` prefix:
+
+```bash
+export OPENZIM_MCP_ML__RERANKER__ENABLED=true
+export OPENZIM_MCP_ML__RERANKER__MIN_QUERY_TOKENS=4
+export OPENZIM_MCP_ML__RERANKER__FINAL_TOP_K=10
+export OPENZIM_MCP_ML__RERANKER__FIRST_CALL_TIMEOUT_SECONDS=5.0
+```
+
+(The `__` double-underscore delimits nested config sections.)
+
+## Telemetry
+
+Reranker activity flows through the existing `_track()` path with these
+event names (all use dot-separator):
+
+- `reranker_engaged` — fires when the cross-encoder actually scored
+  results (i.e., the returned candidates have `rerank_score` set).
+- `reranker_skipped.not_installed` — `[reranker]` extra absent or
+  disabled via env/config.
+- `reranker_skipped.no_results` — Xapian returned zero candidates;
+  nothing to rerank.
+- `reranker_skipped.passthrough` — the reranker ran but bypassed
+  scoring. Two causes:
+  - The skip-on-short-query gate fired (`min_query_tokens` not met)
+  - A mid-inference failure tripped the `ml_fallback` decorator, which
+    returned input candidates sliced to `top_k` (Xapian order preserved)
+
+A model-load failure (timeout, network error) logs a one-line WARNING
+to the configured logger and trips a process-wide kill switch via
+`ml_fallback` — subsequent search calls emit
+`reranker_skipped.not_installed` (because `BGEReranker.get()` returns
+None) until the process restarts.
+
+## Troubleshooting
+
+**"reranker model load failed: timeout"**
+The first-call download exceeded the configured
+`first_call_timeout_seconds` (default 5s). Run
+`openzim-mcp download-models` once to pre-stage, then the next server
+start will use the cached model.
+
+**Install fails with "no wheel for fastembed"**
+The platform isn't in the supported matrix (see above). Use the base
+install without the extra; the server still works, just without rerank.
+
+**Rerank doesn't seem to fire**
+Check the `min_query_tokens` gate (default 4 word tokens) and the
+`OPENZIM_RERANKER_DISABLE` environment variable. The
+`reranker_skipped.*` telemetry counters' relative magnitudes tell you
+which gate fired.

--- a/openzim_mcp/config.py
+++ b/openzim_mcp/config.py
@@ -17,9 +17,11 @@ __all__ = [
     "CacheConfig",
     "ContentConfig",
     "LoggingConfig",
+    "MLConfig",
     "MetaConfig",
     "OpenZimMcpConfig",
     "RateLimitConfig",
+    "RerankerConfig",
     "SearchConfig",
     "SynthesizeConfig",
 ]
@@ -134,6 +136,89 @@ class SynthesizeConfig(BaseModel):
     )
 
 
+class RerankerConfig(BaseModel):
+    """Phase D sub-D-1: cross-encoder reranker config.
+
+    Only applies when the `[reranker]` optional extra is installed.
+    All knobs respect the kill switch in `ml_fallback` — if the model
+    fails to load once, every subsequent search bypasses rerank for
+    the rest of the process."""
+
+    enabled: bool = Field(
+        default=True,
+        description=(
+            "Master kill switch. Set False (or env OPENZIM_RERANKER_DISABLE=1) "
+            "to skip rerank even when the [reranker] extra is importable."
+        ),
+    )
+    model_id: str = Field(
+        default="Xenova/bge-reranker-base-onnx",
+        description=(
+            "FastEmbed model identifier. Default targets English-first "
+            "archives. Multilingual archives can override via "
+            "OPENZIM_RERANKER_MODEL env var (e.g., jina-reranker-v3)."
+        ),
+    )
+    candidate_pool_size: int = Field(
+        default=50,
+        ge=1,
+        le=500,
+        description=(
+            "Xapian top-N to rerank. Larger pool = more recall, more "
+            "rerank cost. 50 is the sweet spot per FastEmbed benchmarks."
+        ),
+    )
+    final_top_k: int = Field(
+        default=10,
+        ge=1,
+        le=100,
+        description=(
+            "Default response cap after rerank. Caller-supplied `limit` "
+            "overrides this when smaller."
+        ),
+    )
+    max_query_length: int = Field(default=256, ge=1, le=4096)
+    max_passage_length: int = Field(default=512, ge=1, le=8192)
+    min_query_tokens: int = Field(
+        default=4,
+        ge=0,
+        le=64,
+        description=(
+            "Skip-on-short-query gate: queries with fewer than this many "
+            "word tokens bypass rerank. Single-word entity queries (e.g., "
+            "`Berlin`) already get a Xapian-score-1.0 canonical-title hit; "
+            "the cross-encoder adds cost without value there. Set 0 to "
+            "disable the gate."
+        ),
+    )
+    first_call_timeout_seconds: float = Field(
+        default=5.0,
+        ge=0.1,
+        le=120.0,
+        description=(
+            "Timeout for the first model load (covers HuggingFace download). "
+            "When exceeded, the kill switch fires and search falls back to "
+            "Xapian-only. Pre-stage with `openzim-mcp download-models` to "
+            "avoid this path."
+        ),
+    )
+    cache_dir: Path | None = Field(
+        default=None,
+        description=(
+            "Override the FastEmbed model cache directory. None → "
+            "$OPENZIM_MODEL_CACHE_DIR/fastembed, fallback "
+            "~/.cache/openzim-mcp/models/fastembed."
+        ),
+    )
+
+
+class MLConfig(BaseModel):
+    """Phase D umbrella config. Sized to today's scope (sub-D-1 only);
+    deferred sub-Ds add their sub-configs when they ship."""
+
+    reranker: RerankerConfig = Field(default_factory=RerankerConfig)
+
+
 class LoggingConfig(BaseModel):
     """Logging configuration."""
 
@@ -160,6 +245,7 @@ class OpenZimMcpConfig(BaseSettings):
     cache: CacheConfig = Field(default_factory=CacheConfig)
     content: ContentConfig = Field(default_factory=ContentConfig)
     logging: LoggingConfig = Field(default_factory=LoggingConfig)
+    ml: MLConfig = Field(default_factory=MLConfig)
     rate_limit: RateLimitConfig = Field(default_factory=RateLimitConfig)
     meta: MetaConfig = Field(default_factory=MetaConfig)
     search: SearchConfig = Field(default_factory=SearchConfig)

--- a/openzim_mcp/config.py
+++ b/openzim_mcp/config.py
@@ -152,7 +152,7 @@ class RerankerConfig(BaseModel):
         ),
     )
     model_id: str = Field(
-        default="Xenova/bge-reranker-base-onnx",
+        default="BAAI/bge-reranker-base",
         description=(
             "FastEmbed model identifier. Default targets English-first "
             "archives. Multilingual archives can override via "

--- a/openzim_mcp/main.py
+++ b/openzim_mcp/main.py
@@ -106,6 +106,15 @@ def _format_pydantic_error(exc: PydanticValidationError) -> str:
 
 def main() -> None:
     """Run the OpenZIM MCP server."""
+    # Phase D sub-D-1: subcommand-style dispatch for `openzim-mcp
+    # download-models`. Early-checks sys.argv to preserve the existing
+    # `openzim-mcp <directories>` invocation shape without restructuring
+    # the argparse subparser tree.
+    if len(sys.argv) >= 2 and sys.argv[1] == "download-models":
+        from openzim_mcp.ml.cli.download import download_models_main
+
+        sys.exit(download_models_main(argv=sys.argv[2:]))
+
     parser = _build_arg_parser()
 
     if len(sys.argv) == 1:

--- a/openzim_mcp/ml/__init__.py
+++ b/openzim_mcp/ml/__init__.py
@@ -1,0 +1,39 @@
+"""ML accelerator subsystem for openzim-mcp v2 Phase D.
+
+Three opt-in capabilities (only one shipping in sub-D-1):
+  * [reranker] — cross-encoder relevance ranker via FastEmbed
+
+Feature-detection happens here; consumers check `detect()` before
+touching any ML code. Lazy-import + lazy-load are enforced by the
+per-feature module (e.g., ml.reranker imports `fastembed` inside
+`BGEReranker.get()`, not at module level).
+"""
+
+from __future__ import annotations
+
+import functools
+import importlib.util
+from dataclasses import dataclass
+
+__all__ = ["MLFeatures", "detect"]
+
+
+@dataclass(frozen=True)
+class MLFeatures:
+    """Snapshot of which ML extras are installed in this process.
+
+    Sized to today's scope. New fields added when their sub-Ds ship —
+    no pre-commitment to deferred items (#12, #15)."""
+
+    reranker: bool
+
+
+@functools.lru_cache(maxsize=1)
+def detect() -> MLFeatures:
+    """Single source of truth for installed ML extras.
+
+    Cached per process; uses `importlib.util.find_spec` only — no
+    imports, no side effects, no model loads."""
+    return MLFeatures(
+        reranker=importlib.util.find_spec("fastembed") is not None,
+    )

--- a/openzim_mcp/ml/cli/__init__.py
+++ b/openzim_mcp/ml/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI subcommands for the ml subsystem."""

--- a/openzim_mcp/ml/cli/download.py
+++ b/openzim_mcp/ml/cli/download.py
@@ -39,8 +39,8 @@ def _build_parser() -> argparse.ArgumentParser:
         "--reranker-model-id",
         default=None,
         help=(
-            "Override the reranker model id (default: "
-            "Xenova/bge-reranker-base-onnx)."
+            f"Override the reranker model id "
+            f"(default: {RerankerConfig().model_id})."
         ),
     )
     return parser

--- a/openzim_mcp/ml/cli/download.py
+++ b/openzim_mcp/ml/cli/download.py
@@ -1,0 +1,72 @@
+"""`openzim-mcp download-models` — pre-stage ML model files.
+
+Run once after `pip install openzim-mcp[reranker]` (or any other ML
+extra) so the first MCP query doesn't hit a network call. Idempotent —
+re-running checks the cache and only fetches missing files."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from typing import List, Optional
+
+from openzim_mcp.config import RerankerConfig
+from openzim_mcp.ml import detect
+
+logger = logging.getLogger(__name__)
+
+
+def _stage_reranker(cfg: RerankerConfig) -> None:
+    """Force-load the reranker model so FastEmbed's HuggingFace cache
+    is populated. Raises on failure."""
+    from openzim_mcp.ml.reranker import _load_model
+
+    _load_model(cfg.model_id, cfg.cache_dir)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="openzim-mcp download-models",
+        description=(
+            "Pre-stage ML model files for installed extras. Run this once "
+            "after installing an extra (e.g., `pip install "
+            "openzim-mcp[reranker]`) on a machine with network access; "
+            "the MCP server can then run offline without first-call "
+            "download delays."
+        ),
+    )
+    parser.add_argument(
+        "--reranker-model-id",
+        default=None,
+        help=(
+            "Override the reranker model id (default: "
+            "Xenova/bge-reranker-base-onnx)."
+        ),
+    )
+    return parser
+
+
+def download_models_main(argv: Optional[List[str]] = None) -> int:
+    """Entry point. Returns process exit code (0 success, 1 failure)."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    features = detect()
+    if not features.reranker:
+        print(
+            "No ml extras installed. Re-run after `pip install "
+            "openzim-mcp[reranker]` to pre-stage the reranker model.",
+        )
+        return 0
+
+    print("Staging reranker model... ", end="", flush=True)
+    cfg = RerankerConfig()
+    if args.reranker_model_id:
+        cfg = cfg.model_copy(update={"model_id": args.reranker_model_id})
+    try:
+        _stage_reranker(cfg)
+        print("done.")
+        return 0
+    except Exception as exc:  # noqa: BLE001 — surface any underlying error
+        print(f"failed: {exc}")
+        return 1

--- a/openzim_mcp/ml/fallback.py
+++ b/openzim_mcp/ml/fallback.py
@@ -1,0 +1,72 @@
+"""Shared fallback decorator for ML entry points.
+
+When an ML call raises, the decorator logs a WARNING (once per feature),
+sets a per-process kill switch for that feature, and routes all future
+calls through `on_failure`. Idempotent — second failure for the same
+feature logs at DEBUG level only."""
+
+from __future__ import annotations
+
+import functools
+import logging
+from typing import Any, Callable, Set, TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+_disabled_features: Set[str] = set()
+
+
+def reset_kill_switches() -> None:
+    """Clear all kill switches. For tests only."""
+    _disabled_features.clear()
+
+
+def ml_fallback(
+    *,
+    feature: str,
+    on_failure: Callable[..., T],
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """Decorator: wrap an ML call so failure routes to a pure-Python fallback.
+
+    On the FIRST exception for `feature`:
+      * log a structured WARNING naming the feature and the underlying error,
+      * set a process-wide kill switch,
+      * return `on_failure(*args, **kwargs)`.
+
+    On SUBSEQUENT calls after the kill switch is set:
+      * `on_failure(*args, **kwargs)` is called WITHOUT entering the wrapped
+        function.
+
+    On SUBSEQUENT exceptions (if a fresh kill-switch had been cleared):
+      * log at DEBUG only to avoid log spam.
+    """
+
+    def decorator(fn: Callable[..., T]) -> Callable[..., T]:
+        @functools.wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            if feature in _disabled_features:
+                logger.debug(
+                    "ml feature %s kill-switched; routing to fallback", feature
+                )
+                return on_failure(*args, **kwargs)
+            try:
+                return fn(*args, **kwargs)
+            except Exception as exc:  # noqa: BLE001 — intentional broad catch
+                if feature in _disabled_features:
+                    logger.debug(
+                        "ml feature %s re-failure suppressed: %s", feature, exc
+                    )
+                else:
+                    logger.warning(
+                        "ml feature %s failed (%s); disabling for this process",
+                        feature,
+                        exc,
+                    )
+                    _disabled_features.add(feature)
+                return on_failure(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/openzim_mcp/ml/reranker.py
+++ b/openzim_mcp/ml/reranker.py
@@ -1,0 +1,130 @@
+"""Cross-encoder reranker (Phase D sub-D-1).
+
+Lazy singleton wrapping FastEmbed's TextCrossEncoder. The whole module
+imports cheaply (no `import fastembed` at top level); the actual library
+import lives inside `_load_model`, which only runs when the
+`[reranker]` extra is installed AND the user actually hits a rerank
+code path."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeout
+from pathlib import Path
+from typing import (  # noqa: F401 — List/Sequence/Tuple used by Task 5
+    Any,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+)
+
+from openzim_mcp.config import RerankerConfig
+from openzim_mcp.ml import detect
+from openzim_mcp.ml.fallback import ml_fallback  # noqa: F401 — used by Task 5
+
+logger = logging.getLogger(__name__)
+
+
+def _load_model(model_id: str, cache_dir: Optional[Path]) -> Any:
+    """Lazy import + load. Called inside BGEReranker.get(). Kept as a
+    module-level function so tests can mock it cleanly."""
+    from fastembed.rerank.cross_encoder import (  # type: ignore[import-not-found]
+        TextCrossEncoder,
+    )
+
+    kwargs: dict[str, Any] = {"model_name": model_id}
+    if cache_dir is not None:
+        kwargs["cache_dir"] = str(cache_dir)
+    return TextCrossEncoder(**kwargs)
+
+
+class BGEReranker:
+    """Singleton wrapper around FastEmbed's cross-encoder reranker.
+
+    Use `BGEReranker.get(config)` to fetch an instance — returns None
+    when the `[reranker]` extra is missing or the kill switch fired.
+    Subsequent calls hit the cached instance."""
+
+    _instance: Optional["BGEReranker"] = None
+    _instance_lock: threading.Lock = threading.Lock()
+
+    def __init__(self, model: Any, config: RerankerConfig) -> None:
+        self._model = model
+        self._config = config
+
+    @classmethod
+    def reset_instance(cls) -> None:
+        """For tests only."""
+        with cls._instance_lock:
+            cls._instance = None
+
+    @classmethod
+    def get(cls, config: Optional[RerankerConfig] = None) -> Optional["BGEReranker"]:
+        """Return the singleton, or None if unavailable.
+
+        The first call attempts to import FastEmbed + load the model
+        with a `first_call_timeout_seconds` wall-clock cap. On timeout
+        or failure, logs a structured WARNING and returns None for
+        every subsequent call this process makes."""
+        # 1. Extra installed?
+        if not detect().reranker:
+            return None
+        # 2. Disabled via env?
+        if os.environ.get("OPENZIM_RERANKER_DISABLE") == "1":
+            logger.debug("reranker disabled via OPENZIM_RERANKER_DISABLE=1")
+            return None
+        # 3. Disabled via config?
+        cfg = config or RerankerConfig()
+        if not cfg.enabled:
+            return None
+        # 4. Cached instance?
+        if cls._instance is not None:
+            return cls._instance
+        # 5. Load with timeout.
+        with cls._instance_lock:
+            if cls._instance is not None:
+                return cls._instance
+            try:
+                cls._instance = cls._load_with_timeout(cfg)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    (
+                        "reranker model load failed: %s. "
+                        "Falling back to Xapian-only ranking for this "
+                        "process. Run `openzim-mcp download-models` to "
+                        "pre-stage the model offline."
+                    ),
+                    exc,
+                )
+                return None
+            return cls._instance
+
+    @classmethod
+    def _load_with_timeout(cls, cfg: RerankerConfig) -> "BGEReranker":
+        timeout = cfg.first_call_timeout_seconds
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(_load_model, cfg.model_id, cfg.cache_dir)
+            try:
+                model = future.result(timeout=timeout)
+            except FuturesTimeout:
+                future.cancel()
+                raise TimeoutError(
+                    f"reranker model load exceeded {timeout}s timeout. "
+                    f"Run `openzim-mcp download-models` to pre-stage."
+                )
+        # First-load audit log: model id + library version.
+        try:
+            import fastembed  # type: ignore[import-not-found]
+
+            logger.info(
+                "reranker loaded: model_id=%s fastembed=%s",
+                cfg.model_id,
+                getattr(fastembed, "__version__", "unknown"),
+            )
+        except Exception:  # pragma: no cover — diagnostic-only path
+            pass
+        return cls(model=model, config=cfg)

--- a/openzim_mcp/ml/reranker.py
+++ b/openzim_mcp/ml/reranker.py
@@ -24,7 +24,7 @@ from typing import (
 
 from openzim_mcp.config import RerankerConfig
 from openzim_mcp.ml import detect
-from openzim_mcp.ml.fallback import ml_fallback  # noqa: F401 — used by Task 5
+from openzim_mcp.ml.fallback import ml_fallback
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +42,21 @@ def _load_model(model_id: str, cache_dir: Optional[Path]) -> Any:
     return TextCrossEncoder(**kwargs)
 
 
+def _rerank_passthrough(
+    _self: "BGEReranker",
+    query: str,
+    candidates: List[dict[str, Any]],
+    top_k: int,
+) -> List[dict[str, Any]]:
+    """Fallback for `BGEReranker.rerank` inference failures.
+
+    Returns candidates sliced to top_k without rerank_score, preserving
+    Xapian's original ordering. Matches the skip-on-short-query gate's
+    response shape so callers see identical behavior on both bypass paths.
+    """
+    return candidates[:top_k]
+
+
 class BGEReranker:
     """Singleton wrapper around FastEmbed's cross-encoder reranker.
 
@@ -51,6 +66,9 @@ class BGEReranker:
 
     _instance: Optional["BGEReranker"] = None
     _instance_lock: threading.Lock = threading.Lock()
+    _load_failed: bool = (
+        False  # Tripped on first load failure; never cleared except by reset_instance.
+    )
 
     def __init__(self, model: Any, config: RerankerConfig) -> None:
         self._model = model
@@ -61,6 +79,7 @@ class BGEReranker:
         """For tests only."""
         with cls._instance_lock:
             cls._instance = None
+            cls._load_failed = False
 
     def score_pairs(self, pairs: Sequence[Tuple[str, str]]) -> List[float]:
         """Batch-score (query, passage) pairs.
@@ -87,6 +106,10 @@ class BGEReranker:
                 scores[i] = float(s)
         return scores
 
+    @ml_fallback(
+        feature="reranker_inference",
+        on_failure=_rerank_passthrough,
+    )
     def rerank(
         self,
         query: str,
@@ -137,8 +160,10 @@ class BGEReranker:
 
         The first call attempts to import FastEmbed + load the model
         with a `first_call_timeout_seconds` wall-clock cap. On timeout
-        or failure, logs a structured WARNING and returns None for
-        every subsequent call this process makes."""
+        or failure, logs a structured WARNING, trips a per-process kill
+        switch, and returns None for every subsequent call this process
+        makes (the retry storm the spec's Risk Mitigations section
+        guarantees is prevented)."""
         # 1. Extra installed?
         if not detect().reranker:
             return None
@@ -153,10 +178,15 @@ class BGEReranker:
         # 4. Cached instance?
         if cls._instance is not None:
             return cls._instance
-        # 5. Load with timeout.
+        # 5. Kill switch tripped on a prior load failure?
+        if cls._load_failed:
+            return None
+        # 6. Load with timeout.
         with cls._instance_lock:
             if cls._instance is not None:
                 return cls._instance
+            if cls._load_failed:
+                return None
             try:
                 cls._instance = cls._load_with_timeout(cfg)
             except Exception as exc:  # noqa: BLE001
@@ -169,6 +199,7 @@ class BGEReranker:
                     ),
                     exc,
                 )
+                cls._load_failed = True
                 return None
             return cls._instance
 

--- a/openzim_mcp/ml/reranker.py
+++ b/openzim_mcp/ml/reranker.py
@@ -106,16 +106,23 @@ class BGEReranker:
     @classmethod
     def _load_with_timeout(cls, cfg: RerankerConfig) -> "BGEReranker":
         timeout = cfg.first_call_timeout_seconds
-        with ThreadPoolExecutor(max_workers=1) as pool:
+        pool = ThreadPoolExecutor(max_workers=1)
+        try:
             future = pool.submit(_load_model, cfg.model_id, cfg.cache_dir)
             try:
                 model = future.result(timeout=timeout)
             except FuturesTimeout:
+                # Don't wait for the worker — the whole point of the timeout
+                # is to bound the caller's wall-clock wait. The worker thread
+                # leaks (it'll finish eventually); pool.shutdown(wait=False)
+                # doesn't block.
                 future.cancel()
                 raise TimeoutError(
                     f"reranker model load exceeded {timeout}s timeout. "
                     f"Run `openzim-mcp download-models` to pre-stage."
                 )
+        finally:
+            pool.shutdown(wait=False)
         # First-load audit log: model id + library version.
         try:
             import fastembed  # type: ignore[import-not-found]

--- a/openzim_mcp/ml/reranker.py
+++ b/openzim_mcp/ml/reranker.py
@@ -14,7 +14,7 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeout
 from pathlib import Path
-from typing import (  # noqa: F401 — List/Sequence/Tuple used by Task 5
+from typing import (
     Any,
     List,
     Optional,
@@ -61,6 +61,75 @@ class BGEReranker:
         """For tests only."""
         with cls._instance_lock:
             cls._instance = None
+
+    def score_pairs(self, pairs: Sequence[Tuple[str, str]]) -> List[float]:
+        """Batch-score (query, passage) pairs.
+
+        Empty input → empty output. Query and passage are truncated at
+        the configured max lengths before being passed to FastEmbed."""
+        if not pairs:
+            return []
+        # Group by query so we make one rerank call per distinct query.
+        # In practice all pairs share the same query (rerank is called
+        # per search), so this collapses to a single batch.
+        by_query: dict[str, List[int]] = {}
+        truncated_passages: List[str] = []
+        for idx, (q, p) in enumerate(pairs):
+            q_trim = q[: self._config.max_query_length]
+            p_trim = p[: self._config.max_passage_length]
+            by_query.setdefault(q_trim, []).append(idx)
+            truncated_passages.append(p_trim)
+        scores: List[float] = [0.0] * len(pairs)
+        for q, idxs in by_query.items():
+            passages = [truncated_passages[i] for i in idxs]
+            batch_scores = list(self._model.rerank(q, passages))
+            for i, s in zip(idxs, batch_scores):
+                scores[i] = float(s)
+        return scores
+
+    def rerank(
+        self,
+        query: str,
+        candidates: List[dict[str, Any]],
+        top_k: int,
+    ) -> List[dict[str, Any]]:
+        """Rerank candidate envelopes against `query`, slice top_k.
+
+        Skip rules:
+          * Query has fewer than `min_query_tokens` whitespace-separated
+            tokens → return candidates unchanged (input order preserved),
+            no `rerank_score` added.
+          * Empty candidates → empty result.
+
+        On rerank, each candidate gains a `rerank_score: float` field.
+        The original `xapian_score` (if present) is preserved."""
+        if not candidates:
+            return []
+        # Skip-on-short-query gate.
+        if self._config.min_query_tokens > 0:
+            token_count = len(query.split())
+            if token_count < self._config.min_query_tokens:
+                logger.debug(
+                    "reranker skipped: query has %d tokens (min %d)",
+                    token_count,
+                    self._config.min_query_tokens,
+                )
+                return candidates[:top_k]
+        # Build pairs.
+        pairs: List[Tuple[str, str]] = []
+        for c in candidates:
+            passage = c.get("snippet") or c.get("path", "")
+            pairs.append((query, str(passage)))
+        scores = self.score_pairs(pairs)
+        # Decorate + sort.
+        decorated = list(zip(candidates, scores))
+        decorated.sort(key=lambda x: x[1], reverse=True)
+        result: List[dict[str, Any]] = []
+        for cand, score in decorated[:top_k]:
+            new_cand = dict(cand)  # shallow copy preserves original envelope
+            new_cand["rerank_score"] = float(score)
+            result.append(new_cand)
+        return result
 
     @classmethod
     def get(cls, config: Optional[RerankerConfig] = None) -> Optional["BGEReranker"]:

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -3319,6 +3319,35 @@ class SimpleToolsHandler:
                         search_query,
                     ),
                 )
+            # Phase D sub-D-1: cross-encoder rerank if available.
+            from openzim_mcp.ml.reranker import BGEReranker
+
+            reranker = BGEReranker.get(self.zim_operations.config.ml.reranker)
+            if reranker is not None:
+                candidates = payload.get("results", [])
+                if candidates:
+                    reranker_cfg = self.zim_operations.config.ml.reranker
+                    effective_top_k = (
+                        min(limit, reranker_cfg.final_top_k)
+                        if limit is not None
+                        else reranker_cfg.final_top_k
+                    )
+                    payload = cast(
+                        SearchResponse,
+                        {
+                            **cast(Dict[str, Any], payload),
+                            "results": reranker.rerank(
+                                query=search_query,
+                                candidates=candidates,
+                                top_k=effective_top_k,
+                            ),
+                        },
+                    )
+                    self._track("reranker_engaged")
+                else:
+                    self._track("reranker_skipped:no_results")
+            else:
+                self._track("reranker_skipped:not_installed")
             # Non-empty results: render via the legacy text formatter so the
             # markdown shape is identical to the non-compact path.
             return self.zim_operations._format_search_text(payload)

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -4487,6 +4487,40 @@ class SimpleToolsHandler:
         )
         return "\n".join(lines)
 
+    @staticmethod
+    def _flatten_archive_hits(
+        per_file: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Flatten per-archive hits into a single tagged list for global rerank."""
+        tagged: List[Dict[str, Any]] = []
+        for entry_idx, entry in enumerate(per_file):
+            if entry.get("error") or not isinstance(entry.get("result"), dict):
+                continue
+            for hit in entry["result"].get("results") or []:
+                tagged.append({**hit, "_rerank_src_idx": entry_idx})
+        return tagged
+
+    @staticmethod
+    def _redistribute_reranked_hits(
+        per_file: List[Dict[str, Any]],
+        reranked_tagged: List[Dict[str, Any]],
+    ) -> None:
+        """Group reranked tagged hits back into per-archive buckets in place.
+
+        Strips the ``_rerank_src_idx`` tag and updates each entry's ``results``
+        + ``has_hits`` fields. Mutates ``per_file``."""
+        grouped: Dict[int, List[Dict[str, Any]]] = {}
+        for hit in reranked_tagged:
+            src_idx = hit.get("_rerank_src_idx", -1)
+            clean = {k: v for k, v in hit.items() if k != "_rerank_src_idx"}
+            grouped.setdefault(src_idx, []).append(clean)
+        for entry_idx, entry in enumerate(per_file):
+            if entry.get("error") or not isinstance(entry.get("result"), dict):
+                continue
+            new_hits = grouped.get(entry_idx, [])
+            entry["result"] = {**entry["result"], "results": new_hits}
+            entry["has_hits"] = bool(new_hits)
+
     def _maybe_rerank_search_all(
         self,
         *,
@@ -4506,13 +4540,7 @@ class SimpleToolsHandler:
 
         reranker_cfg = self.zim_operations.config.ml.reranker
         reranker = BGEReranker.get(reranker_cfg)
-
-        # Build a flat list of tagged candidates from non-error archives.
-        tagged_hits: List[Dict[str, Any]] = []
-        for entry_idx, entry in enumerate(per_file):
-            if not entry.get("error") and isinstance(entry.get("result"), dict):
-                for hit in entry["result"].get("results") or []:
-                    tagged_hits.append({**hit, "_rerank_src_idx": entry_idx})
+        tagged_hits = self._flatten_archive_hits(per_file)
 
         if reranker is None:
             self._track(_RERANKER_SKIPPED_NOT_INSTALLED)
@@ -4526,23 +4554,9 @@ class SimpleToolsHandler:
             candidates=tagged_hits,
             top_k=reranker_cfg.final_top_k,
         )
-        # Group reranked hits back by source archive, stripping the
-        # temporary ``_rerank_src_idx`` tag from each result dict.
-        grouped: Dict[int, List[Dict[str, Any]]] = {}
-        for hit in reranked_tagged:
-            src_idx = hit.get("_rerank_src_idx", -1)
-            clean = {k: v for k, v in hit.items() if k != "_rerank_src_idx"}
-            grouped.setdefault(src_idx, []).append(clean)
-        # Rebuild each archive entry's results in the reranked order.
-        for entry_idx, entry in enumerate(per_file):
-            if not entry.get("error") and isinstance(entry.get("result"), dict):
-                new_hits = grouped.get(entry_idx, [])
-                entry["result"] = {**entry["result"], "results": new_hits}
-                entry["has_hits"] = bool(new_hits)
-        if reranked_tagged and "rerank_score" in reranked_tagged[0]:
-            self._track(_RERANKER_ENGAGED)
-        else:
-            self._track(_RERANKER_SKIPPED_PASSTHROUGH)
+        self._redistribute_reranked_hits(per_file, reranked_tagged)
+        scored = bool(reranked_tagged and "rerank_score" in reranked_tagged[0])
+        self._track(_RERANKER_ENGAGED if scored else _RERANKER_SKIPPED_PASSTHROUGH)
         return per_file
 
     def _handle_search_all(

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -32,7 +32,12 @@ from .title_promotion import (
     iter_query_tails,
     iter_query_windows,
 )
-from .tool_schemas import SearchResponse, SynthesizeResponse
+from .tool_schemas import (
+    SearchAllResponse,
+    SearchResponse,
+    SearchWithFiltersResponse,
+    SynthesizeResponse,
+)
 from .zim_operations import ZimOperations
 
 logger = logging.getLogger(__name__)
@@ -3182,6 +3187,58 @@ class SimpleToolsHandler:
         tool_mismatch = self._cursor_tool_mismatch(options, "search_with_filters")
         if tool_mismatch is not None:
             return tool_mismatch
+        search_query = params.get("query", query)
+        limit = options.get("limit")
+        offset = options.get("offset", 0)
+        if options.get("compact", False):
+            # Phase D sub-D-1: compact path gives us a structured payload
+            # to rerank before rendering. The canonical-title-match splice
+            # lives in ``search_with_filters_with_canonical_splice`` (legacy
+            # path); compact mode skips it and lets the reranker handle
+            # ordering — consistent with how _handle_search treats its
+            # compact vs. legacy paths.
+            payload = self.zim_operations.search_with_filters_data(
+                zim_file_path,
+                search_query,
+                params.get("namespace"),
+                params.get("content_type"),
+                limit,
+                offset,
+            )
+            from openzim_mcp.ml.reranker import BGEReranker
+
+            reranker_cfg = self.zim_operations.config.ml.reranker
+            reranker = BGEReranker.get(reranker_cfg)
+            candidates = payload.get("results", [])
+
+            if reranker is None:
+                self._track("reranker_skipped.not_installed")
+            elif not candidates:
+                self._track("reranker_skipped.no_results")
+            else:
+                if limit is not None and limit > 0:
+                    effective_top_k = min(limit, reranker_cfg.final_top_k)
+                else:
+                    effective_top_k = reranker_cfg.final_top_k
+                reranked = reranker.rerank(
+                    query=search_query,
+                    candidates=candidates,
+                    top_k=effective_top_k,
+                )
+                payload = cast(
+                    SearchWithFiltersResponse,
+                    {**cast(Dict[str, Any], payload), "results": reranked},
+                )
+                if reranked and "rerank_score" in reranked[0]:
+                    self._track("reranker_engaged")
+                else:
+                    self._track("reranker_skipped.passthrough")
+            # SearchWithFiltersResponse has the same core keys as SearchResponse
+            # (query, total, page_info, results, done, next_cursor) so the
+            # text formatter accepts it structurally.
+            return self.zim_operations._format_search_text(
+                cast(SearchResponse, cast(Dict[str, Any], payload))
+            )
         # A11 post-a11 H2: route to the canonical-title-match-aware
         # variant so ``search for berlin in namespace C`` surfaces
         # the canonical ``Berlin`` article instead of dropping it
@@ -3189,11 +3246,11 @@ class SimpleToolsHandler:
         # offset=0 — see the wrapper for paging-stability rationale.
         return self.zim_operations.search_with_filters_with_canonical_splice(
             zim_file_path,
-            params.get("query", query),
+            search_query,
             params.get("namespace"),
             params.get("content_type"),
-            options.get("limit"),
-            options.get("offset", 0),
+            limit,
+            offset,
         )
 
     def _handle_get_article(
@@ -4436,6 +4493,63 @@ class SimpleToolsHandler:
                 actual_query,
                 limit_per_file=options.get("limit", 5),
             )
+            # Phase D sub-D-1: cross-encoder rerank across all archives.
+            # Hits are flattened into a single candidate list (tagged with
+            # their source archive index so they can be redistributed after
+            # reranking), reranked globally so the best hits win regardless
+            # of which archive they come from, then grouped back into the
+            # per-archive structure that ``render_search_all`` expects.
+            from openzim_mcp.ml.reranker import BGEReranker
+
+            reranker_cfg = self.zim_operations.config.ml.reranker
+            reranker = BGEReranker.get(reranker_cfg)
+            per_file: List[Dict[str, Any]] = [
+                cast(Dict[str, Any], e) for e in (data.get("results") or [])
+            ]
+
+            # Build a flat list of tagged candidates from non-error archives.
+            tagged_hits: List[Dict[str, Any]] = []
+            for entry_idx, entry in enumerate(per_file):
+                if not entry.get("error") and isinstance(entry.get("result"), dict):
+                    for hit in entry["result"].get("results") or []:
+                        tagged_hits.append({**hit, "_rerank_src_idx": entry_idx})
+
+            if reranker is None:
+                self._track("reranker_skipped.not_installed")
+            elif not tagged_hits:
+                self._track("reranker_skipped.no_results")
+            else:
+                effective_top_k = reranker_cfg.final_top_k
+                reranked_tagged = reranker.rerank(
+                    query=actual_query,
+                    candidates=tagged_hits,
+                    top_k=effective_top_k,
+                )
+                # Group reranked hits back by source archive, stripping the
+                # temporary ``_rerank_src_idx`` tag from each result dict.
+                grouped: Dict[int, List[Dict[str, Any]]] = {}
+                for hit in reranked_tagged:
+                    src_idx = hit.get("_rerank_src_idx", -1)
+                    clean = {k: v for k, v in hit.items() if k != "_rerank_src_idx"}
+                    grouped.setdefault(src_idx, []).append(clean)
+                # Rebuild each archive entry's results in the reranked order.
+                for entry_idx, entry in enumerate(per_file):
+                    if not entry.get("error") and isinstance(entry.get("result"), dict):
+                        new_hits = grouped.get(entry_idx, [])
+                        entry["result"] = {
+                            **entry["result"],
+                            "results": new_hits,
+                        }
+                        entry["has_hits"] = bool(new_hits)
+                if reranked_tagged and "rerank_score" in reranked_tagged[0]:
+                    self._track("reranker_engaged")
+                else:
+                    self._track("reranker_skipped.passthrough")
+
+            data = cast(
+                SearchAllResponse,
+                {**cast(Dict[str, Any], data), "results": per_file},
+            )
             body = compact_renderers.render_search_all(data, actual_query)
             # H10: surface the aggregate ``reason`` / ``suggestions`` from
             # _meta so the footer renders structured recovery hints in
@@ -4449,7 +4563,6 @@ class SimpleToolsHandler:
             # All-archives-failed signal (Op4): if every per-file entry
             # carries an error, flag with ``archive_unavailable`` so the
             # caller knows the issue is structural, not query-shape.
-            per_file = data.get("results") or []
             if per_file and all(
                 isinstance(e, dict) and e.get("error") for e in per_file
             ):

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -4994,6 +4994,12 @@ class SimpleToolsHandler:
                 cache=self.zim_operations.cache,
                 content_processor=self.zim_operations.content_processor,
                 config=self.zim_operations.config.synthesize,
+                # Phase D sub-D-1: pass the reranker config so the
+                # synthesize pipeline can rerank passage candidates
+                # before section attribution. Passage ordering pays
+                # off most here — this is the deepest content-
+                # fragment-query surface.
+                reranker_config=self.zim_operations.config.ml.reranker,
                 # The original natural-language query goes in the
                 # response so callers can correlate the synthesized
                 # answer with what they actually asked. Without this,

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -35,7 +35,6 @@ from .title_promotion import (
 from .tool_schemas import (
     SearchAllResponse,
     SearchResponse,
-    SearchWithFiltersResponse,
     SynthesizeResponse,
 )
 from .zim_operations import ZimOperations
@@ -92,6 +91,12 @@ _SUBJECT_HINT_TO_SECTION: Dict[str, "tuple[str, ...]"] = {
 # elsewhere in the residual ("famous musicians from X" → trigger on
 # ``musicians``) but shouldn't fire on their own.
 _WEAK_SUBJECT_HINTS: "frozenset[str]" = frozenset({"famous", "notable"})
+
+# Phase D sub-D-1 reranker telemetry events.
+_RERANKER_ENGAGED = "reranker_engaged"
+_RERANKER_SKIPPED_NOT_INSTALLED = "reranker_skipped.not_installed"
+_RERANKER_SKIPPED_NO_RESULTS = "reranker_skipped.no_results"
+_RERANKER_SKIPPED_PASSTHROUGH = "reranker_skipped.passthrough"
 
 
 @dataclass
@@ -3146,6 +3151,53 @@ class SimpleToolsHandler:
             zim_file_path, partial_query, options.get("limit", 10)
         )
 
+    def _maybe_rerank_compact(
+        self,
+        *,
+        payload: Dict[str, Any],
+        query: str,
+        limit: Optional[int],
+        results_key: str = "results",
+    ) -> Dict[str, Any]:
+        """Apply cross-encoder rerank to a compact-mode search payload.
+
+        Reads ``payload[results_key]`` as the candidate list, reranks via
+        ``BGEReranker.get()``, emits telemetry, and returns the payload with
+        the reranked results. No-op when the [reranker] extra is absent
+        or the result list is empty.
+
+        Returns the payload (possibly the same dict, with results swapped).
+        """
+        from openzim_mcp.ml.reranker import BGEReranker
+
+        reranker_cfg = self.zim_operations.config.ml.reranker
+        reranker = BGEReranker.get(reranker_cfg)
+        candidates = payload.get(results_key, [])
+
+        if reranker is None:
+            self._track(_RERANKER_SKIPPED_NOT_INSTALLED)
+            return payload
+        if not candidates:
+            self._track(_RERANKER_SKIPPED_NO_RESULTS)
+            return payload
+
+        if limit is not None and limit > 0:
+            effective_top_k = min(limit, reranker_cfg.final_top_k)
+        else:
+            effective_top_k = reranker_cfg.final_top_k
+
+        reranked = reranker.rerank(
+            query=query,
+            candidates=candidates,
+            top_k=effective_top_k,
+        )
+        payload = {**payload, results_key: reranked}
+        if reranked and "rerank_score" in reranked[0]:
+            self._track(_RERANKER_ENGAGED)
+        else:
+            self._track(_RERANKER_SKIPPED_PASSTHROUGH)
+        return payload
+
     def _handle_filtered_search(
         self,
         query: str,
@@ -3197,47 +3249,25 @@ class SimpleToolsHandler:
             # path); compact mode skips it and lets the reranker handle
             # ordering — consistent with how _handle_search treats its
             # compact vs. legacy paths.
-            payload = self.zim_operations.search_with_filters_data(
-                zim_file_path,
-                search_query,
-                params.get("namespace"),
-                params.get("content_type"),
-                limit,
-                offset,
+            payload: Dict[str, Any] = cast(
+                Dict[str, Any],
+                self.zim_operations.search_with_filters_data(
+                    zim_file_path,
+                    search_query,
+                    params.get("namespace"),
+                    params.get("content_type"),
+                    limit,
+                    offset,
+                ),
             )
-            from openzim_mcp.ml.reranker import BGEReranker
-
-            reranker_cfg = self.zim_operations.config.ml.reranker
-            reranker = BGEReranker.get(reranker_cfg)
-            candidates = payload.get("results", [])
-
-            if reranker is None:
-                self._track("reranker_skipped.not_installed")
-            elif not candidates:
-                self._track("reranker_skipped.no_results")
-            else:
-                if limit is not None and limit > 0:
-                    effective_top_k = min(limit, reranker_cfg.final_top_k)
-                else:
-                    effective_top_k = reranker_cfg.final_top_k
-                reranked = reranker.rerank(
-                    query=search_query,
-                    candidates=candidates,
-                    top_k=effective_top_k,
-                )
-                payload = cast(
-                    SearchWithFiltersResponse,
-                    {**cast(Dict[str, Any], payload), "results": reranked},
-                )
-                if reranked and "rerank_score" in reranked[0]:
-                    self._track("reranker_engaged")
-                else:
-                    self._track("reranker_skipped.passthrough")
+            payload = self._maybe_rerank_compact(
+                payload=payload, query=search_query, limit=limit
+            )
             # SearchWithFiltersResponse has the same core keys as SearchResponse
             # (query, total, page_info, results, done, next_cursor) so the
             # text formatter accepts it structurally.
             return self.zim_operations._format_search_text(
-                cast(SearchResponse, cast(Dict[str, Any], payload))
+                cast(SearchResponse, payload)
             )
         # A11 post-a11 H2: route to the canonical-title-match-aware
         # variant so ``search for berlin in namespace C`` surfaces
@@ -3377,34 +3407,14 @@ class SimpleToolsHandler:
                     ),
                 )
             # Phase D sub-D-1: cross-encoder rerank if available.
-            from openzim_mcp.ml.reranker import BGEReranker
-
-            reranker_cfg = self.zim_operations.config.ml.reranker
-            reranker = BGEReranker.get(reranker_cfg)
-            candidates = payload.get("results", [])
-
-            if reranker is None:
-                self._track("reranker_skipped.not_installed")
-            elif not candidates:
-                self._track("reranker_skipped.no_results")
-            else:
-                if limit is not None and limit > 0:
-                    effective_top_k = min(limit, reranker_cfg.final_top_k)
-                else:
-                    effective_top_k = reranker_cfg.final_top_k
-                reranked = reranker.rerank(
+            payload = cast(
+                SearchResponse,
+                self._maybe_rerank_compact(
+                    payload=cast(Dict[str, Any], payload),
                     query=search_query,
-                    candidates=candidates,
-                    top_k=effective_top_k,
-                )
-                payload = cast(
-                    SearchResponse,
-                    {**cast(Dict[str, Any], payload), "results": reranked},
-                )
-                if reranked and "rerank_score" in reranked[0]:
-                    self._track("reranker_engaged")
-                else:
-                    self._track("reranker_skipped.passthrough")
+                    limit=limit,
+                ),
+            )
             # Non-empty results: render via the legacy text formatter so the
             # markdown shape is identical to the non-compact path.
             return self.zim_operations._format_search_text(payload)
@@ -4477,6 +4487,64 @@ class SimpleToolsHandler:
         )
         return "\n".join(lines)
 
+    def _maybe_rerank_search_all(
+        self,
+        *,
+        per_file: List[Dict[str, Any]],
+        query: str,
+    ) -> List[Dict[str, Any]]:
+        """Cross-archive rerank for _handle_search_all.
+
+        Flattens hits from all non-error archives into a single candidate list
+        (tagged with ``_rerank_src_idx`` to track origin), reranks globally,
+        then redistributes back to per-archive buckets in the reranked order.
+
+        Mutates ``per_file`` entries in place and returns the list.
+        No-op when the [reranker] extra is absent or there are no candidates.
+        """
+        from openzim_mcp.ml.reranker import BGEReranker
+
+        reranker_cfg = self.zim_operations.config.ml.reranker
+        reranker = BGEReranker.get(reranker_cfg)
+
+        # Build a flat list of tagged candidates from non-error archives.
+        tagged_hits: List[Dict[str, Any]] = []
+        for entry_idx, entry in enumerate(per_file):
+            if not entry.get("error") and isinstance(entry.get("result"), dict):
+                for hit in entry["result"].get("results") or []:
+                    tagged_hits.append({**hit, "_rerank_src_idx": entry_idx})
+
+        if reranker is None:
+            self._track(_RERANKER_SKIPPED_NOT_INSTALLED)
+            return per_file
+        if not tagged_hits:
+            self._track(_RERANKER_SKIPPED_NO_RESULTS)
+            return per_file
+
+        reranked_tagged = reranker.rerank(
+            query=query,
+            candidates=tagged_hits,
+            top_k=reranker_cfg.final_top_k,
+        )
+        # Group reranked hits back by source archive, stripping the
+        # temporary ``_rerank_src_idx`` tag from each result dict.
+        grouped: Dict[int, List[Dict[str, Any]]] = {}
+        for hit in reranked_tagged:
+            src_idx = hit.get("_rerank_src_idx", -1)
+            clean = {k: v for k, v in hit.items() if k != "_rerank_src_idx"}
+            grouped.setdefault(src_idx, []).append(clean)
+        # Rebuild each archive entry's results in the reranked order.
+        for entry_idx, entry in enumerate(per_file):
+            if not entry.get("error") and isinstance(entry.get("result"), dict):
+                new_hits = grouped.get(entry_idx, [])
+                entry["result"] = {**entry["result"], "results": new_hits}
+                entry["has_hits"] = bool(new_hits)
+        if reranked_tagged and "rerank_score" in reranked_tagged[0]:
+            self._track(_RERANKER_ENGAGED)
+        else:
+            self._track(_RERANKER_SKIPPED_PASSTHROUGH)
+        return per_file
+
     def _handle_search_all(
         self,
         query: str,
@@ -4499,52 +4567,12 @@ class SimpleToolsHandler:
             # reranking), reranked globally so the best hits win regardless
             # of which archive they come from, then grouped back into the
             # per-archive structure that ``render_search_all`` expects.
-            from openzim_mcp.ml.reranker import BGEReranker
-
-            reranker_cfg = self.zim_operations.config.ml.reranker
-            reranker = BGEReranker.get(reranker_cfg)
             per_file: List[Dict[str, Any]] = [
                 cast(Dict[str, Any], e) for e in (data.get("results") or [])
             ]
-
-            # Build a flat list of tagged candidates from non-error archives.
-            tagged_hits: List[Dict[str, Any]] = []
-            for entry_idx, entry in enumerate(per_file):
-                if not entry.get("error") and isinstance(entry.get("result"), dict):
-                    for hit in entry["result"].get("results") or []:
-                        tagged_hits.append({**hit, "_rerank_src_idx": entry_idx})
-
-            if reranker is None:
-                self._track("reranker_skipped.not_installed")
-            elif not tagged_hits:
-                self._track("reranker_skipped.no_results")
-            else:
-                effective_top_k = reranker_cfg.final_top_k
-                reranked_tagged = reranker.rerank(
-                    query=actual_query,
-                    candidates=tagged_hits,
-                    top_k=effective_top_k,
-                )
-                # Group reranked hits back by source archive, stripping the
-                # temporary ``_rerank_src_idx`` tag from each result dict.
-                grouped: Dict[int, List[Dict[str, Any]]] = {}
-                for hit in reranked_tagged:
-                    src_idx = hit.get("_rerank_src_idx", -1)
-                    clean = {k: v for k, v in hit.items() if k != "_rerank_src_idx"}
-                    grouped.setdefault(src_idx, []).append(clean)
-                # Rebuild each archive entry's results in the reranked order.
-                for entry_idx, entry in enumerate(per_file):
-                    if not entry.get("error") and isinstance(entry.get("result"), dict):
-                        new_hits = grouped.get(entry_idx, [])
-                        entry["result"] = {
-                            **entry["result"],
-                            "results": new_hits,
-                        }
-                        entry["has_hits"] = bool(new_hits)
-                if reranked_tagged and "rerank_score" in reranked_tagged[0]:
-                    self._track("reranker_engaged")
-                else:
-                    self._track("reranker_skipped.passthrough")
+            per_file = self._maybe_rerank_search_all(
+                per_file=per_file, query=actual_query
+            )
 
             data = cast(
                 SearchAllResponse,

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -3322,32 +3322,32 @@ class SimpleToolsHandler:
             # Phase D sub-D-1: cross-encoder rerank if available.
             from openzim_mcp.ml.reranker import BGEReranker
 
-            reranker = BGEReranker.get(self.zim_operations.config.ml.reranker)
-            if reranker is not None:
-                candidates = payload.get("results", [])
-                if candidates:
-                    reranker_cfg = self.zim_operations.config.ml.reranker
-                    effective_top_k = (
-                        min(limit, reranker_cfg.final_top_k)
-                        if limit is not None
-                        else reranker_cfg.final_top_k
-                    )
-                    payload = cast(
-                        SearchResponse,
-                        {
-                            **cast(Dict[str, Any], payload),
-                            "results": reranker.rerank(
-                                query=search_query,
-                                candidates=candidates,
-                                top_k=effective_top_k,
-                            ),
-                        },
-                    )
+            reranker_cfg = self.zim_operations.config.ml.reranker
+            reranker = BGEReranker.get(reranker_cfg)
+            candidates = payload.get("results", [])
+
+            if reranker is None:
+                self._track("reranker_skipped.not_installed")
+            elif not candidates:
+                self._track("reranker_skipped.no_results")
+            else:
+                if limit is not None and limit > 0:
+                    effective_top_k = min(limit, reranker_cfg.final_top_k)
+                else:
+                    effective_top_k = reranker_cfg.final_top_k
+                reranked = reranker.rerank(
+                    query=search_query,
+                    candidates=candidates,
+                    top_k=effective_top_k,
+                )
+                payload = cast(
+                    SearchResponse,
+                    {**cast(Dict[str, Any], payload), "results": reranked},
+                )
+                if reranked and "rerank_score" in reranked[0]:
                     self._track("reranker_engaged")
                 else:
-                    self._track("reranker_skipped:no_results")
-            else:
-                self._track("reranker_skipped:not_installed")
+                    self._track("reranker_skipped.passthrough")
             # Non-empty results: render via the legacy text formatter so the
             # markdown shape is identical to the non-compact path.
             return self.zim_operations._format_search_text(payload)

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from libzim.reader import Archive  # type: ignore[import-untyped]
 
     from openzim_mcp.cache import OpenZimMcpCache
-    from openzim_mcp.config import SynthesizeConfig
+    from openzim_mcp.config import RerankerConfig, SynthesizeConfig
     from openzim_mcp.content_processor import ContentProcessor
 
 from openzim_mcp import bundle as _bundle_mod
@@ -1273,6 +1273,7 @@ def synthesize_query(
     cache: OpenZimMcpCache,
     content_processor: ContentProcessor,
     config: SynthesizeConfig,
+    reranker_config: "Optional[RerankerConfig]" = None,
     original_query: Optional[str] = None,
     strip_links: bool = False,
     omit_passage_text: bool = False,
@@ -1296,6 +1297,11 @@ def synthesize_query(
     ``answer_markdown``) and keeps only the lightweight metadata
     (``cite_id``, ``rank``, ``score``). Cuts the response by ~50%
     on a typical 5-passage synthesize call.
+
+    ``reranker_config`` (sub-D-1): when supplied, the cross-encoder
+    reranker is consulted after passage extraction and before section
+    attribution. If the reranker extra is absent or disabled the
+    parameter has no effect.
     """
     per_archive_hits, archives_searched, archive_by_name = _do_per_archive_search(
         archives,
@@ -1356,6 +1362,83 @@ def synthesize_query(
         top_hits = _demote_list_articles(promoted)
 
     all_passages, hit_keys = _extract_passages_for_top_hits(top_hits)
+
+    # Phase D sub-D-1: rerank passage candidates before section attribution.
+    # Synthesize is the primary content-fragment-query surface; reranking
+    # here re-orders passages by semantic relevance before the attribution
+    # and budget-enforcement stages commit to a final ordering.
+    #
+    # Telemetry: synthesize.py has no _track() plumbing (it's a standalone
+    # module, not a handler class). Log at DEBUG only; operators can
+    # correlate via log context. Events mirror the simple_tools names
+    # (reranker_engaged / reranker_skipped.*) in the log message.
+    if reranker_config is not None:
+        from openzim_mcp.ml.reranker import BGEReranker
+
+        reranker = BGEReranker.get(reranker_config)
+        if reranker is None:
+            logger.debug("synthesize: reranker_skipped.not_installed")
+        elif not all_passages:
+            logger.debug("synthesize: reranker_skipped.no_results")
+        else:
+            # Build path→passage index for round-trip mapping. cite_id
+            # is "archive_name/entry_path"; use it as the envelope path
+            # key (unique per passage within this pipeline run).
+            envelopes = [
+                {
+                    "path": p["cite_id"],
+                    "snippet": p["text_markdown"][: reranker_config.max_passage_length],
+                    "xapian_score": float(p.get("score", 0.0)),
+                }
+                for p in all_passages
+            ]
+            # Rerank ALL passages (top_k = len); top-K trim happens later
+            # via _enforce_budget after deduplication/attribution steps.
+            reranked_envelopes = reranker.rerank(
+                query=query,
+                candidates=envelopes,
+                top_k=len(all_passages),
+            )
+            if reranked_envelopes and "rerank_score" in reranked_envelopes[0]:
+                # Build a lookup from cite_id → rerank_score for sorting.
+                score_by_cite_id = {
+                    e["path"]: e["rerank_score"] for e in reranked_envelopes
+                }
+                # Preserve only passages that survived the reranker
+                # (in case of dedup inside rerank); sort descending.
+                all_passages = [
+                    p for p in all_passages if p["cite_id"] in score_by_cite_id
+                ]
+                all_passages.sort(
+                    key=lambda p: score_by_cite_id[p["cite_id"]],
+                    reverse=True,
+                )
+                # Propagate rerank_score into the passage's score field so
+                # the downstream _boost_by_section_affinity sort (which
+                # uses p["score"]) preserves the rerank ordering rather
+                # than reverting to Xapian BM25 scores.
+                for p in all_passages:
+                    p["score"] = score_by_cite_id[p["cite_id"]]
+                # Re-number ranks to reflect new ordering.
+                for i, p in enumerate(all_passages, start=1):
+                    p["rank"] = i
+                logger.debug(
+                    "synthesize: reranker_engaged — reranked %d passages for query %r",
+                    len(all_passages),
+                    query,
+                )
+                # Also re-order hit_keys to stay parallel with all_passages.
+                cite_id_to_hit_key = {
+                    f"{archive_name}/{hit['path']}": (archive_name, hit["path"])
+                    for archive_name, hit in top_hits
+                }
+                hit_keys = [
+                    cite_id_to_hit_key.get(p["cite_id"], ("", "")) for p in all_passages
+                ]
+            else:
+                # Short query or inference failure — passthrough.
+                logger.debug("synthesize: reranker_skipped.passthrough")
+
     if strip_links:
         all_passages = [_strip_links_in_passage(p) for p in all_passages]
     bundle_lookup = _make_bundle_lookup(

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -1265,6 +1265,98 @@ def _zero_hits_response(
     )
 
 
+def _maybe_rerank_synthesize_passages(
+    all_passages: list[SynthesizePassage],
+    hit_keys: list[tuple[str, str]],
+    *,
+    query: str,
+    top_hits: list[tuple[str, dict[str, Any]]],
+    reranker_config: "Optional[RerankerConfig]",
+) -> tuple[list[SynthesizePassage], list[tuple[str, str]]]:
+    """Apply cross-encoder rerank to synthesize passage candidates.
+
+    Wraps ``BGEReranker.get()`` and returns ``(reranked_passages,
+    parallel_hit_keys)``.  When the [reranker] extra is absent, disabled,
+    or ``reranker_config`` is ``None``, returns the inputs unchanged.
+    """
+    if reranker_config is None:
+        return all_passages, hit_keys
+
+    from openzim_mcp.ml.reranker import BGEReranker
+
+    reranker = BGEReranker.get(reranker_config)
+    if reranker is None:
+        logger.debug("synthesize: reranker_skipped.not_installed")
+        return all_passages, hit_keys
+    if not all_passages:
+        logger.debug("synthesize: reranker_skipped.no_results")
+        return all_passages, hit_keys
+
+    # Build path→passage index for round-trip mapping. cite_id
+    # is "archive_name/entry_path"; use it as the envelope path
+    # key (unique per passage within this pipeline run).
+    envelopes = [
+        {
+            "path": p["cite_id"],
+            "snippet": p["text_markdown"][: reranker_config.max_passage_length],
+            "xapian_score": float(p.get("score", 0.0)),
+        }
+        for p in all_passages
+    ]
+    # Rerank ALL passages (top_k = len); top-K trim happens later
+    # via _enforce_budget after deduplication/attribution steps.
+    reranked_envelopes = reranker.rerank(
+        query=query,
+        candidates=envelopes,
+        top_k=len(all_passages),
+    )
+    if not (reranked_envelopes and "rerank_score" in reranked_envelopes[0]):
+        # Short query or inference failure — passthrough.
+        logger.debug("synthesize: reranker_skipped.passthrough")
+        return all_passages, hit_keys
+
+    # Build a lookup from cite_id → rerank_score for sorting.
+    score_by_cite_id = {e["path"]: e["rerank_score"] for e in reranked_envelopes}
+    # Preserve only passages that survived the reranker
+    # (in case of dedup inside rerank); sort descending.
+    all_passages = [p for p in all_passages if p["cite_id"] in score_by_cite_id]
+    all_passages.sort(
+        key=lambda p: score_by_cite_id[p["cite_id"]],
+        reverse=True,
+    )
+    # Propagate rerank_score into the passage's score field so
+    # the downstream _boost_by_section_affinity sort (which
+    # uses p["score"]) preserves the rerank ordering rather
+    # than reverting to Xapian BM25 scores.
+    for p in all_passages:
+        p["score"] = score_by_cite_id[p["cite_id"]]
+    # Re-number ranks to reflect new ordering.
+    for i, p in enumerate(all_passages, start=1):
+        p["rank"] = i
+    logger.debug(
+        "synthesize: reranker_engaged — reranked %d passages for query %r",
+        len(all_passages),
+        query,
+    )
+    # Also re-order hit_keys to stay parallel with all_passages.
+    cite_id_to_hit_key = {
+        f"{archive_name}/{hit['path']}": (archive_name, hit["path"])
+        for archive_name, hit in top_hits
+    }
+    new_hit_keys: list[tuple[str, str]] = []
+    for p in all_passages:
+        hit_key = cite_id_to_hit_key.get(p["cite_id"])
+        if hit_key is None:
+            logger.warning(
+                "synthesize: hit_key miss for cite_id %r; "
+                "section attribution will degrade for this passage",
+                p["cite_id"],
+            )
+            hit_key = ("", "")
+        new_hit_keys.append(hit_key)
+    return all_passages, new_hit_keys
+
+
 def synthesize_query(
     query: str,
     *,
@@ -1367,85 +1459,13 @@ def synthesize_query(
     # Synthesize is the primary content-fragment-query surface; reranking
     # here re-orders passages by semantic relevance before the attribution
     # and budget-enforcement stages commit to a final ordering.
-    #
-    # Telemetry: synthesize.py has no _track() plumbing (it's a standalone
-    # module, not a handler class). Log at DEBUG only; operators can
-    # correlate via log context. Events mirror the simple_tools names
-    # (reranker_engaged / reranker_skipped.*) in the log message.
-    if reranker_config is not None:
-        from openzim_mcp.ml.reranker import BGEReranker
-
-        reranker = BGEReranker.get(reranker_config)
-        if reranker is None:
-            logger.debug("synthesize: reranker_skipped.not_installed")
-        elif not all_passages:
-            logger.debug("synthesize: reranker_skipped.no_results")
-        else:
-            # Build path→passage index for round-trip mapping. cite_id
-            # is "archive_name/entry_path"; use it as the envelope path
-            # key (unique per passage within this pipeline run).
-            envelopes = [
-                {
-                    "path": p["cite_id"],
-                    "snippet": p["text_markdown"][: reranker_config.max_passage_length],
-                    "xapian_score": float(p.get("score", 0.0)),
-                }
-                for p in all_passages
-            ]
-            # Rerank ALL passages (top_k = len); top-K trim happens later
-            # via _enforce_budget after deduplication/attribution steps.
-            reranked_envelopes = reranker.rerank(
-                query=query,
-                candidates=envelopes,
-                top_k=len(all_passages),
-            )
-            if reranked_envelopes and "rerank_score" in reranked_envelopes[0]:
-                # Build a lookup from cite_id → rerank_score for sorting.
-                score_by_cite_id = {
-                    e["path"]: e["rerank_score"] for e in reranked_envelopes
-                }
-                # Preserve only passages that survived the reranker
-                # (in case of dedup inside rerank); sort descending.
-                all_passages = [
-                    p for p in all_passages if p["cite_id"] in score_by_cite_id
-                ]
-                all_passages.sort(
-                    key=lambda p: score_by_cite_id[p["cite_id"]],
-                    reverse=True,
-                )
-                # Propagate rerank_score into the passage's score field so
-                # the downstream _boost_by_section_affinity sort (which
-                # uses p["score"]) preserves the rerank ordering rather
-                # than reverting to Xapian BM25 scores.
-                for p in all_passages:
-                    p["score"] = score_by_cite_id[p["cite_id"]]
-                # Re-number ranks to reflect new ordering.
-                for i, p in enumerate(all_passages, start=1):
-                    p["rank"] = i
-                logger.debug(
-                    "synthesize: reranker_engaged — reranked %d passages for query %r",
-                    len(all_passages),
-                    query,
-                )
-                # Also re-order hit_keys to stay parallel with all_passages.
-                cite_id_to_hit_key = {
-                    f"{archive_name}/{hit['path']}": (archive_name, hit["path"])
-                    for archive_name, hit in top_hits
-                }
-                hit_keys = []
-                for p in all_passages:
-                    hit_key = cite_id_to_hit_key.get(p["cite_id"])
-                    if hit_key is None:
-                        logger.warning(
-                            "synthesize: hit_key miss for cite_id %r; "
-                            "section attribution will degrade for this passage",
-                            p["cite_id"],
-                        )
-                        hit_key = ("", "")
-                    hit_keys.append(hit_key)
-            else:
-                # Short query or inference failure — passthrough.
-                logger.debug("synthesize: reranker_skipped.passthrough")
+    all_passages, hit_keys = _maybe_rerank_synthesize_passages(
+        all_passages,
+        hit_keys,
+        query=query,
+        top_hits=top_hits,
+        reranker_config=reranker_config,
+    )
 
     if strip_links:
         all_passages = [_strip_links_in_passage(p) for p in all_passages]

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -1432,9 +1432,17 @@ def synthesize_query(
                     f"{archive_name}/{hit['path']}": (archive_name, hit["path"])
                     for archive_name, hit in top_hits
                 }
-                hit_keys = [
-                    cite_id_to_hit_key.get(p["cite_id"], ("", "")) for p in all_passages
-                ]
+                hit_keys = []
+                for p in all_passages:
+                    hit_key = cite_id_to_hit_key.get(p["cite_id"])
+                    if hit_key is None:
+                        logger.warning(
+                            "synthesize: hit_key miss for cite_id %r; "
+                            "section attribution will degrade for this passage",
+                            p["cite_id"],
+                        )
+                        hit_key = ("", "")
+                    hit_keys.append(hit_key)
             else:
                 # Short query or inference failure — passthrough.
                 logger.debug("synthesize: reranker_skipped.passthrough")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,14 @@ dependencies = [
     "tiktoken>=0.7.0,<1.0",
 ]
 
+[project.optional-dependencies]
+# Phase D sub-D-1: cross-encoder reranker via FastEmbed (ONNX-backed,
+# no torch dependency). Adds ~150 MB install footprint. Lazy-imported
+# inside openzim_mcp.ml.reranker; default install is unaffected.
+reranker = [
+    "fastembed>=0.4.0,<1.0",
+]
+
 [project.urls]
 Homepage = "https://github.com/cameronrye/openzim-mcp"
 Repository = "https://github.com/cameronrye/openzim-mcp.git"

--- a/tests/ml/__init__.py
+++ b/tests/ml/__init__.py
@@ -1,0 +1,2 @@
+"""ML accelerator tests. Lives in its own package to keep the
+default `make test` run unchanged when no extras are installed."""

--- a/tests/ml/conftest.py
+++ b/tests/ml/conftest.py
@@ -1,0 +1,26 @@
+"""Shared fixtures + marker registration for ml tests."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "requires_reranker: test requires the [reranker] extra to be installed",
+    )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """Skip @requires_reranker tests when fastembed is not importable."""
+    if importlib.util.find_spec("fastembed") is not None:
+        return
+    skip_marker = pytest.mark.skip(reason="requires [reranker] extra")
+    for item in items:
+        if item.get_closest_marker("requires_reranker") is not None:
+            item.add_marker(skip_marker)

--- a/tests/ml/test_download_cli.py
+++ b/tests/ml/test_download_cli.py
@@ -1,0 +1,50 @@
+"""Tests for the `openzim-mcp download-models` CLI."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openzim_mcp.ml.cli.download import download_models_main
+
+
+class TestDownloadModelsCli:
+    def test_reports_when_no_extras_installed(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with patch("openzim_mcp.ml.cli.download.detect") as mock_detect:
+            mock_detect.return_value = MagicMock(reranker=False)
+            rc = download_models_main(argv=[])
+            captured = capsys.readouterr()
+            assert rc == 0
+            assert "no ml extras installed" in captured.out.lower()
+
+    def test_downloads_reranker_when_extra_present(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch("openzim_mcp.ml.cli.download.detect") as mock_detect,
+            patch("openzim_mcp.ml.cli.download._stage_reranker") as mock_stage,
+        ):
+            mock_detect.return_value = MagicMock(reranker=True)
+            mock_stage.return_value = None  # success
+            rc = download_models_main(argv=[])
+            captured = capsys.readouterr()
+            assert rc == 0
+            assert "reranker" in captured.out.lower()
+            mock_stage.assert_called_once()
+
+    def test_returns_nonzero_on_stage_failure(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch("openzim_mcp.ml.cli.download.detect") as mock_detect,
+            patch("openzim_mcp.ml.cli.download._stage_reranker") as mock_stage,
+        ):
+            mock_detect.return_value = MagicMock(reranker=True)
+            mock_stage.side_effect = RuntimeError("network error")
+            rc = download_models_main(argv=[])
+            captured = capsys.readouterr()
+            assert rc == 1
+            assert "failed" in captured.out.lower()

--- a/tests/ml/test_fallback.py
+++ b/tests/ml/test_fallback.py
@@ -1,0 +1,89 @@
+"""Unit tests for ml_fallback decorator."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from openzim_mcp.ml.fallback import ml_fallback, reset_kill_switches
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> None:
+    """Each test starts with empty kill-switch state."""
+    reset_kill_switches()
+
+
+def _fallback(*args: Any, **kwargs: Any) -> str:
+    return "fallback"
+
+
+class TestMlFallback:
+    def test_success_path_returns_inner_result(self) -> None:
+        @ml_fallback(feature="reranker", on_failure=_fallback)
+        def inner() -> str:
+            return "inner"
+
+        assert inner() == "inner"
+
+    def test_first_exception_logs_warning_and_returns_fallback(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.WARNING)
+
+        @ml_fallback(feature="reranker", on_failure=_fallback)
+        def inner() -> str:
+            raise RuntimeError("boom")
+
+        result = inner()
+        assert result == "fallback"
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1
+        assert "reranker" in warnings[0].message.lower()
+
+    def test_subsequent_calls_after_failure_skip_inner(self) -> None:
+        call_count = 0
+
+        @ml_fallback(feature="reranker", on_failure=_fallback)
+        def inner() -> str:
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("boom")
+
+        inner()  # triggers kill switch
+        inner()  # should NOT call inner again
+        inner()
+        assert call_count == 1  # only the first call entered the wrapped function
+
+    def test_subsequent_failures_log_debug_only(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.DEBUG)
+
+        @ml_fallback(feature="reranker", on_failure=_fallback)
+        def inner() -> str:
+            raise RuntimeError("boom")
+
+        inner()  # WARNING
+        inner()  # DEBUG (kill-switch path)
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        debugs = [r for r in caplog.records if r.levelname == "DEBUG"]
+        assert len(warnings) == 1
+        assert any("reranker" in d.message.lower() for d in debugs)
+
+    def test_kill_switch_is_per_feature(self) -> None:
+        """A failure on reranker doesn't disable a hypothetical other feature."""
+
+        @ml_fallback(feature="reranker", on_failure=_fallback)
+        def reranker_inner() -> str:
+            raise RuntimeError("boom")
+
+        @ml_fallback(feature="other", on_failure=_fallback)
+        def other_inner() -> str:
+            return "other_ok"
+
+        reranker_inner()
+        assert other_inner() == "other_ok"

--- a/tests/ml/test_ml_config.py
+++ b/tests/ml/test_ml_config.py
@@ -19,7 +19,7 @@ class TestRerankerConfig:
         assert cfg.max_query_length == 256
         assert cfg.max_passage_length == 512
         assert cfg.min_query_tokens == 4
-        assert cfg.first_call_timeout_seconds == 5.0
+        assert cfg.first_call_timeout_seconds == pytest.approx(5.0)
         assert cfg.cache_dir is None
 
     def test_pool_size_bounds(self) -> None:

--- a/tests/ml/test_ml_config.py
+++ b/tests/ml/test_ml_config.py
@@ -1,0 +1,52 @@
+"""Tests for MLConfig + RerankerConfig wiring on OpenZimMcpConfig."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from openzim_mcp.config import MLConfig, OpenZimMcpConfig, RerankerConfig
+
+
+class TestRerankerConfig:
+    def test_defaults(self) -> None:
+        cfg = RerankerConfig()
+        assert cfg.enabled is True
+        assert cfg.model_id == "Xenova/bge-reranker-base-onnx"
+        assert cfg.candidate_pool_size == 50
+        assert cfg.final_top_k == 10
+        assert cfg.max_query_length == 256
+        assert cfg.max_passage_length == 512
+        assert cfg.min_query_tokens == 4
+        assert cfg.first_call_timeout_seconds == 5.0
+        assert cfg.cache_dir is None
+
+    def test_pool_size_bounds(self) -> None:
+        # Pydantic v2 validation: pool size must be positive
+        with pytest.raises(Exception):
+            RerankerConfig(candidate_pool_size=0)
+        # Reasonable upper bound prevents runaway memory
+        with pytest.raises(Exception):
+            RerankerConfig(candidate_pool_size=10000)
+
+    def test_min_query_tokens_bounds(self) -> None:
+        # 0 disables the skip gate; that's allowed.
+        RerankerConfig(min_query_tokens=0)
+        # Negative is not.
+        with pytest.raises(Exception):
+            RerankerConfig(min_query_tokens=-1)
+
+
+class TestMLConfig:
+    def test_defaults(self) -> None:
+        cfg = MLConfig()
+        assert isinstance(cfg.reranker, RerankerConfig)
+        assert cfg.reranker.enabled is True
+
+    def test_attaches_to_openzim_config(self, tmp_path: Path) -> None:
+        zim_dir = tmp_path / "zim"
+        zim_dir.mkdir()
+        cfg = OpenZimMcpConfig(allowed_directories=[str(zim_dir)])
+        assert isinstance(cfg.ml, MLConfig)
+        assert isinstance(cfg.ml.reranker, RerankerConfig)

--- a/tests/ml/test_ml_config.py
+++ b/tests/ml/test_ml_config.py
@@ -13,7 +13,7 @@ class TestRerankerConfig:
     def test_defaults(self) -> None:
         cfg = RerankerConfig()
         assert cfg.enabled is True
-        assert cfg.model_id == "Xenova/bge-reranker-base-onnx"
+        assert cfg.model_id == "BAAI/bge-reranker-base"
         assert cfg.candidate_pool_size == 50
         assert cfg.final_top_k == 10
         assert cfg.max_query_length == 256

--- a/tests/ml/test_ml_registry.py
+++ b/tests/ml/test_ml_registry.py
@@ -1,0 +1,44 @@
+"""Unit tests for openzim_mcp.ml.__init__'s feature-detection registry."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from openzim_mcp.ml import MLFeatures, detect
+
+
+class TestDetectRegistry:
+    def setup_method(self) -> None:
+        # Clear the lru_cache between tests so each test gets a fresh detect()
+        detect.cache_clear()
+
+    def test_returns_frozen_dataclass(self) -> None:
+        features = detect()
+        assert isinstance(features, MLFeatures)
+        # frozen dataclass: mutation should raise
+        with pytest.raises(Exception):
+            features.reranker = not features.reranker  # type: ignore[misc]
+
+    def test_reranker_true_when_fastembed_importable(self) -> None:
+        with patch("openzim_mcp.ml.importlib.util.find_spec") as mock_spec:
+            mock_spec.return_value = object()  # truthy: package found
+            features = detect()
+            assert features.reranker is True
+        # Verify find_spec was called with the expected argument
+        mock_spec.assert_called_with("fastembed")
+
+    def test_reranker_false_when_fastembed_missing(self) -> None:
+        with patch("openzim_mcp.ml.importlib.util.find_spec") as mock_spec:
+            mock_spec.return_value = None  # falsy: package not found
+            features = detect()
+            assert features.reranker is False
+
+    def test_detect_is_cached(self) -> None:
+        # Two calls should hit find_spec only once
+        with patch("openzim_mcp.ml.importlib.util.find_spec") as mock_spec:
+            mock_spec.return_value = object()
+            detect()
+            detect()
+            assert mock_spec.call_count == 1

--- a/tests/ml/test_reranker_live.py
+++ b/tests/ml/test_reranker_live.py
@@ -1,0 +1,89 @@
+"""End-to-end tests against the real FastEmbed reranker.
+
+These tests SKIP when the [reranker] extra is not installed. CI runs
+them in a dedicated job (see .github/workflows/test.yml). They confirm
+the FastEmbed API surface matches our wrapper and that the reranker
+actually reorders results in a predictable way.
+
+Model note: tests use Xenova/ms-marco-MiniLM-L-6-v2 (~80 MB) instead
+of the production default (BAAI/bge-reranker-base, ~1 GB) to keep
+CI download times bounded. Both use the same TextCrossEncoder API."""
+
+from __future__ import annotations
+
+import pytest
+
+from openzim_mcp.config import RerankerConfig
+from openzim_mcp.ml.fallback import reset_kill_switches
+from openzim_mcp.ml.reranker import BGEReranker
+
+# Lightweight cross-encoder available in fastembed 0.8+; verified to
+# produce correct semantic ordering for the test fixtures below.
+_TEST_MODEL = "Xenova/ms-marco-MiniLM-L-6-v2"
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> None:
+    BGEReranker.reset_instance()
+    reset_kill_switches()
+
+
+@pytest.mark.requires_reranker
+class TestRerankerIntegration:
+    def test_get_loads_model_on_first_call(self) -> None:
+        # Generous timeout for cold-cache CI runs.
+        cfg = RerankerConfig(model_id=_TEST_MODEL, first_call_timeout_seconds=120.0)
+        reranker = BGEReranker.get(cfg)
+        assert reranker is not None
+
+    def test_reranks_known_corpus_correctly(self) -> None:
+        cfg = RerankerConfig(model_id=_TEST_MODEL, first_call_timeout_seconds=120.0)
+        reranker = BGEReranker.get(cfg)
+        assert reranker is not None
+
+        # Query is content-fragment shaped — semantic relevance should
+        # win over surface keyword overlap.
+        query = "what biological pigment makes plants appear green"
+        candidates = [
+            {
+                "path": "Chlorophyll",
+                "snippet": (
+                    "Chlorophyll is the green pigment in plants that absorbs "
+                    "light for photosynthesis."
+                ),
+                "xapian_score": 0.3,  # intentionally low — Xapian misses it
+            },
+            {
+                "path": "Green",
+                "snippet": (
+                    "Green is the color between blue and yellow on the visible "
+                    "spectrum."
+                ),
+                "xapian_score": 0.9,  # Xapian's top hit (keyword overlap)
+            },
+            {
+                "path": "Plant",
+                "snippet": (
+                    "Plants are mainly multicellular eukaryotes in the kingdom "
+                    "Plantae."
+                ),
+                "xapian_score": 0.5,
+            },
+        ]
+        result = reranker.rerank(query, candidates, top_k=3)
+        # Chlorophyll should win on semantic match despite low Xapian score.
+        assert result[0]["path"] == "Chlorophyll"
+        assert all("rerank_score" in c for c in result)
+
+    def test_score_pairs_returns_one_per_pair(self) -> None:
+        cfg = RerankerConfig(model_id=_TEST_MODEL, first_call_timeout_seconds=120.0)
+        reranker = BGEReranker.get(cfg)
+        assert reranker is not None
+        pairs = [
+            ("query about cats", "Cats are small carnivorous mammals."),
+            ("query about cats", "The sun is the star at the center of the solar system."),
+        ]
+        scores = reranker.score_pairs(pairs)
+        assert len(scores) == 2
+        # First pair (relevant) should score higher than second (irrelevant).
+        assert scores[0] > scores[1]

--- a/tests/ml/test_reranker_live.py
+++ b/tests/ml/test_reranker_live.py
@@ -81,9 +81,29 @@ class TestRerankerIntegration:
         assert reranker is not None
         pairs = [
             ("query about cats", "Cats are small carnivorous mammals."),
-            ("query about cats", "The sun is the star at the center of the solar system."),
+            (
+                "query about cats",
+                "The sun is the star at the center of the solar system.",
+            ),
         ]
         scores = reranker.score_pairs(pairs)
         assert len(scores) == 2
         # First pair (relevant) should score higher than second (irrelevant).
         assert scores[0] > scores[1]
+
+    def test_production_default_model_is_supported_by_fastembed(self) -> None:
+        """Guard: the model ID baked into RerankerConfig must remain in
+        FastEmbed's supported-models registry. If FastEmbed renames or
+        drops `BAAI/bge-reranker-base`, users hit a hard load failure
+        on first MCP query — catch the regression here instead."""
+        from fastembed.rerank.cross_encoder import TextCrossEncoder
+
+        supported = TextCrossEncoder.list_supported_models()
+        # list_supported_models() returns a list of dicts; extract the model names
+        supported_names = {entry["model"] for entry in supported}
+        prod_default = RerankerConfig().model_id
+        assert prod_default in supported_names, (
+            f"RerankerConfig.model_id default ({prod_default!r}) is not in "
+            f"FastEmbed's supported models list. Either FastEmbed dropped it "
+            f"or the default needs updating in openzim_mcp/config.py."
+        )

--- a/tests/ml/test_reranker_synthesize_wiring.py
+++ b/tests/ml/test_reranker_synthesize_wiring.py
@@ -206,13 +206,15 @@ class TestRerankerWiringInSynthesizeQuery:
 
     def test_short_query_passthrough_does_not_crash(self) -> None:
         """A single-token query hits the skip-on-short-query gate inside reranker.rerank.
-        The synthesize pipeline must complete cleanly with passages intact."""
+        The synthesize pipeline must complete cleanly with passages intact and
+        the original BM25 order preserved."""
         hits = [
             {"path": "A/Cats", "snippet": "cats are mammals", "score": 0.9},
+            {"path": "A/Dogs", "snippet": "dogs are mammals", "score": 0.7},
         ]
         cfg = RerankerConfig(min_query_tokens=4)  # "cats" is 1 token → passthrough
         # Build reranker with the same min_query_tokens so gate fires.
-        reranker = _make_reranker([0.8], min_query_tokens=4)
+        reranker = _make_reranker([0.8, 0.6], min_query_tokens=4)
 
         with (
             patch("openzim_mcp.ml.reranker.BGEReranker.get", return_value=reranker),
@@ -222,3 +224,111 @@ class TestRerankerWiringInSynthesizeQuery:
 
         # Pipeline completes; no exception.
         assert "query" in response
+        passages = response.get("passages", [])
+        assert passages, "passthrough must not drop passages"
+        # In the short-query bypass, Xapian BM25 order is preserved: Cats first.
+        assert "Cats" in passages[0]["cite_id"], (
+            "Short-query passthrough should preserve original BM25 order; "
+            f"got cite_id={passages[0]['cite_id']!r}"
+        )
+
+    def test_reranker_ordering_survives_affinity_boost(self) -> None:
+        """Regression: affinity-sort step must respect rerank scores, not BM25.
+
+        Constructs a synthetic bundle so _attribute_sections appends #section_id
+        to both passages, enabling _boost_by_section_affinity to fire. Then
+        verifies the rerank ordering (B > A) is preserved after the affinity
+        pass — i.e. the p["score"] = rerank_score propagation line is effective.
+
+        If that line were deleted, _boost_by_section_affinity would sort by the
+        original Xapian BM25 scores and A (BM25=0.9) would beat B (BM25=0.7).
+        """
+        # BM25 order: A (score=0.9) first, B (score=0.7) second.
+        # Reranker inverts: B gets 0.9, A gets 0.1.
+        hits = [
+            {
+                "path": "A/PageA",
+                "snippet": "chlorophyll absorbs sunlight for energy",
+                "score": 0.9,
+            },
+            {
+                "path": "A/PageB",
+                "snippet": "photosynthesis converts light into glucose",
+                "score": 0.7,
+            },
+        ]
+        cfg = RerankerConfig(min_query_tokens=1)
+
+        # Reranker returns B with score 0.9, A with score 0.1 — inverted BM25 order.
+        def _inverted_rerank(
+            query: str, candidates: list[dict], top_k: int
+        ) -> list[dict]:
+            scored = [
+                {
+                    **c,
+                    "rerank_score": 0.9 if "PageB" in c["path"] else 0.1,
+                }
+                for c in candidates
+            ]
+            return sorted(scored, key=lambda x: x["rerank_score"], reverse=True)[:top_k]
+
+        mock_reranker = MagicMock(spec=BGEReranker)
+        mock_reranker.rerank = MagicMock(side_effect=_inverted_rerank)
+
+        # Build a synthetic bundle so _attribute_sections assigns #section_id
+        # to both passages and _boost_by_section_affinity actually fires.
+        # The bundle's rendered_markdown must contain both passage texts so
+        # _locate_passage succeeds and assigns the section.
+        passage_a_text = "chlorophyll absorbs sunlight for energy"
+        passage_b_text = "photosynthesis converts light into glucose"
+        # Section spans: sec_a covers the first passage (pos 0..len(a)+1),
+        # sec_b covers the second passage, title includes a query token.
+        sec_a_text = passage_a_text + "\n"
+        sec_b_text = passage_b_text + "\n"
+        rendered_md = sec_a_text + sec_b_text
+        len_a = len(sec_a_text)
+        fake_bundle = {
+            "title": "Plants",
+            "rendered_markdown": rendered_md,
+            "sections": [
+                {
+                    "id": "sec_a",
+                    "title": "Chlorophyll",  # contains "chlorophyll" — query token
+                    "char_start": 0,
+                    "char_end": len_a,
+                },
+                {
+                    "id": "sec_b",
+                    "title": "Photosynthesis",  # contains query token
+                    "char_start": len_a,
+                    "char_end": len(rendered_md),
+                },
+            ],
+        }
+
+        with (
+            patch(
+                "openzim_mcp.ml.reranker.BGEReranker.get",
+                return_value=mock_reranker,
+            ),
+            patch(
+                "openzim_mcp.bundle.get_or_build_bundle",
+                return_value=fake_bundle,
+            ),
+        ):
+            response = self._call_synthesize(
+                hits,
+                cfg,
+                query="photosynthesis chlorophyll",
+            )
+
+        passages = response.get("passages", [])
+        assert passages, "passages must not be empty"
+        # B had the highest rerank_score (0.9); it must appear first.
+        # If p["score"] = rerank_score propagation is missing, the affinity sort
+        # reverts to Xapian BM25 and A (0.9 BM25) wins instead.
+        assert "PageB" in passages[0]["cite_id"], (
+            "PageB had rerank_score=0.9 but lost the top slot — "
+            "affinity sort must use rerank_score not BM25. "
+            f"Got cite_id={passages[0]['cite_id']!r}"
+        )

--- a/tests/ml/test_reranker_synthesize_wiring.py
+++ b/tests/ml/test_reranker_synthesize_wiring.py
@@ -1,0 +1,224 @@
+"""Tests for BGEReranker wiring into synthesize_query (Task 9).
+
+Tests operate at the _extract_passages_for_top_hits / synthesize_query level
+using mocked archives and reranker singletons to avoid real ZIM I/O.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openzim_mcp.config import RerankerConfig
+from openzim_mcp.ml import detect
+from openzim_mcp.ml.fallback import reset_kill_switches
+from openzim_mcp.ml.reranker import BGEReranker
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> None:
+    BGEReranker.reset_instance()
+    reset_kill_switches()
+    detect.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_reranker(scores: List[float], *, min_query_tokens: int = 1) -> BGEReranker:
+    """Build a BGEReranker backed by a mock model that returns ``scores``.
+
+    ``min_query_tokens=1`` by default so the skip-on-short-query gate does
+    not fire on test queries; callers that want to exercise the gate should
+    pass a higher value explicitly.
+    """
+    mock_model = MagicMock()
+    mock_model.rerank = MagicMock(return_value=iter(scores))
+    return BGEReranker(
+        model=mock_model, config=RerankerConfig(min_query_tokens=min_query_tokens)
+    )
+
+
+def _make_top_hits(paths: List[str], archive: str = "wiki") -> list[tuple[str, dict]]:
+    """Build minimal top_hits list for _extract_passages_for_top_hits."""
+    return [
+        (archive, {"path": p, "snippet": f"text about {p}", "score": 1.0 - 0.1 * i})
+        for i, p in enumerate(paths)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Unit-level: rerank block logic in synthesize_query
+# ---------------------------------------------------------------------------
+
+
+class TestRerankerWiringInSynthesizeQuery:
+    """Drive synthesize_query with mocked archives + reranker.
+
+    We avoid real libzim I/O by injecting a MagicMock archive whose
+    search_top_k returns controlled hits. Bundle lookups are also mocked
+    to short-circuit attribution so tests focus solely on the rerank step.
+    """
+
+    def _make_search_handler(self, hits: List[dict]) -> Any:
+        handler = MagicMock()
+        handler.search_top_k.return_value = hits
+        # title_match_hit returns None so title-promotion is a no-op.
+        handler.title_match_hit.return_value = None
+        return handler
+
+    def _make_archive_pair(self, stem: str = "wiki") -> tuple[Any, Any]:
+        from pathlib import Path
+        from unittest.mock import MagicMock
+
+        archive = MagicMock()
+        path = MagicMock(spec=Path)
+        path.stem = stem
+        return archive, path
+
+    def _make_cache_and_cp(self) -> tuple[Any, Any]:
+        cache = MagicMock()
+        # Bundle lookup returns None so attribution is a no-op.
+        cache.get.return_value = None
+        cp = MagicMock()
+        cp.html_to_plain_text.side_effect = lambda h: h
+        return cache, cp
+
+    def _call_synthesize(
+        self,
+        hits: List[dict],
+        reranker_config: RerankerConfig,
+        query: str = "photosynthesis and plants",
+    ) -> Any:
+        """Call synthesize_query with mocked archives.
+
+        Callers are responsible for patching BGEReranker.get and
+        openzim_mcp.bundle.get_or_build_bundle before calling this helper.
+        """
+        from openzim_mcp.config import SynthesizeConfig
+        from openzim_mcp.synthesize import synthesize_query
+
+        archive, path = self._make_archive_pair()
+        cache, cp = self._make_cache_and_cp()
+        search_handler = self._make_search_handler(hits)
+
+        return synthesize_query(
+            query,
+            archives=[(archive, path)],
+            search_handler=search_handler,
+            cache=cache,
+            content_processor=cp,
+            config=SynthesizeConfig(top_n=5, per_archive_k=10),
+            reranker_config=reranker_config,
+        )
+
+    def test_reranker_engaged_reorders_passages(self) -> None:
+        """When BGEReranker.get() returns a reranker, passages are reordered
+        by rerank_score rather than Xapian BM25 order.
+
+        Scores in hits order: Low=0.1 (bad), High=0.9 (good) — reranker
+        flips them so High surfaces first.
+        """
+        hits = [
+            {"path": "A/Low", "snippet": "low relevance passage", "score": 0.9},
+            {"path": "A/High", "snippet": "highly relevant passage", "score": 0.7},
+        ]
+        cfg = RerankerConfig(min_query_tokens=1)
+        # Build a pre-wired reranker and inject it via BGEReranker.get().
+        reranker = _make_reranker([0.1, 0.9])
+
+        with (
+            patch("openzim_mcp.ml.reranker.BGEReranker.get", return_value=reranker),
+            patch("openzim_mcp.bundle.get_or_build_bundle", return_value=None),
+        ):
+            response = self._call_synthesize(hits, cfg)
+
+        # After reranking, High should be the top citation.
+        passages = response.get("passages", [])
+        if passages:
+            assert "High" in passages[0]["cite_id"]
+        else:
+            # compact/budget mode dropped passages — check citations ordering.
+            citations = response.get("citations", [])
+            assert any("High" in c["cite_id"] for c in citations)
+
+    def test_reranker_absent_preserves_original_order(self) -> None:
+        """When BGEReranker.get() returns None, passage order is unchanged from
+        Xapian BM25."""
+        hits = [
+            {"path": "A/First", "snippet": "first passage", "score": 0.9},
+            {"path": "A/Second", "snippet": "second passage", "score": 0.7},
+        ]
+        cfg = RerankerConfig()
+
+        with (
+            patch("openzim_mcp.ml.reranker.BGEReranker.get", return_value=None),
+            patch("openzim_mcp.bundle.get_or_build_bundle", return_value=None),
+        ):
+            response = self._call_synthesize(hits, cfg)
+
+        # Passages retain BM25 order: First before Second.
+        passages = response.get("passages", [])
+        if passages:
+            assert "First" in passages[0]["cite_id"]
+
+    def test_reranker_config_none_skips_rerank(self) -> None:
+        """When reranker_config=None is passed, the rerank block is entirely
+        skipped and BGEReranker.get() is never called.
+
+        BGEReranker is imported locally inside synthesize_query, so we patch
+        the classmethod on the class itself via its module path.
+        """
+        hits = [
+            {"path": "A/Alpha", "snippet": "alpha text", "score": 0.9},
+            {"path": "A/Beta", "snippet": "beta text", "score": 0.7},
+        ]
+
+        from openzim_mcp.config import SynthesizeConfig
+        from openzim_mcp.synthesize import synthesize_query
+
+        archive, path = self._make_archive_pair()
+        cache, cp = self._make_cache_and_cp()
+        search_handler = self._make_search_handler(hits)
+
+        with (
+            patch(
+                "openzim_mcp.ml.reranker.BGEReranker.get", return_value=None
+            ) as mock_get,
+            patch("openzim_mcp.bundle.get_or_build_bundle", return_value=None),
+        ):
+            synthesize_query(
+                "alpha beta query",
+                archives=[(archive, path)],
+                search_handler=search_handler,
+                cache=cache,
+                content_processor=cp,
+                config=SynthesizeConfig(),
+                reranker_config=None,  # explicit None — rerank block must not run
+            )
+
+        # BGEReranker.get() must NOT be called when reranker_config is None.
+        mock_get.assert_not_called()
+
+    def test_short_query_passthrough_does_not_crash(self) -> None:
+        """A single-token query hits the skip-on-short-query gate inside reranker.rerank.
+        The synthesize pipeline must complete cleanly with passages intact."""
+        hits = [
+            {"path": "A/Cats", "snippet": "cats are mammals", "score": 0.9},
+        ]
+        cfg = RerankerConfig(min_query_tokens=4)  # "cats" is 1 token → passthrough
+        # Build reranker with the same min_query_tokens so gate fires.
+        reranker = _make_reranker([0.8], min_query_tokens=4)
+
+        with (
+            patch("openzim_mcp.ml.reranker.BGEReranker.get", return_value=reranker),
+            patch("openzim_mcp.bundle.get_or_build_bundle", return_value=None),
+        ):
+            response = self._call_synthesize(hits, cfg, query="cats")
+
+        # Pipeline completes; no exception.
+        assert "query" in response

--- a/tests/ml/test_reranker_unit.py
+++ b/tests/ml/test_reranker_unit.py
@@ -205,3 +205,95 @@ class TestRerank:
         assert [c["path"] for c in result] == ["A", "B"]
         assert all("rerank_score" not in c for c in result)
         reset_kill_switches()  # leave state clean for the next test
+
+
+class TestRerankerWiredToHandleSearch:
+    """Verify that _handle_search routes results through the reranker when
+    available, and degrades gracefully when it is not."""
+
+    def _make_handler(self):  # type: ignore[return]
+        """Build a SimpleToolsHandler backed by a MagicMock ZimOperations.
+
+        The mock is pre-wired with the compact-path data shape so
+        _handle_search's compact branch (the only path where structured
+        results are available for reranking) runs end-to-end.
+        """
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        mock_ops = MagicMock()
+        mock_ops.config.ml.reranker = RerankerConfig()
+        # Compact path: search_zim_file_data returns a non-empty payload.
+        mock_ops.search_zim_file_data.return_value = {
+            "query": "what year was Marie Curie born",
+            "results": [
+                {"path": "A", "title": "Marie Curie", "snippet": "polonium"},
+                {"path": "B", "title": "Curie (unit)", "snippet": "radioactivity"},
+            ],
+            "next_cursor": None,
+            "total": 2,
+            "done": True,
+            "page_info": {"offset": 0, "limit": 10, "returned_count": 2},
+        }
+        mock_ops._format_search_text.return_value = "rendered results"
+        # _splice_title_match_into_search calls find_title_match internally;
+        # short-circuit it so the test doesn't need a real ZIM archive.
+        mock_ops.get_search_suggestions.return_value = []
+        return SimpleToolsHandler(mock_ops)
+
+    def test_handle_search_uses_reranker_when_available(self) -> None:
+        """When BGEReranker.get() returns a reranker, _handle_search routes
+        results through rerank() and tracks 'reranker_engaged'."""
+        mock_reranker = MagicMock()
+        mock_reranker.rerank = MagicMock(
+            side_effect=lambda query, candidates, top_k: [
+                {**c, "rerank_score": 0.5} for c in candidates[:top_k]
+            ]
+        )
+        handler = self._make_handler()
+        with (
+            patch(
+                "openzim_mcp.ml.reranker.BGEReranker.get",
+                return_value=mock_reranker,
+            ),
+            # _splice_title_match_into_search uses find_title_match which
+            # calls into the archive; stub it to return None (no promotion).
+            patch(
+                "openzim_mcp.simple_tools.find_title_match",
+                return_value=None,
+            ),
+        ):
+            result = handler._handle_search(
+                query="what year was Marie Curie born",
+                zim_file_path="/fake/wiki.zim",
+                params={},
+                options={"compact": True},
+            )
+        mock_reranker.rerank.assert_called_once()
+        call_kwargs = mock_reranker.rerank.call_args
+        assert call_kwargs.kwargs["query"] == "what year was Marie Curie born"
+        assert handler.get_telemetry().get("reranker_engaged", 0) == 1
+        assert result == "rendered results"
+
+    def test_handle_search_passthrough_when_reranker_absent(self) -> None:
+        """When BGEReranker.get() returns None, _handle_search skips rerank
+        and tracks 'reranker_skipped:not_installed'. Result shape is unchanged."""
+        handler = self._make_handler()
+        with (
+            patch(
+                "openzim_mcp.ml.reranker.BGEReranker.get",
+                return_value=None,
+            ),
+            patch(
+                "openzim_mcp.simple_tools.find_title_match",
+                return_value=None,
+            ),
+        ):
+            result = handler._handle_search(
+                query="what year was Marie Curie born",
+                zim_file_path="/fake/wiki.zim",
+                params={},
+                options={"compact": True},
+            )
+        assert handler.get_telemetry().get("reranker_skipped:not_installed", 0) == 1
+        assert handler.get_telemetry().get("reranker_engaged", 0) == 0
+        assert result == "rendered results"

--- a/tests/ml/test_reranker_unit.py
+++ b/tests/ml/test_reranker_unit.py
@@ -76,6 +76,28 @@ class TestBGEGet:
         # 2.0s gives generous slack over the 0.5s timeout for CI jitter.
         assert elapsed < 2.0, f"get() blocked for {elapsed:.2f}s past timeout"
 
+    def test_load_failure_trips_kill_switch(self) -> None:
+        """Regression: after a load failure, subsequent get() calls must NOT retry."""
+        call_count = 0
+
+        def failing_load(model_id: str, cache_dir: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("simulated load failure")
+
+        with (
+            patch("openzim_mcp.ml.importlib.util.find_spec") as mock_spec,
+            patch("openzim_mcp.ml.reranker._load_model", side_effect=failing_load),
+        ):
+            mock_spec.return_value = object()
+            cfg = RerankerConfig(first_call_timeout_seconds=2.0)
+            assert BGEReranker.get(cfg) is None
+            assert BGEReranker.get(cfg) is None
+            assert BGEReranker.get(cfg) is None
+        assert (
+            call_count == 1
+        ), f"_load_model should be called once and never retried; got {call_count}"
+
 
 class TestScorePairs:
     def _make_reranker_with_scores(self, scores: List[float]) -> BGEReranker:
@@ -160,3 +182,26 @@ class TestRerank:
     def test_empty_candidates_returns_empty(self) -> None:
         r = self._make_reranker_with_scores([])
         assert r.rerank("any long enough query string", [], top_k=10) == []
+
+    def test_inference_failure_falls_back_to_passthrough(self) -> None:
+        """Regression: a mid-inference raise must return candidates[:top_k] via ml_fallback."""
+        from openzim_mcp.ml.fallback import reset_kill_switches
+
+        reset_kill_switches()
+        mock_model = MagicMock()
+        mock_model.rerank = MagicMock(side_effect=RuntimeError("OOM"))
+        r = BGEReranker(model=mock_model, config=RerankerConfig())
+        candidates = [
+            {"path": "A", "snippet": "...", "xapian_score": 1.0},
+            {"path": "B", "snippet": "...", "xapian_score": 0.9},
+            {"path": "C", "snippet": "...", "xapian_score": 0.8},
+        ]
+        result = r.rerank(
+            "what year did Marie Curie discover radium",
+            candidates,
+            top_k=2,
+        )
+        # Falls back to original order, sliced to top_k, no rerank_score
+        assert [c["path"] for c in result] == ["A", "B"]
+        assert all("rerank_score" not in c for c in result)
+        reset_kill_switches()  # leave state clean for the next test

--- a/tests/ml/test_reranker_unit.py
+++ b/tests/ml/test_reranker_unit.py
@@ -271,6 +271,10 @@ class TestRerankerWiredToHandleSearch:
         mock_reranker.rerank.assert_called_once()
         call_kwargs = mock_reranker.rerank.call_args
         assert call_kwargs.kwargs["query"] == "what year was Marie Curie born"
+        assert call_kwargs.kwargs["candidates"] == [
+            {"path": "A", "title": "Marie Curie", "snippet": "polonium"},
+            {"path": "B", "title": "Curie (unit)", "snippet": "radioactivity"},
+        ]
         assert handler.get_telemetry().get("reranker_engaged", 0) == 1
         assert result == "rendered results"
 
@@ -294,6 +298,37 @@ class TestRerankerWiredToHandleSearch:
                 params={},
                 options={"compact": True},
             )
-        assert handler.get_telemetry().get("reranker_skipped:not_installed", 0) == 1
+        assert handler.get_telemetry().get("reranker_skipped.not_installed", 0) == 1
         assert handler.get_telemetry().get("reranker_engaged", 0) == 0
+        assert result == "rendered results"
+
+    def test_handle_search_emits_passthrough_when_rerank_returns_unscored(
+        self,
+    ) -> None:
+        """Regression: short-query bypass + ml_fallback inference failure both return
+        unscored candidates. The handler must NOT count those as reranker_engaged."""
+        handler = self._make_handler()
+        mock_reranker = MagicMock()
+        mock_reranker.rerank = MagicMock(
+            side_effect=lambda query, candidates, top_k: candidates[:top_k]
+        )
+        with (
+            patch(
+                "openzim_mcp.ml.reranker.BGEReranker.get",
+                return_value=mock_reranker,
+            ),
+            patch(
+                "openzim_mcp.simple_tools.find_title_match",
+                return_value=None,
+            ),
+        ):
+            result = handler._handle_search(
+                query="what year was Marie Curie born",
+                zim_file_path="/fake/wiki.zim",
+                params={},
+                options={"compact": True},
+            )
+        telemetry = handler.get_telemetry()
+        assert telemetry.get("reranker_skipped.passthrough", 0) == 1
+        assert telemetry.get("reranker_engaged", 0) == 0
         assert result == "rendered results"

--- a/tests/ml/test_reranker_unit.py
+++ b/tests/ml/test_reranker_unit.py
@@ -332,3 +332,228 @@ class TestRerankerWiredToHandleSearch:
         assert telemetry.get("reranker_skipped.passthrough", 0) == 1
         assert telemetry.get("reranker_engaged", 0) == 0
         assert result == "rendered results"
+
+
+class TestRerankerWiredToHandleFilteredSearch:
+    """Verify that _handle_filtered_search (compact mode) routes results
+    through the reranker when available, and degrades gracefully when not."""
+
+    def _make_handler(self):  # type: ignore[return]
+        """Build a SimpleToolsHandler backed by a MagicMock ZimOperations.
+
+        Pre-wired so the compact path (search_with_filters_data +
+        _format_search_text) runs end-to-end.
+        """
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        mock_ops = MagicMock()
+        mock_ops.config.ml.reranker = RerankerConfig()
+        mock_ops.search_with_filters_data.return_value = {
+            "query": "what year was Marie Curie born",
+            "results": [
+                {"path": "A", "title": "Marie Curie", "snippet": "polonium"},
+                {"path": "B", "title": "Curie (unit)", "snippet": "radioactivity"},
+            ],
+            "next_cursor": None,
+            "total": 2,
+            "done": True,
+            "page_info": {"offset": 0, "limit": 10, "returned_count": 2},
+            "namespace_filter": None,
+            "content_type_filter": None,
+        }
+        mock_ops._format_search_text.return_value = "rendered filtered results"
+        return SimpleToolsHandler(mock_ops)
+
+    def test_handle_filtered_search_engages_reranker(self) -> None:
+        """When BGEReranker.get() returns a reranker, _handle_filtered_search
+        (compact mode) routes results through rerank() and tracks
+        'reranker_engaged'."""
+        mock_reranker = MagicMock()
+        mock_reranker.rerank = MagicMock(
+            side_effect=lambda query, candidates, top_k: [
+                {**c, "rerank_score": 0.5} for c in candidates[:top_k]
+            ]
+        )
+        handler = self._make_handler()
+        with patch(
+            "openzim_mcp.ml.reranker.BGEReranker.get",
+            return_value=mock_reranker,
+        ):
+            result = handler._handle_filtered_search(
+                query="what year was Marie Curie born",
+                zim_file_path="/fake/wiki.zim",
+                params={},
+                options={"compact": True},
+            )
+        mock_reranker.rerank.assert_called_once()
+        call_kwargs = mock_reranker.rerank.call_args
+        assert call_kwargs.kwargs["query"] == "what year was Marie Curie born"
+        assert handler.get_telemetry().get("reranker_engaged", 0) == 1
+        assert result == "rendered filtered results"
+
+    def test_handle_filtered_search_skips_reranker_when_absent(self) -> None:
+        """When BGEReranker.get() returns None, compact filtered search skips
+        rerank and tracks 'reranker_skipped.not_installed'."""
+        handler = self._make_handler()
+        with patch(
+            "openzim_mcp.ml.reranker.BGEReranker.get",
+            return_value=None,
+        ):
+            result = handler._handle_filtered_search(
+                query="what year was Marie Curie born",
+                zim_file_path="/fake/wiki.zim",
+                params={},
+                options={"compact": True},
+            )
+        assert handler.get_telemetry().get("reranker_skipped.not_installed", 0) == 1
+        assert handler.get_telemetry().get("reranker_engaged", 0) == 0
+        assert result == "rendered filtered results"
+
+    def test_handle_filtered_search_legacy_path_bypasses_reranker(self) -> None:
+        """Non-compact mode takes the legacy string path — reranker is not
+        called and no telemetry is emitted."""
+        handler = self._make_handler()
+        mock_reranker = MagicMock()
+        handler.zim_operations.search_with_filters_with_canonical_splice.return_value = (
+            "legacy filtered results"
+        )
+        with patch(
+            "openzim_mcp.ml.reranker.BGEReranker.get",
+            return_value=mock_reranker,
+        ):
+            result = handler._handle_filtered_search(
+                query="what year was Marie Curie born",
+                zim_file_path="/fake/wiki.zim",
+                params={},
+                options={"compact": False},
+            )
+        mock_reranker.rerank.assert_not_called()
+        assert handler.get_telemetry().get("reranker_engaged", 0) == 0
+        assert result == "legacy filtered results"
+
+
+class TestRerankerWiredToHandleSearchAll:
+    """Verify that _handle_search_all (compact mode) routes results through
+    the reranker globally across archives."""
+
+    def _make_handler(self):  # type: ignore[return]
+        """Build a SimpleToolsHandler with two-archive search_all_data shape."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        mock_ops = MagicMock()
+        mock_ops.config.ml.reranker = RerankerConfig()
+        mock_ops.search_all_data.return_value = {
+            "query": "what year was Marie Curie born",
+            "results": [
+                {
+                    "zim_file_path": "/a.zim",
+                    "name": "archive_a",
+                    "has_hits": True,
+                    "error": False,
+                    "result": {
+                        "query": "what year was Marie Curie born",
+                        "results": [
+                            {
+                                "path": "A1",
+                                "title": "Marie Curie",
+                                "snippet": "polonium",
+                            },
+                        ],
+                        "total": 1,
+                        "done": True,
+                        "next_cursor": None,
+                        "page_info": {"offset": 0, "limit": 5, "returned_count": 1},
+                    },
+                },
+                {
+                    "zim_file_path": "/b.zim",
+                    "name": "archive_b",
+                    "has_hits": True,
+                    "error": False,
+                    "result": {
+                        "query": "what year was Marie Curie born",
+                        "results": [
+                            {
+                                "path": "B1",
+                                "title": "Curie (unit)",
+                                "snippet": "radioactivity",
+                            },
+                        ],
+                        "total": 1,
+                        "done": True,
+                        "next_cursor": None,
+                        "page_info": {"offset": 0, "limit": 5, "returned_count": 1},
+                    },
+                },
+            ],
+            "_meta": {"reason": None, "suggestions": None},
+            "files_searched": 2,
+            "files_with_hits": 2,
+            "files_failed": 0,
+            "budget_exceeded": False,
+            "done": True,
+        }
+        return SimpleToolsHandler(mock_ops)
+
+    def test_handle_search_all_engages_reranker(self) -> None:
+        """When BGEReranker.get() returns a reranker, _handle_search_all
+        (compact mode) routes aggregated results through rerank() and tracks
+        'reranker_engaged'."""
+        mock_reranker = MagicMock()
+        mock_reranker.rerank = MagicMock(
+            side_effect=lambda query, candidates, top_k: [
+                {**c, "rerank_score": 0.5} for c in candidates[:top_k]
+            ]
+        )
+        handler = self._make_handler()
+        with patch(
+            "openzim_mcp.ml.reranker.BGEReranker.get",
+            return_value=mock_reranker,
+        ):
+            handler._handle_search_all(
+                query="what year was Marie Curie born",
+                zim_file_path="/fake/wiki.zim",
+                params={},
+                options={"compact": True},
+            )
+        mock_reranker.rerank.assert_called_once()
+        call_kwargs = mock_reranker.rerank.call_args
+        # Both archive hits should be in the flattened candidates list.
+        assert call_kwargs.kwargs["query"] == "what year was Marie Curie born"
+        assert len(call_kwargs.kwargs["candidates"]) == 2
+        assert handler.get_telemetry().get("reranker_engaged", 0) == 1
+
+    def test_handle_search_all_skips_reranker_when_absent(self) -> None:
+        """When BGEReranker.get() returns None, compact search_all skips
+        rerank and tracks 'reranker_skipped.not_installed'."""
+        handler = self._make_handler()
+        with patch(
+            "openzim_mcp.ml.reranker.BGEReranker.get",
+            return_value=None,
+        ):
+            handler._handle_search_all(
+                query="what year was Marie Curie born",
+                zim_file_path="/fake/wiki.zim",
+                params={},
+                options={"compact": True},
+            )
+        assert handler.get_telemetry().get("reranker_skipped.not_installed", 0) == 1
+        assert handler.get_telemetry().get("reranker_engaged", 0) == 0
+
+    def test_handle_search_all_legacy_path_bypasses_reranker(self) -> None:
+        """Non-compact mode takes the legacy string path — reranker is not called."""
+        handler = self._make_handler()
+        mock_reranker = MagicMock()
+        handler.zim_operations.search_all.return_value = '{"results": []}'
+        with patch(
+            "openzim_mcp.ml.reranker.BGEReranker.get",
+            return_value=mock_reranker,
+        ):
+            handler._handle_search_all(
+                query="what year was Marie Curie born",
+                zim_file_path="/fake/wiki.zim",
+                params={},
+                options={"compact": False},
+            )
+        mock_reranker.rerank.assert_not_called()
+        assert handler.get_telemetry().get("reranker_engaged", 0) == 0

--- a/tests/ml/test_reranker_unit.py
+++ b/tests/ml/test_reranker_unit.py
@@ -557,3 +557,56 @@ class TestRerankerWiredToHandleSearchAll:
             )
         mock_reranker.rerank.assert_not_called()
         assert handler.get_telemetry().get("reranker_engaged", 0) == 0
+
+    def test_handle_search_all_cross_archive_ordering_preserved(self) -> None:
+        """Redistribution: hit B1 outscores A1 — B1 must survive top_k=1 and
+        A1's archive bucket must end up empty after rerank+regrouping."""
+        mock_reranker = MagicMock()
+        # Score B1=0.9, A1=0.1; top_k honours the value passed by the handler
+        # (driven by final_top_k=1 on the config); only B1 survives.
+        mock_reranker.rerank = MagicMock(
+            side_effect=lambda query, candidates, top_k: sorted(
+                [
+                    {**c, "rerank_score": 0.9 if c["path"] == "B1" else 0.1}
+                    for c in candidates
+                ],
+                key=lambda x: x["rerank_score"],
+                reverse=True,
+            )[:top_k]
+        )
+        handler = self._make_handler()
+        # Override final_top_k to 1 so the reranker keeps only the top hit
+        # globally — this is the eviction scenario we want to exercise.
+        handler.zim_operations.config.ml.reranker = RerankerConfig(final_top_k=1)
+        with patch(
+            "openzim_mcp.ml.reranker.BGEReranker.get",
+            return_value=mock_reranker,
+        ):
+            result = handler._handle_search_all(
+                query="what year was Marie Curie born",
+                zim_file_path="/fake/wiki.zim",
+                params={},
+                options={"compact": True},
+            )
+        # Reranker called exactly once with both archives' hits flattened.
+        mock_reranker.rerank.assert_called_once()
+        call_kwargs = mock_reranker.rerank.call_args.kwargs
+        assert call_kwargs["query"] == "what year was Marie Curie born"
+        candidate_paths = {c["path"] for c in call_kwargs["candidates"]}
+        assert candidate_paths == {
+            "A1",
+            "B1",
+        }, "Both archive hits must be flattened into the candidates list"
+
+        # _rerank_src_idx must not leak into the rendered body or hit dicts.
+        assert "_rerank_src_idx" not in result.body
+
+        # B1 (high score) must appear in the rendered output.
+        assert "B1" in result.body, "High-scored hit B1 must survive top_k eviction"
+
+        # A1 (low score, evicted) must not appear — its archive bucket is empty
+        # and render_search_all skips archives with no results.
+        assert "A1" not in result.body, "Low-scored hit A1 must be evicted"
+
+        # Reranker engagement was tracked.
+        assert handler.get_telemetry().get("reranker_engaged", 0) == 1

--- a/tests/ml/test_reranker_unit.py
+++ b/tests/ml/test_reranker_unit.py
@@ -49,3 +49,31 @@ class TestBGEGet:
             assert a is not None
             assert a is b  # same singleton
             assert mock_load.call_count == 1
+
+    def test_timeout_returns_none_within_bounded_time(self) -> None:
+        """Regression: a slow _load_model must not block the caller past timeout."""
+        import threading
+        import time
+
+        event = threading.Event()
+
+        def slow_load(model_id: str, cache_dir: object) -> object:
+            # Simulate a hung download that takes much longer than timeout.
+            event.wait(timeout=30)
+            return MagicMock()
+
+        with (
+            patch("openzim_mcp.ml.importlib.util.find_spec") as mock_spec,
+            patch("openzim_mcp.ml.reranker._load_model", side_effect=slow_load),
+        ):
+            mock_spec.return_value = object()
+            cfg = RerankerConfig(first_call_timeout_seconds=0.5)
+            start = time.monotonic()
+            result = BGEReranker.get(cfg)
+            elapsed = time.monotonic() - start
+        # Unblock the leaked background thread before exiting the test.
+        event.set()
+
+        assert result is None
+        # 2.0s gives generous slack over the 0.5s timeout for CI jitter.
+        assert elapsed < 2.0, f"get() blocked for {elapsed:.2f}s past timeout"

--- a/tests/ml/test_reranker_unit.py
+++ b/tests/ml/test_reranker_unit.py
@@ -1,0 +1,51 @@
+"""Unit tests for BGEReranker (mocked FastEmbed)."""
+
+from __future__ import annotations
+
+from typing import List  # noqa: F401 — used by Task 5's TestScorePairs / TestRerank
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openzim_mcp.config import (  # noqa: F401 — used by Task 5's TestScorePairs / TestRerank
+    RerankerConfig,
+)
+from openzim_mcp.ml import detect
+from openzim_mcp.ml.fallback import reset_kill_switches
+from openzim_mcp.ml.reranker import BGEReranker
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> None:
+    BGEReranker.reset_instance()
+    reset_kill_switches()
+    detect.cache_clear()
+
+
+class TestBGEGet:
+    def test_returns_none_when_extra_absent(self) -> None:
+        with patch("openzim_mcp.ml.importlib.util.find_spec") as mock_spec:
+            mock_spec.return_value = None
+            assert BGEReranker.get() is None
+
+    def test_returns_none_when_disabled_via_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENZIM_RERANKER_DISABLE", "1")
+        # Even if the extra is "installed", env disable wins.
+        with patch("openzim_mcp.ml.importlib.util.find_spec") as mock_spec:
+            mock_spec.return_value = object()
+            assert BGEReranker.get() is None
+
+    def test_returns_singleton_when_extra_present(self) -> None:
+        with (
+            patch("openzim_mcp.ml.importlib.util.find_spec") as mock_spec,
+            patch("openzim_mcp.ml.reranker._load_model") as mock_load,
+        ):
+            mock_spec.return_value = object()
+            mock_load.return_value = MagicMock(name="fastembed_reranker")
+            a = BGEReranker.get()
+            b = BGEReranker.get()
+            assert a is not None
+            assert a is b  # same singleton
+            assert mock_load.call_count == 1

--- a/tests/ml/test_reranker_unit.py
+++ b/tests/ml/test_reranker_unit.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-from typing import List  # noqa: F401 — used by Task 5's TestScorePairs / TestRerank
+from typing import List
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from openzim_mcp.config import (  # noqa: F401 — used by Task 5's TestScorePairs / TestRerank
-    RerankerConfig,
-)
+from openzim_mcp.config import RerankerConfig
 from openzim_mcp.ml import detect
 from openzim_mcp.ml.fallback import reset_kill_switches
 from openzim_mcp.ml.reranker import BGEReranker
@@ -77,3 +75,88 @@ class TestBGEGet:
         assert result is None
         # 2.0s gives generous slack over the 0.5s timeout for CI jitter.
         assert elapsed < 2.0, f"get() blocked for {elapsed:.2f}s past timeout"
+
+
+class TestScorePairs:
+    def _make_reranker_with_scores(self, scores: List[float]) -> BGEReranker:
+        mock_model = MagicMock()
+        mock_model.rerank = MagicMock(return_value=iter(scores))
+        # Bypass BGEReranker.get() and inject a pre-built reranker
+        return BGEReranker(model=mock_model, config=RerankerConfig())
+
+    def test_empty_pairs_returns_empty(self) -> None:
+        r = self._make_reranker_with_scores([])
+        assert r.score_pairs([]) == []
+
+    def test_returns_one_score_per_pair(self) -> None:
+        r = self._make_reranker_with_scores([0.9, 0.5, 0.1])
+        scores = r.score_pairs([("q", "d1"), ("q", "d2"), ("q", "d3")])
+        assert scores == [0.9, 0.5, 0.1]
+
+    def test_truncates_query_at_max_length(self) -> None:
+        cfg = RerankerConfig(max_query_length=5)
+        mock_model = MagicMock()
+        mock_model.rerank = MagicMock(return_value=iter([0.5]))
+        r = BGEReranker(model=mock_model, config=cfg)
+        r.score_pairs([("abcdefghijklmnop", "doc")])
+        # Verify the query passed to fastembed was truncated
+        call_args = mock_model.rerank.call_args
+        # FastEmbed's rerank signature: rerank(query: str, documents: List[str])
+        passed_query = call_args[0][0]
+        assert len(passed_query) <= 5
+
+
+class TestRerank:
+    def _make_reranker_with_scores(self, scores: List[float]) -> BGEReranker:
+        mock_model = MagicMock()
+        mock_model.rerank = MagicMock(return_value=iter(scores))
+        return BGEReranker(model=mock_model, config=RerankerConfig())
+
+    def test_short_query_skips_rerank(self) -> None:
+        r = self._make_reranker_with_scores([0.5, 0.5, 0.5])
+        # "Berlin" is 1 token, well below min_query_tokens=4
+        candidates = [
+            {"path": "A", "snippet": "...", "xapian_score": 1.0},
+            {"path": "B", "snippet": "...", "xapian_score": 0.9},
+        ]
+        result = r.rerank("Berlin", candidates, top_k=2)
+        # Returns input order unchanged (no rerank fired)
+        assert [c["path"] for c in result] == ["A", "B"]
+        # And no rerank_score field added
+        assert all("rerank_score" not in c for c in result)
+
+    def test_long_query_reranks(self) -> None:
+        # Scores ordered to invert Xapian's ordering
+        r = self._make_reranker_with_scores([0.1, 0.9])
+        candidates = [
+            {"path": "A", "snippet": "...", "xapian_score": 1.0},
+            {"path": "B", "snippet": "...", "xapian_score": 0.5},
+        ]
+        result = r.rerank(
+            "what year did Marie Curie discover radium",
+            candidates,
+            top_k=2,
+        )
+        # B now wins (rerank_score=0.9 > 0.1)
+        assert [c["path"] for c in result] == ["B", "A"]
+        assert result[0]["rerank_score"] == 0.9
+        assert result[1]["rerank_score"] == 0.1
+
+    def test_top_k_slices_result(self) -> None:
+        r = self._make_reranker_with_scores([0.9, 0.5, 0.1])
+        candidates = [
+            {"path": "A", "snippet": "...", "xapian_score": 0.5},
+            {"path": "B", "snippet": "...", "xapian_score": 0.5},
+            {"path": "C", "snippet": "...", "xapian_score": 0.5},
+        ]
+        result = r.rerank(
+            "what year did Marie Curie discover radium",
+            candidates,
+            top_k=2,
+        )
+        assert len(result) == 2
+        assert [c["path"] for c in result] == ["A", "B"]
+
+    def test_empty_candidates_returns_empty(self) -> None:
+        r = self._make_reranker_with_scores([])
+        assert r.rerank("any long enough query string", [], top_k=10) == []

--- a/tests/ml/test_reranker_unit.py
+++ b/tests/ml/test_reranker_unit.py
@@ -161,8 +161,8 @@ class TestRerank:
         )
         # B now wins (rerank_score=0.9 > 0.1)
         assert [c["path"] for c in result] == ["B", "A"]
-        assert result[0]["rerank_score"] == 0.9
-        assert result[1]["rerank_score"] == 0.1
+        assert result[0]["rerank_score"] == pytest.approx(0.9)
+        assert result[1]["rerank_score"] == pytest.approx(0.1)
 
     def test_top_k_slices_result(self) -> None:
         r = self._make_reranker_with_scores([0.9, 0.5, 0.1])

--- a/tests/test_post_a19_beta_fixes.py
+++ b/tests/test_post_a19_beta_fixes.py
@@ -241,6 +241,19 @@ class TestP1D2FilteredSearchAndLinksCrossToolCursorRejection:
         mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
         mock.config.meta.footer_enabled = False
         mock.search_with_filters_with_canonical_splice.return_value = "ok"
+        # Phase D sub-D-1: compact mode now calls search_with_filters_data
+        # (the structured path) so the reranker can inspect the payload before
+        # rendering. Wire a minimal return value so _format_search_text doesn't
+        # fail on the MagicMock default.
+        mock.search_with_filters_data.return_value = {
+            "query": "Berlin",
+            "results": [],
+            "total": 0,
+            "done": True,
+            "next_cursor": None,
+            "page_info": {"offset": 0, "limit": 10, "returned_count": 0},
+        }
+        mock._format_search_text.return_value = "ok"
         handler = SimpleToolsHandler(mock)
         out = handler.handle_zim_query(
             "search Berlin in namespace C",
@@ -248,7 +261,13 @@ class TestP1D2FilteredSearchAndLinksCrossToolCursorRejection:
             options={"compact": True},
         )
         assert "Cursor / Tool Mismatch" not in out
-        assert mock.search_with_filters_with_canonical_splice.called
+        # In compact mode, search_with_filters_data is called (structured path);
+        # search_with_filters_with_canonical_splice is the non-compact path.
+        called_either = (
+            mock.search_with_filters_data.called
+            or mock.search_with_filters_with_canonical_splice.called
+        )
+        assert called_either, "filtered_search did not call any search backend"
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,9 @@ revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
 ]
 
 [[package]]
@@ -474,6 +476,27 @@ wheels = [
 ]
 
 [[package]]
+name = "fastembed"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "loguru" },
+    { name = "mmh3" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "pillow" },
+    { name = "py-rust-stemmers" },
+    { name = "requests" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/25/58865e36b6e8a9a0d0ff905b5601aa30db97956327c0df42ec4ed6accc21/fastembed-0.8.0.tar.gz", hash = "sha256:75966edfa8b006ee78514c726bd7f6a50721dadc89305279052be9db72fd53e8", size = 75115, upload-time = "2026-03-23T16:34:41.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/e8/26b7d78bb8972498c467ca34cb12ee2e60d26ba5eae6d8443189a1af37a5/fastembed-0.8.0-py3-none-any.whl", hash = "sha256:40bee672657574a1009e35ec50030a55f2b426842cb011845379817641bbbbd0", size = 116572, upload-time = "2026-03-23T16:34:40.69Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -497,12 +520,61 @@ wheels = [
 ]
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/d8/5c06fc76461418326a7decf8367480c35be11a41fd938633929c60a9ec6b/hf_xet-1.5.0.tar.gz", hash = "sha256:e0fb0a34d9f406eed88233e829a67ec016bec5af19e480eac65a233ea289a948", size = 837196, upload-time = "2026-05-06T06:18:15.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/9b/6912c99070915a4f28119e3c5b52a9abd1eec0ad5cb293b8c967a0c6f5a2/hf_xet-1.5.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7d70fe2ce97b9db73b9c9b9c81fe3693640aec83416a966c446afea54acfae3c", size = 4023383, upload-time = "2026-05-06T06:17:53.947Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6d/9563cfde59b5d8128a9c7ec972a087f4c782e4f7bac5a85234edfd5d5e49/hf_xet-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:73a0dae8c71de3b0633a45c73f4a4a5ed09e94b43441d82981a781d4f12baa42", size = 3792751, upload-time = "2026-05-06T06:17:51.791Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a5/ed5a0cf35b49a0571af5a8f53416dad1877a718c021c9937c3a53cb45781/hf_xet-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a60290ec57e9b71767fba7c3645ddafdd0759974b540441510c629c6db6db24a", size = 4456058, upload-time = "2026-05-06T06:17:40.735Z" },
+    { url = "https://files.pythonhosted.org/packages/60/fb/3ae8bf2a7a37a4197d0195d7247fd25b3952e15cb8a599e285dfaa6f52b3/hf_xet-1.5.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e5de0f6deada0dada870bb376a11bcd1f08abf3a968a6d118f33e72d1b1eb480", size = 4250783, upload-time = "2026-05-06T06:17:38.412Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/8bae40d4d91525085137196e84eb0ed49cf65b5e96e5c3ecdadd8bd0fac2/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c799d49f1a5544a0ef7591c0ee75e0d6b93d6f56dc7a4979f59f7518d2872216", size = 4445594, upload-time = "2026-05-06T06:18:04.219Z" },
+    { url = "https://files.pythonhosted.org/packages/13/59/c74efbbd4e8728172b2cc72a2bc014d2947a4b7bdced932fbd3f5da1a4e5/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2baea1b0b989e5c152fe81425f7745ddc8901280ba3d97c98d8cdece7b706c60", size = 4663995, upload-time = "2026-05-06T06:18:06.1Z" },
+    { url = "https://files.pythonhosted.org/packages/73/32/8e1e0410af64cda9b139d1dcebdc993a8ff9c8c7c0e2696ae356d75ccc0d/hf_xet-1.5.0-cp313-cp313t-win_amd64.whl", hash = "sha256:526345b3ed45f374f6317349df489167606736c876241ba984105afe7fd4839d", size = 3966608, upload-time = "2026-05-06T06:18:19.74Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/34/a8febc8f4edbea8b3e21b02ebc8b628679b84ba7e45cde624a7736b51500/hf_xet-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:786d28e2eb8315d5035544b9d137b4a842d600c434bb91bf7d0d953cce906ad4", size = 3796946, upload-time = "2026-05-06T06:18:17.568Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/20/8fc8996afe5815fa1a6be8e9e5c02f24500f409d599e905800d498a4e14d/hf_xet-1.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:872d5601e6deea30d15865ede55d29eac6daf5a534ab417b99b6ef6b076dd96c", size = 4023495, upload-time = "2026-05-06T06:18:01.94Z" },
+    { url = "https://files.pythonhosted.org/packages/32/6a/93d84463c00cecb561a7508aa6303e35ee2894294eac14245526924415fe/hf_xet-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9929561f5abf4581c8ea79587881dfef6b8abb2a0d8a51915936fc2a614f4e73", size = 3792731, upload-time = "2026-05-06T06:18:00.021Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/5a/8ec8e0c863b382d00b3c2e2af6ded6b06371be617144a625903a6d562f4b/hf_xet-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f7b7bbae318e583a86fb21e5a4a175d6721d628a2874f4bd022d0e660c32a682", size = 4456738, upload-time = "2026-05-06T06:17:49.574Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/ca/f7effa1a67717da2bcc6b6c28f71c6ca648c77acaec4e2c32f40cbe16d85/hf_xet-1.5.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:cf7b2dc6f31a4ea754bb50f74cde482dcf5d366d184076d8530b9872787f3761", size = 4251622, upload-time = "2026-05-06T06:17:47.096Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f2/19247dba3e231cf77dec59ddfb878f00057635ff773d099c9b59d37812c3/hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8dbcbab554c9ef158ef2c991545c3e970ddd8cc7acdcd0a78c5a41095dab4ded", size = 4445667, upload-time = "2026-05-06T06:18:11.983Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/64/6f116801a3bcfb6f59f5c251f48cadc47ea54026441c4a385079286a94fa/hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5906bf7718d3636dc13402914736abe723492cb730f744834f5f5b67d3a12702", size = 4664619, upload-time = "2026-05-06T06:18:13.771Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e8/069542d37946ed08669b127e1496fa99e78196d71de8d41eda5e9f1b7a58/hf_xet-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5f3dc2248fc01cc0a00cd392ab497f1ca373fcbc7e3f2da1f452480b384e839e", size = 3966802, upload-time = "2026-05-06T06:18:28.162Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/91/fc6fdec27b14d04e88c386ac0a0129732b53fa23f7c4a78f4b83a039c567/hf_xet-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b285cea1b5bab46b758772716ba8d6854a1a0310fed1c249d678a8b38601e5a0", size = 3797168, upload-time = "2026-05-06T06:18:26.287Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/fb/69ff198a82cae7eb1a69fb84d93b3a3e4816564d76817fe541ddc96874eb/hf_xet-1.5.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dad0dc84e941b8ba3c860659fe1fdc35c049d47cce293f003287757e971a8f56", size = 4030814, upload-time = "2026-05-06T06:17:57.933Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ff/edcc2b40162bef3ff78e14ab637e5f3b89243d6aee72f5949d3bb6a5af83/hf_xet-1.5.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:fd6e5a9b0fdac4ed03ed45ef79254a655b1aaab514a02202617fbf643f5fdf7a", size = 3798444, upload-time = "2026-05-06T06:17:55.79Z" },
+    { url = "https://files.pythonhosted.org/packages/49/4d/103f76b04310e5e57656696cc184690d20c466af0bca3ca88f8c8ea5d4f3/hf_xet-1.5.0-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3531b1823a0e6d77d80f9ed15ca0e00f0d115094f8ac033d5cae88f4564cc949", size = 4465986, upload-time = "2026-05-06T06:17:44.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a2/546f47f464737b3edbab6f8ddb57f2599b93d2cbb66f06abb475ccb48651/hf_xet-1.5.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9a0ee58cd18d5ea799f7ed11290bbccbe56bdd8b1d97ca74b9cc49a3945d7a3b", size = 4259865, upload-time = "2026-05-06T06:17:42.639Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7f/1be593c1f28613be2e196473481cd81bfc5910795e30a34e8f744f6cac4f/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e60df5a42e9bed8628b6416af2cba4cba57ae9f02de226a06b020d98e1aab18", size = 4459835, upload-time = "2026-05-06T06:18:08.026Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b2/703569fc881f3284487e68cda7b42179978480da3c438042a6bbbb4a671c/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4b35549ce62601b84da4ff9b24d970032ace3d4430f52d91bcbb26c901d6c690", size = 4672414, upload-time = "2026-05-06T06:18:09.864Z" },
+    { url = "https://files.pythonhosted.org/packages/af/37/1b6def445c567286b50aa3b33828158e135b1be44938dde59f11382a500c/hf_xet-1.5.0-cp37-abi3-win_amd64.whl", hash = "sha256:2806c7c17b4d23f8d88f7c4814f838c3b6150773fe339c20af23e1cfaf2797e4", size = 3977238, upload-time = "2026-05-06T06:18:23.621Z" },
+    { url = "https://files.pythonhosted.org/packages/62/94/3b66b148778ee100dcfd69c2ca22b57b41b44d3063ceec934f209e9184ce/hf_xet-1.5.0-cp37-abi3-win_arm64.whl", hash = "sha256:b6c9df403040248c76d808d3e047d64db2d923bae593eb244c41e425cf6cd7be", size = 3806916, upload-time = "2026-05-06T06:18:21.7Z" },
 ]
 
 [[package]]
@@ -549,6 +621,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/b6/e22bd20a25299c34b8c5922c1545a6320825b13906eb0f7298edfd034a0b/huggingface_hub-1.15.0.tar.gz", hash = "sha256:28abfdddda3927fd4de6a63cf26ab012498a2c24dae52baf150c5c6edf98a1d5", size = 784100, upload-time = "2026-05-15T11:42:52.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/11/0b64cc9024329b76d7547c19a67604a61d21d3ba678a69d1b220c29d5112/huggingface_hub-1.15.0-py3-none-any.whl", hash = "sha256:a4a59af04cbc41a3fe3fec429b171ef994ef8c971eda10136746f408dd4e3744", size = 663602, upload-time = "2026-05-15T11:42:50.487Z" },
 ]
 
 [[package]]
@@ -723,6 +815,19 @@ wheels = [
 ]
 
 [[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -781,6 +886,88 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mmh3"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/1a/edb23803a168f070ded7a3014c6d706f63b90c84ccc024f89d794a3b7a6d/mmh3-5.2.1.tar.gz", hash = "sha256:bbea5b775f0ac84945191fb83f845a6fd9a21a03ea7f2e187defac7e401616ad", size = 33775, upload-time = "2026-03-05T15:55:57.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/94/bc5c3b573b40a328c4d141c20e399039ada95e5e2a661df3425c5165fd84/mmh3-5.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0cc21533878e5586b80d74c281d7f8da7932bc8ace50b8d5f6dbf7e3935f63f1", size = 56087, upload-time = "2026-03-05T15:54:21.92Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/80/64a02cc3e95c3af0aaa2590849d9ed24a9f14bb93537addde688e039b7c3/mmh3-5.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4eda76074cfca2787c8cf1bec603eaebdddd8b061ad5502f85cddae998d54f00", size = 40500, upload-time = "2026-03-05T15:54:22.953Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/72/e6d6602ce18adf4ddcd0e48f2e13590cc92a536199e52109f46f259d3c46/mmh3-5.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:eee884572b06bbe8a2b54f424dbd996139442cf83c76478e1ec162512e0dd2c7", size = 40034, upload-time = "2026-03-05T15:54:23.943Z" },
+    { url = "https://files.pythonhosted.org/packages/59/c2/bf4537a8e58e21886ef16477041238cab5095c836496e19fafc34b7445d2/mmh3-5.2.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0d0b7e803191db5f714d264044e06189c8ccd3219e936cc184f07106bd17fd7b", size = 97292, upload-time = "2026-03-05T15:54:25.335Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e2/51ed62063b44d10b06d975ac87af287729eeb5e3ed9772f7584a17983e90/mmh3-5.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e6c219e375f6341d0959af814296372d265a8ca1af63825f65e2e87c618f006", size = 103274, upload-time = "2026-03-05T15:54:26.44Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ce/12a7524dca59eec92e5b31fdb13ede1e98eda277cf2b786cf73bfbc24e81/mmh3-5.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26fb5b9c3946bf7f1daed7b37e0c03898a6f062149127570f8ede346390a0825", size = 106158, upload-time = "2026-03-05T15:54:28.578Z" },
+    { url = "https://files.pythonhosted.org/packages/86/1f/d3ba6dd322d01ab5d44c46c8f0c38ab6bbbf9b5e20e666dfc05bf4a23604/mmh3-5.2.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3c38d142c706201db5b2345166eeef1e7740e3e2422b470b8ba5c8727a9b4c7a", size = 113005, upload-time = "2026-03-05T15:54:29.767Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/a9/15d6b6f913294ea41b44d901741298e3718e1cb89ee626b3694625826a43/mmh3-5.2.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:50885073e2909251d4718634a191c49ae5f527e5e1736d738e365c3e8be8f22b", size = 120744, upload-time = "2026-03-05T15:54:30.931Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b3/70b73923fd0284c439860ff5c871b20210dfdbe9a6b9dd0ee6496d77f174/mmh3-5.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b3f99e1756fc48ad507b95e5d86f2fb21b3d495012ff13e6592ebac14033f166", size = 99111, upload-time = "2026-03-05T15:54:32.353Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/38/99f7f75cd27d10d8b899a1caafb9d531f3903e4d54d572220e3d8ac35e89/mmh3-5.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62815d2c67f2dd1be76a253d88af4e1da19aeaa1820146dec52cf8bee2958b16", size = 98623, upload-time = "2026-03-05T15:54:33.801Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/68/6e292c0853e204c44d2f03ea5f090be3317a0e2d9417ecb62c9eb27687df/mmh3-5.2.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8f767ba0911602ddef289404e33835a61168314ebd3c729833db2ed685824211", size = 106437, upload-time = "2026-03-05T15:54:35.177Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/fedd7284c459cfb58721d461fcf5607a4c1f5d9ab195d113d51d10164d16/mmh3-5.2.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:67e41a497bac88cc1de96eeba56eeb933c39d54bc227352f8455aa87c4ca4000", size = 110002, upload-time = "2026-03-05T15:54:36.673Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ac/ca8e0c19a34f5b71390171d2ff0b9f7f187550d66801a731bb68925126a4/mmh3-5.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3d74a03fb57757ece25aa4b3c1c60157a1cece37a020542785f942e2f827eed5", size = 97507, upload-time = "2026-03-05T15:54:37.804Z" },
+    { url = "https://files.pythonhosted.org/packages/df/94/6ebb9094cfc7ac5e7950776b9d13a66bb4a34f83814f32ba2abc9494fc68/mmh3-5.2.1-cp312-cp312-win32.whl", hash = "sha256:7374d6e3ef72afe49697ecd683f3da12f4fc06af2d75433d0580c6746d2fa025", size = 40773, upload-time = "2026-03-05T15:54:40.077Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/cd3527198cf159495966551c84a5f36805a10ac17b294f41f67b83f6a4d6/mmh3-5.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:3a9fed49c6ce4ed7e73f13182760c65c816da006debe67f37635580dfb0fae00", size = 41560, upload-time = "2026-03-05T15:54:41.148Z" },
+    { url = "https://files.pythonhosted.org/packages/15/96/6fe5ebd0f970a076e3ed5512871ce7569447b962e96c125528a2f9724470/mmh3-5.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:bbfcb95d9a744e6e2827dfc66ad10e1020e0cac255eb7f85652832d5a264c2fc", size = 39313, upload-time = "2026-03-05T15:54:42.171Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a5/9daa0508a1569a54130f6198d5462a92deda870043624aa3ea72721aa765/mmh3-5.2.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:723b2681ed4cc07d3401bbea9c201ad4f2a4ca6ba8cddaff6789f715dd2b391e", size = 40832, upload-time = "2026-03-05T15:54:43.212Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/6b/3230c6d80c1f4b766dedf280a92c2241e99f87c1504ff74205ec8cebe451/mmh3-5.2.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:3619473a0e0d329fd4aec8075628f8f616be2da41605300696206d6f36920c3d", size = 41964, upload-time = "2026-03-05T15:54:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/62/fb/648bfddb74a872004b6ee751551bfdda783fe6d70d2e9723bad84dbe5311/mmh3-5.2.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:e48d4dbe0f88e53081da605ae68644e5182752803bbc2beb228cca7f1c4454d6", size = 39114, upload-time = "2026-03-05T15:54:45.205Z" },
+    { url = "https://files.pythonhosted.org/packages/95/c2/ab7901f87af438468b496728d11264cb397b3574d41506e71b92128e0373/mmh3-5.2.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a482ac121de6973897c92c2f31defc6bafb11c83825109275cffce54bb64933f", size = 39819, upload-time = "2026-03-05T15:54:46.509Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/ed/6f88dda0df67de1612f2e130ffea34cf84aaee5bff5b0aff4dbff2babe34/mmh3-5.2.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:17fbb47f0885ace8327ce1235d0416dc86a211dcd8cc1e703f41523be32cfec8", size = 40330, upload-time = "2026-03-05T15:54:47.864Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/66/7516d23f53cdf90f43fce24ab80c28f45e6851d78b46bef8c02084edf583/mmh3-5.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d51fde50a77f81330523562e3c2734ffdca9c4c9e9d355478117905e1cfe16c6", size = 56078, upload-time = "2026-03-05T15:54:48.9Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/34/4d152fdf4a91a132cb226b671f11c6b796eada9ab78080fb5ce1e95adaab/mmh3-5.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:19bbd3b841174ae6ed588536ab5e1b1fe83d046e668602c20266547298d939a9", size = 40498, upload-time = "2026-03-05T15:54:49.942Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/4c/8e3af1b6d85a299767ec97bd923f12b06267089c1472c27c1696870d1175/mmh3-5.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:be77c402d5e882b6fbacfd90823f13da8e0a69658405a39a569c6b58fdb17b03", size = 40033, upload-time = "2026-03-05T15:54:50.994Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f2/966ea560e32578d453c9e9db53d602cbb1d0da27317e232afa7c38ceba11/mmh3-5.2.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:fd96476f04db5ceba1cfa0f21228f67c1f7402296f0e73fee3513aa680ad237b", size = 97320, upload-time = "2026-03-05T15:54:52.072Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/0d/2c5f9893b38aeb6b034d1a44ecd55a010148054f6a516abe53b5e4057297/mmh3-5.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:707151644085dd0f20fe4f4b573d28e5130c4aaa5f587e95b60989c5926653b5", size = 103299, upload-time = "2026-03-05T15:54:53.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fc/2ebaef4a4d4376f89761274dc274035ffd96006ab496b4ee5af9b08f21a9/mmh3-5.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3737303ca9ea0f7cb83028781148fcda4f1dac7821db0c47672971dabcf63593", size = 106222, upload-time = "2026-03-05T15:54:55.092Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/ea7ffe126d0ba0406622602a2d05e1e1a6841cc92fc322eb576c95b27fad/mmh3-5.2.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2778fed822d7db23ac5008b181441af0c869455b2e7d001f4019636ac31b6fe4", size = 113048, upload-time = "2026-03-05T15:54:56.305Z" },
+    { url = "https://files.pythonhosted.org/packages/85/57/9447032edf93a64aa9bef4d9aa596400b1756f40411890f77a284f6293ca/mmh3-5.2.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d57dea657357230cc780e13920d7fa7db059d58fe721c80020f94476da4ca0a1", size = 120742, upload-time = "2026-03-05T15:54:57.453Z" },
+    { url = "https://files.pythonhosted.org/packages/53/82/a86cc87cc88c92e9e1a598fee509f0409435b57879a6129bf3b3e40513c7/mmh3-5.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:169e0d178cb59314456ab30772429a802b25d13227088085b0d49b9fe1533104", size = 99132, upload-time = "2026-03-05T15:54:58.583Z" },
+    { url = "https://files.pythonhosted.org/packages/54/f7/6b16eb1b40ee89bb740698735574536bc20d6cdafc65ae702ea235578e05/mmh3-5.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7e4e1f580033335c6f76d1e0d6b56baf009d1a64d6a4816347e4271ba951f46d", size = 98686, upload-time = "2026-03-05T15:55:00.078Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/88/a601e9f32ad1410f438a6d0544298ea621f989bd34a0731a7190f7dec799/mmh3-5.2.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:2bd9f19f7f1fcebd74e830f4af0f28adad4975d40d80620be19ffb2b2af56c9f", size = 106479, upload-time = "2026-03-05T15:55:01.532Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/ce29ae3dfc4feec4007a437a1b7435fb9507532a25147602cd5b52be86db/mmh3-5.2.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:c88653877aeb514c089d1b3d473451677b8b9a6d1497dbddf1ae7934518b06d2", size = 110030, upload-time = "2026-03-05T15:55:02.934Z" },
+    { url = "https://files.pythonhosted.org/packages/13/30/ae444ef2ff87c805d525da4fa63d27cda4fe8a48e77003a036b8461cfd5c/mmh3-5.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fceef7fe67c81e1585198215e42ad3fdba3a25644beda8fbdaf85f4d7b93175a", size = 97536, upload-time = "2026-03-05T15:55:04.135Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f9/dc3787ee5c813cc27fe79f45ad4500d9b5437f23a7402435cc34e07c7718/mmh3-5.2.1-cp313-cp313-win32.whl", hash = "sha256:54b64fb2433bc71488e7a449603bf8bd31fbcf9cb56fbe1eb6d459e90b86c37b", size = 40769, upload-time = "2026-03-05T15:55:05.277Z" },
+    { url = "https://files.pythonhosted.org/packages/43/67/850e0b5a1e97799822ebfc4ca0e8c6ece3ed8baf7dcdf64de817dfdda2ca/mmh3-5.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:cae6383181f1e345317742d2ddd88f9e7d2682fa4c9432e3a74e47d92dce0229", size = 41563, upload-time = "2026-03-05T15:55:06.283Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/cc/98c90b28e1da5458e19fbfaf4adb5289208d3bfccd45dd14eab216a2f0bb/mmh3-5.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:022aa1a528604e6c83d0a7705fdef0b5355d897a9e0fa3a8d26709ceaa06965d", size = 39310, upload-time = "2026-03-05T15:55:07.323Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b4/65bc1fb2bb7f83e91c30865023b1847cf89a5f237165575e8c83aa536584/mmh3-5.2.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:d771f085fcdf4035786adfb1d8db026df1eb4b41dac1c3d070d1e49512843227", size = 40794, upload-time = "2026-03-05T15:55:09.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/86/7168b3d83be8eb553897b1fac9da8bbb06568e5cfe555ffc329ebb46f59d/mmh3-5.2.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:7f196cd7910d71e9d9860da0ff7a77f64d22c1ad931f1dd18559a06e03109fc0", size = 41923, upload-time = "2026-03-05T15:55:10.924Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9b/b653ab611c9060ce8ff0ba25c0226757755725e789292f3ca138a58082cd/mmh3-5.2.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b1f12bd684887a0a5d55e6363ca87056f361e45451105012d329b86ec19dbe0b", size = 39131, upload-time = "2026-03-05T15:55:11.961Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b4/5a2e0d34ab4d33543f01121e832395ea510132ea8e52cdf63926d9d81754/mmh3-5.2.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:d106493a60dcb4aef35a0fac85105e150a11cf8bc2b0d388f5a33272d756c966", size = 39825, upload-time = "2026-03-05T15:55:13.013Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/69/81699a8f39a3f8d368bec6443435c0c392df0d200ad915bf0d222b588e03/mmh3-5.2.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:44983e45310ee5b9f73397350251cdf6e63a466406a105f1d16cb5baa659270b", size = 40344, upload-time = "2026-03-05T15:55:14.026Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b3/71c8c775807606e8fd8acc5c69016e1caf3200d50b50b6dd4b40ce10b76c/mmh3-5.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:368625fb01666655985391dbad3860dc0ba7c0d6b9125819f3121ee7292b4ac8", size = 56291, upload-time = "2026-03-05T15:55:15.137Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/75/2c24517d4b2ce9e4917362d24f274d3d541346af764430249ddcc4cb3a08/mmh3-5.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:72d1cc63bcc91e14933f77d51b3df899d6a07d184ec515ea7f56bff659e124d7", size = 40575, upload-time = "2026-03-05T15:55:16.518Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/b9/e4a360164365ac9f07a25f0f7928e3a66eb9ecc989384060747aa170e6aa/mmh3-5.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e8b4b5580280b9265af3e0409974fb79c64cf7523632d03fbf11df18f8b0181e", size = 40052, upload-time = "2026-03-05T15:55:17.735Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ca/120d92223a7546131bbbc31c9174168ee7a73b1366f5463ffe69d9e691fe/mmh3-5.2.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4cbbde66f1183db040daede83dd86c06d663c5bb2af6de1142b7c8c37923dd74", size = 97311, upload-time = "2026-03-05T15:55:18.959Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/71/c1a60c1652b8813ef9de6d289784847355417ee0f2980bca002fe87f4ae5/mmh3-5.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8ff038d52ef6aa0f309feeba00c5095c9118d0abf787e8e8454d6048db2037fc", size = 103279, upload-time = "2026-03-05T15:55:20.448Z" },
+    { url = "https://files.pythonhosted.org/packages/48/29/ad97f4be1509cdcb28ae32c15593ce7c415db47ace37f8fad35b493faa9a/mmh3-5.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4130d0b9ce5fad6af07421b1aecc7e079519f70d6c05729ab871794eded8617", size = 106290, upload-time = "2026-03-05T15:55:21.6Z" },
+    { url = "https://files.pythonhosted.org/packages/77/29/1f86d22e281bd8827ba373600a4a8b0c0eae5ca6aa55b9a8c26d2a34decc/mmh3-5.2.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f6e0bfe77d238308839699944164b96a2eeccaf55f2af400f54dc20669d8d5f2", size = 113116, upload-time = "2026-03-05T15:55:22.826Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7c/339971ea7ed4c12d98f421f13db3ea576a9114082ccb59d2d1a0f00ccac1/mmh3-5.2.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f963eafc0a77a6c0562397da004f5876a9bcf7265a7bcc3205e29636bc4a1312", size = 120740, upload-time = "2026-03-05T15:55:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/92/3c7c4bdb8e926bb3c972d1e2907d77960c1c4b250b41e8366cf20c6e4373/mmh3-5.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:92883836caf50d5255be03d988d75bc93e3f86ba247b7ca137347c323f731deb", size = 99143, upload-time = "2026-03-05T15:55:25.456Z" },
+    { url = "https://files.pythonhosted.org/packages/df/0a/33dd8706e732458c8375eae63c981292de07a406bad4ec03e5269654aa2c/mmh3-5.2.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:57b52603e89355ff318025dd55158f6e71396c0f1f609d548e9ea9c94cc6ce0a", size = 98703, upload-time = "2026-03-05T15:55:26.723Z" },
+    { url = "https://files.pythonhosted.org/packages/51/04/76bbce05df76cbc3d396f13b2ea5b1578ef02b6a5187e132c6c33f99d596/mmh3-5.2.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f40a95186a72fa0b67d15fef0f157bfcda00b4f59c8a07cbe5530d41ac35d105", size = 106484, upload-time = "2026-03-05T15:55:28.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8f/c6e204a2c70b719c1f62ffd9da27aef2dddcba875ea9c31ca0e87b975a46/mmh3-5.2.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:58370d05d033ee97224c81263af123dea3d931025030fd34b61227a768a8858a", size = 110012, upload-time = "2026-03-05T15:55:29.532Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/37/7181efd8e39db386c1ebc3e6b7d1f702a09d7c1197a6f2742ed6b5c16597/mmh3-5.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7be6dfb49e48fd0a7d91ff758a2b51336f1cd21f9d44b20f6801f072bd080cdd", size = 97508, upload-time = "2026-03-05T15:55:31.01Z" },
+    { url = "https://files.pythonhosted.org/packages/42/0f/afa7ca2615fd85e1469474bb860e381443d0b868c083b62b41cb1d7ca32f/mmh3-5.2.1-cp314-cp314-win32.whl", hash = "sha256:54fe8518abe06a4c3852754bfd498b30cc58e667f376c513eac89a244ce781a4", size = 41387, upload-time = "2026-03-05T15:55:32.403Z" },
+    { url = "https://files.pythonhosted.org/packages/71/0d/46d42a260ee1357db3d486e6c7a692e303c017968e14865e00efa10d09fc/mmh3-5.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:3f796b535008708846044c43302719c6956f39ca2d93f2edda5319e79a29efbb", size = 42101, upload-time = "2026-03-05T15:55:33.646Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/7b/848a8378059d96501a41159fca90d6a99e89736b0afbe8e8edffeac8c74b/mmh3-5.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:cd471ede0d802dd936b6fab28188302b2d497f68436025857ca72cd3810423fe", size = 39836, upload-time = "2026-03-05T15:55:35.026Z" },
+    { url = "https://files.pythonhosted.org/packages/27/61/1dabea76c011ba8547c25d30c91c0ec22544487a8750997a27a0c9e1180b/mmh3-5.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5174a697ce042fa77c407e05efe41e03aa56dae9ec67388055820fb48cf4c3ba", size = 57727, upload-time = "2026-03-05T15:55:36.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/32/731185950d1cf2d5e28979cc8593016ba1619a295faba10dda664a4931b5/mmh3-5.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0a3984146e414684a6be2862d84fcb1035f4984851cb81b26d933bab6119bf00", size = 41308, upload-time = "2026-03-05T15:55:37.254Z" },
+    { url = "https://files.pythonhosted.org/packages/76/aa/66c76801c24b8c9418b4edde9b5e57c75e72c94e29c48f707e3962534f18/mmh3-5.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:bd6e7d363aa93bd3421b30b6af97064daf47bc96005bddba67c5ffbc6df426b8", size = 40758, upload-time = "2026-03-05T15:55:38.61Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/bb/79a1f638a02f0ae389f706d13891e2fbf7d8c0a22ecde67ba828951bb60a/mmh3-5.2.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:113f78e7463a36dbbcea05bfe688efd7fa759d0f0c56e73c974d60dcfec3dfcc", size = 109670, upload-time = "2026-03-05T15:55:40.13Z" },
+    { url = "https://files.pythonhosted.org/packages/26/94/8cd0e187a288985bcfc79bf5144d1d712df9dee74365f59d26e3a1865be6/mmh3-5.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7e8ec5f606e0809426d2440e0683509fb605a8820a21ebd120dcdba61b74ef7f", size = 117399, upload-time = "2026-03-05T15:55:42.076Z" },
+    { url = "https://files.pythonhosted.org/packages/42/94/dfea6059bd5c5beda565f58a4096e43f4858fb6d2862806b8bbd12cbb284/mmh3-5.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22b0f9971ec4e07e8223f2beebe96a6cfc779d940b6f27d26604040dd74d3a44", size = 120386, upload-time = "2026-03-05T15:55:43.481Z" },
+    { url = "https://files.pythonhosted.org/packages/47/cb/f9c45e62aaa67220179f487772461d891bb582bb2f9783c944832c60efd9/mmh3-5.2.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:85ffc9920ffc39c5eee1e3ac9100c913a0973996fbad5111f939bbda49204bb7", size = 125924, upload-time = "2026-03-05T15:55:44.638Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/fe54a4a7c11bc9f623dfc1707decd034245602b076dfc1dcc771a4163170/mmh3-5.2.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7aec798c2b01aaa65a55f1124f3405804184373abb318a3091325aece235f67c", size = 135280, upload-time = "2026-03-05T15:55:45.866Z" },
+    { url = "https://files.pythonhosted.org/packages/97/67/fe7e9e9c143daddd210cd22aef89cbc425d58ecf238d2b7d9eb0da974105/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55dbbd8ffbc40d1697d5e2d0375b08599dae8746b0b08dea05eee4ce81648fac", size = 110050, upload-time = "2026-03-05T15:55:47.074Z" },
+    { url = "https://files.pythonhosted.org/packages/43/c4/6d4b09fcbef80794de447c9378e39eefc047156b290fa3dd2d5257ca8227/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:6c85c38a279ca9295a69b9b088a2e48aa49737bb1b34e6a9dc6297c110e8d912", size = 111158, upload-time = "2026-03-05T15:55:48.239Z" },
+    { url = "https://files.pythonhosted.org/packages/81/a6/ca51c864bdb30524beb055a6d8826db3906af0834ec8c41d097a6e8573d5/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:6290289fa5fb4c70fd7f72016e03633d60388185483ff3b162912c81205ae2cf", size = 116890, upload-time = "2026-03-05T15:55:49.405Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/04/5a1fe2e2ad843d03e89af25238cbc4f6840a8bb6c4329a98ab694c71deda/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:4fc6cd65dc4d2fdb2625e288939a3566e36127a84811a4913f02f3d5931da52d", size = 123121, upload-time = "2026-03-05T15:55:50.61Z" },
+    { url = "https://files.pythonhosted.org/packages/af/4d/3c820c6f4897afd25905270a9f2330a23f77a207ea7356f7aadace7273c0/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:623f938f6a039536cc02b7582a07a080f13fdfd48f87e63201d92d7e34d09a18", size = 110187, upload-time = "2026-03-05T15:55:52.143Z" },
+    { url = "https://files.pythonhosted.org/packages/21/54/1d71cd143752361c0aebef16ad3f55926a6faf7b112d355745c1f8a25f7f/mmh3-5.2.1-cp314-cp314t-win32.whl", hash = "sha256:29bc3973676ae334412efdd367fcd11d036b7be3efc1ce2407ef8676dabfeb82", size = 41934, upload-time = "2026-03-05T15:55:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e4/63a2a88f31d93dea03947cccc2a076946857e799ea4f7acdecbf43b324aa/mmh3-5.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:28cfab66577000b9505a0d068c731aee7ca85cd26d4d63881fab17857e0fe1fb", size = 43036, upload-time = "2026-03-05T15:55:55.252Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0f/59204bf136d1201f8d7884cfbaf7498c5b4674e87a4c693f9bde63741ce1/mmh3-5.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:dfd51b4c56b673dfbc43d7d27ef857dd91124801e2806c69bb45585ce0fa019b", size = 40391, upload-time = "2026-03-05T15:55:56.697Z" },
 ]
 
 [[package]]
@@ -889,6 +1076,99 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/b1/d111b1df656761f980d9e298a60039a9cb66036b1d039e777537743d0ac3/onnxruntime-1.26.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:05b028781b322ad74b57ce5b50aa5280bb1fe96ceec334628ade681e0b24c1ac", size = 18016624, upload-time = "2026-05-12T00:41:01.735Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a0/3f9d896a0385a36bd04345d6d0b802821a5782adde562e7e135f6bb71c73/onnxruntime-1.26.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:91f2bb870a4b9224eba0a6728c1fa7a9e552b8e59e1083c51fbbc3d013f2b5c0", size = 16052692, upload-time = "2026-05-08T19:07:13.829Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/2a4e04f8dbeffad19bbcced4bcd4289bf478921518437404d6b92bdf213b/onnxruntime-1.26.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b6dd70599005bd1bf29779f04a91978b92b5e719c11a20068a8f8e535f725b6", size = 18185439, upload-time = "2026-05-08T19:07:36.299Z" },
+    { url = "https://files.pythonhosted.org/packages/44/fc/026d0a7162b9c2153dac292baea9e027c42304dc1d9dc6f8ff5b4cfbaedd/onnxruntime-1.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:a26374dc7fbcaae593601086b242120e13f2310558df0991da6dd8b8fac00414", size = 13026427, upload-time = "2026-05-08T19:08:03.503Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/27/1dcf88e45e4c69db5f7b106f2dacc3801ba98994e082ca03e1dfdf7bfe57/onnxruntime-1.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:54a8053410fd31fd66469bd754fcfe8a4df9f7eb44756b4b5479bf50c842d948", size = 12796647, upload-time = "2026-05-08T19:07:52.108Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a2/c801242685e0ce48a4ca51dfafbb588765e0446397e123be53ba5598f3f5/onnxruntime-1.26.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:ccce19c5f771b8268902f77d9fed9e88f9499465d6780808faa6611a789d33f0", size = 18016563, upload-time = "2026-05-08T19:07:28.081Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/64/0492c0b1db04e29b2630c87cfa36f9d6872b1ca8614b90c5cad58fac7d76/onnxruntime-1.26.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bdbed8cf3b672b66acb032f33a253bc27f42bce6ece48ae3fab4fa483a5e96e0", size = 16052634, upload-time = "2026-05-08T19:07:16.885Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/26/4d09ddc755a84fc8d5e192991626b0e0680e8f6c5d58f4f1d05c42bc48cf/onnxruntime-1.26.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c07af6fc6d5557835f2b6ee7a96d8b3235d0c57a8e230efdedaee106a8a3cbc6", size = 18185632, upload-time = "2026-05-08T19:07:38.756Z" },
+    { url = "https://files.pythonhosted.org/packages/77/89/3e52249aa08fa301e217ecba07b5246a8338fa2b401e109326e3fc5be0f9/onnxruntime-1.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:61bec80655efa460591c2bc655392d57d2650ce85533a6b9b3b7a790d7ea7916", size = 13026751, upload-time = "2026-05-08T19:08:06.2Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b3/c1c8782b14af6797c303de132d6eef26a9fb80dfacd3750ce57911d11c6b/onnxruntime-1.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:a6677545ff451e3539a02746d2f207d8c5baa4a0a818886bb9d6a6eb9511ee89", size = 12796807, upload-time = "2026-05-08T19:07:54.879Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f5/47b0676408abec652c14b84d7173e389837832d850c24f87184277313e8d/onnxruntime-1.26.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e016edc15d3c19f36807e1c6b10be5b27807688c32720f91b5ae480a95215d0", size = 16057265, upload-time = "2026-05-08T19:07:19.603Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/45/33ab6deeef010ca844c877dd618cebc079590bbe52d2a3678e7223b1b908/onnxruntime-1.26.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f5fc48a91a046a6a5c9b147f83fb41d65d24d24923373b222cdd248f0f4f4aac", size = 18197590, upload-time = "2026-05-08T19:07:41.422Z" },
+    { url = "https://files.pythonhosted.org/packages/40/89/17546c1c20f6bfc3ae41c22152378a26edfea918af3129e2139dcd7c99f3/onnxruntime-1.26.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:33a791f31432a3af1a96db5e54818b37aba5e5eefc2e6af5794c10a9118a9993", size = 18019724, upload-time = "2026-05-08T19:07:30.723Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/24/89457a35f6af29538a76647f2c18c3a28277e6c19234c847e7b4b7c19860/onnxruntime-1.26.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e90c00732c4553618103149d93f688e8c3063017938f8983e21a71d9f3b6d22e", size = 16054821, upload-time = "2026-05-08T19:07:22.348Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f9/15b2e1815cf570d238e0135529f80d2dce64e8e8818a1489cae83823c5c6/onnxruntime-1.26.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01498e80ba8988428d08c2d51b1338f89e3de2a93e6ffe555f79c68f26a5c06b", size = 18185815, upload-time = "2026-05-08T19:07:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/65/2e11055faf015e4b07f45b513fa49b391baf2e19d92d77d73ebee13c1004/onnxruntime-1.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:7ead61450d8405167c87dd3a31d8da1d576b490a57dab1aa8b82a7da6825f5aa", size = 13349887, upload-time = "2026-05-08T19:08:08.671Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e4/0f9d1a5718b1781c610c1e354765a3820597081754277a6a9a2b50705702/onnxruntime-1.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:31d71a53490e46910877d0902b5ad99c69a5955e5c7ea6c82863519410e1ba7c", size = 13140121, upload-time = "2026-05-08T19:07:57.804Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/42/3b8e635f067d06d9f45bede470b8d539d101a4166c272213158dfd08b6ce/onnxruntime-1.26.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d7b6d258fb78fdfcf049795bcfaa74dcb90ae7baa277afd21e6fd28b83f2c496", size = 16057240, upload-time = "2026-05-08T19:07:25.163Z" },
+    { url = "https://files.pythonhosted.org/packages/93/99/f2be40a31b908d96b861ae0ce98582fa376c18a7f816b9d5eb4cd6aa0a4c/onnxruntime-1.26.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4eefd386a45202aefb7a5132b94f32df9d506c9edcc7faf2fc60d65183f4b183", size = 18197382, upload-time = "2026-05-08T19:07:46.965Z" },
+]
+
+[[package]]
 name = "openzim-mcp"
 version = "2.0.0a25"
 source = { editable = "." }
@@ -900,6 +1180,11 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "tiktoken" },
+]
+
+[package.optional-dependencies]
+reranker = [
+    { name = "fastembed" },
 ]
 
 [package.dev-dependencies]
@@ -920,6 +1205,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.3,<5.0" },
+    { name = "fastembed", marker = "extra == 'reranker'", specifier = ">=0.4.0,<1.0" },
     { name = "html2text", specifier = ">=2025.4.15,<2027.0" },
     { name = "libzim", specifier = ">=3.9.0,<4.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.27.0,<2.0" },
@@ -927,6 +1213,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.14.0,<3.0" },
     { name = "tiktoken", specifier = ">=0.7.0,<1.0" },
 ]
+provides-extras = ["reranker"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -968,6 +1255,75 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
 ]
 
 [[package]]
@@ -1060,12 +1416,55 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "7.35.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/fd/5b1491d9e4b586d621c54f4c36b888714164b6875f8d6afa3f9072906a51/protobuf-7.35.0.tar.gz", hash = "sha256:a2efd84605f41e559f1881b0912b44099d0a2ac9bf46b3474823f10fb393b0e6", size = 458677, upload-time = "2026-05-19T23:02:29.197Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ee/93d06e358a4aa32280b00e722d3ea0a1f25fc3cc5778d80581c9cca2c10e/protobuf-7.35.0-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:66be6c513931c794fa92c080ffee41671390da3d79da219cf9c0c0907f035dda", size = 433225, upload-time = "2026-05-19T23:02:19.884Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/39/1c76c2da93f3c507e958e0aecee2391cc44d4625de6c728bbc555195b5a8/protobuf-7.35.0-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:fcbe42a4ac09d3ec9c987ddfcd956afd0b15f1ff613bd8371bde9405ffd5c8e5", size = 328847, upload-time = "2026-05-19T23:02:22.3Z" },
+    { url = "https://files.pythonhosted.org/packages/91/1a/39f7ce90a238c1a987a4d81ec26379e02ca0aff367de68e4a1fa474215b9/protobuf-7.35.0-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:4cbf5cc286130e06a6c9bbefac442431173906dfcc979712183d4adcc01b37ee", size = 344030, upload-time = "2026-05-19T23:02:23.591Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5b/6baf9008817964454055ff3fe65f1de0b5f1e26c80c82f7fb108b7cd4ea3/protobuf-7.35.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:6c0f98f10c8a05ea30f8993dfef2de093d27b490fdae78bb60c8343795d55011", size = 327130, upload-time = "2026-05-19T23:02:24.637Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e5/e46adb0badc388bfb84877a5f9f026aff63f60e611016cf64dbe77e05446/protobuf-7.35.0-cp310-abi3-win32.whl", hash = "sha256:4c4617b83ade0e279d1d2bfe04025a1adb87f9ed657de038620dc0ff959357f6", size = 428946, upload-time = "2026-05-19T23:02:25.741Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ab/547fbd9e16d879dd13c167478f8ae0a83a428008ca07a5e06acdc23ad473/protobuf-7.35.0-cp310-abi3-win_amd64.whl", hash = "sha256:f05bcadf9a2a6b8dda047007075135fb7d08c73d9177aabc067e1be46881a201", size = 439996, upload-time = "2026-05-19T23:02:26.808Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ef/50433d346c56657a70d27f156c7b349ac59a068b01de4eb796e747eecc43/protobuf-7.35.0-py3-none-any.whl", hash = "sha256:c13f325cf242bad135c350629eeb5d54b24228eb472fb3e2e9ebbd4c5dc20ca0", size = 171659, upload-time = "2026-05-19T23:02:27.842Z" },
+]
+
+[[package]]
 name = "py-cpuinfo"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
+name = "py-rust-stemmers"
+version = "0.1.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/63/4fbc14810c32d2a884e2e94e406a7d5bf8eee53e1103f558433817230342/py_rust_stemmers-0.1.5.tar.gz", hash = "sha256:e9c310cfb5c2470d7c7c8a0484725965e7cab8b1237e106a0863d5741da3e1f7", size = 9388, upload-time = "2025-02-19T13:56:28.708Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e1/ea8ac92454a634b1bb1ee0a89c2f75a4e6afec15a8412527e9bbde8c6b7b/py_rust_stemmers-0.1.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:29772837126a28263bf54ecd1bc709dd569d15a94d5e861937813ce51e8a6df4", size = 286085, upload-time = "2025-02-19T13:55:23.871Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/fe1cc3d36a19c1ce39792b1ed151ddff5ee1d74c8801f0e93ff36e65f885/py_rust_stemmers-0.1.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4d62410ada44a01e02974b85d45d82f4b4c511aae9121e5f3c1ba1d0bea9126b", size = 272021, upload-time = "2025-02-19T13:55:25.685Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/38/b8f94e5e886e7ab181361a0911a14fb923b0d05b414de85f427e773bf445/py_rust_stemmers-0.1.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b28ef729a4c83c7d9418be3c23c0372493fcccc67e86783ff04596ef8a208cdf", size = 310547, upload-time = "2025-02-19T13:55:26.891Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/08/62e97652d359b75335486f4da134a6f1c281f38bd3169ed6ecfb276448c3/py_rust_stemmers-0.1.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a979c3f4ff7ad94a0d4cf566ca7bfecebb59e66488cc158e64485cf0c9a7879f", size = 315237, upload-time = "2025-02-19T13:55:28.116Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/b9/fc0278432f288d2be4ee4d5cc80fd8013d604506b9b0503e8b8cae4ba1c3/py_rust_stemmers-0.1.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c3593d895453fa06bf70a7b76d6f00d06def0f91fc253fe4260920650c5e078", size = 324419, upload-time = "2025-02-19T13:55:29.211Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/5b/74e96eaf622fe07e83c5c389d101540e305e25f76a6d0d6fb3d9e0506db8/py_rust_stemmers-0.1.5-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:96ccc7fd042ffc3f7f082f2223bb7082ed1423aa6b43d5d89ab23e321936c045", size = 324792, upload-time = "2025-02-19T13:55:30.948Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/f7/b76816d7d67166e9313915ad486c21d9e7da0ac02703e14375bb1cb64b5a/py_rust_stemmers-0.1.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ef18cfced2c9c676e0d7d172ba61c3fab2aa6969db64cc8f5ca33a7759efbefe", size = 488014, upload-time = "2025-02-19T13:55:32.066Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ed/7d9bed02f78d85527501f86a867cd5002d97deb791b9a6b1b45b00100010/py_rust_stemmers-0.1.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:541d4b5aa911381e3d37ec483abb6a2cf2351b4f16d5e8d77f9aa2722956662a", size = 575582, upload-time = "2025-02-19T13:55:34.005Z" },
+    { url = "https://files.pythonhosted.org/packages/93/40/eafd1b33688e8e8ae946d1ef25c4dc93f5b685bd104b9c5573405d7e1d30/py_rust_stemmers-0.1.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ffd946a36e9ac17ca96821963663012e04bc0ee94d21e8b5ae034721070b436c", size = 493267, upload-time = "2025-02-19T13:55:35.294Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6a/15135b69e4fd28369433eb03264d201b1b0040ba534b05eddeb02a276684/py_rust_stemmers-0.1.5-cp312-none-win_amd64.whl", hash = "sha256:6ed61e1207f3b7428e99b5d00c055645c6415bb75033bff2d06394cbe035fd8e", size = 209395, upload-time = "2025-02-19T13:55:36.519Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b8/030036311ec25952bf3083b6c105be5dee052a71aa22d5fbeb857ebf8c1c/py_rust_stemmers-0.1.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:398b3a843a9cd4c5d09e726246bc36f66b3d05b0a937996814e91f47708f5db5", size = 286086, upload-time = "2025-02-19T13:55:37.581Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/be/0465dcb3a709ee243d464e89231e3da580017f34279d6304de291d65ccb0/py_rust_stemmers-0.1.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4e308fc7687901f0c73603203869908f3156fa9c17c4ba010a7fcc98a7a1c5f2", size = 272019, upload-time = "2025-02-19T13:55:39.183Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/b6/76ca5b1f30cba36835938b5d9abee0c130c81833d51b9006264afdf8df3c/py_rust_stemmers-0.1.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f9efc4da5e734bdd00612e7506de3d0c9b7abc4b89d192742a0569d0d1fe749", size = 310545, upload-time = "2025-02-19T13:55:40.339Z" },
+    { url = "https://files.pythonhosted.org/packages/56/8f/5be87618cea2fe2e70e74115a20724802bfd06f11c7c43514b8288eb6514/py_rust_stemmers-0.1.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cc2cc8d2b36bc05b8b06506199ac63d437360ae38caefd98cd19e479d35afd42", size = 315236, upload-time = "2025-02-19T13:55:41.55Z" },
+    { url = "https://files.pythonhosted.org/packages/00/02/ea86a316aee0f0a9d1449ad4dbffff38f4cf0a9a31045168ae8b95d8bdf8/py_rust_stemmers-0.1.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a231dc6f0b2a5f12a080dfc7abd9e6a4ea0909290b10fd0a4620e5a0f52c3d17", size = 324419, upload-time = "2025-02-19T13:55:42.693Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/1612c22545dcc0abe2f30fc08f30a2332f2224dd536fa1508444a9ca0e39/py_rust_stemmers-0.1.5-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5845709d48afc8b29e248f42f92431155a3d8df9ba30418301c49c6072b181b0", size = 324794, upload-time = "2025-02-19T13:55:43.896Z" },
+    { url = "https://files.pythonhosted.org/packages/66/18/8a547584d7edac9e7ac9c7bdc53228d6f751c0f70a317093a77c386c8ddc/py_rust_stemmers-0.1.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e48bfd5e3ce9d223bfb9e634dc1425cf93ee57eef6f56aa9a7120ada3990d4be", size = 488014, upload-time = "2025-02-19T13:55:45.088Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/87/4619c395b325e26048a6e28a365afed754614788ba1f49b2eefb07621a03/py_rust_stemmers-0.1.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:35d32f6e7bdf6fd90e981765e32293a8be74def807147dea9fdc1f65d6ce382f", size = 575582, upload-time = "2025-02-19T13:55:46.436Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6e/214f1a889142b7df6d716e7f3fea6c41e87bd6c29046aa57e175d452b104/py_rust_stemmers-0.1.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:191ea8bf922c984631ffa20bf02ef0ad7eec0465baeaed3852779e8f97c7e7a3", size = 493269, upload-time = "2025-02-19T13:55:49.057Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/b9/c5185df277576f995ae34418eb2b2ac12f30835412270f9e05c52face521/py_rust_stemmers-0.1.5-cp313-none-win_amd64.whl", hash = "sha256:e564c9efdbe7621704e222b53bac265b0e4fbea788f07c814094f0ec6b80adcf", size = 209397, upload-time = "2025-02-19T13:55:50.853Z" },
 ]
 
 [[package]]
@@ -1742,6 +2141,33 @@ wheels = [
 ]
 
 [[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/39/b87a87d5bb9470610b80a2d31df42fcffeaf35118b8b97952b2aff598cc7/tokenizers-0.23.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e03d6ffcbe0d56ee9c1ccd070e70a13fa750727c0277e138152acbc0252c2224", size = 3146732, upload-time = "2026-04-27T14:43:15.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6a/068ed9f6e444c9d7e9d55ce134181325700f3d7f30410721bdc8f848d727/tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e", size = 3054954, upload-time = "2026-04-27T14:43:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/36/e006edf031154cba92b8416057d92c3abe3635e4c4b0aa0b5b9bb39dde70/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf13402aff9bc533c89cb849ec3b412dc3fbeacc9744840e423d7bf3f7dc0e3", size = 3374081, upload-time = "2026-04-27T14:43:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ef/7735d226f9c7f874a6bee5e3f27fb25ecabdf207d37b8cf45286d0795893/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f836ca703b89ae07919a309f9651f7a88fd5a33d5f718ba5ad0870ec0256bad6", size = 3247641, upload-time = "2026-04-27T14:43:03.856Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d9/24827036f6e21297bfffda0768e58eb6096a4f411e932964a01707857931/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae848657742035523fdf261773630cb819a26995fcd3d9ecae0c1daf6e5a4959", size = 3585624, upload-time = "2026-04-27T14:43:10.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/22f3582b3a4f49358293a5206e25317621ee4526bfe9cdaa0f07a12e770e/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b09e85775d5187941e7bab30e941b4134ab4a7dd8c68e783d231fb7ca27c51", size = 3844062, upload-time = "2026-04-27T14:43:05.643Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/65/b8f8814eef95800f20721384136d9a1d22241d50b2874357cb70542c392f/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea5a0ce170074329faaa8ea3f6400ecde604b6678192688533af80980daae71a", size = 3460098, upload-time = "2026-04-27T14:43:08.854Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d5/1353e5f677ec27c2494fb6a6725e82d56c985f53e90ec511369e7e4f02c6/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4", size = 3346235, upload-time = "2026-04-27T14:43:12.377Z" },
+    { url = "https://files.pythonhosted.org/packages/71/89/39b6b8fc073fb6d413d0147aa333dc7eff7be65639ac9d19930a0b21bf33/tokenizers-0.23.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:56f3a77de629917652f876294dc9fe6bad4a0c43bc229dc72e59bb23a0f4729a", size = 3426398, upload-time = "2026-04-27T14:43:07.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/80/127c854da64827e5b79264ce524993a90dddcb320e5cd42412c5c02f9e8a/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d10a6d957ef01896dc274e890eee27d41bd0e74ef31e60616f0fc311345184e", size = 9823279, upload-time = "2026-04-27T14:43:17.222Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ba/44c2502feb1a058f096ddfb4e0996ef3225a01a388e1a9b094e91689fe93/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1974288a609c343774f1b897c8b482c791ab17b75ab5c8c2b1737565c1d82288", size = 9644986, upload-time = "2026-04-27T14:43:19.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c1/464019a9fb059870bfe4eebb4ba12208f3042035e258bf5e782906bd3847/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:120468fb4c24faf0543c835a4fabafa4deb3f20a035c9b6e83d0b553a97615d4", size = 9976181, upload-time = "2026-04-27T14:43:21.463Z" },
+    { url = "https://files.pythonhosted.org/packages/79/94/3ac1432bda31626071e9b6a12709b97ae05131c804b94c8f3ac622c5da32/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e3d8f40ea6268047de7046906326abed5134f27d4e8447b23763afe5808c8a96", size = 10113853, upload-time = "2026-04-27T14:43:23.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1793,6 +2219,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]
@@ -1866,4 +2304,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3f/8b/6331f7a7fe70131c301106ec1e7cf23e2501bf7d4ca3636805801ca191bb/virtualenv-21.3.0.tar.gz", hash = "sha256:733750db978ec95c2d8eb4feadaa57091002bce404cb39ba69899cf7bd28944e", size = 7614069, upload-time = "2026-04-27T17:05:58.927Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/eb/03bfb1299d4c4510329e470f13f9a4ce793df7fcb5a2fd3510f911066f61/virtualenv-21.3.0-py3-none-any.whl", hash = "sha256:4d28ee41f6d9ec8f1f00cd472b9ffbcedda1b3d3b9a575b5c94a2d004fd51bd7", size = 7594690, upload-time = "2026-04-27T17:05:55.468Z" },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]


### PR DESCRIPTION
Implements sub-D-1 of [v2 Phase D](docs/superpowers/specs/2026-05-20-v2-phase-d-ml-accelerators-design.md).

## What's new

Optional `[reranker]` extra (install with `pip install openzim-mcp[reranker]`) adds a cross-encoder rerank pass on top of Xapian's BM25 results. When the extra is absent, all behaviour is unchanged.

- New module `openzim_mcp/ml/` — feature-detection registry, `ml_fallback` decorator, `BGEReranker` lazy singleton
- New `openzim-mcp download-models` CLI for air-gapped pre-staging
- Wired into all four search surfaces: `_handle_search`, `_handle_filtered_search`, `_handle_search_all`, `synthesize._collect_passages`
- Telemetry events: `reranker_engaged`, `reranker_skipped.not_installed`, `reranker_skipped.no_results`, `reranker_skipped.passthrough`
- Skip-on-short-query gate (`min_query_tokens=4`) bypasses rerank for entity queries — `Berlin` already has a Xapian-score-1.0 canonical-title hit

## Risk mitigations baked in

- **5-second wall-clock timeout on first-call model load** with a true non-blocking shutdown — operators don't hang waiting on a stuck download
- **Persistent kill switch on load failure** — after the first failure, `BGEReranker.get()` returns `None` immediately for the rest of the process; no retry storms
- **`@ml_fallback` on `rerank()`** — mid-inference exceptions degrade to Xapian-only ordering via `_rerank_passthrough`, with WARNING + DEBUG-on-retry logging
- **Production model ID guarded by integration test** — `test_production_default_model_is_supported_by_fastembed` catches FastEmbed registry drift before users do
- **Cross-archive rerank in `_handle_search_all`** redistributes globally-top-K hits back to per-archive buckets; ordering test pins this contract
- **`synthesize` rerank propagates `rerank_score` into `p["score"]`** so `_boost_by_section_affinity` doesn't silently revert to BM25 order
- **Supported platforms documented** — Linux/macOS/Windows x86_64+ARM64; edge platforms (Alpine, ARM32) explicitly out of scope

## Telemetry review

Per the spec's 2-week telemetry review gate: after this ships, we measure `reranker_engaged` fire rate, `reranker_skipped.*` reason distribution, and `_load_failed` occurrence (via WARNING log line `reranker model load failed`) before committing sub-D-2 to writing-plans.

## Tests

- 27+ new tests in `tests/ml/`: unit (mocked FastEmbed), integration (live FastEmbed, marker-gated), wiring tests for all four call sites
- Full suite: **2188 passing, 54 skipped** (no-extras path unchanged)
- New CI job `test-reranker` runs the marker-gated integration tests with `[reranker]` installed on ubuntu-latest, Python 3.12 + 3.13

## Reality-check deviations from the original plan

- **Model ID** corrected from `Xenova/bge-reranker-base-onnx` (doesn't exist in FastEmbed 0.8.0) to `BAAI/bge-reranker-base`. Discovered by Task 11's integration test.
- **`_meta.reranked` flag** dropped from response shape — search handlers render to markdown strings, not JSON envelopes. Telemetry events + the INFO log on first load are the canonical signals for "rerank is active."
- **`_handle_filtered_search`** had no structured-payload path; one was added (the legacy raw-string path is unchanged).

## Spec/plan docs included

This branch carries three preceding docs commits (the Phase D spec, the trimmed spec, and the sub-D-1 implementation plan) — they're the design context for the implementation.
