### PR TITLE
fix(v2): post-b3 beta-test sweep — 1 defect (X's Y auto-fetch tokenization)

### DIFF
--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -3891,6 +3891,34 @@ class SimpleToolsHandler:
         because the title-match boost isn't strong enough. The 1.0 gate
         promotes the canonical past that ranking.
         """
+        # Post-b3: probe the FULL topic (with original punctuation
+        # preserved) BEFORE iter_query_tails decomposes it.
+        # ``iter_query_tails`` tokenizes on alphanumeric runs, so
+        # apostrophe-bearing possessives split: ``einstein's theory``
+        # becomes the tokens ``["einstein", "s", "theory"]`` and the
+        # yielded tails (``"einstein s theory"`` / ``"s theory"`` /
+        # ``"theory"``) all lose the apostrophe. The longer tails
+        # then fail to match any canonical title-index entry (which
+        # are stored WITH the apostrophe — ``Einstein's_theory``
+        # redirects to ``Theory_of_relativity``), and the shortest
+        # tail ``"theory"`` wins via the generic ``Theory`` article.
+        # Live impact across the b3 sweep: ``Einstein's theory`` →
+        # ``Theory`` (expected ``Theory_of_relativity``); ``Plato's
+        # cave`` → ``Cave`` (expected ``Allegory_of_the_cave``);
+        # ``Plato's Republic`` → ``Republic`` (expected
+        # ``Republic_(Plato)``). Probing the original topic with
+        # punctuation at the start catches these. ``min_score=0.95``
+        # mirrors the canonical-or-fuzzy gate Rule 2/3/4's probe
+        # uses (intent_parser.py:317), accepting both direct hits
+        # (1.0) and high-confidence redirects / spelling variants
+        # (0.95). Non-possessive queries hit this probe with the same
+        # behavior they'd get from pass-1's longest tail — the new
+        # call returns redundantly on those, never less correct.
+        promoted = find_title_match(
+            self.zim_operations, zim_file_path, topic, min_score=0.95
+        )
+        if promoted is not None:
+            return promoted
         # Pass 1: strict 1.0-score gate across every trailing tail.
         # Prefer an exact title match on any tail (even a short one)
         # over a typo-tolerant fuzzy match on a longer noisier tail.

--- a/tests/test_post_b3_beta_fixes.py
+++ b/tests/test_post_b3_beta_fixes.py
@@ -1,0 +1,456 @@
+r"""Regression tests for the post-b3 beta-test sweep.
+
+The post-b3 live-MCP probe pass against v2.0.0b3 confirmed all six
+post-b2 fix families land cleanly on live (D1-D4 + the pass-2/pass-3
+siblings). Deeper probing of the ``tell me about X's Y`` shape — the
+attack surface b2 D3 partially closed — surfaced a pre-existing
+silent-wrong-answer in the auto-fetch flow that b3 didn't reach.
+
+## Defect — ``X's Y`` auto-fetch silent-wrong-answer
+
+``_promote_topic_via_title_index`` (simple_tools.py:3868) iterates
+trailing tails via ``iter_query_tails`` (title_promotion.py:191).
+``iter_query_tails`` tokenizes on alphanumeric runs, so the
+apostrophe in ``X's Y`` is treated as a separator: the topic
+``"einstein's theory"`` becomes the tokens
+``["einstein", "s", "theory"]``. Tails yielded longest-first:
+
+- ``"einstein s theory"`` — no canonical match (the canonical
+  is stored WITH the apostrophe — ``Einstein's_theory`` is a
+  redirect to ``Theory_of_relativity``)
+- ``"s theory"`` — no canonical match
+- ``"theory"`` — matches the generic ``Theory`` article at score
+  1.0 → wins → wrong article fetched
+
+Live impact (post-b3):
+- ``tell me about Einstein's theory`` → ``Theory`` (expected
+  ``Theory_of_relativity`` — confirmed canonical at 1.00 via
+  ``find article titled einstein's theory``)
+- ``tell me about Plato's cave`` → ``Cave`` (expected
+  ``Allegory_of_the_cave`` — confirmed at 1.00)
+- ``tell me about Plato's Republic`` → ``Republic`` (expected
+  ``Republic_(Plato)`` — confirmed at 0.95)
+- ``tell me about Darwin's evolution`` → ``Evolution``
+
+The bug is pre-existing — it would have affected any user typing
+``tell me about X's Y`` for years — but surfaced via the post-b3
+sweep's deeper probing of possessive shapes. The b2 D3 retry
+correctly suppresses decomposition for these cases (the title-probe
+gate fires True because the redirect chain is canonical), but the
+downstream auto-fetch flow's tail iteration then picks the wrong
+tail.
+
+## Fix
+
+In ``_promote_topic_via_title_index``, probe the FULL topic (with
+original punctuation preserved) BEFORE entering the tail iteration.
+``find_title_match`` uses libzim's title index directly — it
+correctly handles apostrophes and redirects. ``min_score=0.95``
+mirrors the canonical-or-fuzzy gate that Rule 2/3/4's probe uses
+(intent_parser.py:317), accepting both direct hits (1.0) and
+high-confidence redirects (0.95).
+
+Non-possessive queries hit this new probe with the same behavior
+they would get from pass-1's longest tail — the new call returns
+redundantly on those, never less correct.
+
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from unittest.mock import patch
+
+
+class TestPossessiveAutofetchProbe:
+    """Pin the post-b3 fix: ``_promote_topic_via_title_index`` probes
+    the full topic with original punctuation BEFORE iter_query_tails
+    decomposes it.
+
+    The fix lives in ``simple_tools._promote_topic_via_title_index``;
+    the test patches ``find_title_match`` at the import site to
+    isolate behavior."""
+
+    def _make_handler_with_mock_promote(self) -> Any:
+        """Build a minimal stub carrying the method we test under.
+        The method is called unbound so we can pass any duck-typed
+        object as ``self``."""
+
+        class _StubOps:
+            pass
+
+        class _Handler:
+            zim_operations = _StubOps()
+
+        return _Handler()
+
+    def test_full_topic_probe_runs_before_tail_iteration(self) -> None:
+        """Live repro shape: ``einstein's theory`` should resolve
+        through the new full-topic probe to ``Theory_of_relativity``
+        (the canonical redirect target), NOT through tail iteration
+        which would pick ``Theory`` (the shortest tail)."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        handler = self._make_handler_with_mock_promote()
+
+        # The mock returns the canonical redirect target for the
+        # full topic (apostrophe preserved); returns ``Theory`` for
+        # any bare ``"theory"`` tail. If the fix is correct, the
+        # full-topic probe wins and ``Theory`` (the wrong tail)
+        # never gets called.
+        def fake_find_title_match(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            if topic == "einstein's theory":
+                return {
+                    "path": "Theory_of_relativity",
+                    "title": "Theory of relativity",
+                    "zim_file": "test.zim",
+                }
+            return None
+
+        with patch(
+            "openzim_mcp.simple_tools.find_title_match",
+            side_effect=fake_find_title_match,
+        ):
+            result = SimpleToolsHandler._promote_topic_via_title_index(
+                handler,  # type: ignore[arg-type]
+                "test.zim",
+                "einstein's theory",
+            )
+        assert result is not None
+        assert result["path"] == "Theory_of_relativity"
+
+    def test_full_topic_probe_uses_min_score_095(self) -> None:
+        """The full-topic probe must use ``min_score=0.95`` so it
+        catches both direct hits (1.0) and high-confidence redirects
+        (0.95). Live repro: ``Plato's Republic`` resolves to
+        ``Republic_(Plato)`` at score 0.95 via the title index.
+
+        Verify by inspection: ``min_score=0.95`` appears in the new
+        call inside ``_promote_topic_via_title_index``."""
+        import inspect
+
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        source = inspect.getsource(SimpleToolsHandler._promote_topic_via_title_index)
+        # The new call must explicitly pass min_score=0.95.
+        assert "min_score=0.95" in source, (
+            "post-b3 full-topic probe must use min_score=0.95 to match "
+            "the canonical-or-fuzzy gate (Rule 2/3/4 convention)"
+        )
+
+    def test_full_topic_probe_runs_before_pass_1(self) -> None:
+        """Structural guard: the full-topic ``find_title_match`` call
+        must appear BEFORE the ``for tail in iter_query_tails`` loop
+        in the source. Future contributors who reorder this would
+        silently re-break the apostrophe-tokenization fix."""
+        import inspect
+
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        source = inspect.getsource(SimpleToolsHandler._promote_topic_via_title_index)
+        # Look for actual code constructs, not mentions in comments.
+        # ``min_score=0.95`` is unique to the post-b3 full-topic
+        # probe call site. ``for tail in iter_query_tails(`` is the
+        # pass-1 loop opener.
+        probe_idx = source.find("min_score=0.95")
+        loop_idx = source.find("for tail in iter_query_tails(")
+        assert probe_idx > 0, "full-topic probe call missing"
+        assert loop_idx > 0, "iter_query_tails loop missing"
+        assert probe_idx < loop_idx, (
+            "full-topic probe must run BEFORE iter_query_tails loop "
+            "to preserve apostrophe-bearing canonical matches"
+        )
+
+    def test_full_topic_probe_returns_none_falls_through(self) -> None:
+        """When the full-topic probe finds no canonical (e.g., prose
+        queries like ``famous people from big rapids michigan``), it
+        must fall through to the existing tail iteration cleanly."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        handler = self._make_handler_with_mock_promote()
+        call_log: List[str] = []
+
+        def fake_find_title_match(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            call_log.append(topic)
+            # Only match the tail "big rapids michigan", not the
+            # full prose query — simulates the existing tail-iteration
+            # behavior.
+            if topic == "big rapids michigan":
+                return {
+                    "path": "Big_Rapids,_Michigan",
+                    "title": "Big Rapids, Michigan",
+                    "zim_file": "test.zim",
+                }
+            return None
+
+        with patch(
+            "openzim_mcp.simple_tools.find_title_match",
+            side_effect=fake_find_title_match,
+        ):
+            result = SimpleToolsHandler._promote_topic_via_title_index(
+                handler,  # type: ignore[arg-type]
+                "test.zim",
+                "famous people from big rapids michigan",
+            )
+        assert result is not None
+        assert result["path"] == "Big_Rapids,_Michigan"
+        # The full topic was probed first (as the new pass-0), but
+        # didn't match — tail iteration then ran and found the
+        # canonical entity tail.
+        assert call_log[0] == "famous people from big rapids michigan"
+        assert "big rapids michigan" in call_log
+
+    def test_full_topic_probe_preserves_apostrophe(self) -> None:
+        """The fix's whole point: the topic string passed to
+        ``find_title_match`` must include the apostrophe so the title
+        index can match the canonical entry. iter_query_tails would
+        have stripped the apostrophe; the new pass-0 doesn't."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        handler = self._make_handler_with_mock_promote()
+        topic_seen: List[str] = []
+
+        def fake_find_title_match(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            topic_seen.append(topic)
+            return None  # force fall-through
+
+        with patch(
+            "openzim_mcp.simple_tools.find_title_match",
+            side_effect=fake_find_title_match,
+        ):
+            SimpleToolsHandler._promote_topic_via_title_index(
+                handler,  # type: ignore[arg-type]
+                "test.zim",
+                "plato's cave",
+            )
+        # First call (the new pass-0) sees the apostrophe-preserving
+        # form. The subsequent tail-iteration calls don't.
+        assert topic_seen[0] == "plato's cave", (
+            "full-topic probe must receive the original topic with " "apostrophe intact"
+        )
+        # Tail iteration calls strip the apostrophe (yielding
+        # "plato s cave", "s cave", "cave").
+        tail_calls = topic_seen[1:]
+        assert any("'" not in t for t in tail_calls), (
+            "tail iteration is expected to yield apostrophe-less "
+            "tails (sanity check that we're hitting the legacy path)"
+        )
+
+
+class TestPossessivePromoteIntegration:
+    """End-to-end-shaped test exercising the failure mode the
+    post-b3 sweep observed. Uses a more complete mock of the
+    handler chain so we cover the call path from
+    ``_promote_topic_via_title_index`` back through the live shape."""
+
+    def test_einsteins_theory_resolves_to_relativity(self) -> None:
+        """Live repro: ``einstein's theory`` should resolve through
+        the redirect chain to ``Theory_of_relativity``, NOT to the
+        generic ``Theory`` article that the tail-iteration would
+        pick."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        class _StubOps:
+            pass
+
+        class _Handler:
+            zim_operations = _StubOps()
+
+        def fake_find_title_match(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            # The title index for "einstein's theory" resolves to
+            # Theory_of_relativity at score 1.0 (verified live).
+            # The pre-fix tail iteration would have yielded
+            # "einstein s theory" / "s theory" / "theory" — only
+            # the last matches anything ("Theory" canonical).
+            if topic == "einstein's theory":
+                return {
+                    "path": "Theory_of_relativity",
+                    "title": "Theory of relativity",
+                    "zim_file": "test.zim",
+                }
+            if topic == "theory":
+                return {
+                    "path": "Theory",
+                    "title": "Theory",
+                    "zim_file": "test.zim",
+                }
+            return None
+
+        with patch(
+            "openzim_mcp.simple_tools.find_title_match",
+            side_effect=fake_find_title_match,
+        ):
+            result = SimpleToolsHandler._promote_topic_via_title_index(
+                _Handler(),  # type: ignore[arg-type]
+                "test.zim",
+                "einstein's theory",
+            )
+        assert result is not None
+        # Critical assertion: ``Theory_of_relativity``, NOT ``Theory``.
+        assert result["path"] == "Theory_of_relativity"
+        assert result["path"] != "Theory"
+
+    def test_platos_cave_resolves_to_allegory(self) -> None:
+        """Live repro: ``plato's cave`` should resolve to
+        ``Allegory_of_the_cave`` (1.00), NOT to the generic ``Cave``
+        article."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        class _StubOps:
+            pass
+
+        class _Handler:
+            zim_operations = _StubOps()
+
+        def fake_find_title_match(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            if topic == "plato's cave":
+                return {
+                    "path": "Allegory_of_the_cave",
+                    "title": "Allegory of the cave",
+                    "zim_file": "test.zim",
+                }
+            if topic == "cave":
+                return {
+                    "path": "Cave",
+                    "title": "Cave",
+                    "zim_file": "test.zim",
+                }
+            return None
+
+        with patch(
+            "openzim_mcp.simple_tools.find_title_match",
+            side_effect=fake_find_title_match,
+        ):
+            result = SimpleToolsHandler._promote_topic_via_title_index(
+                _Handler(),  # type: ignore[arg-type]
+                "test.zim",
+                "plato's cave",
+            )
+        assert result is not None
+        assert result["path"] == "Allegory_of_the_cave"
+        assert result["path"] != "Cave"
+
+    def test_platos_republic_at_0_95_score_caught(self) -> None:
+        """Live repro: ``plato's republic`` resolves to
+        ``Republic_(Plato)`` at score 0.95 via the title index. The
+        new probe's ``min_score=0.95`` accepts this (Rule 2/3/4
+        canonical-or-fuzzy convention).
+
+        Mock the find_title_match to accept only when the requested
+        min_score <= 0.95 — exercising the score threshold."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        class _StubOps:
+            pass
+
+        class _Handler:
+            zim_operations = _StubOps()
+
+        def fake_find_title_match(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            # Score 0.95 is below the strict 1.0 gate the existing
+            # tail iteration uses — only the new pass-0 (which uses
+            # min_score=0.95) catches this.
+            if topic == "plato's republic" and min_score <= 0.95:
+                return {
+                    "path": "Republic_(Plato)",
+                    "title": "Republic (Plato)",
+                    "zim_file": "test.zim",
+                }
+            # Generic Republic at 1.0 would be caught by tail
+            # iteration if the new pass-0 misses.
+            if topic == "republic":
+                return {
+                    "path": "Republic",
+                    "title": "Republic",
+                    "zim_file": "test.zim",
+                }
+            return None
+
+        with patch(
+            "openzim_mcp.simple_tools.find_title_match",
+            side_effect=fake_find_title_match,
+        ):
+            result = SimpleToolsHandler._promote_topic_via_title_index(
+                _Handler(),  # type: ignore[arg-type]
+                "test.zim",
+                "plato's republic",
+            )
+        assert result is not None
+        # Must catch the 0.95 score on the full topic, not fall
+        # through to the strict-1.0 tail-iteration which would pick
+        # the generic ``Republic``.
+        assert result["path"] == "Republic_(Plato)"
+
+
+class TestRegressionGuards:
+    """Pin the post-b3 invariant: the apostrophe-tokenization bug
+    drove this sweep. Future contributors who change
+    ``_promote_topic_via_title_index`` should preserve the
+    full-topic-with-punctuation probe at the start."""
+
+    def test_promote_function_starts_with_full_topic_probe(self) -> None:
+        """The first ``find_title_match`` call inside
+        ``_promote_topic_via_title_index`` must pass the bare
+        ``topic`` argument (not a tail-iterated form). If a
+        future refactor moves tail iteration up, this guard fires."""
+        import inspect
+
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        source = inspect.getsource(SimpleToolsHandler._promote_topic_via_title_index)
+        # The first occurrence of find_title_match must be passing
+        # the bare ``topic`` (not ``tail`` or ``window``).
+        first_call_idx = source.find("find_title_match(")
+        assert first_call_idx > 0, "find_title_match call missing"
+        # Look at the args of the first call.
+        # Take the next 200 chars to capture the multi-line call.
+        first_call_snippet = source[first_call_idx : first_call_idx + 200]
+        # The bare ``topic`` argument should appear before ``tail`` or
+        # ``window`` — i.e., the first call uses the full topic.
+        assert ", topic," in first_call_snippet or ", topic\n" in first_call_snippet, (
+            "first find_title_match call must use the bare ``topic`` "
+            "argument (full topic with punctuation), not a tail or "
+            "window form"
+        )


### PR DESCRIPTION
ONE pre-existing defect surfaced by the post-b3 live-MCP sweep against v2.0.0b3.

All six post-b2 fix families verified clean on live first; deeper probing of the `tell me about X's Y` shape — the attack surface b2 D3 partially closed — exposed a silent-wrong-answer in the auto-fetch flow that the b3 release didn't reach.

## Defect — `X's Y` auto-fetch picks the wrong tail when `X's Y` is a canonical redirect

`_promote_topic_via_title_index` ([simple_tools.py:3868](openzim_mcp/simple_tools.py#L3868)) iterates trailing tails via `iter_query_tails` ([title_promotion.py:191](openzim_mcp/title_promotion.py#L191)). `iter_query_tails` tokenizes on alphanumeric runs, so the apostrophe in `X's Y` is treated as a **separator**. The topic `"einstein's theory"` becomes the tokens `["einstein", "s", "theory"]`; tails yielded longest-first:

- `"einstein s theory"` — no canonical match (the canonical is stored WITH the apostrophe — `Einstein's_theory` is a redirect to `Theory_of_relativity`)
- `"s theory"` — no canonical match
- `"theory"` — matches the generic `Theory` article at score 1.0 → **wins → wrong article fetched**

### Live impact (post-b3 live probe, all silent-wrong-answers)

| Query | Returned | Expected |
|---|---|---|
| `tell me about Einstein's theory` | `Theory` | `Theory_of_relativity` (confirmed canonical at score 1.00 via `find article titled einstein's theory`) |
| `tell me about Plato's cave` | `Cave` | `Allegory_of_the_cave` (confirmed at 1.00) |
| `tell me about Plato's Republic` | `Republic` | `Republic_(Plato)` (confirmed at 0.95) |
| `tell me about Darwin's evolution` | `Evolution` | Darwin / Origin_of_Species |

### Working cases (for contrast — same shape but no full-possessive canonical)

- `Hubble's law` → `Hubble's_law` ✓
- `Ohm's law` → `Ohm's_law` ✓
- `Achilles' heel` → `Achilles'_heel` ✓
- `Photosythesis's reproduction` → `Photosynthesis` ✓ (post-b2 D3 retry's decomposition fires because no full-possessive canonical exists; topic → `photosynthesis` entity)

### Pre-existing, exposed by deeper probing

The bug would have affected any user typing `tell me about X's Y` for years. It was masked because:

- Pre-b1, fuzzy-search rescues at search time often surfaced the right article through different ranking paths.
- Pre-b2 D3, the retry that exposes the probe gate's True/False decision didn't exist.
- The specific repros (Einstein's theory, Plato's cave/Republic) weren't in the prior adversarial set.

**Why b2 D3 doesn't catch this**: D3's probe gate correctly suppresses decomposition when `title_probe(topic)` finds a canonical (because `Einstein's_theory` redirects to `Theory_of_relativity` at score 1.0). So topic stays as `einstein's theory` → the buggy old auto-fetch flow runs → wrong tail wins. The defect is in the older auto-fetch flow's tail-iteration, not in the b2 D3 retry.

## Fix

Probe the **FULL topic with original punctuation preserved** BEFORE entering the tail iteration in `_promote_topic_via_title_index`. `find_title_match` uses libzim's title index directly — it correctly handles apostrophes and redirects. The new probe uses `min_score=0.95` to mirror the canonical-or-fuzzy gate Rule 2/3/4 already use ([intent_parser.py:317](openzim_mcp/intent_parser.py#L317)), accepting both direct hits (1.0) and high-confidence redirects (0.95).

Live verification of the threshold: `find article titled` returns score **1.00** for Einstein's theory / Plato's cave; score **0.95** for Plato's Republic. All three need the 0.95 gate.

Non-possessive queries hit this new probe with the same behavior they'd get from pass-1's longest tail — the call returns redundantly on those, never less correct. The pre-existing prose-query case (`famous people from big rapids michigan`) still falls through to tail iteration cleanly because the prose phrase isn't itself canonical.

## Audits clean across the b3 fix surface

- **D1** trailing modal politeness — verified live on all 4 repros (`Tokyo if you would`, `if you could`, `would you`, `Apollo 11 if you would`). All resolve to the clean topic.
- **D2** reranker no-results telemetry — `<!-- reranker=skipped:no_results -->` now appears on `search for asdfqwerzxcv nonexistent`.
- **D3** possessive multi-token retry — `Photosythesis's reproduction` → `Photosynthesis` ✓ (the specific case D3 targeted).
- **D4** filtered search qualifier — `search Berlin in namespace C` → `Found 3 filtered matches for "Berlin" (filters: namespace=C)` ✓.
- **Pass-2** universal modal-politeness extension — `search for biology if you would`, `find article titled Berlin if you would`, `links in Photosynthesis would you`, `suggestions for biolog if you could` all peel the modal cleanly.
- **Pass-3** chained-intent guidance — `tell me about Tokyo if you would then list namespaces` AND `tell me about Tokyo then list namespaces if you would` produce clean bullets.

## Recurring adversarial set clean

- `lord of the rings` → `The_Lord_of_the_Rings` ✓ (P1-D3 probe gate)
- `an american in paris` → `An_American_in_Paris` ✓ (no offensive misroute)
- `the Beatles` → `The_Beatles` ✓
- `Köln, München, and Berlin` → 3-entity chain rejection with original case + diacritics preserved ✓
- `Stalin` → multi-match disambig with capital S ✓
- `walk namespace M` → 12 entries ✓
- `M/Title` bait → namespace-path redirect ✓
- `Definately` → `Definiteness_(disambiguation)` (fuzzy correction) ✓

## Tests

```
2369 passed, 54 skipped (full suite, 31s)
```

9 new tests in `tests/test_post_b3_beta_fixes.py` across 3 classes:

- **`TestPossessiveAutofetchProbe`** — verifies the full-topic probe fires first, uses `min_score=0.95`, runs before tail iteration, falls through cleanly on no-canonical, and preserves the apostrophe in the probed topic.
- **`TestPossessivePromoteIntegration`** — three end-to-end-shaped tests covering the live repros (Einstein's theory → Theory_of_relativity; Plato's cave → Allegory_of_the_cave; Plato's Republic → Republic_(Plato) at the 0.95 threshold).
- **`TestRegressionGuards`** — structural guard pinning that the first `find_title_match` call inside the method must use the bare `topic` argument (not a tail/window form).

mypy clean (52 source files). black + flake8 clean.

## Methodology — "fix unlocks new paths" 10 sweeps strong

Classic shape: b1 P1-D5 made `Photosythesis's reproduction` REACH the auto-fetch path; b2 D3 added the possessive retry to fix the immediate silent-wrong-answer; the post-b3 sweep's live probing of MORE possessive shapes revealed that the underlying auto-fetch flow has a tokenization bug for possessives where the full phrase is a canonical REDIRECT to a different article. Each sweep peels back another layer.

## What's not in this PR

Version bump / CHANGELOG entry — follows the sweep convention (release PR is separate).
