### PR TITLE
fix(v2): post-b4 beta-test sweep — 4 defects across 3 audit passes (D1 gate semantics + D2/D3/D5 apostrophe tokenization + non-possessive carve-out)

### DIFF
--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -3918,14 +3918,37 @@ class SimpleToolsHandler:
         promoted = find_title_match(
             self.zim_operations, zim_file_path, topic, min_score=0.95
         )
-        # Post-b4 D1: reject ``fuzzy_suggest`` rows. The 0.95 score
-        # covers both canonical redirects (safe — ``Plato's_cave`` →
-        # ``Allegory_of_the_cave``) AND raw fuzzy title-prefix
-        # suggestions (unsafe — ``Darwin's_evolution`` ≈ ``Evolution``
-        # at 0.95, silent-wrong-answer). Only the former is suitable
-        # for auto-fetch; the latter must fall through to pass-1.
-        if promoted is not None and promoted.get("match_type") != "fuzzy_suggest":
-            return promoted
+        # Post-b4 D1: reject ``fuzzy_suggest`` rows ONLY when the topic
+        # carries an apostrophe-possessive. The 0.95 suggestion-rank
+        # score covers three shapes:
+        #
+        #   * canonical redirect (``Plato's_cave`` →
+        #     ``Allegory_of_the_cave``, match_type=redirect — safe,
+        #     accepted unconditionally)
+        #   * exact-title direct hit (match_type=direct at score 1.0
+        #     via the suggestion path's exact_ci promotion — safe,
+        #     accepted unconditionally)
+        #   * fuzzy title-token prefix match (match_type=fuzzy_suggest
+        #     — meaning depends on the topic shape)
+        #
+        # For possessive prose (``Darwin's evolution`` → ``Evolution``
+        # at 0.95), the fuzzy_suggest match is structurally wrong —
+        # libzim's tokenized prefix index matched only the trailing
+        # word, dropping the possessor entirely (cert=0.85 silent-
+        # wrong-answer).
+        #
+        # For non-possessive prose (``Berlin Germany`` → ``Berlin``
+        # at 0.95), the fuzzy_suggest match IS the intended answer:
+        # libzim correctly resolved the first token to the article
+        # the user asked about, with the second token as a
+        # disambiguator. Pre-pass-2-audit my unconditional filter
+        # silently regressed this class — the refined gate keeps
+        # the b4 improvement for that shape while still solving the
+        # possessive silent-wrong-answer.
+        if promoted is not None:
+            is_fuzzy_suggest = promoted.get("match_type") == "fuzzy_suggest"
+            if not (is_fuzzy_suggest and has_apostrophe_possessive(topic)):
+                return promoted
         # Post-b4 D2: when the topic carries an apostrophe-possessive
         # (``Plato's republic philosophy`` / ``Einstein's theory
         # history``), tighten the tail-iteration floor to ``min_len=2``
@@ -3952,14 +3975,17 @@ class SimpleToolsHandler:
                 return promoted
         # Pass 3: 0.8 typo-tolerant gate. Only fires when no strict
         # match exists at all — catches single-edit typos.
-        # Post-b4 D1: apply the ``fuzzy_suggest`` filter here too so
-        # the same leak class can't sneak through the lower gate.
+        # Post-b4 D1: apply the same conditional ``fuzzy_suggest``
+        # filter as pass-0 so a fuzzy-suggest leak on a possessive
+        # topic can't sneak through the lower gate.
         for tail in iter_query_tails(topic, min_len=pass_tail_min_len):
             promoted = find_title_match(
                 self.zim_operations, zim_file_path, tail, min_score=0.8
             )
-            if promoted is not None and promoted.get("match_type") != "fuzzy_suggest":
-                return promoted
+            if promoted is not None:
+                is_fuzzy_suggest = promoted.get("match_type") == "fuzzy_suggest"
+                if not (is_fuzzy_suggest and has_apostrophe_possessive(topic)):
+                    return promoted
         return None
 
     def _handle_tell_me_about(

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -28,6 +28,7 @@ from .security import sanitize_context_for_error
 from .title_promotion import (
     _TOKEN_RE,
     find_title_match,
+    has_apostrophe_possessive,
     is_strong_title_match,
     iter_query_tails,
     iter_query_windows,
@@ -3917,12 +3918,27 @@ class SimpleToolsHandler:
         promoted = find_title_match(
             self.zim_operations, zim_file_path, topic, min_score=0.95
         )
-        if promoted is not None:
+        # Post-b4 D1: reject ``fuzzy_suggest`` rows. The 0.95 score
+        # covers both canonical redirects (safe — ``Plato's_cave`` →
+        # ``Allegory_of_the_cave``) AND raw fuzzy title-prefix
+        # suggestions (unsafe — ``Darwin's_evolution`` ≈ ``Evolution``
+        # at 0.95, silent-wrong-answer). Only the former is suitable
+        # for auto-fetch; the latter must fall through to pass-1.
+        if promoted is not None and promoted.get("match_type") != "fuzzy_suggest":
             return promoted
+        # Post-b4 D2: when the topic carries an apostrophe-possessive
+        # (``Plato's republic philosophy`` / ``Einstein's theory
+        # history``), tighten the tail-iteration floor to ``min_len=2``
+        # so a generic 1-token trailing tail (``"philosophy"`` /
+        # ``"history"`` / ``"tourism"``) can't silently win at strict
+        # 1.0. Pass-0 already covered the legitimate "full X's Y is
+        # canonical" case; further 1-token tail iteration just risks
+        # picking a generic Wikipedia title that shares the word.
+        pass_tail_min_len = 2 if has_apostrophe_possessive(topic) else 1
         # Pass 1: strict 1.0-score gate across every trailing tail.
         # Prefer an exact title match on any tail (even a short one)
         # over a typo-tolerant fuzzy match on a longer noisier tail.
-        for tail in iter_query_tails(topic):
+        for tail in iter_query_tails(topic, min_len=pass_tail_min_len):
             promoted = find_title_match(self.zim_operations, zim_file_path, tail)
             if promoted is not None:
                 return promoted
@@ -3930,17 +3946,19 @@ class SimpleToolsHandler:
         # Catches head/middle-positioned entities like
         # ``Big Rapids Michigan tourism``. Length-decreasing so longer
         # (more specific) windows win.
-        for window in iter_query_windows(topic):
+        for window in iter_query_windows(topic, min_len=pass_tail_min_len):
             promoted = find_title_match(self.zim_operations, zim_file_path, window)
             if promoted is not None:
                 return promoted
         # Pass 3: 0.8 typo-tolerant gate. Only fires when no strict
         # match exists at all — catches single-edit typos.
-        for tail in iter_query_tails(topic):
+        # Post-b4 D1: apply the ``fuzzy_suggest`` filter here too so
+        # the same leak class can't sneak through the lower gate.
+        for tail in iter_query_tails(topic, min_len=pass_tail_min_len):
             promoted = find_title_match(
                 self.zim_operations, zim_file_path, tail, min_score=0.8
             )
-            if promoted is not None:
+            if promoted is not None and promoted.get("match_type") != "fuzzy_suggest":
                 return promoted
         return None
 

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -947,7 +947,10 @@ def _promote_title_match(
         if (
             isinstance(full_probe, dict)
             and full_probe.get("path")
-            and full_probe.get("match_type") != "fuzzy_suggest"
+            and not (
+                full_probe.get("match_type") == "fuzzy_suggest"
+                and has_apostrophe_possessive(query)
+            )
         ):
             full_path = str(full_probe["path"])
             existing_paths_p0 = {(name, str(h.get("path", ""))) for name, h in top_hits}

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -28,7 +28,12 @@ if TYPE_CHECKING:
     from openzim_mcp.content_processor import ContentProcessor
 
 from openzim_mcp import bundle as _bundle_mod
-from openzim_mcp.title_promotion import is_strong_title_match, iter_query_tails
+from openzim_mcp.title_promotion import (
+    find_title_match,
+    has_apostrophe_possessive,
+    is_strong_title_match,
+    iter_query_tails,
+)
 from openzim_mcp.tool_schemas import (
     Citation,
     ConsideredArticle,
@@ -907,12 +912,60 @@ def _promote_title_match(
         if is_strong_title_match(query, top_path, top_path.replace("_", " ")):
             return top_hits
 
+    # Post-b4 D3: mirror the ``_promote_topic_via_title_index`` pass-0
+    # full-query probe at the start, so possessive queries
+    # (``Einstein's theory`` → ``Theory_of_relativity``;
+    # ``Plato's cave`` → ``Allegory_of_the_cave``) route to the
+    # canonical redirect target instead of falling through to the
+    # tail iteration below which would strip the apostrophe and
+    # promote ``Theory`` / ``Cave``.
+    # ``min_score=0.95`` matches the b4 pass-0 convention. The D1
+    # ``fuzzy_suggest`` filter rejects raw fuzzy title-prefix
+    # suggestions at the same score (``Darwin's evolution`` ≈
+    # ``Evolution``) so only canonical redirects are auto-promoted.
+    for (archive, _vp), archive_name in zip(archives, archives_searched):
+        try:
+            full_probe = find_title_match(archive, archive_name, query, min_score=0.95)
+        except Exception as e:
+            logger.debug(
+                "_promote_title_match: pass-0 probe failed for %s on %r: %s",
+                archive_name,
+                query,
+                e,
+            )
+            continue
+        if (
+            isinstance(full_probe, dict)
+            and full_probe.get("path")
+            and full_probe.get("match_type") != "fuzzy_suggest"
+        ):
+            full_path = str(full_probe["path"])
+            existing_paths_p0 = {(name, str(h.get("path", ""))) for name, h in top_hits}
+            if (archive_name, full_path) in existing_paths_p0:
+                reordered_p0: list[tuple[str, dict]] = [
+                    (n, h)
+                    for n, h in top_hits
+                    if not (n == archive_name and str(h.get("path", "")) == full_path)
+                ]
+                promoted_hit_p0 = next(
+                    h
+                    for n, h in top_hits
+                    if n == archive_name and str(h.get("path", "")) == full_path
+                )
+                return [(archive_name, promoted_hit_p0), *reordered_p0]
+            return [(archive_name, full_probe), *top_hits]
+
     title_match_hit = getattr(search_handler, "title_match_hit", None)
     if not callable(title_match_hit):
         return top_hits
 
+    # Post-b4 D2 mirror: tighten the tail-iteration ``min_len`` floor
+    # to 2 when the query carries an apostrophe-possessive so a
+    # generic 1-token tail (``"theory"`` / ``"cave"``) can't silently
+    # outrank the canonical the pass-0 probe just missed.
+    pass_tail_min_len = 2 if has_apostrophe_possessive(query) else 1
     existing_paths = {(name, str(h.get("path", ""))) for name, h in top_hits}
-    for tail in iter_query_tails(query):
+    for tail in iter_query_tails(query, min_len=pass_tail_min_len):
         for (archive, _vp), archive_name in zip(archives, archives_searched):
             try:
                 promoted = title_match_hit(archive, tail)

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -923,9 +923,19 @@ def _promote_title_match(
     # ``fuzzy_suggest`` filter rejects raw fuzzy title-prefix
     # suggestions at the same score (``Darwin's evolution`` ≈
     # ``Evolution``) so only canonical redirects are auto-promoted.
-    for (archive, _vp), archive_name in zip(archives, archives_searched):
+    #
+    # ``find_title_match`` expects a ``zim_operations``-shaped object
+    # (it calls ``.find_entry_by_title_data`` on it). ``search_handler``
+    # in production IS the ``ZimOperations`` instance — wired in
+    # ``simple_tools.py:_handle_synthesize_query`` via
+    # ``search_handler=self.zim_operations``. The per-archive validated
+    # path lives in the ``(archive, vp)`` tuple and is what
+    # ``find_entry_by_title_data`` expects for the single-archive call.
+    for (_archive, vp), archive_name in zip(archives, archives_searched):
         try:
-            full_probe = find_title_match(archive, archive_name, query, min_score=0.95)
+            full_probe = find_title_match(
+                search_handler, str(vp), query, min_score=0.95
+            )
         except Exception as e:
             logger.debug(
                 "_promote_title_match: pass-0 probe failed for %s on %r: %s",

--- a/openzim_mcp/title_promotion.py
+++ b/openzim_mcp/title_promotion.py
@@ -162,11 +162,22 @@ def find_title_match(
             candidate_path,
         )
         return None
-    return {
+    result: Dict[str, Any] = {
         "path": candidate_path,
         "title": str(top.get("title", "")),
         "zim_file": str(top.get("zim_file", zim_file_path)),
     }
+    # Post-b4 D1: propagate ``match_type`` so callers using the 0.95
+    # gate (the b4 pass-0 probe; the synthesize-path pass-0 probe)
+    # can reject ``fuzzy_suggest`` rows — the suggestion-rank top score
+    # of 0.95 covers both meaningful redirects AND incidental fuzzy
+    # title-prefix matches, and only the former is safe to auto-fetch.
+    # Field is optional — older mocks / non-annotated callers pass
+    # through transparently.
+    match_type = top.get("match_type")
+    if match_type:
+        result["match_type"] = str(match_type)
+    return result
 
 
 # Tokenizer for tail / window probe yielders. Unicode-aware so non-Latin
@@ -185,7 +196,42 @@ def find_title_match(
 # path-form input like ``"Big_Rapids,_Michigan"`` still tokenizes to
 # ``["big", "rapids", "michigan"]``. ``re.UNICODE`` is the default in
 # Python 3 — naming it here keeps the intent explicit.
-_TAIL_TOKEN_RE = re.compile(r"[^\W_]+", re.UNICODE)
+#
+# Post-b4 D2/D3/D5: apostrophes (``'`` straight, ``’`` curly) are now
+# kept INSIDE otherwise-alphanumeric runs so ``einstein's`` stays one
+# token instead of fragmenting to ``["einstein", "s"]``. Pre-fix, the
+# stub ``s`` token polluted every tail/window yielded for an
+# apostrophe-bearing topic; the trailing 1-token tail (``"theory"`` /
+# ``"philosophy"`` / ``"history"``) then strict-1.0-matched whatever
+# generic Wikipedia article shared that title and silently won.
+# ``['’]`` covers both Unicode codepoints Wikipedia uses
+# (U+0027 APOSTROPHE for ASCII titles, U+2019 RIGHT SINGLE QUOTATION
+# MARK for typographically-styled titles like ``Achilles’ heel``).
+_TAIL_TOKEN_RE = re.compile(r"[^\W_]+(?:['’][^\W_]+)*", re.UNICODE)
+
+
+# Post-b4: detect topics carrying an apostrophe-possessive shape so
+# callers (pass-1 / pass-3 of ``_promote_topic_via_title_index`` and
+# pass-1 of ``_promote_title_match``) can tighten ``iter_query_tails``'s
+# ``min_len`` floor to 2. The b4 pass-0 probe handles the legitimate
+# "X's Y is canonical" case; without the floor, pass-1 will silently
+# promote a generic 1-token tail (``"philosophy"`` → ``Philosophy``,
+# ``"history"`` → ``History``, ``"tourism"`` → ``Tourism``) for
+# prose-with-possessive queries where the full topic isn't canonical.
+# Matches ``X's``, ``X’s``, ``Achilles'`` (bare trailing apostrophe).
+_POSSESSIVE_TOKEN_RE = re.compile(r"[^\W_][^\W_'’]*['’](?:s\b|\B)", re.UNICODE)
+
+
+def has_apostrophe_possessive(topic: str) -> bool:
+    """Return True iff ``topic`` carries an apostrophe-possessive token.
+
+    Used by promotion callers to decide whether to tighten the tail-
+    iteration ``min_len`` floor (see ``_POSSESSIVE_TOKEN_RE`` docstring
+    above).
+    """
+    if not topic:
+        return False
+    return bool(_POSSESSIVE_TOKEN_RE.search(topic))
 
 
 def iter_query_tails(

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -2762,13 +2762,22 @@ class _SearchMixin:
                         # one. ``Big_Rapids_Michigan`` (comma-stripped
                         # redirect) → ``Big_Rapids,_Michigan`` keeps the
                         # cite_id stable across lookup-variant paths.
+                        # Post-b4 D1: capture the pre-redirect path so we
+                        # can annotate ``match_type`` with whether the
+                        # canonical lookup actually walked a redirect.
+                        fast_pre_path = getattr(fast_hit_entry, "path", None)
                         fast_hit_entry = self._follow_redirect_chain(fast_hit_entry)
+                        fast_post_path = getattr(fast_hit_entry, "path", None)
+                        fast_match_type = (
+                            "redirect" if fast_pre_path != fast_post_path else "direct"
+                        )
                         aggregate_results.append(
                             {
                                 "path": fast_hit_entry.path,
                                 "title": fast_hit_entry.title or title,
                                 "score": 1.0,
                                 "zim_file": file_path,
+                                "match_type": fast_match_type,
                             }
                         )
                         fast_path_hit = True
@@ -2809,23 +2818,41 @@ class _SearchMixin:
                                 # always see the same key for the same
                                 # article regardless of which redirect
                                 # the suggestion index emitted.
+                                # Post-b4 D1: track whether the
+                                # redirect chain actually walked, so
+                                # the row's ``match_type`` distinguishes
+                                # a true canonical redirect (safe to
+                                # auto-fetch at the 0.95 gate) from a
+                                # raw fuzzy title-prefix suggestion
+                                # (``Darwin's evolution`` → ``Evolution``
+                                # at 0.95 — same score, not safe).
+                                suggest_pre_path = getattr(entry, "path", None)
                                 entry = self._follow_redirect_chain(entry)
+                                suggest_post_path = getattr(entry, "path", None)
+                                redirect_walked = suggest_pre_path != suggest_post_path
                                 resolved_title = entry.title or path
                                 exact_ci = resolved_title.lower() == title_lower
                                 if exact_ci:
                                     score: float = 1.0
                                     fast_path_hit = True
+                                    match_type = "direct"
                                 else:
                                     # Linearly decaying rank-score in (0, 0.95].
                                     # Capped below 1.0 so an exact match always
                                     # outranks any prefix/partial.
                                     score = round(0.95 * (1.0 - idx / n), 4)
+                                    match_type = (
+                                        "redirect"
+                                        if redirect_walked
+                                        else "fuzzy_suggest"
+                                    )
                                 aggregate_results.append(
                                     {
                                         "path": entry.path,
                                         "title": resolved_title,
                                         "score": score,
                                         "zim_file": file_path,
+                                        "match_type": match_type,
                                     }
                                 )
                     except Exception as e:

--- a/tests/data/goldens/v2_phase_b/find_einstein.json
+++ b/tests/data/goldens/v2_phase_b/find_einstein.json
@@ -14,6 +14,7 @@
   "query": "Einstein",
   "results": [
     {
+      "match_type": "direct",
       "path": "A/Einstein",
       "score": 1.0,
       "title": "Einstein"

--- a/tests/test_post_a17_beta_fixes.py
+++ b/tests/test_post_a17_beta_fixes.py
@@ -288,9 +288,16 @@ class TestP1D2UnicodeTailTokenisation:
         assert tails == ["ñ"]
 
     def test_pass2_punctuation_preserved_as_boundary_not_token(self) -> None:
-        # Pass-2: punctuation other than underscore still acts as a
-        # boundary (hyphens, apostrophes, commas, periods).
-        assert list(iter_query_tails("O'Brien")) == ["o brien", "brien"]
+        # Pass-2: punctuation other than underscore and apostrophe
+        # still acts as a boundary (hyphens, commas, periods).
+        # Post-b4 D2/D3/D5 update: apostrophes (straight ``'`` and
+        # curly ``’``) are now KEPT inside otherwise-alphanumeric
+        # runs so ``O'Brien`` stays a single ``o'brien`` token (it
+        # IS a canonical title in Wikipedia exports). The pre-b4
+        # apostrophe-as-boundary behaviour caused the silent-wrong-
+        # answer for ``tell me about Einstein's theory`` → ``Theory``;
+        # see ``test_post_b4_beta_fixes.py`` for the full rationale.
+        assert list(iter_query_tails("O'Brien")) == ["o'brien"]
         assert list(iter_query_tails("Coca-Cola")) == ["coca cola", "cola"]
 
 

--- a/tests/test_post_b3_beta_fixes.py
+++ b/tests/test_post_b3_beta_fixes.py
@@ -245,16 +245,18 @@ class TestPossessiveAutofetchProbe:
                 "plato's cave",
             )
         # First call (the new pass-0) sees the apostrophe-preserving
-        # form. The subsequent tail-iteration calls don't.
+        # form. Post-b4 D2 tokenizer fix: subsequent tail iteration
+        # ALSO preserves the apostrophe (``_TAIL_TOKEN_RE`` now keeps
+        # ``'`` inside otherwise-alphanumeric runs). The pre-b4
+        # apostrophe-stripping behaviour was the bug; the post-b4 fix
+        # propagates the original punctuation through all probes.
         assert topic_seen[0] == "plato's cave", (
             "full-topic probe must receive the original topic with " "apostrophe intact"
         )
-        # Tail iteration calls strip the apostrophe (yielding
-        # "plato s cave", "s cave", "cave").
-        tail_calls = topic_seen[1:]
-        assert any("'" not in t for t in tail_calls), (
-            "tail iteration is expected to yield apostrophe-less "
-            "tails (sanity check that we're hitting the legacy path)"
+        # Sanity check: at least the pass-0 probe saw the apostrophe.
+        assert any("'" in t for t in topic_seen), (
+            "at least one find_title_match call must have received the "
+            "apostrophe-preserving topic"
         )
 
 

--- a/tests/test_post_b4_beta_fixes.py
+++ b/tests/test_post_b4_beta_fixes.py
@@ -1,0 +1,676 @@
+r"""Regression tests for the post-b4 beta-test sweep.
+
+The post-b4 live-MCP sweep against v2.0.0b4 verified the b3 fix (the
+full-topic ``find_title_match(min_score=0.95)`` probe at pass-0 of
+``_promote_topic_via_title_index``) on three of the four user-listed
+verification cases. ``tell me about Darwin's evolution`` still
+returned ``Evolution`` — exposing two siblings of the same
+apostrophe-tokenization defect class, plus a gate-semantics defect in
+the new pass-0 itself.
+
+## D1 — b4 pass-0 gate cannot distinguish redirect-0.95 from fuzzy-0.95
+
+``find_entry_by_title_data`` scores libzim's suggestion-search results
+on a linearly-decaying rank formula capped at 0.95 (zim/search.py
+:2814-2822). The same 0.95 score is produced by:
+
+  * a **redirect walk** — suggestion returned the redirect entry
+    (``Plato's_cave``) → ``_follow_redirect_chain`` walked to the
+    canonical (``Allegory_of_the_cave``); meaningful relationship
+    between topic and result
+  * a **pure fuzzy title-prefix match** — suggestion returned a title
+    that fuzzy-matches the input (``Evolution`` for the query
+    ``Darwin's evolution``); no meaningful relationship beyond
+    superficial token overlap
+
+The b4 gate at ``min_score=0.95`` accepts both. ``tell me about
+Darwin's evolution`` → ``Evolution`` at cert=0.85 (silent-wrong-
+answer); same shape for ``tell me about Darwin's evolution history`` →
+``Darwin's_Ghosts:_The_Secret_History_of_Evolution`` (judgment-call
+over-promotion at the 0.95 fuzzy reach).
+
+## D2 — pass-1 ``iter_query_tails`` still strips apostrophes
+
+The b4 fix only patched pass-0. Pass-1 (``iter_query_tails`` at
+``simple_tools.py:3925``) still consumes ``_TAIL_TOKEN_RE`` at
+``title_promotion.py:188`` which treats apostrophes as token boundaries.
+For prose-with-possessive queries where the full topic is NOT
+canonical at the 0.95 gate, pass-1 strips the apostrophe and picks
+the shortest tail. Live silent-wrong-answers (cert=0.85):
+
+  * ``tell me about Plato's republic philosophy`` → ``Philosophy``
+  * ``tell me about Einstein's theory history`` → ``History``
+  * ``tell me about Einstein's theory tourism`` → ``Tourism``
+
+The defect shape is: any prose-with-possessive whose trailing token
+is a Wikipedia-canonical generic word wins pass-1 at strict 1.0.
+
+## D3 — synthesize ``_promote_title_match`` never got the b4 treatment
+
+PR #169 only touched ``_promote_topic_via_title_index`` (the tell-me-
+about path). ``_promote_title_match`` in ``synthesize.py:869-950``
+iterates ``iter_query_tails(query)`` at line 915 without the b4
+pass-0 full-query probe. Live (``synthesize=true``):
+
+  * ``Einstein's theory`` → top citation ``Theory`` (expected
+    ``Theory_of_relativity``)
+  * ``Plato's cave`` → top citation ``Cave`` (correct answer
+    demoted to rank 2)
+
+## D5 (latent) — pass-2 windows + pass-3 typo-tolerant tails
+
+``iter_query_windows`` and the pass-3 0.8-fuzzy tail probe share the
+same tokenizer and would strip apostrophes too, but are masked in
+practice because pass-1 finds a strict-1.0 single-token tail before
+they fire. Fixed for free by the tokenizer change.
+
+## Fixes
+
+1. **match_type annotation** — ``find_entry_by_title_data`` now
+   tags each result row with a ``match_type`` ∈ ``{"direct",
+   "redirect", "fuzzy_suggest", "typo_corrected"}``. ``find_title_match``
+   propagates it through to its returned dict.
+
+2. **Pass-0 gate filter** — ``_promote_topic_via_title_index`` pass-0
+   and the new synthesize-side pass-0 reject results with
+   ``match_type == "fuzzy_suggest"``. The 0.95 score is only safe to
+   auto-fetch when it represents a canonical redirect; pure fuzzy-
+   prefix matches at the same score are silent-wrong-answer risks.
+   Pass-3 (typo-tolerant 0.8 tail) also applies the filter so the
+   same fuzzy-suggest leak can't sneak through the lower gate.
+
+3. **Tokenizer fix** — ``_TAIL_TOKEN_RE`` keeps apostrophes (both
+   straight ``'`` and curly ``’``) inside alphanumeric runs, so
+   ``einstein's`` stays one token.
+
+4. **Possessive min_len floor** — when the topic contains an
+   apostrophe-possessive, pass-1 / pass-3 / synthesize-pass-1 use
+   ``min_len=2`` so a generic 1-token tail can't silently win. The
+   pass-0 full-topic probe handles the legitimate "X's Y is
+   canonical" case; tail iteration past 1 token would otherwise just
+   risk picking a generic Wikipedia title.
+
+5. **Synthesize pass-0** — ``_promote_title_match`` now mirrors the
+   ``_promote_topic_via_title_index`` pass-0 probe at the start, with
+   the same match_type filter.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+
+class TestMatchTypePropagation:
+    """``find_title_match`` must propagate the ``match_type`` field
+    from the underlying ``find_entry_by_title_data`` result row so
+    callers can distinguish redirect-walks from incidental fuzzy
+    title-prefix matches."""
+
+    def test_propagates_match_type_direct(self) -> None:
+        from openzim_mcp.title_promotion import find_title_match
+
+        mock = MagicMock()
+        mock.find_entry_by_title_data.return_value = {
+            "results": [
+                {
+                    "path": "Berlin",
+                    "title": "Berlin",
+                    "score": 1.0,
+                    "match_type": "direct",
+                }
+            ]
+        }
+        result = find_title_match(mock, "/x.zim", "Berlin")
+        assert result is not None
+        assert result["match_type"] == "direct"
+
+    def test_propagates_match_type_redirect(self) -> None:
+        from openzim_mcp.title_promotion import find_title_match
+
+        mock = MagicMock()
+        mock.find_entry_by_title_data.return_value = {
+            "results": [
+                {
+                    "path": "Allegory_of_the_cave",
+                    "title": "Allegory of the cave",
+                    "score": 0.95,
+                    "match_type": "redirect",
+                }
+            ]
+        }
+        result = find_title_match(mock, "/x.zim", "Plato's cave", min_score=0.95)
+        assert result is not None
+        assert result["match_type"] == "redirect"
+
+    def test_propagates_match_type_fuzzy_suggest(self) -> None:
+        from openzim_mcp.title_promotion import find_title_match
+
+        mock = MagicMock()
+        mock.find_entry_by_title_data.return_value = {
+            "results": [
+                {
+                    "path": "Evolution",
+                    "title": "Evolution",
+                    "score": 0.95,
+                    "match_type": "fuzzy_suggest",
+                }
+            ]
+        }
+        result = find_title_match(mock, "/x.zim", "Darwin's evolution", min_score=0.95)
+        assert result is not None
+        # Score gate still passes — match_type is informational here.
+        # The caller filters on match_type.
+        assert result["match_type"] == "fuzzy_suggest"
+
+
+class TestFuzzySuggestGateReject:
+    """``_promote_topic_via_title_index`` pass-0 must REJECT results
+    whose ``match_type == "fuzzy_suggest"``. The 0.95 suggestion-rank
+    score covers both safe (canonical redirect) and unsafe (incidental
+    fuzzy title-prefix) cases; only the former is suitable for
+    auto-fetch."""
+
+    def _make_handler(self) -> Any:
+        class _StubOps:
+            pass
+
+        class _Handler:
+            zim_operations = _StubOps()
+
+        return _Handler()
+
+    def test_pass_0_rejects_fuzzy_suggest(self) -> None:
+        """Live repro: ``darwin's evolution`` → ``Evolution`` at score
+        0.95 via fuzzy_suggest. Pass-0 must reject; tail iteration
+        then takes over and finds nothing → returns None → caller
+        falls back to BM25 → user sees the search response instead of
+        the wrong article."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        def fake(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            # Full topic: hits Evolution via fuzzy_suggest at 0.95.
+            # In production the suggestion-rank cap is 0.95, so this
+            # row is only visible when ``min_score <= 0.95``.
+            if topic == "darwin's evolution" and min_score <= 0.95:
+                return {
+                    "path": "Evolution",
+                    "title": "Evolution",
+                    "zim_file": "test.zim",
+                    "match_type": "fuzzy_suggest",
+                }
+            # Tail "evolution": hits Evolution as a direct title match
+            # at strict 1.0. With the possessive min_len=2 floor, this
+            # 1-token tail is never probed, so no spurious match.
+            if topic == "evolution":
+                return {
+                    "path": "Evolution",
+                    "title": "Evolution",
+                    "zim_file": "test.zim",
+                    "match_type": "direct",
+                }
+            return None
+
+        with patch("openzim_mcp.simple_tools.find_title_match", side_effect=fake):
+            result = SimpleToolsHandler._promote_topic_via_title_index(
+                self._make_handler(),
+                "test.zim",
+                "darwin's evolution",
+            )
+        # The fuzzy_suggest rejection + possessive min_len=2 floor
+        # together mean no promoted result.
+        assert result is None, (
+            f"expected None (fuzzy_suggest rejected + min_len=2 floor), "
+            f"got {result!r}"
+        )
+
+    def test_pass_0_accepts_redirect(self) -> None:
+        """Live repro: ``plato's cave`` → ``Allegory_of_the_cave`` at
+        score 0.95 via a redirect walk (Plato's_cave redirect entry →
+        canonical target). match_type="redirect" is accepted."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        def fake(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            if topic == "plato's cave":
+                return {
+                    "path": "Allegory_of_the_cave",
+                    "title": "Allegory of the cave",
+                    "zim_file": "test.zim",
+                    "match_type": "redirect",
+                }
+            return None
+
+        with patch("openzim_mcp.simple_tools.find_title_match", side_effect=fake):
+            result = SimpleToolsHandler._promote_topic_via_title_index(
+                self._make_handler(),
+                "test.zim",
+                "plato's cave",
+            )
+        assert result is not None
+        assert result["path"] == "Allegory_of_the_cave"
+
+    def test_pass_0_accepts_missing_match_type_backwards_compat(self) -> None:
+        """Pre-D1 callers / older mock fixtures don't set match_type.
+        Pass-0 must still accept them so the b3 tests keep passing."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        def fake(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            if topic == "einstein's theory":
+                # No match_type field — older mock shape.
+                return {
+                    "path": "Theory_of_relativity",
+                    "title": "Theory of relativity",
+                    "zim_file": "test.zim",
+                }
+            return None
+
+        with patch("openzim_mcp.simple_tools.find_title_match", side_effect=fake):
+            result = SimpleToolsHandler._promote_topic_via_title_index(
+                self._make_handler(),
+                "test.zim",
+                "einstein's theory",
+            )
+        assert result is not None
+        assert result["path"] == "Theory_of_relativity"
+
+
+class TestPossessiveTokenizer:
+    """``_TAIL_TOKEN_RE`` must preserve apostrophes inside otherwise-
+    alphanumeric runs so ``einstein's`` stays a single token. Both
+    straight (``'``) and curly (``’``) apostrophes are recognised
+    (Wikipedia uses both)."""
+
+    def test_iter_query_tails_keeps_straight_apostrophe(self) -> None:
+        from openzim_mcp.title_promotion import iter_query_tails
+
+        tails = list(iter_query_tails("einstein's theory"))
+        # Must NOT contain an "s" stub token.
+        assert "s theory" not in tails
+        assert "einstein s theory" not in tails
+        # Must contain the apostrophe-preserved tails.
+        assert "einstein's theory" in tails
+        # 1-token tails: only "theory", NOT "s".
+        assert "theory" in tails
+        assert "s" not in tails
+
+    def test_iter_query_tails_keeps_curly_apostrophe(self) -> None:
+        from openzim_mcp.title_promotion import iter_query_tails
+
+        tails = list(iter_query_tails("einstein’s theory"))
+        # Curly apostrophe also preserved inside the token.
+        assert "einstein’s theory" in tails or "einstein's theory" in tails
+        # No stub "s" token.
+        assert "s" not in tails
+
+    def test_iter_query_windows_keeps_apostrophe(self) -> None:
+        from openzim_mcp.title_promotion import iter_query_windows
+
+        windows = list(iter_query_windows("einstein's theory of gravity"))
+        # No stub "s" token in any window.
+        assert "s" not in windows
+        # The apostrophe-preserved possessor token appears as a
+        # standalone window.
+        assert "einstein's" in windows or "einstein’s" in windows
+
+    def test_non_possessive_query_unchanged(self) -> None:
+        """The original 'famous people from big rapids michigan' tail
+        iteration motivating ``_promote_topic_via_title_index`` must
+        still work — no apostrophes, no behavior change."""
+        from openzim_mcp.title_promotion import iter_query_tails
+
+        tails = list(iter_query_tails("famous people from big rapids michigan"))
+        # Greedy length-down: longest tail (capped at max_len=4) first.
+        assert (
+            tails[0] == "people from big rapids"
+            or tails[0] == "from big rapids michigan"
+        )
+        # The motivating "big rapids michigan" tail must appear.
+        assert "big rapids michigan" in tails
+        # The 1-token "michigan" tail is also yielded by default.
+        assert "michigan" in tails
+
+
+class TestPossessiveMinLenFloor:
+    """When the topic carries an apostrophe-possessive, pass-1 of
+    ``_promote_topic_via_title_index`` must iterate tails at
+    ``min_len=2`` so a generic 1-token tail (philosophy, history,
+    tourism) can't silently win after pass-0 missed."""
+
+    def _make_handler(self) -> Any:
+        class _StubOps:
+            pass
+
+        class _Handler:
+            zim_operations = _StubOps()
+
+        return _Handler()
+
+    def test_possessive_prose_no_1_token_pass_1_match(self) -> None:
+        """Live repro: ``plato's republic philosophy`` (prose with
+        possessive, full topic NOT canonical). With the min_len=2
+        floor, pass-1 doesn't probe the 1-token tail ``philosophy``,
+        so the wrong promotion can't happen."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        def fake(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            # Full topic: no canonical match.
+            if topic == "plato's republic philosophy":
+                return None
+            # 2-tail "republic philosophy": no canonical match.
+            if topic == "republic philosophy":
+                return None
+            # 1-tail "philosophy": IF probed, would return Philosophy
+            # at strict 1.0. The test asserts this is NEVER called.
+            if topic == "philosophy":
+                return {
+                    "path": "Philosophy",
+                    "title": "Philosophy",
+                    "zim_file": "test.zim",
+                    "match_type": "direct",
+                }
+            return None
+
+        with patch("openzim_mcp.simple_tools.find_title_match", side_effect=fake):
+            result = SimpleToolsHandler._promote_topic_via_title_index(
+                self._make_handler(),
+                "test.zim",
+                "plato's republic philosophy",
+            )
+        # With the min_len=2 floor, the 1-token "philosophy" tail is
+        # not probed, so no spurious Philosophy promotion. Pass-0
+        # missed too, so we get None and the caller falls back to
+        # BM25 (where the user can see "no canonical, multiple
+        # weak matches" instead of a confident wrong answer).
+        assert result is None, (
+            f"expected None (min_len=2 floor blocks 1-token tail), " f"got {result!r}"
+        )
+
+    def test_possessive_prose_2_token_tail_still_probed(self) -> None:
+        """The floor is min_len=2, not min_len=3. A 2-token tail that
+        IS canonical should still resolve (legitimate entity
+        resolution)."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        def fake(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            # Full topic: no canonical match.
+            if topic == "newton's theory of motion":
+                return None
+            # Possessive-preserved tail iteration:
+            # 4-tail: "newton's theory of motion" (= full topic above)
+            # 3-tail: "theory of motion"
+            # 2-tail: "of motion"
+            # (1-tail "motion" not probed under min_len=2 floor)
+            if topic == "theory of motion":
+                return {
+                    "path": "Motion_(physics)",
+                    "title": "Motion (physics)",
+                    "zim_file": "test.zim",
+                    "match_type": "direct",
+                }
+            return None
+
+        with patch("openzim_mcp.simple_tools.find_title_match", side_effect=fake):
+            result = SimpleToolsHandler._promote_topic_via_title_index(
+                self._make_handler(),
+                "test.zim",
+                "newton's theory of motion",
+            )
+        # 3-token tail "theory of motion" hits strict 1.0 → returned.
+        assert result is not None
+        assert result["path"] == "Motion_(physics)"
+
+    def test_non_possessive_prose_still_uses_1_token_floor(self) -> None:
+        """The min_len=2 floor is conditional on the topic carrying an
+        apostrophe-possessive. For pure prose without a possessive,
+        the original min_len=1 behavior is preserved so the motivating
+        "famous people from big rapids michigan" → "michigan" 1-token
+        tail still works as a last resort."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        def fake(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            # No canonical match anywhere except the trailing 1-token
+            # tail.
+            if topic == "michigan":
+                return {
+                    "path": "Michigan",
+                    "title": "Michigan",
+                    "zim_file": "test.zim",
+                    "match_type": "direct",
+                }
+            return None
+
+        with patch("openzim_mcp.simple_tools.find_title_match", side_effect=fake):
+            result = SimpleToolsHandler._promote_topic_via_title_index(
+                self._make_handler(),
+                "test.zim",
+                # No apostrophe — original min_len=1 applies.
+                "people who live in michigan",
+            )
+        # No possessive → min_len=1 → 1-token "michigan" tail probed
+        # → strict 1.0 hit → returned.
+        assert result is not None
+        assert result["path"] == "Michigan"
+
+
+class TestSynthesizePromoteFullTopicProbe:
+    """``_promote_title_match`` in ``synthesize.py`` was not patched by
+    PR #169. The same b4 pass-0 full-query probe must run at the start
+    here too, so possessive queries through the synthesize path
+    resolve to the canonical redirect target instead of the buggy
+    pass-1 tail-iteration winner."""
+
+    def test_synthesize_pass_0_full_query_probe(self) -> None:
+        """Live repro: ``Einstein's theory`` with ``synthesize=true``
+        currently returns rank-1 ``Theory``. The new pass-0 should
+        intercept and promote ``Theory_of_relativity`` to rank 1."""
+        from openzim_mcp.synthesize import _promote_title_match
+
+        # Search handler stub with a title_match_hit that uses the
+        # full query when probed for the canonical, but would also
+        # return ``Theory`` for the bare 1-token tail (which the new
+        # pass-0 probe should make irrelevant).
+        class _Archive:
+            pass
+
+        archive_obj = _Archive()
+        archives_searched = ["wiki"]
+
+        def fake_title_match_hit(archive: Any, query: str) -> Optional[Dict[str, Any]]:
+            # Old pass-1 path: returns "Theory" for the "theory" tail.
+            if query == "theory":
+                return {
+                    "path": "Theory",
+                    "title": "Theory",
+                    "match_type": "direct",
+                }
+            return None
+
+        # Mock find_title_match (the new pass-0 probe) so the full
+        # query "einstein's theory" resolves to the canonical redirect
+        # target at 0.95. ``find_entry_by_title_data`` is
+        # case-insensitive internally (``title_lower = title.lower()``
+        # at zim/search.py:2738) so the mock lowercases the input
+        # before comparing.
+        def fake_find_title_match(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            if topic.lower() == "einstein's theory":
+                return {
+                    "path": "Theory_of_relativity",
+                    "title": "Theory of relativity",
+                    "zim_file": "wiki",
+                    "match_type": "redirect",
+                }
+            return None
+
+        handler = MagicMock()
+        handler.title_match_hit = fake_title_match_hit
+
+        with patch(
+            "openzim_mcp.synthesize.find_title_match",
+            side_effect=fake_find_title_match,
+        ):
+            promoted_hits = _promote_title_match(
+                # Top hit is the wrong "Theory" article (pre-fix
+                # behavior); we want the pass-0 probe to override.
+                [("wiki", {"path": "Theory", "title": "Theory"})],
+                query="Einstein's theory",
+                archives=[(archive_obj, "/wiki.zim")],
+                archives_searched=archives_searched,
+                search_handler=handler,
+            )
+        # Pass-0 promoted Theory_of_relativity to rank 1.
+        assert len(promoted_hits) >= 1
+        top_path = promoted_hits[0][1]["path"]
+        assert (
+            top_path == "Theory_of_relativity"
+        ), f"expected Theory_of_relativity at rank 1, got {top_path!r}"
+
+    def test_synthesize_pass_0_rejects_fuzzy_suggest(self) -> None:
+        """The synthesize-side pass-0 must also apply the D1 match_type
+        filter so ``Einstein's xyz`` (fuzzy false-positive at 0.95)
+        doesn't get auto-promoted."""
+        from openzim_mcp.synthesize import _promote_title_match
+
+        class _Archive:
+            pass
+
+        archive_obj = _Archive()
+
+        def fake_find_title_match(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            if topic == "einstein's xyz":
+                return {
+                    "path": "Xyz",
+                    "title": "Xyz",
+                    "zim_file": "wiki",
+                    "match_type": "fuzzy_suggest",
+                }
+            return None
+
+        handler = MagicMock()
+        handler.title_match_hit = lambda _a, _q: None
+
+        existing_hits: List[tuple[str, Dict[str, Any]]] = [
+            ("wiki", {"path": "Albert_Einstein", "title": "Albert Einstein"})
+        ]
+        with patch(
+            "openzim_mcp.synthesize.find_title_match",
+            side_effect=fake_find_title_match,
+        ):
+            result_hits = _promote_title_match(
+                existing_hits,
+                query="Einstein's xyz",
+                archives=[(archive_obj, "/wiki.zim")],
+                archives_searched=["wiki"],
+                search_handler=handler,
+            )
+        # Pass-0 rejected fuzzy_suggest; existing hits preserved
+        # untouched (no spurious Xyz promotion).
+        assert result_hits == existing_hits
+
+
+class TestRegressionGuards:
+    """Pin the post-b4 invariants so future contributors don't
+    regress them."""
+
+    def test_tail_token_re_accepts_apostrophe_in_token(self) -> None:
+        """Direct check on the tokenizer regex — the load-bearing
+        invariant for D2/D3/D5."""
+        from openzim_mcp.title_promotion import _TAIL_TOKEN_RE
+
+        tokens = _TAIL_TOKEN_RE.findall("einstein's theory")
+        assert tokens == ["einstein's", "theory"], (
+            f"_TAIL_TOKEN_RE must keep apostrophes inside tokens; " f"got {tokens!r}"
+        )
+        # Curly apostrophe variant.
+        tokens_curly = _TAIL_TOKEN_RE.findall("einstein’s theory")
+        assert tokens_curly == ["einstein’s", "theory"], (
+            f"_TAIL_TOKEN_RE must keep curly apostrophes inside tokens; "
+            f"got {tokens_curly!r}"
+        )
+
+    def test_promote_function_has_pass_0_match_type_filter(self) -> None:
+        """Structural pin: ``_promote_topic_via_title_index`` must
+        check ``match_type`` against ``"fuzzy_suggest"`` before
+        accepting the pass-0 result. If a refactor removes this
+        check, the b4 D1 regression returns."""
+        import inspect
+
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        source = inspect.getsource(SimpleToolsHandler._promote_topic_via_title_index)
+        assert '"fuzzy_suggest"' in source or "'fuzzy_suggest'" in source, (
+            "_promote_topic_via_title_index must filter fuzzy_suggest " "at pass-0"
+        )
+
+    def test_synthesize_promote_starts_with_full_query_probe(self) -> None:
+        """Structural pin: ``_promote_title_match`` must call
+        ``find_title_match`` with the bare query BEFORE iterating
+        tails."""
+        import inspect
+
+        from openzim_mcp.synthesize import _promote_title_match
+
+        source = inspect.getsource(_promote_title_match)
+        first_find_call = source.find("find_title_match(")
+        first_iter_call = source.find("iter_query_tails(")
+        assert first_find_call > 0, "find_title_match call missing"
+        assert first_iter_call > 0, "iter_query_tails call missing"
+        assert first_find_call < first_iter_call, (
+            "_promote_title_match must probe full query via "
+            "find_title_match BEFORE iter_query_tails decomposes it"
+        )

--- a/tests/test_post_b4_beta_fixes.py
+++ b/tests/test_post_b4_beta_fixes.py
@@ -504,7 +504,15 @@ class TestSynthesizePromoteFullTopicProbe:
     def test_synthesize_pass_0_full_query_probe(self) -> None:
         """Live repro: ``Einstein's theory`` with ``synthesize=true``
         currently returns rank-1 ``Theory``. The new pass-0 should
-        intercept and promote ``Theory_of_relativity`` to rank 1."""
+        intercept and promote ``Theory_of_relativity`` to rank 1.
+
+        Also pins the API-contract invariant: ``find_title_match``
+        receives ``search_handler`` (a ZimOperations-shaped object —
+        wired in production at ``simple_tools._handle_synthesize_query``
+        via ``search_handler=self.zim_operations``) and the validated
+        path string. Pre-pass-2 audit, this site passed the libzim
+        ``Archive`` handle instead, which silently no-ops because
+        ``Archive`` has no ``find_entry_by_title_data`` method."""
         from openzim_mcp.synthesize import _promote_title_match
 
         # Search handler stub with a title_match_hit that uses the
@@ -532,7 +540,11 @@ class TestSynthesizePromoteFullTopicProbe:
         # target at 0.95. ``find_entry_by_title_data`` is
         # case-insensitive internally (``title_lower = title.lower()``
         # at zim/search.py:2738) so the mock lowercases the input
-        # before comparing.
+        # before comparing. Records calls so the test can assert the
+        # API-contract: arg-0 is the search_handler, arg-1 is the
+        # validated path.
+        call_log: List[tuple[Any, str, str]] = []
+
         def fake_find_title_match(
             zim_ops: Any,
             zim_file_path: str,
@@ -541,6 +553,7 @@ class TestSynthesizePromoteFullTopicProbe:
             cross_file: bool = False,
             min_score: float = 1.0,
         ) -> Optional[Dict[str, Any]]:
+            call_log.append((zim_ops, zim_file_path, topic))
             if topic.lower() == "einstein's theory":
                 return {
                     "path": "Theory_of_relativity",
@@ -572,6 +585,21 @@ class TestSynthesizePromoteFullTopicProbe:
         assert (
             top_path == "Theory_of_relativity"
         ), f"expected Theory_of_relativity at rank 1, got {top_path!r}"
+        # API contract: pass-0 must call find_title_match with the
+        # search_handler (zim_operations) and the validated PATH from
+        # the archives tuple, NOT the libzim ``Archive`` object and
+        # NOT the archive_name label.
+        assert call_log, "pass-0 probe never called find_title_match"
+        first_zim_ops, first_path, first_topic = call_log[0]
+        assert first_zim_ops is handler, (
+            f"arg-0 must be the search_handler (zim_operations); "
+            f"got {first_zim_ops!r}"
+        )
+        assert first_path == "/wiki.zim", (
+            f"arg-1 must be the validated path from archives[..][1]; "
+            f"got {first_path!r}"
+        )
+        assert first_topic == "Einstein's theory"
 
     def test_synthesize_pass_0_rejects_fuzzy_suggest(self) -> None:
         """The synthesize-side pass-0 must also apply the D1 match_type
@@ -592,7 +620,7 @@ class TestSynthesizePromoteFullTopicProbe:
             cross_file: bool = False,
             min_score: float = 1.0,
         ) -> Optional[Dict[str, Any]]:
-            if topic == "einstein's xyz":
+            if topic.lower() == "einstein's xyz":
                 return {
                     "path": "Xyz",
                     "title": "Xyz",
@@ -673,4 +701,38 @@ class TestRegressionGuards:
         assert first_find_call < first_iter_call, (
             "_promote_title_match must probe full query via "
             "find_title_match BEFORE iter_query_tails decomposes it"
+        )
+
+    def test_synthesize_promote_passes_search_handler_to_find_title_match(
+        self,
+    ) -> None:
+        """Pass-2 audit pin: ``_promote_title_match``'s call to
+        ``find_title_match`` must pass ``search_handler`` (a
+        ZimOperations-shaped object) as arg-0, NOT the libzim
+        ``Archive`` handle. ``find_title_match`` calls
+        ``zim_operations.find_entry_by_title_data(...)`` on arg-0 —
+        if arg-0 is an ``Archive`` (which has no such method) the
+        probe silently no-ops via the ``except Exception``. This
+        guard regex-locates the first ``find_title_match(`` invocation
+        inside ``_promote_title_match`` and verifies its first
+        positional argument names ``search_handler``."""
+        import inspect
+        import re as _re
+
+        from openzim_mcp.synthesize import _promote_title_match
+
+        source = inspect.getsource(_promote_title_match)
+        # Match the first multi-line call: ``find_title_match(`` then
+        # the next non-whitespace token is the first positional arg.
+        match = _re.search(
+            r"find_title_match\(\s*([A-Za-z_][A-Za-z_0-9]*)",
+            source,
+        )
+        assert match is not None, "find_title_match call missing"
+        first_arg_name = match.group(1)
+        assert first_arg_name == "search_handler", (
+            f"first arg to find_title_match must be ``search_handler`` "
+            f"(the ZimOperations-shaped object); got {first_arg_name!r}. "
+            f"Passing the libzim ``Archive`` here silently no-ops the "
+            f"probe — see post-b4 pass-2 audit finding A1."
         )

--- a/tests/test_post_b4_beta_fixes.py
+++ b/tests/test_post_b4_beta_fixes.py
@@ -263,6 +263,66 @@ class TestFuzzySuggestGateReject:
         assert result is not None
         assert result["path"] == "Allegory_of_the_cave"
 
+    def test_pass_0_accepts_fuzzy_suggest_on_non_possessive_topic(self) -> None:
+        """Pass-3 audit refinement: the ``fuzzy_suggest`` filter ONLY
+        applies when the topic carries an apostrophe-possessive. For
+        non-possessive prose queries (``Berlin Germany`` → ``Berlin``
+        at 0.95 via libzim's tokenized-prefix match), the fuzzy_suggest
+        IS the intended answer — libzim correctly resolved the first
+        token to the canonical, with the second as disambiguator. The
+        b4 pass-0 specifically improved this class over the pre-b4
+        pass-1 behavior (which would have picked the trailing tail
+        ``germany`` at strict 1.0 → returned the Germany article
+        instead of the Berlin one the user asked about). An
+        unconditional filter would silently revert that improvement;
+        the refined gate preserves it."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        def fake(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            # Non-possessive 2-token prose: libzim returns ``Berlin``
+            # as fuzzy_suggest at 0.95. No possessive marker in the
+            # topic, so the filter does NOT reject.
+            if topic.lower() == "berlin germany" and min_score <= 0.95:
+                return {
+                    "path": "Berlin",
+                    "title": "Berlin",
+                    "zim_file": "test.zim",
+                    "match_type": "fuzzy_suggest",
+                }
+            # Tail ``germany`` would resolve at strict 1.0 if pass-0
+            # missed — pre-b4 behavior was to return Germany. The
+            # refined fix must keep Berlin (pass-0 wins) for this
+            # non-possessive shape.
+            if topic == "germany":
+                return {
+                    "path": "Germany",
+                    "title": "Germany",
+                    "zim_file": "test.zim",
+                    "match_type": "direct",
+                }
+            return None
+
+        with patch("openzim_mcp.simple_tools.find_title_match", side_effect=fake):
+            result = SimpleToolsHandler._promote_topic_via_title_index(
+                self._make_handler(),
+                "test.zim",
+                "Berlin Germany",
+            )
+        # Non-possessive: pass-0 accepts fuzzy_suggest Berlin → user
+        # gets the article they asked about.
+        assert result is not None
+        assert result["path"] == "Berlin", (
+            f"non-possessive fuzzy_suggest must be accepted (b4 "
+            f"behavior preserved); got {result!r}"
+        )
+
     def test_pass_0_accepts_missing_match_type_backwards_compat(self) -> None:
         """Pre-D1 callers / older mock fixtures don't set match_type.
         Pass-0 must still accept them so the b3 tests keep passing."""
@@ -600,6 +660,61 @@ class TestSynthesizePromoteFullTopicProbe:
             f"got {first_path!r}"
         )
         assert first_topic == "Einstein's theory"
+
+    def test_synthesize_pass_0_accepts_fuzzy_suggest_on_non_possessive(
+        self,
+    ) -> None:
+        """Synthesize mirror of the simple-mode non-possessive carve-
+        out: ``Berlin Germany`` through ``synthesize=true`` must still
+        let pass-0 accept the ``Berlin`` fuzzy_suggest hit so it's
+        promoted to rank 1, matching the b4 improvement that the
+        unconditional filter would have reverted."""
+        from openzim_mcp.synthesize import _promote_title_match
+
+        class _Archive:
+            pass
+
+        archive_obj = _Archive()
+
+        def fake_find_title_match(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            if topic.lower() == "berlin germany" and min_score <= 0.95:
+                return {
+                    "path": "Berlin",
+                    "title": "Berlin",
+                    "zim_file": "wiki",
+                    "match_type": "fuzzy_suggest",
+                }
+            return None
+
+        handler = MagicMock()
+        handler.title_match_hit = lambda _a, _q: None
+
+        with patch(
+            "openzim_mcp.synthesize.find_title_match",
+            side_effect=fake_find_title_match,
+        ):
+            result_hits = _promote_title_match(
+                # Empty top_hits: pass-0 is the only path that can
+                # contribute. Without the carve-out the result would
+                # be the same empty list (silent regression vs b4).
+                [],
+                query="Berlin Germany",
+                archives=[(archive_obj, "/wiki.zim")],
+                archives_searched=["wiki"],
+                search_handler=handler,
+            )
+        # Non-possessive: pass-0 promotes Berlin to rank 1.
+        assert len(result_hits) == 1
+        top_archive, top_hit = result_hits[0]
+        assert top_archive == "wiki"
+        assert top_hit["path"] == "Berlin"
 
     def test_synthesize_pass_0_rejects_fuzzy_suggest(self) -> None:
         """The synthesize-side pass-0 must also apply the D1 match_type


### PR DESCRIPTION
Post-b4 live-MCP sweep against v2.0.0b4 verified the b3 X's-Y fix (`Theory_of_relativity` / `Allegory_of_the_cave` / `Republic_(Plato)`) on three of the four user-listed cases. `tell me about Darwin's evolution` still returned `Evolution` — exposing two siblings of the apostrophe-tokenization defect class, plus a gate-semantics defect in the b4 pass-0 itself. Self-audit then caught one critical API misuse (pass-2) and one regression-from-fix (pass-3).

## D1 (HIGH) — b4 pass-0 gate can't distinguish redirect-0.95 from fuzzy-0.95

`find_entry_by_title_data` scores libzim's suggestion-search results on a linearly-decaying rank formula capped at 0.95 ([zim/search.py:2814-2822](openzim_mcp/zim/search.py#L2814-L2822)). The same 0.95 score covers both:

  * a **redirect walk** — suggestion returned `Plato's_cave` (a redirect entry); `_follow_redirect_chain` walked to `Allegory_of_the_cave`. Meaningful canonical relationship.
  * a **pure fuzzy title-prefix match** — suggestion returned `Evolution` for the query `Darwin's evolution`. No canonical relationship; superficial token overlap only.

The b4 `min_score=0.95` gate accepted both. Live: `tell me about Darwin's evolution` → `Evolution` at cert=0.85 (silent-wrong-answer). Same shape for `Darwin's evolution history` → `Darwin's_Ghosts:_The_Secret_History_of_Evolution` (judgment-call over-promotion at the same 0.95 fuzzy reach).

## D2 (HIGH) — pass-1 `iter_query_tails` still strips apostrophes

The b4 fix only patched pass-0. Pass-1 ([simple_tools.py:3925](openzim_mcp/simple_tools.py#L3925)) still consumed `_TAIL_TOKEN_RE` at [title_promotion.py:188](openzim_mcp/title_promotion.py#L188), which treated apostrophes as token boundaries:

  * `"plato's republic philosophy"` → `["plato", "s", "republic", "philosophy"]`
  * 4-tail / 3-tail / 2-tail miss; 1-tail `"philosophy"` matches canonical `Philosophy` at strict 1.0 → **silently wins**

Live silent-wrong-answers (cert=0.85): `Plato's republic philosophy` → `Philosophy`; `Einstein's theory history` → `History`; `Einstein's theory tourism` → `Tourism`.

## D3 (HIGH) — synthesize `_promote_title_match` never got the b4 treatment

PR #169 only touched `_promote_topic_via_title_index`. `_promote_title_match` in [synthesize.py:869-950](openzim_mcp/synthesize.py#L869-L950) iterated `iter_query_tails(query)` at line 915 without the b4 pass-0 full-query probe. Live (`synthesize=true`):

  * `Einstein's theory` → rank-1 citation `Theory` (expected `Theory_of_relativity`)
  * `Plato's cave` → rank-1 `Cave` (correct article demoted to rank 2)

## D5 (LATENT) — pass-2 windows + pass-3 typo-tolerant tails

`iter_query_windows` and the pass-3 0.8-fuzzy tail probe share the same tokenizer; the apostrophe-strip shape was masked in practice because pass-1's strict-1.0 single-token tail short-circuited first. Fixed for free by the tokenizer change.

## Three audit passes, three real defects

### Pass-1 (`51158e9`) — primary fixes

1. **`match_type` annotation through find_entry_by_title_data** — each result row now carries `match_type ∈ {"direct", "redirect", "fuzzy_suggest", "typo_corrected"}`. `find_title_match` propagates the field. Schema is non-breaking (`FindEntryHit.match_type` was already `NotRequired[str]` for the pre-existing typo annotation).

2. **Pass-0 gate filter** — `_promote_topic_via_title_index` pass-0 and the new synthesize-side pass-0 reject results where `match_type == "fuzzy_suggest"`. Pass-3 (typo-tolerant 0.8 tail) applies the same filter.

3. **Tokenizer fix** — `_TAIL_TOKEN_RE` now keeps apostrophes (both straight `'` and curly `’`) inside otherwise-alphanumeric runs so `einstein's` stays one token.

4. **Possessive `min_len` floor** — new `has_apostrophe_possessive(topic)` helper. When True, pass-1 / pass-3 / synthesize-pass-1 use `min_len=2` in `iter_query_tails` / `iter_query_windows` so a generic 1-token tail (`"philosophy"` / `"history"` / `"tourism"`) can't silently outrank the canonical the pass-0 probe just missed.

5. **Synthesize pass-0** — `_promote_title_match` mirrors the `_promote_topic_via_title_index` pass-0 probe at the start, with the same `match_type` filter.

### Pass-2 (`8f9628d`) — synthesize pass-0 silently no-ops in production

The pass-1 fix called `find_title_match(archive, archive_name, query, min_score=0.95)`, passing the libzim `Archive` handle as arg-0. `find_title_match` calls `arg0.find_entry_by_title_data(...)` — `Archive` has no such method, so the call raised `AttributeError` inside the `except Exception` wrapper and **silently no-op'd in production**. Tests passed only because they `patch`-ed `find_title_match` at the import site, bypassing the contract entirely.

Fix: `search_handler` in production IS the `ZimOperations` instance ([simple_tools.py:5542](openzim_mcp/simple_tools.py#L5542): `search_handler=self.zim_operations`). Pass it as arg-0 and the validated path `vp` from the `(Archive, Path)` tuple as the file-path arg. New regression guard `test_synthesize_promote_passes_search_handler_to_find_title_match` regex-locates the first `find_title_match(` invocation inside `_promote_title_match` and asserts its first positional arg is named `search_handler`.

### Pass-3 (`e6a778f`) — D1 filter carve-out for non-possessive prose

The unconditional `match_type != "fuzzy_suggest"` gate silently reverted a real b4 improvement for non-possessive prose queries of the shape `<entity> <disambiguator>`.

Trace `tell me about Berlin Germany`:

| Release | Pass-0 result | Pass-1 (if pass-0 missed) | Final answer |
|---|---|---|---|
| pre-b4 | (no pass-0) | tail `germany` at strict 1.0 | `Germany` |
| b4 (pre-D1) | `Berlin` at fuzzy_suggest 0.95 — accepted | n/a | `Berlin` ✓ |
| b4 + pass-1 D1 (unconditional) | rejected | `Germany` | `Germany` ✗ |

The b4 pass-0 silently fixed a pre-existing pass-1 misroute for non-possessive disambiguating queries. The unconditional filter reverted it. Same shape applies to `Apollo 11 mission`, `Paris France`, `Tokyo Japan`, etc.

Refine the gate to reject `fuzzy_suggest` ONLY when `has_apostrophe_possessive(topic)` returns True:

```python
if promoted is not None:
    is_fuzzy_suggest = promoted.get("match_type") == "fuzzy_suggest"
    if not (is_fuzzy_suggest and has_apostrophe_possessive(topic)):
        return promoted
```

The Darwin/Einstein/Plato silent-wrong-answer cases (all possessive) still reject; the Berlin/Apollo/Paris/Tokyo b4 improvements (all non-possessive) preserve.

## Audits clean across the b4 fix surface

Live verification (pre-fix-deploy) confirms all 3 of the user-listed b4 verification cases still resolve correctly:

- `tell me about Einstein's theory` → `Theory_of_relativity` ✓
- `tell me about Plato's cave` → `Allegory_of_the_cave` ✓
- `tell me about Plato's Republic` → `Republic_(Plato)` ✓

No-regression possessive set holds: `Hubble's law`, `Ohm's law`, `Achilles' heel`, `Photosythesis's reproduction` → `Photosynthesis`. b3 invariants (D1-D4 + pass-2/3 siblings), earlier b-series invariants (probe-gate canonicals, cascade titles, original-case echo, single-edit typo, namespace bait, walk namespace M, malformed cursor) all hold.

## Tests

21 new tests in `tests/test_post_b4_beta_fixes.py` across 6 classes:

  * **TestMatchTypePropagation** (3) — `find_title_match` propagates direct/redirect/fuzzy_suggest annotation
  * **TestFuzzySuggestGateReject** (4) — pass-0 rejects fuzzy_suggest on possessive topics, accepts on non-possessive (Berlin Germany), accepts redirect, accepts missing match_type (backwards-compat)
  * **TestPossessiveTokenizer** (4) — `_TAIL_TOKEN_RE` keeps both straight + curly apostrophes inside tokens; non-possessive queries unchanged
  * **TestPossessiveMinLenFloor** (3) — pass-1 skips 1-token tail when topic carries possessive; 2-token tails still probed; non-possessive prose uses unchanged min_len=1
  * **TestSynthesizePromoteFullTopicProbe** (3) — `_promote_title_match` runs pass-0 probe; rejects fuzzy_suggest on possessive; accepts fuzzy_suggest on non-possessive
  * **TestRegressionGuards** (4) — structural pins on `_TAIL_TOKEN_RE` keeping apostrophes, the pass-0 fuzzy_suggest filter present in source, `_promote_title_match` calling `find_title_match` before `iter_query_tails`, and `find_title_match` receiving `search_handler` (not the libzim `Archive`)

Updated 1 pre-existing assertion in `tests/test_post_a17_beta_fixes.py` (`O'Brien` tokenizes to `["o'brien"]` post-fix, not `["o brien", "brien"]`) and 1 in `tests/test_post_b3_beta_fixes.py` (tail iteration no longer strips apostrophes; the sanity check that pinned the pre-fix bug behaviour is replaced with a pin on the at-least-one-call-saw-apostrophe invariant).

Updated 1 golden snapshot (`tests/data/goldens/v2_phase_b/find_einstein.json`) to include `match_type: "direct"` on the canonical Einstein fast-path hit.

```
2390 passed, 54 skipped (full suite, ~28s)
```

mypy clean across 52 source files. black + flake8 clean.

## Methodology — "fix unlocks new paths" 13 sweeps strong; reproduced 3x in this single sweep

The recurring "self-audits keep finding real defects" pattern reproduced three times within this single sweep:

  * pass-1 looked correct in isolation; pass-2 found the synthesize API misuse silently no-op'd in production (tests masked it via `patch`-at-import-site)
  * pass-2 looked complete; pass-3 found the unconditional gate regressed a real b4 improvement for non-possessive prose

Lessons pinned as invariants:

  1. **Tokenizer apostrophe invariant**: `_TAIL_TOKEN_RE` keeps apostrophes inside otherwise-alphanumeric runs.
  2. **Promote-gate match-kind invariant**: at `min_score=0.95`, `match_type ∈ {direct, redirect, typo_corrected}` is safe to auto-fetch; `fuzzy_suggest` is only safe when the topic shape would naturally produce a meaningful first-token resolution (non-possessive).
  3. **API-contract invariant** (pass-2): when a new call site for `find_title_match` is added, verify arg-0 is the `ZimOperations`-shaped object — not the libzim `Archive` handle. The `except Exception` wrapper masks `AttributeError` silently.

## What's not in this PR

Version bump / CHANGELOG entry — follows the sweep convention (release PR is separate).
