### PR TITLE
fix(v2): post-b1 sweep — air-gapped pre-stage, telemetry visibility, first-call timeout

### DIFF
--- a/docs/v2/extras-reranker.md
+++ b/docs/v2/extras-reranker.md
@@ -38,7 +38,7 @@ openzim-mcp download-models
 ```
 
 Idempotent — safe to re-run. Without pre-staging, the first MCP query
-that triggers rerank has a 5-second timeout; on timeout the reranker
+that triggers rerank has a 15-second timeout; on timeout the reranker
 falls back to Xapian-only ranking for the rest of the process and logs
 a structured warning.
 
@@ -78,7 +78,7 @@ Set via environment variables with the `OPENZIM_MCP_` prefix:
 export OPENZIM_MCP_ML__RERANKER__ENABLED=true
 export OPENZIM_MCP_ML__RERANKER__MIN_QUERY_TOKENS=4
 export OPENZIM_MCP_ML__RERANKER__FINAL_TOP_K=10
-export OPENZIM_MCP_ML__RERANKER__FIRST_CALL_TIMEOUT_SECONDS=5.0
+export OPENZIM_MCP_ML__RERANKER__FIRST_CALL_TIMEOUT_SECONDS=15.0
 ```
 
 (The `__` double-underscore delimits nested config sections.)
@@ -100,6 +100,12 @@ event names (all use dot-separator):
   - A mid-inference failure tripped the `ml_fallback` decorator, which
     returned input candidates sliced to `top_k` (Xapian order preserved)
 
+Each reranker event also emits a single INFO-level log line per call
+of the form `telemetry: <event>`. This makes engagement observable to
+operators running in simple tool mode, who don't have access to
+`get_server_health` to read the counter directly. Set the logger to
+WARNING or higher to suppress them.
+
 A model-load failure (timeout, network error) logs a one-line WARNING
 to the configured logger and trips a process-wide kill switch via
 `ml_fallback` — subsequent search calls emit
@@ -110,9 +116,11 @@ None) until the process restarts.
 
 **"reranker model load failed: timeout"**
 The first-call download exceeded the configured
-`first_call_timeout_seconds` (default 5s). Run
-`openzim-mcp download-models` once to pre-stage, then the next server
-start will use the cached model.
+`first_call_timeout_seconds` (default 15s — sized for ONNX session
+creation on a warm cache). Run `openzim-mcp download-models` once to
+pre-stage; the next server start will use the cached model. On slower
+hardware or cold-cache fetches, raise the timeout via
+`OPENZIM_MCP_ML__RERANKER__FIRST_CALL_TIMEOUT_SECONDS`.
 
 **Install fails with "no wheel for fastembed"**
 The platform isn't in the supported matrix (see above). Use the base

--- a/openzim_mcp/config.py
+++ b/openzim_mcp/config.py
@@ -193,14 +193,16 @@ class RerankerConfig(BaseModel):
         ),
     )
     first_call_timeout_seconds: float = Field(
-        default=5.0,
+        default=15.0,
         ge=0.1,
         le=120.0,
         description=(
             "Timeout for the first model load (covers HuggingFace download). "
             "When exceeded, the kill switch fires and search falls back to "
             "Xapian-only. Pre-stage with `openzim-mcp download-models` to "
-            "avoid this path."
+            "avoid this path. Default sized for ONNX session creation on a "
+            "warm cache (~7–10 s on modest hardware); raise for cold-cache "
+            "downloads."
         ),
     )
     cache_dir: Path | None = Field(

--- a/openzim_mcp/intent_parser.py
+++ b/openzim_mcp/intent_parser.py
@@ -955,7 +955,9 @@ class IntentParser:
         query = cls._normalize_topic_case(query)
         query = cls._apply_misspelling_map(query, title_probe=title_probe)
         query = cls._detect_stopword_phrase(query, title_probe=title_probe)
-        return cls._decompose_x_of_y(query)
+        # Post-b1 P1-D3: Rule 4 now also consults the probe so it can
+        # suppress decomposition of canonical multi-word titles.
+        return cls._decompose_x_of_y(query, title_probe=title_probe)
 
     @staticmethod
     def _attach_decomposition_hint(
@@ -1460,6 +1462,19 @@ class IntentParser:
 
     # ----- sub-D-2 Tier 1 query rewriting rules -----
 
+    # Post-b1 P1-D5 / P1-D6: split a token into (leading-non-word,
+    # core, trailing-non-word) for misspelling-map retry. ``^`` and
+    # ``$`` anchors plus lazy ``(.*?)`` ensure the match always
+    # succeeds, with all three groups potentially empty. ``\W``
+    # includes the apostrophe so leading/trailing single quotes get
+    # stripped (covers ``'recieve'``), while interior possessive
+    # ``'s`` stays attached to the core — the subsequent
+    # possessive-strip step in ``_apply_misspelling_map`` peels
+    # it off and reattaches on map hit. Underscores aren't in ``\W``
+    # so they survive in the core (rare in queries; matches the
+    # rest of the codebase's tokenization choices).
+    _MISSPELL_AFFIX_RE = re.compile(r"^(\W*)(.*?)(\W*)$")
+
     @classmethod
     def _normalize_topic_case(cls, query: str) -> str:
         """Sub-D-2 rule 1: lowercase the query.
@@ -1475,7 +1490,8 @@ class IntentParser:
     _exclusions_path: Optional["Path"] = None
 
     @classmethod
-    def _apply_misspelling_map(
+    def _apply_misspelling_map(  # noqa: C901
+
         cls,
         query: str,
         *,
@@ -1506,10 +1522,44 @@ class IntentParser:
                 continue
             lower = part.lower()
             replacement = mapping.get(lower)
+            # Post-b1 P1-D5 / P1-D6: when the raw token misses the map,
+            # retry with a stripped form. Two real defect classes:
+            #   * trailing/leading punctuation (``bilogy.``,
+            #     ``"photosythesis"``) — the period/quote attached to
+            #     the misspelling defeats the lookup.
+            #   * possessive ``'s`` (``photosythesis's reproduction``)
+            #     — the suffix changes the lookup key.
+            # The retry strips a leading/trailing non-word boundary
+            # AND a possessive suffix, reattaching them to the
+            # substitution on hit. ``re.match`` always returns a match
+            # here (the pattern can match the empty string).
+            lookup_core = lower
+            prefix_chars = ""
+            suffix_chars = ""
+            possessive = ""
+            if replacement is None:
+                core_match = cls._MISSPELL_AFFIX_RE.match(lower)
+                if core_match is not None:
+                    prefix_chars = core_match.group(1)
+                    lookup_core = core_match.group(2)
+                    suffix_chars = core_match.group(3)
+                    if lookup_core.endswith("'s"):
+                        possessive = "'s"
+                        lookup_core = lookup_core[:-2]
+                    if lookup_core and lookup_core != lower:
+                        replacement = mapping.get(lookup_core)
+                        if replacement is not None:
+                            replacement = (
+                                prefix_chars + replacement + possessive + suffix_chars
+                            )
             if replacement is None:
                 out.append(part)
                 continue
-            if lower in exclusions:
+            # Honor exclusions against the same key that matched (the
+            # stripped core when the retry hit, else the original
+            # lowercased token).
+            exclusion_key = lookup_core if lookup_core != lower else lower
+            if exclusion_key in exclusions or lower in exclusions:
                 out.append(part)
                 continue
             if title_probe is not None and title_probe(part):
@@ -1629,7 +1679,12 @@ class IntentParser:
     )
 
     @classmethod
-    def _decompose_x_of_y(cls, query: str) -> tuple[str, Optional[dict[str, str]]]:
+    def _decompose_x_of_y(
+        cls,
+        query: str,
+        *,
+        title_probe: Optional[Callable[[str], bool]] = None,
+    ) -> tuple[str, Optional[dict[str, str]]]:
         """Sub-D-2 rule 4: decompose `<attr> of <entity>` and
         `<entity>'s <attr>` shapes.
 
@@ -1644,10 +1699,21 @@ class IntentParser:
         Idempotent: a rewritten ``berlin population`` no longer matches
         either regex.
 
-        Guard: when the attr word is a recognised intent keyword (e.g.
+        Guard 1: when the attr word is a recognised intent keyword (e.g.
         ``structure``, ``sections``, ``metadata``), the query is a
         structured command and must NOT be decomposed — decomposing
-        would destroy the command signal and misroute the query."""
+        would destroy the command signal and misroute the query.
+
+        Guard 2 (post-b1 P1-D3): probe-gated — when ``title_probe`` is
+        provided and the FULL query canonically resolves to a real
+        article (``lord of the rings``, ``the art of war``, ``history
+        of rome``, ``birth of venus``), decomposition is suppressed.
+        Without this guard, every ``X of Y`` canonical title was
+        torn apart into ``Y X`` and looked up as ``Y``, returning
+        wrong articles (``Lord_of_the_Rings`` → ``The_Rings`` Iranian
+        horror film; ``The_Art_of_War`` → ``War``; ``History_of_Rome``
+        → ``Rome``). Degrades to substitute-without-probe when
+        ``title_probe`` is None (legacy behaviour)."""
         m = cls._X_OF_Y_RE.match(query)
         if not m:
             m = cls._POSSESSIVE_RE.match(query)
@@ -1655,7 +1721,11 @@ class IntentParser:
             return query, None
         entity = m.group("entity").strip()
         attr = m.group("attr").strip()
-        # Guard: do not decompose known command-keyword attributes.
+        # Guard 1: do not decompose known command-keyword attributes.
         if attr.lower() in cls._DECOMPOSE_SKIP_ATTRS:
+            return query, None
+        # Guard 2 (post-b1 P1-D3): suppress decomposition when the
+        # full query is itself a canonical title.
+        if title_probe is not None and title_probe(query):
             return query, None
         return f"{entity} {attr}", {"entity": entity, "attribute": attr}

--- a/openzim_mcp/intent_parser.py
+++ b/openzim_mcp/intent_parser.py
@@ -1462,18 +1462,44 @@ class IntentParser:
 
     # ----- sub-D-2 Tier 1 query rewriting rules -----
 
-    # Post-b1 P1-D5 / P1-D6: split a token into (leading-non-word,
-    # core, trailing-non-word) for misspelling-map retry. ``^`` and
-    # ``$`` anchors plus lazy ``(.*?)`` ensure the match always
-    # succeeds, with all three groups potentially empty. ``\W``
-    # includes the apostrophe so leading/trailing single quotes get
-    # stripped (covers ``'recieve'``), while interior possessive
-    # ``'s`` stays attached to the core — the subsequent
-    # possessive-strip step in ``_apply_misspelling_map`` peels
-    # it off and reattaches on map hit. Underscores aren't in ``\W``
-    # so they survive in the core (rare in queries; matches the
-    # rest of the codebase's tokenization choices).
-    _MISSPELL_AFFIX_RE = re.compile(r"^(\W*)(.*?)(\W*)$")
+    @staticmethod
+    def _split_misspelling_affixes(token: str) -> Tuple[str, str, str]:
+        """Post-b1 P1-D5 / P1-D6: split ``token`` into
+        ``(leading_affix, core, trailing_affix)`` where affix
+        characters are non-word (``\\W`` equivalent).
+
+        Linear-time, no regex backtracking — replaces the original
+        ``^(\\W*)(.*?)(\\W*)$`` regex that SonarCloud's S5852
+        ReDoS detector flagged (lazy ``.*?`` between two greedy
+        ``\\W*`` quantifiers tripped the static analyzer despite
+        the actual runtime being bounded-linear on token-length
+        inputs). Same precedent-rewrite pattern the post-a22 sweep
+        applied to the implicit-concat regex in
+        ``_chained_intent_guidance``.
+
+        Word chars: ``\\w`` equivalent — alphanumerics +
+        underscore. Underscore handled explicitly because
+        ``str.isalnum`` excludes it (whereas ``\\w`` includes it).
+        Unicode letters / digits flow through unchanged
+        (``str.isalnum`` is Unicode-aware), so non-Latin tokens
+        like ``München.`` split correctly to ``("", "München",
+        ".")`` — matching the original regex semantics.
+
+        Apostrophes are non-word, so leading/trailing single
+        quotes get stripped (``'recieve'`` → ``("'", "recieve",
+        "'")``) while interior possessive ``'s`` stays attached
+        to the core (``photosythesis's`` → ``("", "photosythesis's",
+        "")``) — the caller's subsequent possessive-strip step
+        peels ``'s`` off and reattaches on map hit.
+        """
+        n = len(token)
+        i = 0
+        while i < n and not (token[i].isalnum() or token[i] == "_"):
+            i += 1
+        j = n
+        while j > i and not (token[j - 1].isalnum() or token[j - 1] == "_"):
+            j -= 1
+        return token[:i], token[i:j], token[j:]
 
     @classmethod
     def _normalize_topic_case(cls, query: str) -> str:
@@ -1491,7 +1517,6 @@ class IntentParser:
 
     @classmethod
     def _apply_misspelling_map(  # noqa: C901
-
         cls,
         query: str,
         *,
@@ -1538,20 +1563,18 @@ class IntentParser:
             suffix_chars = ""
             possessive = ""
             if replacement is None:
-                core_match = cls._MISSPELL_AFFIX_RE.match(lower)
-                if core_match is not None:
-                    prefix_chars = core_match.group(1)
-                    lookup_core = core_match.group(2)
-                    suffix_chars = core_match.group(3)
-                    if lookup_core.endswith("'s"):
-                        possessive = "'s"
-                        lookup_core = lookup_core[:-2]
-                    if lookup_core and lookup_core != lower:
-                        replacement = mapping.get(lookup_core)
-                        if replacement is not None:
-                            replacement = (
-                                prefix_chars + replacement + possessive + suffix_chars
-                            )
+                prefix_chars, lookup_core, suffix_chars = (
+                    cls._split_misspelling_affixes(lower)
+                )
+                if lookup_core.endswith("'s"):
+                    possessive = "'s"
+                    lookup_core = lookup_core[:-2]
+                if lookup_core and lookup_core != lower:
+                    replacement = mapping.get(lookup_core)
+                    if replacement is not None:
+                        replacement = (
+                            prefix_chars + replacement + possessive + suffix_chars
+                        )
             if replacement is None:
                 out.append(part)
                 continue

--- a/openzim_mcp/ml/cli/download.py
+++ b/openzim_mcp/ml/cli/download.py
@@ -10,10 +10,32 @@ import argparse
 import logging
 from typing import List, Optional
 
-from openzim_mcp.config import RerankerConfig
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from openzim_mcp.config import MLConfig, RerankerConfig
 from openzim_mcp.ml import detect
 
 logger = logging.getLogger(__name__)
+
+
+class _StagingSettings(BaseSettings):
+    """Env-var-aware loader for the download-models CLI.
+
+    Mirrors ``OpenZimMcpConfig``'s env prefix + nested delimiter so the
+    CLI honours ``OPENZIM_MCP_ML__RERANKER__*`` (notably
+    ``CACHE_DIR``) — the same vars the runtime uses. ``OpenZimMcpConfig``
+    itself requires ``allowed_directories`` and isn't appropriate here
+    (the CLI doesn't need a ZIM directory to pre-stage model files).
+    """
+
+    ml: MLConfig = Field(default_factory=MLConfig)
+
+    model_config = SettingsConfigDict(
+        env_prefix="OPENZIM_MCP_",
+        env_nested_delimiter="__",
+        case_sensitive=False,
+    )
 
 
 def _stage_reranker(cfg: RerankerConfig) -> None:
@@ -24,7 +46,7 @@ def _stage_reranker(cfg: RerankerConfig) -> None:
     _load_model(cfg.model_id, cfg.cache_dir)
 
 
-def _build_parser() -> argparse.ArgumentParser:
+def _build_parser(default_model_id: str) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="openzim-mcp download-models",
         description=(
@@ -38,17 +60,15 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--reranker-model-id",
         default=None,
-        help=(
-            f"Override the reranker model id "
-            f"(default: {RerankerConfig().model_id})."
-        ),
+        help=f"Override the reranker model id (default: {default_model_id}).",
     )
     return parser
 
 
 def download_models_main(argv: Optional[List[str]] = None) -> int:
     """Entry point. Returns process exit code (0 success, 1 failure)."""
-    parser = _build_parser()
+    cfg = _StagingSettings().ml.reranker
+    parser = _build_parser(default_model_id=cfg.model_id)
     args = parser.parse_args(argv)
 
     features = detect()
@@ -60,7 +80,6 @@ def download_models_main(argv: Optional[List[str]] = None) -> int:
         return 0
 
     print("Staging reranker model... ", end="", flush=True)
-    cfg = RerankerConfig()
     if args.reranker_model_id:
         cfg = cfg.model_copy(update={"model_id": args.reranker_model_id})
     try:

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -98,6 +98,20 @@ _RERANKER_SKIPPED_NOT_INSTALLED = "reranker_skipped.not_installed"
 _RERANKER_SKIPPED_NO_RESULTS = "reranker_skipped.no_results"
 _RERANKER_SKIPPED_PASSTHROUGH = "reranker_skipped.passthrough"
 
+# Telemetry events that also emit an INFO log on every increment. The
+# in-memory counter is only visible via ``get_server_health`` (advanced
+# tool mode); operators running in simple mode have no other way to see
+# reranker engagement. Keep this set small — every entry is a per-query
+# INFO line.
+_INFO_LEVEL_TELEMETRY_EVENTS: "frozenset[str]" = frozenset(
+    {
+        _RERANKER_ENGAGED,
+        _RERANKER_SKIPPED_NOT_INSTALLED,
+        _RERANKER_SKIPPED_NO_RESULTS,
+        _RERANKER_SKIPPED_PASSTHROUGH,
+    }
+)
+
 # Phase D sub-D-2 query-rewrite telemetry events.
 _QUERY_REWRITE_MISSPELLING = "query_rewrite.misspelling"
 _QUERY_REWRITE_STOPWORD_PHRASE = "query_rewrite.stopword_phrase"
@@ -142,8 +156,15 @@ class SimpleToolsHandler:
         self._telemetry: Counter[str] = Counter()
 
     def _track(self, event: str) -> None:
-        """Increment the named telemetry counter."""
+        """Increment the named telemetry counter.
+
+        Events in ``_INFO_LEVEL_TELEMETRY_EVENTS`` also emit a single
+        INFO log line per call so simple-mode operators (who don't have
+        ``get_server_health``) can observe them in the server log.
+        """
         self._telemetry[event] += 1
+        if event in _INFO_LEVEL_TELEMETRY_EVENTS:
+            logger.info("telemetry: %s", event)
 
     def get_telemetry(self) -> Dict[str, int]:
         """Return a snapshot of the in-memory telemetry counters.

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -175,6 +175,41 @@ class SimpleToolsHandler:
         """
         return dict(self._telemetry)
 
+    def _compute_rerank_state(
+        self, before: Dict[str, int]
+    ) -> Optional[str]:
+        """Post-b1: compute the per-request reranker engagement state
+        from a pre-call snapshot of the four reranker counters.
+
+        Returns one of ``engaged`` / ``skipped:not_installed`` /
+        ``skipped:no_results`` / ``skipped:passthrough`` when the
+        current request bumped a counter, else ``None`` (non-search
+        intent, no rerank attempt). Surfaced as
+        ``<!-- reranker=<state> -->`` in the response envelope so
+        callers using the simple-tool surface alone (without access
+        to ``get_server_health``) can confirm whether D-1's
+        cross-encoder rerank actually engaged. Priority order
+        favours ``engaged`` then the more specific skip reasons so
+        a request that hits both ``no_results`` and ``passthrough``
+        (rare; multi-archive partial failure) is summarised
+        unambiguously."""
+        order = (
+            _RERANKER_ENGAGED,
+            _RERANKER_SKIPPED_NOT_INSTALLED,
+            _RERANKER_SKIPPED_NO_RESULTS,
+            _RERANKER_SKIPPED_PASSTHROUGH,
+        )
+        labels = {
+            _RERANKER_ENGAGED: "engaged",
+            _RERANKER_SKIPPED_NOT_INSTALLED: "skipped:not_installed",
+            _RERANKER_SKIPPED_NO_RESULTS: "skipped:no_results",
+            _RERANKER_SKIPPED_PASSTHROUGH: "skipped:passthrough",
+        }
+        for event in order:
+            if self._telemetry.get(event, 0) > before.get(event, 0):
+                return labels[event]
+        return None
+
     # Named profiles for ``compact_budget``. ``medium`` matches the
     # legacy hardcoded 6000-char cap so callers that don't pass a
     # ``compact_budget`` see no behavior change. The bracketing values
@@ -223,6 +258,45 @@ class SimpleToolsHandler:
         if isinstance(raw, int):
             return max(cls._COMPACT_BUDGET_MIN, min(raw, cls._COMPACT_BUDGET_MAX))
         return default
+
+    @staticmethod
+    def _recase_from_original(token: str, original_query: str) -> str:
+        """Post-b1 P1-D2: return ``token`` in the casing it appears
+        with in ``original_query`` (case-insensitive substring search).
+
+        Falls back to ``token`` unchanged when the lookup misses (e.g.,
+        when the topic was reshaped by a rewrite step that doesn't
+        preserve a clean substring — Rule 2 misspelling substitution,
+        Rule 4 entity-attribute reorder). The original-case form is
+        used in user-facing guidance text (chain rejection bullets,
+        soft-connector footer) so the caller's recovery copy-paste
+        path keeps the diacritics and casing they originally typed."""
+        if not original_query or not token:
+            return token
+        idx = original_query.lower().find(token.lower())
+        if idx < 0:
+            return token
+        return original_query[idx : idx + len(token)]
+
+    def _probe_archive_path(self, zim_file_path: Optional[str]) -> Optional[str]:
+        """Post-b1 P1-D1: resolve the archive the query-rewrite title
+        probe should consult.
+
+        ``handle_zim_query`` auto-selects the single loaded archive
+        downstream (line ~776) when ``zim_file_path`` is omitted — the
+        recommended calling pattern per the tool's own docstring. The
+        probe was previously built BEFORE that resolution, so a
+        ``None`` caller-supplied path produced a ``None`` probe and
+        rules 2/3/4 ran in degraded mode for the overwhelming majority
+        of real calls. Mirror the same auto-select policy so the probe
+        sees the same archive the search will actually run against
+        (single-archive case). In multi-archive mode without an
+        explicit path, ``_auto_select_zim_file()`` returns ``None`` and
+        the probe stays degraded — that's the only genuinely ambiguous
+        case where falling back to "no probe" is the right answer."""
+        if zim_file_path:
+            return zim_file_path
+        return self._auto_select_zim_file()
 
     def _build_title_probe(
         self, zim_file_path: Optional[str]
@@ -557,6 +631,29 @@ class SimpleToolsHandler:
                     operation="synthesize_pipeline_error",
                     message=f"Synthesize pipeline failed: {e}",
                 )
+        # Post-b1: snapshot reranker telemetry counters so the response
+        # envelope can surface whether rerank engaged for this specific
+        # request. The four counters (engaged / skipped.not_installed /
+        # skipped.no_results / skipped.passthrough) live in
+        # ``self._telemetry`` and are advanced-mode-only via
+        # ``get_server_health``; HTTP-MCP hosts that filter that tool
+        # out leave simple-tool callers with no in-band visibility.
+        # The delta-based check is best-effort and matches the existing
+        # telemetry-Counter concurrency model (Counter mutations are not
+        # atomic across threads, so a parallel request could leak its
+        # event in — same tradeoff the post-b1 INFO log already accepts).
+        _RERANK_EVENTS_BEFORE = {
+            _RERANKER_ENGAGED: self._telemetry.get(_RERANKER_ENGAGED, 0),
+            _RERANKER_SKIPPED_NOT_INSTALLED: self._telemetry.get(
+                _RERANKER_SKIPPED_NOT_INSTALLED, 0
+            ),
+            _RERANKER_SKIPPED_NO_RESULTS: self._telemetry.get(
+                _RERANKER_SKIPPED_NO_RESULTS, 0
+            ),
+            _RERANKER_SKIPPED_PASSTHROUGH: self._telemetry.get(
+                _RERANKER_SKIPPED_PASSTHROUGH, 0
+            ),
+        }
         try:
             # Reject empty / whitespace-only queries upfront. The router
             # would otherwise classify the input as a low-confidence search
@@ -621,7 +718,15 @@ class SimpleToolsHandler:
             # clean (it doesn't know about _track); the cost is two extra
             # rule passes worth of CPU per query.
             if self.zim_operations.config.query_rewrite.enabled:
-                title_probe = self._build_title_probe(zim_file_path)
+                # Post-b1 P1-D1: resolve the probe archive BEFORE
+                # building the probe so it sees the same archive
+                # ``handle_zim_query`` will auto-select downstream
+                # (single-archive case). Pre-fix, ``zim_file_path``
+                # was passed straight through and produced a None
+                # probe whenever the caller omitted the path — the
+                # documented-as-recommended pattern.
+                probe_path = self._probe_archive_path(zim_file_path)
+                title_probe = self._build_title_probe(probe_path)
                 after_lower = IntentParser._normalize_topic_case(query)
                 after_misspell = IntentParser._apply_misspelling_map(
                     after_lower, title_probe=title_probe
@@ -633,7 +738,13 @@ class SimpleToolsHandler:
                 )
                 if after_stopword != after_misspell:
                     self._track(_QUERY_REWRITE_STOPWORD_PHRASE)
-                _, hint_probe = IntentParser._decompose_x_of_y(after_stopword)
+                # Post-b1 P1-D3: pass the same probe so Rule 4 can
+                # suppress decomposition when the full query is itself
+                # a canonical title (``lord of the rings``,
+                # ``the art of war``, ``history of rome``).
+                _, hint_probe = IntentParser._decompose_x_of_y(
+                    after_stopword, title_probe=title_probe
+                )
                 if hint_probe is not None:
                     self._track(_QUERY_REWRITE_X_OF_Y)
             else:
@@ -644,6 +755,15 @@ class SimpleToolsHandler:
                 title_probe=title_probe,
                 query_rewrite_enabled=self.zim_operations.config.query_rewrite.enabled,
             )
+            # Post-b1 P1-D2: stash the pre-rewrite, original-case query
+            # in params so user-facing guidance (multi-entity chain
+            # rejection, soft-connector footer) can echo entities back
+            # in the caller's casing instead of Rule 1's lowercased
+            # form. The leading underscore marks this as a wiring-layer
+            # hint — consumers should treat its absence as the legacy
+            # behaviour (use the lowercase value as-is).
+            if isinstance(params, dict):
+                params.setdefault("_pre_rewrite_query", query)
             # Post-a21 P1-D1: defence-in-depth strip of trailing
             # politeness on user-supplied content fields in ``params``.
             # Idempotent when ``parse_intent`` already cleaned them
@@ -859,6 +979,17 @@ class SimpleToolsHandler:
             # ``cert``.
             if isinstance(result, str):
                 result = result + (f"\n<!-- intent={intent} cert={confidence:.2f} -->")
+                # Post-b1: surface reranker engagement state in-band so
+                # simple-tool callers (the default mode) can confirm
+                # whether D-1's cross-encoder rerank actually engaged
+                # for this request. Mirrors the intent telemetry shape
+                # (HTML comment, invisible to humans, addressable by a
+                # calling LLM). Emitted only when the request actually
+                # touched a search path — non-search intents leave the
+                # counter untouched and the comment is suppressed.
+                _rerank_state = self._compute_rerank_state(_RERANK_EVENTS_BEFORE)
+                if _rerank_state is not None:
+                    result = result + f"\n<!-- reranker={_rerank_state} -->"
             if options.get("compact", False):
                 # Belt-and-suspenders cap: even after every per-intent
                 # trim, a backend can return more than the simple-mode
@@ -1407,6 +1538,7 @@ class SimpleToolsHandler:
         *,
         zim_file_path: Optional[str] = None,
         top_path: Optional[str] = None,
+        original_query: Optional[str] = None,
     ) -> Optional[str]:
         """A16 post-a16 D1 (pass-2): when ``topic`` contains an ambiguous
         connector between two substantive proper-noun-shaped halves
@@ -1520,6 +1652,12 @@ class SimpleToolsHandler:
                 return None
             picked = left if left_in else right
             dropped = right if left_in else left
+            # Post-b1 P1-D2: recase picked/dropped against the
+            # original pre-Rule-1-lowercase query so the footer echoes
+            # the caller's casing.
+            if original_query:
+                picked = self._recase_from_original(picked, original_query)
+                dropped = self._recase_from_original(dropped, original_query)
             connector_display = m.group(0).strip() or "(connector)"
             return (
                 f"\n\n_Note: your query contained `{connector_display}` "
@@ -1772,6 +1910,14 @@ class SimpleToolsHandler:
 
         Returns None to fall through to normal resolution; returns a
         structured Markdown body when the chain should be rejected.
+
+        Post-b1 P1-D2: when ``params["_pre_rewrite_query"]`` is set
+        (the original, pre-Rule-1-lowercase query), bullets echo each
+        entity in the caller's original casing instead of Rule 1's
+        lowercased form. Pre-fix, ``tell me about Köln, München, and
+        Berlin`` returned bullets reading ``tell me about köln`` /
+        ``münchen`` / ``berlin`` — corrupted diacritics + casing that
+        broke the user's recovery copy-paste path.
         """
         if intent != "tell_me_about":
             return None
@@ -1781,6 +1927,14 @@ class SimpleToolsHandler:
         halves = self._split_multi_entity(topic)
         if not halves:
             return None
+        # Post-b1 P1-D2: recase each half against the original query.
+        original_query = (
+            params.get("_pre_rewrite_query")
+            if isinstance(params, dict)
+            else None
+        )
+        if isinstance(original_query, str) and original_query:
+            halves = [self._recase_from_original(h, original_query) for h in halves]
         # Probe the title index for the whole topic — if it resolves
         # cleanly to a single article whose path loosely matches the
         # topic, the user meant a real multi-entity title (band name,
@@ -4027,12 +4181,22 @@ class SimpleToolsHandler:
         # hint, return the section body instead of the (often empty)
         # lead. Motivating case: ``famous musician from big rapids
         # michigan`` from the 2026-05-18 live transcript.
+        # Post-b1 P1-D2: thread the original-case query through so the
+        # nested soft-connector footer can recase its entity references.
+        original_query_for_subject = (
+            params.get("_pre_rewrite_query") if isinstance(params, dict) else None
+        )
         subject_section_result = self._maybe_render_subject_section(
             zim_file_path=zim_file_path,
             topic=topic,
             top_path=top_path,
             top_title=top_title,
             options=options,
+            original_query=(
+                original_query_for_subject
+                if isinstance(original_query_for_subject, str)
+                else None
+            ),
         )
         if subject_section_result is not None:
             return subject_section_result
@@ -4099,11 +4263,19 @@ class SimpleToolsHandler:
         # picked vs. dropped. Suppressed when the returned title
         # already contains both halves (``Romeo and Juliet`` is one
         # article whose title spans the connector — no footer needed).
+        # Post-b1 P1-D2: thread the original-case query through so the
+        # footer echoes entity names in the caller's casing.
+        original_query = (
+            params.get("_pre_rewrite_query") if isinstance(params, dict) else None
+        )
         soft_footer = self._soft_connector_footer(
             topic,
             top_title,
             zim_file_path=zim_file_path,
             top_path=top_path,
+            original_query=original_query
+            if isinstance(original_query, str)
+            else None,
         )
         if soft_footer:
             result = result + soft_footer
@@ -4235,6 +4407,7 @@ class SimpleToolsHandler:
         top_path: str,
         top_title: str,
         options: Dict[str, Any],
+        original_query: Optional[str] = None,
     ) -> Optional[str]:
         """Try the subject-attribute decomposition path. Returns the
         rendered response string on a successful subject-section match,
@@ -4354,6 +4527,7 @@ class SimpleToolsHandler:
             top_title or top_path,
             zim_file_path=zim_file_path,
             top_path=top_path,
+            original_query=original_query,
         )
         if soft_footer:
             result = result + soft_footer
@@ -5069,7 +5243,11 @@ class SimpleToolsHandler:
         # clean (it doesn't know about _track); the cost is two extra
         # rule passes worth of CPU per query.
         if self.zim_operations.config.query_rewrite.enabled:
-            title_probe = self._build_title_probe(zim_file_path)
+            # Post-b1 P1-D1: mirror of the simple-branch fix at line
+            # ~624 — pre-resolve zim_file_path so the probe sees the
+            # single auto-selected archive when the caller omits it.
+            probe_path = self._probe_archive_path(zim_file_path)
+            title_probe = self._build_title_probe(probe_path)
             after_lower = IntentParser._normalize_topic_case(query)
             after_misspell = IntentParser._apply_misspelling_map(
                 after_lower, title_probe=title_probe
@@ -5081,7 +5259,11 @@ class SimpleToolsHandler:
             )
             if after_stopword != after_misspell:
                 self._track(_QUERY_REWRITE_STOPWORD_PHRASE)
-            _, hint_probe = IntentParser._decompose_x_of_y(after_stopword)
+            # Post-b1 P1-D3: pass probe to Rule 4 (mirror of the
+            # simple-branch wiring).
+            _, hint_probe = IntentParser._decompose_x_of_y(
+                after_stopword, title_probe=title_probe
+            )
             if hint_probe is not None:
                 self._track(_QUERY_REWRITE_X_OF_Y)
         else:

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -3482,6 +3482,20 @@ class SimpleToolsHandler:
         search_query = params.get("query", query)
         limit = options.get("limit")
         offset = options.get("offset", 0)
+        # Post-b1 P3-D1: build the original-case display form so the
+        # backend's ``Found N filtered matches for "X"`` /
+        # ``No filtered matches for "X"`` echoes show the caller's
+        # casing. Same shape as the _handle_search hoisting above.
+        pre_rewrite = (
+            params.get("_pre_rewrite_query")
+            if isinstance(params, dict)
+            else None
+        )
+        display_query = (
+            self._recase_from_original(search_query, pre_rewrite)
+            if isinstance(pre_rewrite, str) and pre_rewrite
+            else search_query
+        )
         if options.get("compact", False):
             # Phase D sub-D-1: compact path gives us a structured payload
             # to rerank before rendering. The canonical-title-match splice
@@ -3507,7 +3521,8 @@ class SimpleToolsHandler:
             # (query, total, page_info, results, done, next_cursor) so the
             # text formatter accepts it structurally.
             return self.zim_operations._format_search_text(
-                cast(SearchResponse, payload)
+                cast(SearchResponse, payload),
+                display_query=display_query,
             )
         # A11 post-a11 H2: route to the canonical-title-match-aware
         # variant so ``search for berlin in namespace C`` surfaces
@@ -3521,6 +3536,7 @@ class SimpleToolsHandler:
             params.get("content_type"),
             limit,
             offset,
+            display_query=display_query,
         )
 
     def _handle_get_article(
@@ -3613,6 +3629,22 @@ class SimpleToolsHandler:
         search_query = params.get("query", query)
         limit = options.get("limit")
         offset = options.get("offset", 0)
+        # Post-b1 P3-D1: build the original-case display form once.
+        # Passed to backend renderers so user-facing echoes
+        # (``Found N matches for "X"`` / ``No search results found
+        # for "X"``) reflect the caller's casing instead of Rule 1's
+        # lowercased extraction. Search matching uses ``search_query``
+        # unchanged — Xapian is case-insensitive.
+        pre_rewrite = (
+            params.get("_pre_rewrite_query")
+            if isinstance(params, dict)
+            else None
+        )
+        display_query = (
+            self._recase_from_original(search_query, pre_rewrite)
+            if isinstance(pre_rewrite, str) and pre_rewrite
+            else search_query
+        )
 
         if options.get("compact", False):
             # Use the dict variant so we can inspect _meta.suggestions on
@@ -3625,25 +3657,11 @@ class SimpleToolsHandler:
             if payload.get("total", 0) == 0:
                 # Let handle_zim_query's footer step render the structured
                 # suggestion footer (format_footer empty-result variant).
+                # Post-b1 P2-D2: ``display_query`` was hoisted above
+                # for use by the backend renderers (P3-D1); reuse it
+                # here so the no-results echo also reflects the
+                # caller's original casing.
                 meta = payload.get("_meta", {})
-                # Post-b1 P2-D2: recase the echoed search query against
-                # the original pre-Rule-1-lowercase query so the user
-                # sees ``No results for "Biology"`` instead of ``No
-                # results for "biology"`` when they typed ``Biology``.
-                # Sibling shape to P1-D2 (chain rejection / footer)
-                # and P2-D1 (disambig heading). Falls back to
-                # ``search_query`` unchanged when the original isn't
-                # available.
-                pre_rewrite = (
-                    params.get("_pre_rewrite_query")
-                    if isinstance(params, dict)
-                    else None
-                )
-                display_query = (
-                    self._recase_from_original(search_query, pre_rewrite)
-                    if isinstance(pre_rewrite, str) and pre_rewrite
-                    else search_query
-                )
                 return _HandlerResult(
                     body=f'No results for "{display_query}".',
                     reason=meta.get("reason", "0_hits"),
@@ -3675,15 +3693,25 @@ class SimpleToolsHandler:
             )
             # Non-empty results: render via the legacy text formatter so the
             # markdown shape is identical to the non-compact path.
-            return self.zim_operations._format_search_text(payload)
+            # Post-b1 P3-D1: pass display_query so ``Found N matches
+            # for "X"`` echoes in the caller's original case.
+            return self.zim_operations._format_search_text(
+                payload, display_query=display_query
+            )
 
         # compact=False: unchanged legacy path. Title promotion is
         # applied in compact mode only (the default surface for
         # ``zim_query``). Legacy callers of the non-compact rendered
         # string keep byte-identical output, including the original
         # BM25 ranking.
+        # Post-b1 P3-D1: pass display_query so non-compact callers
+        # also get the original-case echo.
         return self.zim_operations.search_zim_file(
-            zim_file_path, search_query, limit, offset
+            zim_file_path,
+            search_query,
+            limit,
+            offset,
+            display_query=display_query,
         )
 
     @staticmethod

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -175,9 +175,7 @@ class SimpleToolsHandler:
         """
         return dict(self._telemetry)
 
-    def _compute_rerank_state(
-        self, before: Dict[str, int]
-    ) -> Optional[str]:
+    def _compute_rerank_state(self, before: Dict[str, int]) -> Optional[str]:
         """Post-b1: compute the per-request reranker engagement state
         from a pre-call snapshot of the four reranker counters.
 
@@ -1929,9 +1927,7 @@ class SimpleToolsHandler:
             return None
         # Post-b1 P1-D2: recase each half against the original query.
         original_query = (
-            params.get("_pre_rewrite_query")
-            if isinstance(params, dict)
-            else None
+            params.get("_pre_rewrite_query") if isinstance(params, dict) else None
         )
         if isinstance(original_query, str) and original_query:
             halves = [self._recase_from_original(h, original_query) for h in halves]
@@ -3487,9 +3483,7 @@ class SimpleToolsHandler:
         # ``No filtered matches for "X"`` echoes show the caller's
         # casing. Same shape as the _handle_search hoisting above.
         pre_rewrite = (
-            params.get("_pre_rewrite_query")
-            if isinstance(params, dict)
-            else None
+            params.get("_pre_rewrite_query") if isinstance(params, dict) else None
         )
         display_query = (
             self._recase_from_original(search_query, pre_rewrite)
@@ -3636,9 +3630,7 @@ class SimpleToolsHandler:
         # lowercased extraction. Search matching uses ``search_query``
         # unchanged — Xapian is case-insensitive.
         pre_rewrite = (
-            params.get("_pre_rewrite_query")
-            if isinstance(params, dict)
-            else None
+            params.get("_pre_rewrite_query") if isinstance(params, dict) else None
         )
         display_query = (
             self._recase_from_original(search_query, pre_rewrite)
@@ -4222,17 +4214,13 @@ class SimpleToolsHandler:
             # so the disambig heading echoes the caller's casing
             # instead of Rule 1's lowercased topic.
             disambig_original = (
-                params.get("_pre_rewrite_query")
-                if isinstance(params, dict)
-                else None
+                params.get("_pre_rewrite_query") if isinstance(params, dict) else None
             )
             return self._render_disambiguation(
                 topic,
                 strong_matches,
                 original_query=(
-                    disambig_original
-                    if isinstance(disambig_original, str)
-                    else None
+                    disambig_original if isinstance(disambig_original, str) else None
                 ),
             )
 
@@ -4335,9 +4323,7 @@ class SimpleToolsHandler:
             top_title,
             zim_file_path=zim_file_path,
             top_path=top_path,
-            original_query=original_query
-            if isinstance(original_query, str)
-            else None,
+            original_query=original_query if isinstance(original_query, str) else None,
         )
         if soft_footer:
             result = result + soft_footer

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -3626,8 +3626,26 @@ class SimpleToolsHandler:
                 # Let handle_zim_query's footer step render the structured
                 # suggestion footer (format_footer empty-result variant).
                 meta = payload.get("_meta", {})
+                # Post-b1 P2-D2: recase the echoed search query against
+                # the original pre-Rule-1-lowercase query so the user
+                # sees ``No results for "Biology"`` instead of ``No
+                # results for "biology"`` when they typed ``Biology``.
+                # Sibling shape to P1-D2 (chain rejection / footer)
+                # and P2-D1 (disambig heading). Falls back to
+                # ``search_query`` unchanged when the original isn't
+                # available.
+                pre_rewrite = (
+                    params.get("_pre_rewrite_query")
+                    if isinstance(params, dict)
+                    else None
+                )
+                display_query = (
+                    self._recase_from_original(search_query, pre_rewrite)
+                    if isinstance(pre_rewrite, str) and pre_rewrite
+                    else search_query
+                )
                 return _HandlerResult(
-                    body=f'No results for "{search_query}".',
+                    body=f'No results for "{display_query}".',
                     reason=meta.get("reason", "0_hits"),
                     suggestions=meta.get("suggestions"),
                 )
@@ -4172,7 +4190,23 @@ class SimpleToolsHandler:
                         related_extends_paths.append(m_path)
         elif len(strong_matches) >= 2:
             self._track("disambiguation_returned")
-            return self._render_disambiguation(topic, strong_matches)
+            # Post-b1 P2-D1: pass the pre-rewrite original-case query
+            # so the disambig heading echoes the caller's casing
+            # instead of Rule 1's lowercased topic.
+            disambig_original = (
+                params.get("_pre_rewrite_query")
+                if isinstance(params, dict)
+                else None
+            )
+            return self._render_disambiguation(
+                topic,
+                strong_matches,
+                original_query=(
+                    disambig_original
+                    if isinstance(disambig_original, str)
+                    else None
+                ),
+            )
 
         # Subject-attribute decomposition (2026-05-18): when the
         # original topic carried a subject category hint
@@ -4720,7 +4754,12 @@ class SimpleToolsHandler:
         return None
 
     @staticmethod
-    def _render_disambiguation(topic: str, candidates: list) -> str:
+    def _render_disambiguation(
+        topic: str,
+        candidates: list,
+        *,
+        original_query: Optional[str] = None,
+    ) -> str:
         """Render a "did you mean?" list when 2+ articles strong-match
         the topic (e.g. Mercury → planet/element/mythology).
 
@@ -4730,6 +4769,13 @@ class SimpleToolsHandler:
         article <path>``) are concrete enough that a small model can
         copy them verbatim. Capped at 5 candidates — beyond that the
         list itself becomes hard to skim.
+
+        Post-b1 P2-D1: ``original_query`` (the pre-Rule-1-lowercase
+        query) lets the heading echo ``topic`` in the caller's
+        original casing. Pre-fix, ``tell me about Stalin`` returned
+        ``**Multiple articles match "stalin"**`` — same shape as the
+        post-b1 P1-D2 footer leak but in a different user-facing
+        string. Falls back to ``topic`` unchanged when not provided.
         """
         # Wrap the long subtitle in parens so the implicit-string
         # concatenation is unambiguous to readers (and to CodeQL's
@@ -4740,8 +4786,13 @@ class SimpleToolsHandler:
             "_Several archive articles strong-match this topic. "
             "Pick one explicitly:_"
         )
+        display_topic = (
+            SimpleToolsHandler._recase_from_original(topic, original_query)
+            if original_query
+            else topic
+        )
         lines = [
-            f'**Multiple articles match "{topic}"** — which one did you mean?',
+            f'**Multiple articles match "{display_topic}"** — which one did you mean?',
             "",
             subtitle,
             "",

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -1286,10 +1286,10 @@ def _maybe_rerank_synthesize_passages(
 
     reranker = BGEReranker.get(reranker_config)
     if reranker is None:
-        logger.debug("synthesize: reranker_skipped.not_installed")
+        logger.info("telemetry: reranker_skipped.not_installed")
         return all_passages, hit_keys
     if not all_passages:
-        logger.debug("synthesize: reranker_skipped.no_results")
+        logger.info("telemetry: reranker_skipped.no_results")
         return all_passages, hit_keys
 
     # Build path→passage index for round-trip mapping. cite_id
@@ -1312,7 +1312,7 @@ def _maybe_rerank_synthesize_passages(
     )
     if not (reranked_envelopes and "rerank_score" in reranked_envelopes[0]):
         # Short query or inference failure — passthrough.
-        logger.debug("synthesize: reranker_skipped.passthrough")
+        logger.info("telemetry: reranker_skipped.passthrough")
         return all_passages, hit_keys
 
     # Build a lookup from cite_id → rerank_score for sorting.
@@ -1333,8 +1333,8 @@ def _maybe_rerank_synthesize_passages(
     # Re-number ranks to reflect new ordering.
     for i, p in enumerate(all_passages, start=1):
         p["rank"] = i
-    logger.debug(
-        "synthesize: reranker_engaged — reranked %d passages for query %r",
+    logger.info(
+        "telemetry: reranker_engaged — reranked %d passages for query %r",
         len(all_passages),
         query,
     )

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -172,8 +172,16 @@ def _format_filtered_response(
     total_results: int,
     offset: int,
     limit: int,
+    *,
+    display_query: Optional[str] = None,
 ) -> str:
-    """Render the human-readable response body, header, and pagination footer."""
+    """Render the human-readable response body, header, and pagination footer.
+
+    Post-b1 P3-D1: ``display_query`` overrides ``query`` in the user-
+    facing echo string. ``query`` is the matched form (lowercased by
+    Sub-D-2 Rule 1); ``display_query`` is the original-case form so
+    the caller sees the casing they typed.
+    """
     capped_note = (
         f" (filtered from first {scan.scanned} of " f"~{total_results} unfiltered hits)"
         if scan.scan_cap_hit
@@ -186,9 +194,10 @@ def _format_filtered_response(
         if scan.total_filtered_is_lower_bound
         else str(scan.filtered_count)
     )
+    echo_query = display_query if display_query else query
 
     parts: List[str] = [
-        f'Found {total_filtered_text} filtered matches for "{query}"'
+        f'Found {total_filtered_text} filtered matches for "{echo_query}"'
         f"{filter_text}, "
         f"showing {offset + 1}-{offset + len(results)}{capped_note}:\n\n",
     ]
@@ -324,6 +333,8 @@ class _SearchMixin:
         query: str,
         limit: Optional[int] = None,
         offset: int = 0,
+        *,
+        display_query: Optional[str] = None,
     ) -> str:
         """Markdown-rendered search result (legacy surface).
 
@@ -333,9 +344,14 @@ class _SearchMixin:
 
         Args:
             zim_file_path: Path to the ZIM file
-            query: Search query term
+            query: Search query term (lowercased upstream by Sub-D-2 Rule 1)
             limit: Maximum number of results to return
             offset: Result starting offset (for pagination)
+            display_query: Optional original-case form of ``query`` for
+                user-facing echo strings (post-b1 P3-D1). The search
+                backend matches case-insensitively, so this only
+                affects the rendered ``Found N matches for "X"`` /
+                ``No results found for "X"`` strings.
 
         Returns:
             Search result text
@@ -345,7 +361,7 @@ class _SearchMixin:
             OpenZimMcpArchiveError: If search operation fails
         """
         payload = self.search_zim_file_data(zim_file_path, query, limit, offset)
-        return self._format_search_text(payload)
+        return self._format_search_text(payload, display_query=display_query)
 
     def search_zim_file_data(
         self,
@@ -691,13 +707,29 @@ class _SearchMixin:
             total_results,
         )
 
-    def _format_search_text(self, payload: "SearchResponse") -> str:
+    def _format_search_text(
+        self,
+        payload: "SearchResponse",
+        *,
+        display_query: Optional[str] = None,
+    ) -> str:
         """Render a structured search payload as the legacy markdown text.
 
         Mirrors the original ``_perform_search`` output exactly so callers
         (and tests) that consume the rendered text keep working unchanged.
+
+        Post-b1 P3-D1: ``display_query`` (optional) overrides
+        ``payload["query"]`` in the user-facing echo strings (``Found N
+        matches for "X"``, ``No search results found for "X"``, recovery
+        hints). The search backend itself is case-insensitive (Xapian),
+        so ``payload["query"]`` stays as the matched form for cache
+        keys / cursor encoding; only the rendered echoes change.
+        Pre-fix, ``search for Biology`` (after Rule 1 lowercase) showed
+        ``Found N matches for "biology"`` — sibling of the post-b1
+        P1-D2 / P2-D1 / P2-D2 lowercase-leak family.
         """
         query = payload["query"]
+        echo_query = display_query if display_query else query
         total_results = payload["total"] or 0
         page_info = payload["page_info"]
         offset = page_info["offset"]
@@ -715,11 +747,11 @@ class _SearchMixin:
             #   * tell_me_about runs a structured search + auto-fetch
             #     for any reasonably-named topic.
             return (
-                f'No search results found for "{query}".\n\n'
+                f'No search results found for "{echo_query}".\n\n'
                 f"**Try one of these:**\n"
-                f"- `suggestions for {query[:30]}` — autocomplete to "
+                f"- `suggestions for {echo_query[:30]}` — autocomplete to "
                 f"catch typos or partial names\n"
-                f"- `tell me about {query[:30]}` — structured topic "
+                f"- `tell me about {echo_query[:30]}` — structured topic "
                 f"lookup with auto article fetch\n"
                 f"- A shorter or differently-cased query"
             )
@@ -728,12 +760,12 @@ class _SearchMixin:
         # detect via ``total < offset`` plus an empty results list.
         if not results and offset >= total_results:
             return (
-                f'Found {total_results} matches for "{query}", '
+                f'Found {total_results} matches for "{echo_query}", '
                 f"but offset {offset} exceeds total results."
             )
 
         result_text = (
-            f'Found {total_results} matches for "{query}", '
+            f'Found {total_results} matches for "{echo_query}", '
             f"showing {offset + 1}-{offset + len(results)}:\n\n"
         )
 
@@ -809,6 +841,8 @@ class _SearchMixin:
         content_type: Optional[str] = None,
         limit: Optional[int] = None,
         offset: int = 0,
+        *,
+        display_query: Optional[str] = None,
     ) -> str:
         """A11 post-a11 H2: ``search_with_filters`` plus the canonical-
         title-match splice that plain ``search`` already gets through
@@ -834,6 +868,7 @@ class _SearchMixin:
                 content_type,
                 limit,
                 offset,
+                display_query=display_query,
             )
         if limit is None:
             limit = self.config.content.default_search_limit
@@ -860,6 +895,7 @@ class _SearchMixin:
                 content_type,
                 limit,
                 offset,
+                display_query=display_query,
             )
 
         canonical_path = canonical["path"]
@@ -880,6 +916,7 @@ class _SearchMixin:
                     content_type,
                     limit,
                     offset,
+                    display_query=display_query,
                 )
         # Same content-type gate when applicable; the title-index probe
         # doesn't carry mimetype info, so skip the splice rather than
@@ -892,6 +929,7 @@ class _SearchMixin:
                 content_type,
                 limit,
                 offset,
+                display_query=display_query,
             )
 
         # Get the structured payload, splice, then render via the same
@@ -1022,6 +1060,7 @@ class _SearchMixin:
             total_results=filtered_count,
             offset=offset,
             limit=limit,
+            display_query=display_query,
         )
 
     def search_with_filters(
@@ -1032,6 +1071,8 @@ class _SearchMixin:
         content_type: Optional[str] = None,
         limit: Optional[int] = None,
         offset: int = 0,
+        *,
+        display_query: Optional[str] = None,
     ) -> str:
         """Markdown-rendered filtered search (legacy surface).
 
@@ -1078,9 +1119,13 @@ class _SearchMixin:
         validated_path = self.path_validator.validate_zim_file(validated_path)
 
         # Check cache (legacy markdown cache, separate from the v2b dict cache).
+        # Post-b1 P3-D1: include display_query in the cache key. Two calls
+        # with the same matched query but different display forms must
+        # render different text; a stale cache would echo the wrong
+        # casing back to the second caller.
         cache_key = (
             f"search_filtered:{validated_path}:{query}:{namespace}:"
-            f"{content_type}:{limit}:{offset}"
+            f"{content_type}:{limit}:{offset}:dq={display_query or ''}"
         )
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
@@ -1090,7 +1135,13 @@ class _SearchMixin:
         try:
             with _zim_ops_mod.zim_archive(validated_path) as archive:
                 result, total_filtered = self._perform_filtered_search(
-                    archive, query, namespace, content_type, limit, offset
+                    archive,
+                    query,
+                    namespace,
+                    content_type,
+                    limit,
+                    offset,
+                    display_query=display_query,
                 )
 
             # Don't cache zero-result responses: libzim's lazy index warm-up
@@ -1419,6 +1470,8 @@ class _SearchMixin:
         content_type: Optional[str],
         limit: int,
         offset: int,
+        *,
+        display_query: Optional[str] = None,
     ) -> Tuple[str, int]:
         """Perform filtered search operation.
 
@@ -1426,7 +1479,14 @@ class _SearchMixin:
             (result_text, total_filtered) — caller uses total_filtered to decide
             whether the response is safe to cache. ``total_filtered`` is 0 for
             both the unfiltered no-results and the post-filter no-matches cases.
+
+        Post-b1 P3-D1: ``display_query`` (when set) replaces ``query``
+        in user-facing echo strings (``No search results found for "X"``,
+        ``No filtered matches for "X"``, ``Found N filtered matches for
+        "X"``). Matching uses ``query`` unchanged; only the rendered
+        echo changes.
         """
+        echo_query = display_query if display_query else query
         # Canonicalise user-supplied namespace ("c" -> "C", "content" -> "C")
         # so the comparison against namespace prefixes derived from libzim
         # paths (which always surface in canonical form) does not silently
@@ -1439,7 +1499,7 @@ class _SearchMixin:
         search = searcher.search(query_obj)
         total_results = search.getEstimatedMatches()
         if total_results == 0:
-            return f'No search results found for "{query}"', 0
+            return f'No search results found for "{echo_query}"', 0
 
         page, scan = self._scan_filtered_search(
             archive, search, total_results, namespace, content_type, limit, offset
@@ -1447,16 +1507,23 @@ class _SearchMixin:
 
         filter_text = _format_filter_text(namespace, content_type)
         if scan.filtered_count == 0:
-            return f'No filtered matches for "{query}"{filter_text}', 0
+            return f'No filtered matches for "{echo_query}"{filter_text}', 0
         if offset >= scan.filtered_count:
             return (
-                f'Found {scan.filtered_count} filtered matches for "{query}"'
+                f'Found {scan.filtered_count} filtered matches for "{echo_query}"'
                 f"{filter_text}, but offset {offset} exceeds total results."
             ), scan.filtered_count
 
         results = self._build_filtered_results(page, content_type, offset, query=query)
         result_text = _format_filtered_response(
-            query, filter_text, results, scan, total_results, offset, limit
+            query,
+            filter_text,
+            results,
+            scan,
+            total_results,
+            offset,
+            limit,
+            display_query=display_query,
         )
         return result_text, scan.filtered_count
 

--- a/tests/ml/test_download_cli.py
+++ b/tests/ml/test_download_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -48,3 +49,60 @@ class TestDownloadModelsCli:
             captured = capsys.readouterr()
             assert rc == 1
             assert "failed" in captured.out.lower()
+
+    def test_honours_cache_dir_env_var(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Sweep-PR regression: the CLI must read
+        ``OPENZIM_MCP_ML__RERANKER__CACHE_DIR`` so the air-gapped
+        pre-stage workflow lands files where the runtime expects them.
+        Direct ``RerankerConfig()`` instantiation silently ignored env
+        vars because it inherits from ``BaseModel``, not ``BaseSettings``."""
+        cache_dir = tmp_path / "fastembed-staging"
+        cache_dir.mkdir()
+        monkeypatch.setenv("OPENZIM_MCP_ML__RERANKER__CACHE_DIR", str(cache_dir))
+        with (
+            patch("openzim_mcp.ml.cli.download.detect") as mock_detect,
+            patch("openzim_mcp.ml.cli.download._stage_reranker") as mock_stage,
+        ):
+            mock_detect.return_value = MagicMock(reranker=True)
+            rc = download_models_main(argv=[])
+            assert rc == 0
+            (cfg,) = mock_stage.call_args.args
+            assert cfg.cache_dir == cache_dir
+
+    def test_honours_model_id_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Same root cause: ``OPENZIM_MCP_ML__RERANKER__MODEL_ID`` must
+        flow through to the staging call. The CLI flag still overrides
+        the env var (argparse default left None when --reranker-model-id
+        absent)."""
+        monkeypatch.setenv(
+            "OPENZIM_MCP_ML__RERANKER__MODEL_ID", "BAAI/bge-reranker-large"
+        )
+        with (
+            patch("openzim_mcp.ml.cli.download.detect") as mock_detect,
+            patch("openzim_mcp.ml.cli.download._stage_reranker") as mock_stage,
+        ):
+            mock_detect.return_value = MagicMock(reranker=True)
+            rc = download_models_main(argv=[])
+            assert rc == 0
+            (cfg,) = mock_stage.call_args.args
+            assert cfg.model_id == "BAAI/bge-reranker-large"
+
+    def test_cli_flag_overrides_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(
+            "OPENZIM_MCP_ML__RERANKER__MODEL_ID", "BAAI/bge-reranker-base"
+        )
+        with (
+            patch("openzim_mcp.ml.cli.download.detect") as mock_detect,
+            patch("openzim_mcp.ml.cli.download._stage_reranker") as mock_stage,
+        ):
+            mock_detect.return_value = MagicMock(reranker=True)
+            rc = download_models_main(
+                argv=["--reranker-model-id", "jinaai/jina-reranker-v3"]
+            )
+            assert rc == 0
+            (cfg,) = mock_stage.call_args.args
+            assert cfg.model_id == "jinaai/jina-reranker-v3"

--- a/tests/ml/test_ml_config.py
+++ b/tests/ml/test_ml_config.py
@@ -19,7 +19,7 @@ class TestRerankerConfig:
         assert cfg.max_query_length == 256
         assert cfg.max_passage_length == 512
         assert cfg.min_query_tokens == 4
-        assert cfg.first_call_timeout_seconds == pytest.approx(5.0)
+        assert cfg.first_call_timeout_seconds == pytest.approx(15.0)
         assert cfg.cache_dir is None
 
     def test_pool_size_bounds(self) -> None:

--- a/tests/ml/test_reranker_unit.py
+++ b/tests/ml/test_reranker_unit.py
@@ -333,6 +333,31 @@ class TestRerankerWiredToHandleSearch:
         assert telemetry.get("reranker_engaged", 0) == 0
         assert result == "rendered results"
 
+    def test_track_emits_info_log_for_reranker_events(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Sweep-PR: reranker events must hit the operator log at INFO so
+        simple-mode users (no ``get_server_health``) can observe engagement.
+        Non-reranker telemetry events stay counter-only."""
+        handler = self._make_handler()
+        with caplog.at_level("INFO", logger="openzim_mcp.simple_tools"):
+            handler._track("reranker_engaged")
+            handler._track("reranker_skipped.not_installed")
+            handler._track("reranker_skipped.no_results")
+            handler._track("reranker_skipped.passthrough")
+            handler._track("some_other_event")
+        info_messages = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelname == "INFO" and r.name == "openzim_mcp.simple_tools"
+        ]
+        assert "telemetry: reranker_engaged" in info_messages
+        assert "telemetry: reranker_skipped.not_installed" in info_messages
+        assert "telemetry: reranker_skipped.no_results" in info_messages
+        assert "telemetry: reranker_skipped.passthrough" in info_messages
+        # Counter-only event must NOT log.
+        assert all("some_other_event" not in m for m in info_messages)
+
 
 class TestRerankerWiredToHandleFilteredSearch:
     """Verify that _handle_filtered_search (compact mode) routes results

--- a/tests/test_post_a16_beta_fixes.py
+++ b/tests/test_post_a16_beta_fixes.py
@@ -275,10 +275,10 @@ class TestD1SoftFooter:
             options={"compact": False},
         )
         assert "query contained" in out
-        # Sub-D-2 Rule 1 lowercases the query; footer mentions lowercase names.
-        assert "berlin" in out
-        assert "paris" in out
-        assert "tell me about berlin" in out
+        # Post-b1 P1-D2: footer echoes entities in caller's original case.
+        assert "Berlin" in out
+        assert "Paris" in out
+        assert "tell me about Berlin" in out
 
     def test_both_halves_in_title_suppresses_footer(self) -> None:
         # ``Romeo and Juliet`` resolved to ``Romeo and Juliet`` → no
@@ -322,8 +322,8 @@ class TestD1SoftFooter:
             options={"compact": False},
         )
         assert "query contained" in out
-        # Sub-D-2 Rule 1 lowercases the query; footer mentions lowercase names.
-        assert "berlin" in out
+        # Post-b1 P1-D2: footer echoes entities in caller's original case.
+        assert "Berlin" in out
 
 
 class TestD1RealTopicWithLowercaseRightUnchanged:

--- a/tests/test_post_a17_beta_fixes.py
+++ b/tests/test_post_a17_beta_fixes.py
@@ -150,7 +150,8 @@ class TestP1D1TitleSpansConnectorSuppression:
             options={"compact": False},
         )
         assert "query contained" in out
-        assert "berlin" in out  # Sub-D-2 Rule 1 lowercases topic before footer is built
+        # Post-b1 P1-D2: footer entities echo in caller's original case.
+        assert "Berlin" in out
 
     def test_pre_fix_both_halves_in_title_still_suppresses(self) -> None:
         # Regression guard: ``Berlin and Brandenburg`` resolved to
@@ -196,7 +197,8 @@ class TestP1D1TitleSpansConnectorSuppression:
         )
         # Title "Beethoven" doesn't span the connector → fires as before.
         assert "query contained" in out
-        assert "mozart" in out  # Sub-D-2 Rule 1 lowercases topic before footer is built
+        # Post-b1 P1-D2: footer entities echo in caller's original case.
+        assert "Mozart" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_post_a18_beta_fixes.py
+++ b/tests/test_post_a18_beta_fixes.py
@@ -287,9 +287,9 @@ class TestP3D2SoftConnectorAliasFallback:
             "soft-connector footer must fire when one half resolves "
             "via title alias to the returned top_path"
         )
-        # Sub-D-2 Rule 1 lowercases topics before the footer is built.
-        assert "berlin" in out
-        assert "tell me about berlin" in out
+        # Post-b1 P1-D2: footer echoes entities in caller's original case.
+        assert "Berlin" in out
+        assert "tell me about Berlin" in out
 
     def test_neither_half_resolves_via_alias_still_suppresses(self) -> None:
         # Defensive: when neither half's title-alias resolves to

--- a/tests/test_post_a21_beta_fixes.py
+++ b/tests/test_post_a21_beta_fixes.py
@@ -376,10 +376,14 @@ class TestMultiEntityChainGuidance:
             "Multi-Entity Chain Detected" in body
         ), f"Expected chain warning; got: {body[:400]}"
         # Each entity should be enumerated in the warning.
-        # Sub-D-2 Rule 1 lowercases everything before chain detection.
+        # Post-b1 P1-D2: chain rejection bullets now echo each entity
+        # in the caller's original casing (recased via the pre-rewrite
+        # query stashed in params["_pre_rewrite_query"]). Pre-fix the
+        # bullets were lowercased and broke the user's copy-paste
+        # recovery path.
         assert (
-            "köln" in body and "münchen" in body and "berlin" in body
-        ), f"Entities not enumerated: {body[:400]}"
+            "Köln" in body and "München" in body and "Berlin" in body
+        ), f"Entities not enumerated in original case: {body[:400]}"
 
     def test_three_entity_or_chain_with_non_latin_fires_warning(self) -> None:
         handler, _mock = self._handler(title_resolves={})
@@ -389,8 +393,8 @@ class TestMultiEntityChainGuidance:
         )
         body = str(result)
         assert "Multi-Entity Chain Detected" in body
-        # Sub-D-2 Rule 1 lowercases ASCII; non-Latin codepoints are untouched.
-        assert "berlin" in body and "東京" in body and "tokyo" in body
+        # Post-b1 P1-D2: entities echo in original case.
+        assert "Berlin" in body and "東京" in body and "Tokyo" in body
 
     def test_four_entity_chain_fires_warning(self) -> None:
         handler, _mock = self._handler(title_resolves={})

--- a/tests/test_post_b1_beta_fixes.py
+++ b/tests/test_post_b1_beta_fixes.py
@@ -748,6 +748,100 @@ class TestPass2CrossFeatureIntegration:
 # ===========================================================================
 
 
+class TestPass2SiblingDefects:
+    """Pass-2 source-level audit caught two additional lowercase-leak
+    siblings to P1-D2 (chain rejection / soft-connector footer). Both
+    echo a Rule-1-lowercased topic/query in a user-facing string. Live
+    confirmation: P2-D1 reproduced in the original pass-1 smoke gate
+    (``the Beatles`` → ``**Multiple articles match "beatles"**``); P2-D2
+    affects every empty-result search whose original-case form differs
+    from the lowercased extraction (``search for Biology xyz`` → ``No
+    results for "biology xyz"``).
+
+    Out of scope (separate change required): zim/search.py's ``Found N
+    matches for "X"`` / ``No search results found for "X"`` /
+    ``No filtered matches for "X"`` echoes (5 sites) — fixing them
+    requires plumbing a separate ``display_query`` kwarg through the
+    search backend's format functions. Higher cost, lower per-call
+    impact than the dispatcher-edge cases fixed here."""
+
+    def test_p2_d1_disambiguation_heading_recased(self) -> None:
+        # Pre-fix: ``**Multiple articles match "stalin"**``.
+        # Post-fix: ``**Multiple articles match "Stalin"**``.
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        out = SimpleToolsHandler._render_disambiguation(
+            topic="stalin",
+            candidates=[
+                {"title": "Joseph Stalin", "path": "Joseph_Stalin", "score": 1.0},
+                {
+                    "title": "Stalin: Paradoxes of Power",
+                    "path": "Stalin:_Paradoxes",
+                    "score": 0.95,
+                },
+            ],
+            original_query="tell me about Stalin",
+        )
+        assert '**Multiple articles match "Stalin"**' in out
+        assert '**Multiple articles match "stalin"**' not in out
+
+    def test_p2_d1_disambiguation_preserves_diacritics(self) -> None:
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        out = SimpleToolsHandler._render_disambiguation(
+            topic="münchen",
+            candidates=[
+                {"title": "Munich", "path": "Munich", "score": 1.0},
+                {"title": "FC München", "path": "FC_Munich", "score": 0.96},
+            ],
+            original_query="tell me about München",
+        )
+        assert '**Multiple articles match "München"**' in out
+
+    def test_p2_d1_disambiguation_falls_back_when_no_original(self) -> None:
+        # No original_query passed → legacy lowercase echo.
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        out = SimpleToolsHandler._render_disambiguation(
+            topic="stalin",
+            candidates=[
+                {"title": "Joseph Stalin", "path": "Joseph_Stalin", "score": 1.0},
+                {"title": "Stalin (film)", "path": "Stalin_(film)", "score": 0.96},
+            ],
+        )
+        assert '**Multiple articles match "stalin"**' in out
+
+    def test_p2_d1_disambiguation_falls_back_when_token_missing(self) -> None:
+        # ``original_query`` doesn't contain the topic (e.g., Rule 4
+        # reordered words) → helper returns the lowercase topic
+        # unchanged. Documented graceful-degrade case.
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        out = SimpleToolsHandler._render_disambiguation(
+            topic="population",  # decomposed entity, not in original
+            candidates=[
+                {"title": "Population", "path": "Population", "score": 1.0},
+                {"title": "Population (statistics)", "path": "P_stats", "score": 0.96},
+            ],
+            original_query="tell me about Berlin's growth",
+        )
+        # No "population" substring in the original → falls back to lowercase.
+        assert '**Multiple articles match "population"**' in out
+
+    def test_p2_d2_no_results_heading_via_recase_helper(self) -> None:
+        # Direct test of the _recase_from_original helper applied to
+        # a search_query. The full integration via _handle_search
+        # requires constructing the whole handler — the helper test
+        # exercises the same logic the handler uses.
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        original = 'search for "Biology Phylogenetics"'
+        recased = SimpleToolsHandler._recase_from_original(
+            "biology phylogenetics", original
+        )
+        assert recased == "Biology Phylogenetics"
+
+
 class TestRegressionGuards:
     """Pin the existing-contract behaviours that the post-b1 fixes
     must not regress. Each guard targets a code path the fixes

--- a/tests/test_post_b1_beta_fixes.py
+++ b/tests/test_post_b1_beta_fixes.py
@@ -748,6 +748,172 @@ class TestPass2CrossFeatureIntegration:
 # ===========================================================================
 
 
+class TestPass3SearchBackendEchoPlumbing:
+    """Pass-3 source-level audit followed pass-2's deferral. The 5
+    user-facing echo strings in ``zim/search.py`` (``Found N matches
+    for "X"``, ``No search results found for "X"``, recovery hints,
+    filtered variants) all read ``payload["query"]`` / the function-
+    local ``query`` arg, which the dispatcher passes as Rule-1-
+    lowercased. Pass-2 documented these as backend-plumbing work;
+    pass-3 lands the plumbing via a new optional ``display_query``
+    kwarg threaded through ``_format_search_text`` →
+    ``search_zim_file``, and ``_format_filtered_response`` →
+    ``search_with_filters`` / ``_perform_filtered_search`` /
+    ``search_with_filters_with_canonical_splice``.
+
+    Backend matching is unchanged — Xapian is case-insensitive, so
+    the query/cache key keep the lowercase form for stability; only
+    the user-facing echoes pick up the original case."""
+
+    def _make_format_payload(
+        self,
+        *,
+        query: str = "biology",
+        total: int = 0,
+        results: Optional[list] = None,
+    ) -> Dict[str, Any]:
+        """Build a minimal SearchResponse-shaped dict for
+        ``_format_search_text``. Only the keys the formatter reads
+        need to be set."""
+        return {
+            "query": query,
+            "total": total,
+            "page_info": {"offset": 0, "limit": 5},
+            "results": results or [],
+            "done": True,
+        }
+
+    def test_format_search_text_no_results_uses_display_query(self) -> None:
+        # Pre-fix: ``No search results found for "biology"``.
+        # Post-fix: ``No search results found for "Biology"``.
+        # Use _SearchMixin._format_search_text as an unbound function so
+        # we don't have to construct the full backend.
+        from openzim_mcp.zim.search import _SearchMixin
+
+        payload = self._make_format_payload(query="biology", total=0)
+
+        class _Stub:
+            pass
+
+        fn = _SearchMixin._format_search_text
+        out = fn(_Stub(), payload, display_query="Biology")  # type: ignore[arg-type]
+        assert 'No search results found for "Biology".' in out
+        assert "biology" not in out  # the lowercase form is fully replaced
+
+    def test_format_search_text_no_results_falls_back_when_no_display(
+        self,
+    ) -> None:
+        # Legacy behaviour: when display_query is None, echo uses
+        # payload["query"].
+        from openzim_mcp.zim.search import _SearchMixin
+
+        payload = self._make_format_payload(query="biology", total=0)
+
+        class _Stub:
+            pass
+
+        fn = _SearchMixin._format_search_text
+        out = fn(_Stub(), payload)  # type: ignore[arg-type]
+        assert 'No search results found for "biology".' in out
+
+    def test_format_search_text_with_results_uses_display_query(self) -> None:
+        from openzim_mcp.zim.search import _SearchMixin
+
+        payload = self._make_format_payload(
+            query="biology",
+            total=10,
+            results=[
+                {"title": "Biology", "path": "Biology", "snippet": "..."},
+            ],
+        )
+
+        class _Stub:
+            pass
+
+        fn = _SearchMixin._format_search_text
+        out = fn(_Stub(), payload, display_query="Biology")  # type: ignore[arg-type]
+        assert 'Found 10 matches for "Biology"' in out
+
+    def test_format_search_text_offset_exceeds_uses_display_query(self) -> None:
+        from openzim_mcp.zim.search import _SearchMixin
+
+        # offset >= total + empty results triggers the
+        # "offset exceeds total" echo (line ~731).
+        payload = {
+            "query": "biology",
+            "total": 5,
+            "page_info": {"offset": 100, "limit": 5},
+            "results": [],
+            "done": True,
+        }
+
+        class _Stub:
+            pass
+
+        fn = _SearchMixin._format_search_text
+        out = fn(_Stub(), payload, display_query="Biology")  # type: ignore[arg-type]
+        assert 'Found 5 matches for "Biology"' in out
+
+    def test_format_filtered_response_uses_display_query(self) -> None:
+        # _format_filtered_response is a module-level free function;
+        # call it directly with a minimal _FilteredScanState.
+        from openzim_mcp.zim.search import _FilteredScanState, _format_filtered_response
+
+        scan = _FilteredScanState(
+            filtered_count=10,
+            scanned=10,
+            scan_cap_hit=False,
+            total_filtered_is_lower_bound=False,
+        )
+        out = _format_filtered_response(
+            query="biology",
+            filter_text=" (namespace=C)",
+            results=[
+                {
+                    "title": "Biology",
+                    "path": "Biology",
+                    "snippet": "...",
+                    "namespace": "C",
+                }
+            ],
+            scan=scan,
+            total_results=10,
+            offset=0,
+            limit=5,
+            display_query="Biology",
+        )
+        assert 'Found 10 filtered matches for "Biology"' in out
+        # Original lowercase form should NOT appear in the echo header.
+        assert 'matches for "biology"' not in out
+
+    def test_format_filtered_response_falls_back_no_display(self) -> None:
+        from openzim_mcp.zim.search import _FilteredScanState, _format_filtered_response
+
+        scan = _FilteredScanState(
+            filtered_count=10,
+            scanned=10,
+            scan_cap_hit=False,
+            total_filtered_is_lower_bound=False,
+        )
+        out = _format_filtered_response(
+            query="biology",
+            filter_text="",
+            results=[
+                {
+                    "title": "Biology",
+                    "path": "Biology",
+                    "snippet": "...",
+                    "namespace": "C",
+                }
+            ],
+            scan=scan,
+            total_results=10,
+            offset=0,
+            limit=5,
+        )
+        assert 'Found 10 filtered matches for "biology"' in out
+
+
 class TestPass2SiblingDefects:
     """Pass-2 source-level audit caught two additional lowercase-leak
     siblings to P1-D2 (chain rejection / soft-connector footer). Both

--- a/tests/test_post_b1_beta_fixes.py
+++ b/tests/test_post_b1_beta_fixes.py
@@ -1,0 +1,821 @@
+r"""Regression tests for the post-b1 beta-test sweep.
+
+The post-b1 live-MCP sweep against the 118 GB Wikipedia ZIM after
+v2.0.0b1 deployed surfaced SIX user-facing defects in the new Phase D
+Tier-1 query-rewriting (sub-D-2) wiring, plus an in-band telemetry gap
+for the new cross-encoder reranker (sub-D-1).
+
+Defects span FOUR surfaces:
+
+* **P1-D1 — title_probe built from caller-supplied zim_file_path BEFORE
+  auto-archive-selection.** The handler builds the probe at the top of
+  ``handle_zim_query`` from the raw caller argument; the auto-select
+  fallback happens later (line ~776). When the caller follows the tool
+  docstring's recommendation to OMIT ``zim_file_path``, the probe is
+  built with ``None`` and returns ``None``, causing all probe-gated
+  rules (Rule 2 misspellings, Rule 3 article-strip, Rule 4 X-of-Y) to
+  silently degrade. Live impact:
+
+    - ``the Beatles`` → ``**Multiple articles match "beatles"**`` disambig
+      (Rule 3 stripped ``the`` instead of suppressing on probe-hit)
+    - ``An American in Paris`` → 🚨 ``Niggas_in_Paris`` (offensive
+      misroute; Rule 3 stripped ``an`` then fuzzy-matched the wrong song)
+    - ``A Christmas Carol`` → ``Christmas_carol`` concept (Dickens
+      novella destroyed)
+
+  Fix: add ``_probe_archive_path()`` helper that calls
+  ``_auto_select_zim_file()`` when the caller-supplied path is empty,
+  then call it before ``_build_title_probe`` at both wiring sites
+  (simple-branch line ~624, synthesize-branch line ~5071-72).
+
+* **P1-D2 — Rule 1's full-query lowercase leaks into user-facing chain
+  rejection bullets and soft-connector footer.** ``_multi_entity_chain
+  _guidance`` and ``_soft_connector_footer`` echo entities from
+  ``params["topic"]``, which is extracted from the lowercased query
+  inside ``parse_intent``. Live impact: ``tell me about Köln, München,
+  and Berlin`` → rejection bullets read ``tell me about köln`` /
+  ``münchen`` / ``berlin``; the caller's recovery copy-paste path
+  loses casing and diacritics. Fix: stash the pre-rewrite
+  original-case query in ``params["_pre_rewrite_query"]`` at the
+  wiring layer; thread it through both functions; new helper
+  ``_recase_from_original()`` finds each lowercase token in the
+  original query via case-insensitive substring lookup.
+
+* **P1-D3 — Rule 4 ``_decompose_x_of_y`` has NO title-probe guard at
+  all.** The decomposition regex ``^(?P<attr>\w+)\s+of\s+(?P<entity>
+  .{1,200})$`` fires for every ``X of Y`` query whose attr isn't in
+  the structural-intent skip-set (``structure``, ``summary``,
+  ``list``...). Real-content nouns (``art``, ``lord``, ``origin``,
+  ``birth``, ``death``, ``wealth``, ``state``, ``king``, ``history``,
+  ``population``) decompose unconditionally — for canonical
+  X-of-Y titles, the lookup goes to the bare entity. Live impact:
+
+    - ``lord of the rings`` → ``The_Rings`` (1985 Iranian horror film)
+    - ``the art of war`` → ``War`` concept (not Sun Tzu)
+    - ``wealth of nations`` → ``Nation`` concept (not Adam Smith)
+    - ``state of the union`` → ``The_Union`` disambig
+    - ``origin of species`` → ``Species`` concept (not Darwin)
+    - ``birth of venus`` → ``Venus`` disambig (not Botticelli painting)
+    - ``death of stalin`` → ``Stalin`` disambig (not Iannucci film)
+    - ``history of rome`` → ``Rome`` city (not ``History_of_Rome``)
+
+  Fix: mirror Rule 3's probe gate inside Rule 4 — when ``title_probe
+  (query)`` is True, return ``(query, None)`` and suppress
+  decomposition. Forward the same probe from ``_apply_tier1_rewrites``
+  alongside rules 2 and 3.
+
+* **P1-D5 / P1-D6 — Rule 2 misses possessives and trailing
+  punctuation.** ``_apply_misspelling_map`` splits on whitespace only.
+  Tokens with attached punctuation (``bilogy.``, ``"recieve"``,
+  ``photosythesis``'s possessive) don't match the bare-stem keys
+  (``bilogy``, ``recieve``, ``photosythesis``). Live impact:
+
+    - ``tell me about Photosythesis's reproduction`` → ``No search
+      results found`` (no fallback path catches the possessive form)
+    - ``tell me about bilogy.`` rescued accidentally by the post-a11
+      fuzzy fallback, but the rewrite layer itself is silently
+      ineffective for trailing punctuation
+
+  Fix: when raw-token lookup misses, run ``_MISSPELL_AFFIX_RE``
+  to split into ``(prefix, core, suffix)``, strip a trailing ``'s``
+  possessive, retry the map on the core, and reattach the affixes
+  to the substitution on hit.
+
+* **(D-1 telemetry gap)**: reranker engagement state lives in
+  ``self._telemetry`` Counter, surfaced only via the advanced
+  ``get_server_health`` tool. Some HTTP-MCP hosts filter that tool
+  out, leaving simple-tool callers with no in-band way to confirm
+  whether D-1 reranking actually engaged for their request.
+  ``bbda863`` already added INFO-level logging, but logs aren't
+  reachable for external simple-tool callers. Fix: snapshot the
+  four reranker counters at the start of ``handle_zim_query``; new
+  ``_compute_rerank_state()`` returns a one-of-four engagement
+  state from the post-call delta; appended as
+  ``<!-- reranker=<state> -->`` in the response envelope
+  (mirrors the existing ``<!-- intent=... cert=... -->`` shape).
+
+Methodology continues to hold:
+  * "Narrow-scope sibling" pattern reproduced at the FEATURE level:
+    the new D-2 wiring shipped four probe-gated rules but the probe
+    itself was gated narrower than the recommended usage — every
+    rule that consults the probe is affected.
+  * "Fix unlocks new paths" reproduced for the 6th sweep — D-2's
+    Rule 4 LANDED (decomposes ``population of berlin`` cleanly to
+    ``berlin``) but exposed the canonical-title-decomposition
+    family that has no guard at all.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Callable, Dict, List, Optional
+
+import pytest
+
+from openzim_mcp.intent_parser import IntentParser
+
+# ===========================================================================
+# P1-D1: title_probe degrades when caller omits zim_file_path
+# ===========================================================================
+
+
+class _StubZimOps:
+    """Minimal stub of ``ZimOperations`` for probe-archive tests. The
+    real object has dozens of methods; we only need
+    ``list_zim_files_data`` for ``_auto_select_zim_file`` plus a
+    ``config`` shim. Mock-style frameworks would work too but a small
+    stub stays readable and explicit about the contract being tested."""
+
+    def __init__(self, files: List[Dict[str, Any]]) -> None:
+        self._files = files
+
+        class _RewriteCfg:
+            enabled = True
+
+        class _RerankerCfg:
+            enabled = True
+
+        class _MlCfg:
+            reranker = _RerankerCfg()
+
+        class _Cfg:
+            query_rewrite = _RewriteCfg()
+            ml = _MlCfg()
+
+        self.config = _Cfg()
+
+    def list_zim_files_data(self) -> List[Dict[str, Any]]:
+        return self._files
+
+
+class _ProbeHarness:
+    """Adapter that exposes ONLY the methods the P1-D1 fix touches:
+    ``_probe_archive_path``, ``_build_title_probe``, and
+    ``_auto_select_zim_file``. Avoids constructing the full
+    SimpleToolsHandler (which would require a real backend).
+
+    Methods are called as unbound (``SimpleToolsHandler._probe_archive
+    _path(harness, ...)``) so we can pass any duck-typed object as
+    ``self``. mypy can't see that we're satisfying the structural
+    contract, hence ``# type: ignore[arg-type]`` on each call site."""
+
+    def __init__(self, files: List[Dict[str, Any]]) -> None:
+        self.zim_operations = _StubZimOps(files)
+
+    def _auto_select_zim_file(self) -> Optional[str]:
+        # Mirror the real implementation's contract: single loaded
+        # archive → return its path; zero or >1 → None.
+        files = self.zim_operations.list_zim_files_data()
+        if len(files) == 1:
+            return str(files[0]["path"])
+        return None
+
+    def probe_archive_path(self, candidate: Optional[str]) -> Optional[str]:
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        return SimpleToolsHandler._probe_archive_path(self, candidate)  # type: ignore[arg-type]
+
+
+class TestP1D1ProbeArchiveResolution:
+    """P1-D1: pre-fix, ``title_probe`` was built from the raw caller-
+    supplied ``zim_file_path`` BEFORE downstream auto-resolution. When
+    the caller followed the docstring's recommendation to OMIT the
+    path, the probe was ``None`` and every probe-gated rewrite (Rule
+    2, Rule 3, post-fix Rule 4) silently degraded.
+
+    Fix: ``_probe_archive_path`` falls back to
+    ``_auto_select_zim_file`` when the caller-supplied path is None,
+    so the probe sees the same archive ``handle_zim_query`` will
+    auto-select downstream."""
+
+    def test_explicit_path_passes_through_unchanged(self) -> None:
+        harness = _ProbeHarness(
+            [{"path": "/data/wikipedia.zim", "name": "wikipedia.zim"}]
+        )
+        assert (
+            harness.probe_archive_path("/data/something_else.zim")
+            == "/data/something_else.zim"
+        )
+
+    def test_none_input_falls_back_to_auto_select_single_archive(self) -> None:
+        # Single-archive case: auto-select returns the only loaded archive.
+        # Pre-fix this returned None and built a None probe.
+        harness = _ProbeHarness(
+            [{"path": "/data/wikipedia.zim", "name": "wikipedia.zim"}]
+        )
+        assert harness.probe_archive_path(None) == "/data/wikipedia.zim"
+
+    def test_none_input_with_multiple_archives_stays_none(self) -> None:
+        # Multi-archive without explicit path is genuinely ambiguous —
+        # _auto_select_zim_file returns None, so the probe correctly
+        # stays in degraded mode.
+        harness = _ProbeHarness(
+            [
+                {"path": "/data/wiki_en.zim", "name": "wiki_en.zim"},
+                {"path": "/data/wiki_de.zim", "name": "wiki_de.zim"},
+            ]
+        )
+        assert harness.probe_archive_path(None) is None
+
+    def test_none_input_with_zero_archives_stays_none(self) -> None:
+        # No archives loaded — there is nothing for the probe to consult.
+        harness = _ProbeHarness([])
+        assert harness.probe_archive_path(None) is None
+
+    def test_empty_string_input_treated_as_none(self) -> None:
+        # Defence: an empty-string ``zim_file_path`` should NOT bypass
+        # the auto-select fallback. ``if zim_file_path`` correctly
+        # short-circuits on the empty string.
+        harness = _ProbeHarness(
+            [{"path": "/data/wikipedia.zim", "name": "wikipedia.zim"}]
+        )
+        assert harness.probe_archive_path("") == "/data/wikipedia.zim"
+
+
+# ===========================================================================
+# P1-D3: Rule 4 _decompose_x_of_y now consults title_probe to suppress
+#        decomposition of canonical multi-word titles
+# ===========================================================================
+
+
+def _probe_factory(*canonical_titles: str) -> Callable[[str], bool]:
+    """Build a title_probe that returns True iff ``query`` (case-
+    insensitive) matches one of the canonical titles passed in."""
+    lowered = {t.lower() for t in canonical_titles}
+
+    def probe(q: str) -> bool:
+        return q.lower() in lowered
+
+    return probe
+
+
+class TestP1D3Rule4ProbeGate:
+    """P1-D3: Rule 4 used to fire unconditionally for any
+    ``<word> of <stuff>`` query whose attribute word wasn't in the
+    structural-intent skip-set. Canonical multi-word titles
+    (``lord of the rings``, ``the art of war``, ``birth of venus``,
+    ``history of rome``) were silently torn apart, with the resulting
+    bare-entity lookup returning unrelated articles.
+
+    Fix: probe the full query; on a canonical-title hit, return
+    ``(query, None)`` and skip decomposition."""
+
+    @pytest.mark.parametrize(
+        "canonical_query",
+        [
+            "lord of the rings",
+            "art of war",
+            "the art of war",
+            "wealth of nations",
+            "state of the union",
+            "origin of species",
+            "birth of venus",
+            "death of stalin",
+            "history of rome",
+            "king of england",
+            "rise of the planet of the apes",
+        ],
+    )
+    def test_probe_hit_suppresses_decomposition(
+        self, canonical_query: str
+    ) -> None:
+        # Probe returns True for the full query → no decomposition.
+        probe = _probe_factory(canonical_query)
+        rewritten, hint = IntentParser._decompose_x_of_y(
+            canonical_query, title_probe=probe
+        )
+        assert rewritten == canonical_query
+        assert hint is None
+
+    def test_probe_miss_still_decomposes(self) -> None:
+        # ``population of berlin`` is NOT a canonical title (the title
+        # is just ``berlin``). The probe misses; decomposition still
+        # fires and the hint flows through to _handle_tell_me_about.
+        probe = _probe_factory("berlin")  # only ``berlin`` is canonical
+        rewritten, hint = IntentParser._decompose_x_of_y(
+            "population of berlin", title_probe=probe
+        )
+        assert rewritten == "berlin population"
+        assert hint == {"entity": "berlin", "attribute": "population"}
+
+    def test_no_probe_legacy_behavior(self) -> None:
+        # Without a probe (degraded mode, e.g. multi-archive without
+        # explicit path), Rule 4 falls back to its pre-fix behaviour
+        # of decomposing everything. The DEGRADATION class P1-D1 is
+        # the real fix; this test pins the legacy fall-through.
+        rewritten, hint = IntentParser._decompose_x_of_y("lord of the rings")
+        assert hint == {"entity": "the rings", "attribute": "lord"}
+        assert rewritten == "the rings lord"
+
+    def test_skip_attr_short_circuits_before_probe(self) -> None:
+        # ``structure of biology`` — ``structure`` is in
+        # _DECOMPOSE_SKIP_ATTRS, so the skip check returns early
+        # before the probe is consulted. Doesn't matter if a probe is
+        # passed; structural commands NEVER decompose.
+        probe = _probe_factory("biology")  # entity probes True
+        rewritten, hint = IntentParser._decompose_x_of_y(
+            "structure of biology", title_probe=probe
+        )
+        assert hint is None
+        assert rewritten == "structure of biology"
+
+    def test_possessive_form_also_consults_probe(self) -> None:
+        # The possessive shape ``berlin's population`` goes through
+        # the SAME ``title_probe`` gate. If the FULL query (with
+        # possessive) is canonical, suppress.
+        probe = _probe_factory("berlin's population")  # contrived
+        rewritten, hint = IntentParser._decompose_x_of_y(
+            "berlin's population", title_probe=probe
+        )
+        assert rewritten == "berlin's population"
+        assert hint is None
+
+    def test_pipeline_forwards_probe_to_rule_4(self) -> None:
+        # End-to-end: _apply_tier1_rewrites forwards the probe to all
+        # three probe-gated rules. ``lord of the rings`` with a
+        # canonical-title probe must return ``(query, None)``.
+        probe = _probe_factory("lord of the rings")
+        rewritten, hint = IntentParser._apply_tier1_rewrites(
+            "Lord of the Rings",
+            title_probe=probe,
+            enabled=True,
+        )
+        # Rule 1 lowercases; Rule 4 probe-suppresses decomposition.
+        assert rewritten == "lord of the rings"
+        assert hint is None
+
+
+# ===========================================================================
+# P1-D5 / P1-D6: Rule 2 affix-stripped retry
+# ===========================================================================
+
+
+class TestP1D5PossessiveMisspelling:
+    """P1-D5: ``photosythesis's reproduction`` previously didn't get
+    fixed by Rule 2 because the possessive ``'s`` made the lookup
+    key ``photosythesis's`` (not in map). Live: returned ``No search
+    results found``. Fix: strip a trailing ``'s`` before map lookup,
+    reattach on hit."""
+
+    def test_possessive_misspelling_corrected(self) -> None:
+        out = IntentParser._apply_misspelling_map(
+            "photosythesis's reproduction", title_probe=None
+        )
+        assert out == "photosynthesis's reproduction"
+
+    def test_possessive_misspelling_preserves_following_tokens(self) -> None:
+        out = IntentParser._apply_misspelling_map(
+            "tell me about photosythesis's reproduction",
+            title_probe=None,
+        )
+        assert out == "tell me about photosynthesis's reproduction"
+
+    def test_possessive_on_clean_word_no_change(self) -> None:
+        # ``berlin's population`` — ``berlin`` isn't a misspelling
+        # key. Lookup misses both raw and after-strip.
+        out = IntentParser._apply_misspelling_map(
+            "berlin's population", title_probe=None
+        )
+        assert out == "berlin's population"
+
+    def test_possessive_on_excluded_word_preserved(self) -> None:
+        # Exclusions check applies to the post-strip core too. If a
+        # word is on the exclusions list, possessive form should also
+        # be preserved.
+        class _OverrideParser(IntentParser):
+            pass
+
+        import tempfile
+
+
+
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".txt", delete=False
+        ) as f_map:
+            f_map.write("photosythesis=photosynthesis\n")
+            mp = f_map.name
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".txt", delete=False
+        ) as f_excl:
+            f_excl.write("photosythesis\n")
+            ep = f_excl.name
+        _OverrideParser._misspellings_path = mp  # type: ignore[assignment]
+        _OverrideParser._exclusions_path = ep  # type: ignore[assignment]
+        try:
+            out = _OverrideParser._apply_misspelling_map(
+                "photosythesis's reproduction", title_probe=None
+            )
+            assert out == "photosythesis's reproduction", (
+                f"Exclusion should suppress possessive too; got {out!r}"
+            )
+        finally:
+            import os
+            os.unlink(mp)
+            os.unlink(ep)
+
+
+class TestP1D6PunctuationMisspelling:
+    """P1-D6: tokens with leading/trailing punctuation
+    (``bilogy.``, ``"recieve"``, ``(photosythesis)``) previously
+    bypassed Rule 2 because the lookup key included the punctuation.
+    Fix: strip leading/trailing non-word characters before lookup,
+    reattach on hit."""
+
+    @pytest.mark.parametrize(
+        "before, after",
+        [
+            ("tell me about bilogy.", "tell me about biology."),
+            ("bilogy.", "biology."),
+            ("bilogy?", "biology?"),
+            ("bilogy!", "biology!"),
+            ("bilogy,", "biology,"),
+            ("bilogy;", "biology;"),
+            ('"recieve"', '"receive"'),
+            ("(recieve)", "(receive)"),
+            ("'recieve'", "'receive'"),
+            ("recieve.", "receive."),
+        ],
+    )
+    def test_punctuation_attached_misspelling_corrected(
+        self, before: str, after: str
+    ) -> None:
+        assert (
+            IntentParser._apply_misspelling_map(before, title_probe=None) == after
+        )
+
+    def test_punctuation_then_possessive_combined(self) -> None:
+        # ``"photosythesis's"`` — leading quote, possessive, trailing
+        # quote all in one token. Affix regex strips the quotes, the
+        # possessive-suffix step strips ``'s``, lookup matches.
+        out = IntentParser._apply_misspelling_map(
+            '"photosythesis\'s"', title_probe=None
+        )
+        assert out == '"photosynthesis\'s"'
+
+    def test_punctuation_on_clean_word_no_change(self) -> None:
+        # ``biology.`` — clean word with trailing period. Lookup
+        # misses (it's not a misspelling). Affix retry strips the
+        # period, looks up ``biology``, still misses. Token returns
+        # unchanged.
+        out = IntentParser._apply_misspelling_map("biology.", title_probe=None)
+        assert out == "biology."
+
+    def test_hyphenated_not_split(self) -> None:
+        # ``photo-synthesis`` doesn't whitespace-split, isn't a
+        # misspelling map key, hyphen isn't stripped by the affix
+        # retry (it's interior to the word). Stays unchanged —
+        # documented limitation; Rule 2 is not a hyphen-splitter.
+        out = IntentParser._apply_misspelling_map(
+            "tell me about photo-synthesis", title_probe=None
+        )
+        assert out == "tell me about photo-synthesis"
+
+    def test_probe_suppresses_post_retry(self) -> None:
+        # The title-probe gate consults the ORIGINAL token (not the
+        # stripped core) so legitimate proper-noun-with-punctuation
+        # tokens that happen to match a misspelling after-strip still
+        # get suppressed if the original is a real entity.
+        def probe(token: str) -> bool:
+            return token == "Bilogy."  # contrived canonical title
+
+        out = IntentParser._apply_misspelling_map(
+            "Bilogy.", title_probe=probe
+        )
+        assert out == "Bilogy."  # probe suppression wins
+
+
+# ===========================================================================
+# P1-D2: original-case topic preservation in chain rejection / footer
+# ===========================================================================
+
+
+class TestP1D2RecaseHelper:
+    """P1-D2: ``_recase_from_original`` finds a (lowercase) token in
+    the original-case query and returns the matched slice in its
+    original casing. Falls back to the input token when no match."""
+
+    def test_simple_recase_diacritics_preserved(self) -> None:
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        original = "tell me about Köln, München, and Berlin"
+        assert (
+            SimpleToolsHandler._recase_from_original("köln", original) == "Köln"
+        )
+        assert (
+            SimpleToolsHandler._recase_from_original("münchen", original)
+            == "München"
+        )
+        assert (
+            SimpleToolsHandler._recase_from_original("berlin", original) == "Berlin"
+        )
+
+    def test_simple_recase_articles_preserved(self) -> None:
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        original = "tell me about The Beatles and The Rolling Stones"
+        assert (
+            SimpleToolsHandler._recase_from_original("the beatles", original)
+            == "The Beatles"
+        )
+        assert (
+            SimpleToolsHandler._recase_from_original(
+                "the rolling stones", original
+            )
+            == "The Rolling Stones"
+        )
+
+    def test_token_not_in_original_falls_back_to_input(self) -> None:
+        # If the token doesn't appear in the original (e.g., Rule 4
+        # reordered the words), the helper falls back to the
+        # lowercase input — no recasing possible.
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        original = "Tell me about Berlin"
+        assert (
+            SimpleToolsHandler._recase_from_original("munich", original)
+            == "munich"
+        )
+
+    def test_empty_inputs_handled(self) -> None:
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        assert SimpleToolsHandler._recase_from_original("", "anything") == ""
+        assert SimpleToolsHandler._recase_from_original("token", "") == "token"
+
+
+# ===========================================================================
+# Reranker telemetry: in-band response-envelope comment
+# ===========================================================================
+
+
+class TestRerankerStateComment:
+    """Post-b1: ``_compute_rerank_state`` returns the per-request
+    reranker engagement state by comparing the current telemetry
+    counter to a pre-call snapshot. Used to emit the
+    ``<!-- reranker=<state> -->`` HTML comment in the response."""
+
+    def _make_handler_stub(self) -> Any:
+        """Build a minimal stub carrying just the ``_telemetry``
+        Counter. The ``_compute_rerank_state`` method is called
+        unbound (passing the stub as ``self``) so this stays decoupled
+        from SimpleToolsHandler's heavier construction surface."""
+
+        class _Stub:
+            def __init__(self) -> None:
+                self._telemetry: Counter[str] = Counter()
+
+            def compute(self, before: Dict[str, int]) -> Optional[str]:
+                from openzim_mcp.simple_tools import SimpleToolsHandler
+
+                fn = SimpleToolsHandler._compute_rerank_state
+                return fn(self, before)  # type: ignore[arg-type]
+
+        return _Stub()
+
+    def test_no_event_returns_none(self) -> None:
+        from openzim_mcp.simple_tools import (
+            _RERANKER_ENGAGED,
+            _RERANKER_SKIPPED_NOT_INSTALLED,
+            _RERANKER_SKIPPED_NO_RESULTS,
+            _RERANKER_SKIPPED_PASSTHROUGH,
+        )
+
+        stub = self._make_handler_stub()
+        before = {
+            _RERANKER_ENGAGED: 0,
+            _RERANKER_SKIPPED_NOT_INSTALLED: 0,
+            _RERANKER_SKIPPED_NO_RESULTS: 0,
+            _RERANKER_SKIPPED_PASSTHROUGH: 0,
+        }
+        # Counters unchanged — non-search intent, no rerank attempt.
+        assert stub.compute(before) is None
+
+    def test_engaged_detected(self) -> None:
+        from openzim_mcp.simple_tools import _RERANKER_ENGAGED
+
+        stub = self._make_handler_stub()
+        before = {_RERANKER_ENGAGED: 0}
+        stub._telemetry[_RERANKER_ENGAGED] = 1
+        assert stub.compute(before) == "engaged"
+
+    def test_skipped_not_installed_detected(self) -> None:
+        from openzim_mcp.simple_tools import _RERANKER_SKIPPED_NOT_INSTALLED
+
+        stub = self._make_handler_stub()
+        before = {_RERANKER_SKIPPED_NOT_INSTALLED: 5}
+        stub._telemetry[_RERANKER_SKIPPED_NOT_INSTALLED] = 6
+        assert (
+            stub.compute(before) == "skipped:not_installed"
+        )
+
+    def test_skipped_no_results_detected(self) -> None:
+        from openzim_mcp.simple_tools import _RERANKER_SKIPPED_NO_RESULTS
+
+        stub = self._make_handler_stub()
+        before = {_RERANKER_SKIPPED_NO_RESULTS: 0}
+        stub._telemetry[_RERANKER_SKIPPED_NO_RESULTS] = 1
+        assert stub.compute(before) == "skipped:no_results"
+
+    def test_skipped_passthrough_detected(self) -> None:
+        from openzim_mcp.simple_tools import _RERANKER_SKIPPED_PASSTHROUGH
+
+        stub = self._make_handler_stub()
+        before = {_RERANKER_SKIPPED_PASSTHROUGH: 0}
+        stub._telemetry[_RERANKER_SKIPPED_PASSTHROUGH] = 1
+        assert (
+            stub.compute(before) == "skipped:passthrough"
+        )
+
+    def test_engaged_priority_over_skip(self) -> None:
+        # If both ``engaged`` and a skip counter bump (rare; cross-
+        # archive partial failure), ``engaged`` wins so the caller
+        # sees the most favourable summary.
+        from openzim_mcp.simple_tools import (
+            _RERANKER_ENGAGED,
+            _RERANKER_SKIPPED_PASSTHROUGH,
+        )
+
+        stub = self._make_handler_stub()
+        before = {
+            _RERANKER_ENGAGED: 0,
+            _RERANKER_SKIPPED_PASSTHROUGH: 0,
+        }
+        stub._telemetry[_RERANKER_ENGAGED] = 1
+        stub._telemetry[_RERANKER_SKIPPED_PASSTHROUGH] = 1
+        assert stub.compute(before) == "engaged"
+
+
+# ===========================================================================
+# Cross-feature integration: the six pass-1 fixes interact at the
+# dispatcher level
+# ===========================================================================
+
+
+class TestPass2CrossFeatureIntegration:
+    """Pass-2 source-level audit: the post-b1 fixes ride on the same
+    dispatcher path. Verify the composition order:
+
+      1. Rule 1 lowercases the query.
+      2. Rule 2 applies misspelling map (with affix retry + probe).
+      3. Rule 3 strips a leading article (probe-gated).
+      4. Rule 4 decomposes X-of-Y (probe-gated).
+      5. parse_intent runs the existing regex chain.
+
+    Each rule sees the output of the previous; probes flow through
+    rules 2-4. Cross-feature combinations should compose cleanly."""
+
+    def test_rule_2_then_rule_4_with_probe(self) -> None:
+        # ``population of bilogy`` — Rule 2 fixes ``bilogy`` →
+        # ``biology``; Rule 4 then decomposes ``population of biology``.
+        # Probe consulted for FULL post-Rule-3 query ``population of
+        # biology`` — assume probe misses (not a canonical title).
+        probe = _probe_factory("biology")  # only ``biology`` is canonical
+        rewritten, hint = IntentParser._apply_tier1_rewrites(
+            "population of bilogy",
+            title_probe=probe,
+            enabled=True,
+        )
+        assert rewritten == "biology population"
+        assert hint == {"entity": "biology", "attribute": "population"}
+
+    def test_rule_3_strip_unblocked_by_probe_suppression(self) -> None:
+        # ``the beatles`` with probe returning True for the full query
+        # → Rule 3 keeps the article, Rule 4 doesn't match (no `` of ``
+        # in `the beatles`).
+        probe = _probe_factory("the beatles")
+        rewritten, hint = IntentParser._apply_tier1_rewrites(
+            "The Beatles",
+            title_probe=probe,
+            enabled=True,
+        )
+        assert rewritten == "the beatles"
+        assert hint is None
+
+    def test_rule_3_strip_fires_when_probe_misses(self) -> None:
+        # ``the goverment of berlin`` — Rule 3 strips ``the`` (probe
+        # misses on the FULL query, even though ``berlin`` is canonical);
+        # Rule 2 corrects ``goverment`` → ``government``; Rule 4
+        # decomposes ``government of berlin`` to ``berlin government``.
+        probe = _probe_factory("berlin")
+        rewritten, hint = IntentParser._apply_tier1_rewrites(
+            "the goverment of berlin",
+            title_probe=probe,
+            enabled=True,
+        )
+        # After Rule 2: ``the government of berlin``
+        # After Rule 3: ``government of berlin`` (the stripped)
+        # After Rule 4: ``berlin government``
+        assert rewritten == "berlin government"
+        assert hint == {"entity": "berlin", "attribute": "government"}
+
+    def test_kill_switch_skips_all_four_rules_including_probe_gates(self) -> None:
+        # Master switch off: query passes through unchanged regardless
+        # of probe behaviour. This pins the existing kill-switch
+        # contract — the new probe wiring must not break it.
+        probe = _probe_factory("anything")
+        rewritten, hint = IntentParser._apply_tier1_rewrites(
+            "The Lord Of The Rings",
+            title_probe=probe,
+            enabled=False,
+        )
+        assert rewritten == "The Lord Of The Rings"
+        assert hint is None
+
+    def test_misspelling_with_possessive_then_x_of_y(self) -> None:
+        # ``photosythesis's role`` doesn't match Rule 4 (only one ``of``
+        # rule). But Rule 2 should fix the possessive misspelling
+        # regardless. ``recieve's effect on biology`` exercises both
+        # rules: Rule 2 fixes ``recieve``, Rule 4 doesn't fire (the
+        # possessive shape is ``<word>'s <word>``, but `recieve` →
+        # `receive` then matches `_POSSESSIVE_RE` as
+        # `receive's effect on biology`? No — possessive regex needs
+        # `entity's attr` with `attr` a single word; ``effect on
+        # biology`` is 3 words.) So Rule 4 stays out.
+        rewritten, hint = IntentParser._apply_tier1_rewrites(
+            "recieve's effect",
+            title_probe=None,
+            enabled=True,
+        )
+        # Rule 2 fixes possessive: ``receive's effect``
+        # Rule 4 possessive regex: attr=``effect``, entity=``receive`` →
+        # decomposes to ``receive effect`` with hint.
+        assert rewritten == "receive effect"
+        assert hint == {"entity": "receive", "attribute": "effect"}
+
+
+# ===========================================================================
+# Regression guards: confirm the post-b1 fixes don't break prior contracts
+# ===========================================================================
+
+
+class TestRegressionGuards:
+    """Pin the existing-contract behaviours that the post-b1 fixes
+    must not regress. Each guard targets a code path the fixes
+    touched but whose pre-fix behaviour is still correct."""
+
+    def test_rule_3_section_command_guard_still_fires(self) -> None:
+        # ``the X section of Y`` is a get_section command; Rule 3 must
+        # NOT strip ``the`` because it's load-bearing for the
+        # intent regex. Even with probe=None (degraded mode), the
+        # section-command guard short-circuits before strip.
+        out = IntentParser._detect_stopword_phrase(
+            "the history section of biology", title_probe=None
+        )
+        assert out == "the history section of biology"
+
+    def test_rule_4_skip_attr_still_short_circuits(self) -> None:
+        # ``summary of berlin`` — ``summary`` is a structural-intent
+        # keyword. Even with a probe (post-fix), the skip-set check
+        # runs FIRST so structural commands never decompose.
+        probe = _probe_factory("berlin")
+        rewritten, hint = IntentParser._decompose_x_of_y(
+            "summary of berlin", title_probe=probe
+        )
+        assert rewritten == "summary of berlin"
+        assert hint is None
+
+    def test_rule_2_correction_without_probe_still_works(self) -> None:
+        # The probe-degraded path (multi-archive without explicit
+        # path) still corrects plain misspellings — degraded only
+        # means false-positive suppression isn't available, not that
+        # correction is off entirely.
+        out = IntentParser._apply_misspelling_map(
+            "tell me about photosythesis", title_probe=None
+        )
+        assert out == "tell me about photosynthesis"
+
+    def test_decompose_population_of_berlin_no_probe(self) -> None:
+        # Without a probe, Rule 4 decomposes (legacy behaviour). This
+        # is the path the integration tests in test_query_rewrite_tier1
+        # already pin; the post-b1 fix must not regress it.
+        rewritten, hint = IntentParser._decompose_x_of_y(
+            "population of berlin"
+        )
+        assert rewritten == "berlin population"
+        assert hint == {"entity": "berlin", "attribute": "population"}
+
+    def test_existing_misspelling_lookup_still_idempotent(self) -> None:
+        # A corrected word ("biology") is never itself a key in the
+        # map. Running Rule 2 a second time is a no-op.
+        once = IntentParser._apply_misspelling_map(
+            "bilogy", title_probe=None
+        )
+        twice = IntentParser._apply_misspelling_map(once, title_probe=None)
+        assert once == "biology"
+        assert twice == "biology"
+
+    def test_multi_entity_chain_helper_unchanged_signature(self) -> None:
+        # The helper still takes (intent, params, zim_file_path). New
+        # behaviour reads params["_pre_rewrite_query"] but doesn't
+        # require it (legacy callers see legacy output).
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        import inspect
+
+        sig = inspect.signature(SimpleToolsHandler._multi_entity_chain_guidance)
+        assert list(sig.parameters) == [
+            "self",
+            "intent",
+            "params",
+            "zim_file_path",
+        ]

--- a/tests/test_post_b1_beta_fixes.py
+++ b/tests/test_post_b1_beta_fixes.py
@@ -276,9 +276,7 @@ class TestP1D3Rule4ProbeGate:
             "rise of the planet of the apes",
         ],
     )
-    def test_probe_hit_suppresses_decomposition(
-        self, canonical_query: str
-    ) -> None:
+    def test_probe_hit_suppresses_decomposition(self, canonical_query: str) -> None:
         # Probe returns True for the full query → no decomposition.
         probe = _probe_factory(canonical_query)
         rewritten, hint = IntentParser._decompose_x_of_y(
@@ -387,16 +385,10 @@ class TestP1D5PossessiveMisspelling:
 
         import tempfile
 
-
-
-        with tempfile.NamedTemporaryFile(
-            "w", suffix=".txt", delete=False
-        ) as f_map:
+        with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as f_map:
             f_map.write("photosythesis=photosynthesis\n")
             mp = f_map.name
-        with tempfile.NamedTemporaryFile(
-            "w", suffix=".txt", delete=False
-        ) as f_excl:
+        with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as f_excl:
             f_excl.write("photosythesis\n")
             ep = f_excl.name
         _OverrideParser._misspellings_path = mp  # type: ignore[assignment]
@@ -405,11 +397,12 @@ class TestP1D5PossessiveMisspelling:
             out = _OverrideParser._apply_misspelling_map(
                 "photosythesis's reproduction", title_probe=None
             )
-            assert out == "photosythesis's reproduction", (
-                f"Exclusion should suppress possessive too; got {out!r}"
-            )
+            assert (
+                out == "photosythesis's reproduction"
+            ), f"Exclusion should suppress possessive too; got {out!r}"
         finally:
             import os
+
             os.unlink(mp)
             os.unlink(ep)
 
@@ -439,9 +432,7 @@ class TestP1D6PunctuationMisspelling:
     def test_punctuation_attached_misspelling_corrected(
         self, before: str, after: str
     ) -> None:
-        assert (
-            IntentParser._apply_misspelling_map(before, title_probe=None) == after
-        )
+        assert IntentParser._apply_misspelling_map(before, title_probe=None) == after
 
     def test_punctuation_then_possessive_combined(self) -> None:
         # ``"photosythesis's"`` — leading quote, possessive, trailing
@@ -478,9 +469,7 @@ class TestP1D6PunctuationMisspelling:
         def probe(token: str) -> bool:
             return token == "Bilogy."  # contrived canonical title
 
-        out = IntentParser._apply_misspelling_map(
-            "Bilogy.", title_probe=probe
-        )
+        out = IntentParser._apply_misspelling_map("Bilogy.", title_probe=probe)
         assert out == "Bilogy."  # probe suppression wins
 
 
@@ -498,16 +487,11 @@ class TestP1D2RecaseHelper:
         from openzim_mcp.simple_tools import SimpleToolsHandler
 
         original = "tell me about Köln, München, and Berlin"
+        assert SimpleToolsHandler._recase_from_original("köln", original) == "Köln"
         assert (
-            SimpleToolsHandler._recase_from_original("köln", original) == "Köln"
+            SimpleToolsHandler._recase_from_original("münchen", original) == "München"
         )
-        assert (
-            SimpleToolsHandler._recase_from_original("münchen", original)
-            == "München"
-        )
-        assert (
-            SimpleToolsHandler._recase_from_original("berlin", original) == "Berlin"
-        )
+        assert SimpleToolsHandler._recase_from_original("berlin", original) == "Berlin"
 
     def test_simple_recase_articles_preserved(self) -> None:
         from openzim_mcp.simple_tools import SimpleToolsHandler
@@ -518,9 +502,7 @@ class TestP1D2RecaseHelper:
             == "The Beatles"
         )
         assert (
-            SimpleToolsHandler._recase_from_original(
-                "the rolling stones", original
-            )
+            SimpleToolsHandler._recase_from_original("the rolling stones", original)
             == "The Rolling Stones"
         )
 
@@ -531,10 +513,7 @@ class TestP1D2RecaseHelper:
         from openzim_mcp.simple_tools import SimpleToolsHandler
 
         original = "Tell me about Berlin"
-        assert (
-            SimpleToolsHandler._recase_from_original("munich", original)
-            == "munich"
-        )
+        assert SimpleToolsHandler._recase_from_original("munich", original) == "munich"
 
     def test_empty_inputs_handled(self) -> None:
         from openzim_mcp.simple_tools import SimpleToolsHandler
@@ -575,8 +554,8 @@ class TestRerankerStateComment:
     def test_no_event_returns_none(self) -> None:
         from openzim_mcp.simple_tools import (
             _RERANKER_ENGAGED,
-            _RERANKER_SKIPPED_NOT_INSTALLED,
             _RERANKER_SKIPPED_NO_RESULTS,
+            _RERANKER_SKIPPED_NOT_INSTALLED,
             _RERANKER_SKIPPED_PASSTHROUGH,
         )
 
@@ -604,9 +583,7 @@ class TestRerankerStateComment:
         stub = self._make_handler_stub()
         before = {_RERANKER_SKIPPED_NOT_INSTALLED: 5}
         stub._telemetry[_RERANKER_SKIPPED_NOT_INSTALLED] = 6
-        assert (
-            stub.compute(before) == "skipped:not_installed"
-        )
+        assert stub.compute(before) == "skipped:not_installed"
 
     def test_skipped_no_results_detected(self) -> None:
         from openzim_mcp.simple_tools import _RERANKER_SKIPPED_NO_RESULTS
@@ -622,9 +599,7 @@ class TestRerankerStateComment:
         stub = self._make_handler_stub()
         before = {_RERANKER_SKIPPED_PASSTHROUGH: 0}
         stub._telemetry[_RERANKER_SKIPPED_PASSTHROUGH] = 1
-        assert (
-            stub.compute(before) == "skipped:passthrough"
-        )
+        assert stub.compute(before) == "skipped:passthrough"
 
     def test_engaged_priority_over_skip(self) -> None:
         # If both ``engaged`` and a skip counter bump (rare; cross-
@@ -1048,18 +1023,14 @@ class TestRegressionGuards:
         # Without a probe, Rule 4 decomposes (legacy behaviour). This
         # is the path the integration tests in test_query_rewrite_tier1
         # already pin; the post-b1 fix must not regress it.
-        rewritten, hint = IntentParser._decompose_x_of_y(
-            "population of berlin"
-        )
+        rewritten, hint = IntentParser._decompose_x_of_y("population of berlin")
         assert rewritten == "berlin population"
         assert hint == {"entity": "berlin", "attribute": "population"}
 
     def test_existing_misspelling_lookup_still_idempotent(self) -> None:
         # A corrected word ("biology") is never itself a key in the
         # map. Running Rule 2 a second time is a no-op.
-        once = IntentParser._apply_misspelling_map(
-            "bilogy", title_probe=None
-        )
+        once = IntentParser._apply_misspelling_map("bilogy", title_probe=None)
         twice = IntentParser._apply_misspelling_map(once, title_probe=None)
         assert once == "biology"
         assert twice == "biology"
@@ -1068,9 +1039,9 @@ class TestRegressionGuards:
         # The helper still takes (intent, params, zim_file_path). New
         # behaviour reads params["_pre_rewrite_query"] but doesn't
         # require it (legacy callers see legacy output).
-        from openzim_mcp.simple_tools import SimpleToolsHandler
-
         import inspect
+
+        from openzim_mcp.simple_tools import SimpleToolsHandler
 
         sig = inspect.signature(SimpleToolsHandler._multi_entity_chain_guidance)
         assert list(sig.parameters) == [


### PR DESCRIPTION
Three defects surfaced operating the b1 reranker integration. All three are narrow-scope follow-ups to PR #163 (sub-D-1) — the recurring sweep pattern.

## 1. `download-models` silently ignored env vars (air-gapped pre-stage was broken)

`docs/v2/extras-reranker.md` advertises `openzim-mcp download-models` as the canonical pre-stage step for air-gapped deployments. In practice it didn't honour `OPENZIM_MCP_ML__RERANKER__CACHE_DIR` (or any other `OPENZIM_MCP_ML__RERANKER__*` var) because the CLI built a bare `RerankerConfig()` — and `RerankerConfig` is a plain `BaseModel`, not `BaseSettings`. Files landed under FastEmbed's default cache while the runtime — which goes through `OpenZimMcpConfig` and reads the env var correctly — looked in the operator-configured directory and re-downloaded on first call.

Fix: route the CLI through a small `_StagingSettings(BaseSettings)` that mirrors `OpenZimMcpConfig`'s `env_prefix` + `env_nested_delimiter` and exposes only `ml: MLConfig`. `OpenZimMcpConfig` itself wasn't appropriate (requires `allowed_directories`).

New tests: cache-dir env var honoured, model-id env var honoured, CLI flag still overrides env var.

## 2. Reranker telemetry was invisible in simple mode

`reranker_engaged` / `reranker_skipped.*` counters fire through `SimpleToolsHandler._track()`, which only writes to the in-memory `_telemetry` dict — and the only way to read that dict is `get_server_health`, which is **advanced-mode-only**. Simple-mode operators (the default) had no way to confirm rerank was actually engaging. Pure DEBUG logs in `synthesize.py` didn't help either; they're off by default.

Fix: `_track()` now also emits a single INFO log line per call (`telemetry: <event>`) for the four reranker events via a new `_INFO_LEVEL_TELEMETRY_EVENTS` frozenset. The four DEBUG logs in `synthesize.py` get the same INFO-level treatment for consistency. Counter behavior is unchanged.

Set the logger to WARNING+ to suppress. Docs updated.

## 3. `first_call_timeout_seconds: 5.0` was too tight

The 5-second default was sized against the older "first-call = HuggingFace download" assumption. In practice, even a fully pre-staged model takes ~7-10s on modest hardware for ONNX session creation alone, tripping the kill switch and degrading to BM25-only for the rest of the process. The advertised pre-stage workflow couldn't help because the trip wasn't about download time.

Fix: raise default to 15.0s. Validator bounds (0.1 ≤ x ≤ 120.0) unchanged. Operators on cold caches or slower hardware can still override via `OPENZIM_MCP_ML__RERANKER__FIRST_CALL_TIMEOUT_SECONDS`. Description string updated to explain the sizing.

## Tests

```
2249 passed, 54 skipped (full suite, 72s)
```

New tests:
- `tests/ml/test_download_cli.py`: env-var honouring + CLI override precedence (3 tests)
- `tests/ml/test_reranker_unit.py`: `_track` INFO-log emission for reranker events, non-reranker events stay counter-only (1 test)
- `tests/ml/test_ml_config.py`: default updated 5.0 → 15.0

Lint, format, type-check all clean.

## What's not in this PR

Version bump / CHANGELOG entry — follows the sweep convention (release PR is separate).