### PR TITLE
fix(v2): post-b6 beta-test sweep — 2 defects (Z1 associative-redirect filter + Z2 synthesize insert shape)

### DIFF
--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -27,7 +27,7 @@ from .responses import ToolErrorPayload, tool_error
 from .security import sanitize_context_for_error
 from .title_promotion import (
     _TOKEN_RE,
-    extract_possessor_tokens,
+    accept_possessive_promotion,
     find_title_match,
     has_apostrophe_possessive,
     is_strong_title_match,
@@ -120,72 +120,12 @@ _QUERY_REWRITE_STOPWORD_PHRASE = "query_rewrite.stopword_phrase"
 _QUERY_REWRITE_X_OF_Y = "query_rewrite.x_of_y"
 
 
-# Post-b6 Z1: shared filter for ``_promote_topic_via_title_index``
-# (pass-0 + pass-3) and the synthesize-path ``_promote_title_match``
-# pass-0. Returns True iff ``promoted`` is safe to auto-fetch for the
-# given ``topic``.
-#
-# The libzim suggestion-search produces three relevant shapes at the
-# 0.95+ score band:
-#
-#   * ``match_type="direct"`` — exact-title hit (post-redirect title
-#     equals user input case-insensitively). Always safe.
-#   * ``match_type="redirect"`` — libzim found a redirect entry, and
-#     ``_follow_redirect_chain`` walked it to a canonical. SAFE iff
-#     the pre-redirect path is semantically related to the user's
-#     query — checked by requiring at least one possessor token to
-#     appear in the pre-redirect path's tokens. Otherwise UNSAFE: an
-#     associative redirect (some unrelated redirect entry whose
-#     destination happens to share a user token).
-#   * ``match_type="fuzzy_suggest"`` — libzim returned the canonical
-#     directly via token-prefix matching, no redirect walked. SAFE
-#     for non-possessive prose (``Berlin Germany`` → ``Berlin`` is
-#     the user's intent), UNSAFE for possessives (``Darwin's
-#     evolution`` → ``Evolution`` drops the possessor entirely —
-#     silent-wrong-answer cert=0.85).
-#
-# For non-possessive topics, all three shapes are accepted (the b4
-# improvements for ``<entity> <disambiguator>`` shapes are preserved).
-_POSSESSOR_PATH_TOKEN_RE = re.compile(r"[a-z0-9]+")
-
-
-def _accept_possessive_promotion(promoted: Dict[str, Any], topic: str) -> bool:
-    """Return True iff ``promoted`` is safe to auto-fetch for ``topic``.
-
-    See module-level comment above ``_POSSESSOR_PATH_TOKEN_RE`` for
-    the shape-by-shape acceptance matrix.
-    """
-    if not has_apostrophe_possessive(topic):
-        # Non-possessive: all three match_type shapes are safe; the
-        # b4 pass-0 win for ``<entity> <disambiguator>`` queries
-        # depends on this.
-        return True
-    match_type = promoted.get("match_type")
-    if match_type == "direct":
-        return True
-    if match_type == "fuzzy_suggest":
-        # Possessive + fuzzy_suggest — the D1 attack surface (Darwin's
-        # evolution → Evolution; Plato's republic philosophy →
-        # Philosophy). Reject.
-        return False
-    if match_type == "redirect":
-        # Possessive + redirect — accept only when the pre-redirect
-        # path is semantically related to the user's query. Probe:
-        # at least one possessor token appears in the pre-redirect
-        # path's tokens.
-        possessors = set(extract_possessor_tokens(topic))
-        if not possessors:
-            return True
-        pre_path = promoted.get("pre_redirect_path", "") or promoted.get("path", "")
-        pre_tokens = set(_POSSESSOR_PATH_TOKEN_RE.findall(pre_path.lower()))
-        # Accept iff any possessor appears verbatim as a token in the
-        # pre-redirect path. ``Plato's_cave`` → tokens contain
-        # ``plato`` → ACCEPT. ``Evolutionary_theory`` → no ``darwin``
-        # → REJECT.
-        return bool(possessors & pre_tokens)
-    # Unknown / missing match_type — backwards-compat for callers and
-    # mocks that don't annotate. Accept (legacy behaviour).
-    return True
+# Post-b6 Z1: the shared D1+Z1 filter lives in ``title_promotion`` as
+# ``accept_possessive_promotion`` (imported above). simple_tools and
+# synthesize both use it so the two-mode tell-me-about/synthesize
+# paths apply identical safety logic. The legacy thin wrapper kept
+# here would have duplicated the helper across modules — replaced
+# with the direct import.
 
 
 @dataclass
@@ -3987,7 +3927,7 @@ class SimpleToolsHandler:
         promoted = find_title_match(
             self.zim_operations, zim_file_path, topic, min_score=0.95
         )
-        if promoted is not None and _accept_possessive_promotion(promoted, topic):
+        if promoted is not None and accept_possessive_promotion(promoted, topic):
             return promoted
         # Post-b4 D2: when the topic carries an apostrophe-possessive
         # (``Plato's republic philosophy`` / ``Einstein's theory
@@ -4022,7 +3962,7 @@ class SimpleToolsHandler:
             promoted = find_title_match(
                 self.zim_operations, zim_file_path, tail, min_score=0.8
             )
-            if promoted is not None and _accept_possessive_promotion(promoted, topic):
+            if promoted is not None and accept_possessive_promotion(promoted, topic):
                 return promoted
         return None
 

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -27,6 +27,7 @@ from .responses import ToolErrorPayload, tool_error
 from .security import sanitize_context_for_error
 from .title_promotion import (
     _TOKEN_RE,
+    extract_possessor_tokens,
     find_title_match,
     has_apostrophe_possessive,
     is_strong_title_match,
@@ -117,6 +118,74 @@ _INFO_LEVEL_TELEMETRY_EVENTS: "frozenset[str]" = frozenset(
 _QUERY_REWRITE_MISSPELLING = "query_rewrite.misspelling"
 _QUERY_REWRITE_STOPWORD_PHRASE = "query_rewrite.stopword_phrase"
 _QUERY_REWRITE_X_OF_Y = "query_rewrite.x_of_y"
+
+
+# Post-b6 Z1: shared filter for ``_promote_topic_via_title_index``
+# (pass-0 + pass-3) and the synthesize-path ``_promote_title_match``
+# pass-0. Returns True iff ``promoted`` is safe to auto-fetch for the
+# given ``topic``.
+#
+# The libzim suggestion-search produces three relevant shapes at the
+# 0.95+ score band:
+#
+#   * ``match_type="direct"`` — exact-title hit (post-redirect title
+#     equals user input case-insensitively). Always safe.
+#   * ``match_type="redirect"`` — libzim found a redirect entry, and
+#     ``_follow_redirect_chain`` walked it to a canonical. SAFE iff
+#     the pre-redirect path is semantically related to the user's
+#     query — checked by requiring at least one possessor token to
+#     appear in the pre-redirect path's tokens. Otherwise UNSAFE: an
+#     associative redirect (some unrelated redirect entry whose
+#     destination happens to share a user token).
+#   * ``match_type="fuzzy_suggest"`` — libzim returned the canonical
+#     directly via token-prefix matching, no redirect walked. SAFE
+#     for non-possessive prose (``Berlin Germany`` → ``Berlin`` is
+#     the user's intent), UNSAFE for possessives (``Darwin's
+#     evolution`` → ``Evolution`` drops the possessor entirely —
+#     silent-wrong-answer cert=0.85).
+#
+# For non-possessive topics, all three shapes are accepted (the b4
+# improvements for ``<entity> <disambiguator>`` shapes are preserved).
+_POSSESSOR_PATH_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _accept_possessive_promotion(promoted: Dict[str, Any], topic: str) -> bool:
+    """Return True iff ``promoted`` is safe to auto-fetch for ``topic``.
+
+    See module-level comment above ``_POSSESSOR_PATH_TOKEN_RE`` for
+    the shape-by-shape acceptance matrix.
+    """
+    if not has_apostrophe_possessive(topic):
+        # Non-possessive: all three match_type shapes are safe; the
+        # b4 pass-0 win for ``<entity> <disambiguator>`` queries
+        # depends on this.
+        return True
+    match_type = promoted.get("match_type")
+    if match_type == "direct":
+        return True
+    if match_type == "fuzzy_suggest":
+        # Possessive + fuzzy_suggest — the D1 attack surface (Darwin's
+        # evolution → Evolution; Plato's republic philosophy →
+        # Philosophy). Reject.
+        return False
+    if match_type == "redirect":
+        # Possessive + redirect — accept only when the pre-redirect
+        # path is semantically related to the user's query. Probe:
+        # at least one possessor token appears in the pre-redirect
+        # path's tokens.
+        possessors = set(extract_possessor_tokens(topic))
+        if not possessors:
+            return True
+        pre_path = promoted.get("pre_redirect_path", "") or promoted.get("path", "")
+        pre_tokens = set(_POSSESSOR_PATH_TOKEN_RE.findall(pre_path.lower()))
+        # Accept iff any possessor appears verbatim as a token in the
+        # pre-redirect path. ``Plato's_cave`` → tokens contain
+        # ``plato`` → ACCEPT. ``Evolutionary_theory`` → no ``darwin``
+        # → REJECT.
+        return bool(possessors & pre_tokens)
+    # Unknown / missing match_type — backwards-compat for callers and
+    # mocks that don't annotate. Accept (legacy behaviour).
+    return True
 
 
 @dataclass
@@ -3918,37 +3987,8 @@ class SimpleToolsHandler:
         promoted = find_title_match(
             self.zim_operations, zim_file_path, topic, min_score=0.95
         )
-        # Post-b4 D1: reject ``fuzzy_suggest`` rows ONLY when the topic
-        # carries an apostrophe-possessive. The 0.95 suggestion-rank
-        # score covers three shapes:
-        #
-        #   * canonical redirect (``Plato's_cave`` →
-        #     ``Allegory_of_the_cave``, match_type=redirect — safe,
-        #     accepted unconditionally)
-        #   * exact-title direct hit (match_type=direct at score 1.0
-        #     via the suggestion path's exact_ci promotion — safe,
-        #     accepted unconditionally)
-        #   * fuzzy title-token prefix match (match_type=fuzzy_suggest
-        #     — meaning depends on the topic shape)
-        #
-        # For possessive prose (``Darwin's evolution`` → ``Evolution``
-        # at 0.95), the fuzzy_suggest match is structurally wrong —
-        # libzim's tokenized prefix index matched only the trailing
-        # word, dropping the possessor entirely (cert=0.85 silent-
-        # wrong-answer).
-        #
-        # For non-possessive prose (``Berlin Germany`` → ``Berlin``
-        # at 0.95), the fuzzy_suggest match IS the intended answer:
-        # libzim correctly resolved the first token to the article
-        # the user asked about, with the second token as a
-        # disambiguator. Pre-pass-2-audit my unconditional filter
-        # silently regressed this class — the refined gate keeps
-        # the b4 improvement for that shape while still solving the
-        # possessive silent-wrong-answer.
-        if promoted is not None:
-            is_fuzzy_suggest = promoted.get("match_type") == "fuzzy_suggest"
-            if not (is_fuzzy_suggest and has_apostrophe_possessive(topic)):
-                return promoted
+        if promoted is not None and _accept_possessive_promotion(promoted, topic):
+            return promoted
         # Post-b4 D2: when the topic carries an apostrophe-possessive
         # (``Plato's republic philosophy`` / ``Einstein's theory
         # history``), tighten the tail-iteration floor to ``min_len=2``
@@ -3982,10 +4022,8 @@ class SimpleToolsHandler:
             promoted = find_title_match(
                 self.zim_operations, zim_file_path, tail, min_score=0.8
             )
-            if promoted is not None:
-                is_fuzzy_suggest = promoted.get("match_type") == "fuzzy_suggest"
-                if not (is_fuzzy_suggest and has_apostrophe_possessive(topic)):
-                    return promoted
+            if promoted is not None and _accept_possessive_promotion(promoted, topic):
+                return promoted
         return None
 
     def _handle_tell_me_about(

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 from openzim_mcp import bundle as _bundle_mod
 from openzim_mcp.title_promotion import (
+    extract_possessor_tokens,
     find_title_match,
     has_apostrophe_possessive,
     is_strong_title_match,
@@ -871,6 +872,102 @@ def _do_per_archive_search(
     return per_archive_hits, archives_searched, archive_by_name
 
 
+# Post-b6 Z1: token regex for pre-redirect-path token-membership
+# check. Matches ASCII alphanumerics inside path forms like
+# ``Plato's_cave`` → tokens ``{"plato", "s", "cave"}``. Apostrophes
+# and underscores act as boundaries.
+_PRE_REDIRECT_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _accept_synthesize_possessive_promotion(promoted: dict, query: str) -> bool:
+    """Return True iff ``promoted`` is safe to auto-fetch for ``query``.
+
+    Synthesize-path mirror of
+    ``simple_tools._accept_possessive_promotion``. Kept here instead
+    of imported to avoid the synthesize → simple_tools circular
+    dependency (simple_tools handles the synthesize dispatch).
+
+    See the simple_tools helper's docstring for the shape-by-shape
+    acceptance matrix. Briefly:
+      * non-possessive queries: accept all match_types (preserves
+        the b4 non-possessive disambiguator wins).
+      * possessive + direct: accept (user typed an exact title).
+      * possessive + fuzzy_suggest: reject (D1 attack surface).
+      * possessive + redirect: accept iff a query possessor token
+        appears verbatim in the pre-redirect path's tokens (Z1).
+      * missing match_type: accept (backwards-compat with older
+        callers and test mocks).
+    """
+    if not has_apostrophe_possessive(query):
+        return True
+    match_type = promoted.get("match_type")
+    if match_type == "direct":
+        return True
+    if match_type == "fuzzy_suggest":
+        return False
+    if match_type == "redirect":
+        possessors = set(extract_possessor_tokens(query))
+        if not possessors:
+            return True
+        pre_path = promoted.get("pre_redirect_path", "") or promoted.get("path", "")
+        pre_tokens = set(_PRE_REDIRECT_TOKEN_RE.findall(pre_path.lower()))
+        return bool(possessors & pre_tokens)
+    return True
+
+
+def _build_pass0_promoted_hit(
+    full_probe: dict,
+    archive: Any,
+    title_match_hit: Any,
+) -> dict:
+    """Build a ``search_top_k``-shaped hit (``{path, snippet, score}``)
+    from a ``find_title_match`` result so downstream extraction and
+    score-based ranking handle the pass-0 promotion correctly.
+
+    Post-b6 Z2: pre-fix, ``_promote_title_match`` passed the raw
+    ``find_title_match`` dict (shape ``{path, title, zim_file,
+    match_type, pre_redirect_path}``) into ``top_hits``. Downstream
+    (``_extract_passages`` + ranking) reads ``snippet`` and ``score``
+    from each hit; the missing fields demoted the canonical to the
+    bottom of the citation list when it wasn't already in BM25
+    top_hits. The fix re-probes via ``title_match_hit`` using the
+    resolved title (which the fast-path lookup matches exactly now
+    that we know the canonical), so the resulting dict carries a
+    real snippet and score=1.0.
+
+    Falls back to a minimal hit (empty snippet, score=1.0) only if
+    the re-probe handler is missing or returns ``None`` — uncommon
+    in production (search_handler is always wired) but handles test
+    stubs and degraded paths gracefully.
+    """
+    full_path = str(full_probe.get("path") or "")
+    canonical_title = str(full_probe.get("title") or full_path.replace("_", " "))
+    if callable(title_match_hit):
+        try:
+            reprobed = title_match_hit(archive, canonical_title)
+        except Exception as exc:
+            logger.debug(
+                "_build_pass0_promoted_hit: title_match_hit re-probe failed "
+                "for %r: %s",
+                canonical_title,
+                exc,
+            )
+            reprobed = None
+        if isinstance(reprobed, dict) and str(reprobed.get("path") or "") == full_path:
+            # Re-probe landed on the same canonical — use its
+            # search_top_k shape directly.
+            return reprobed
+    # Fallback: minimal hit with the canonical path. Score=1.0 to
+    # match title_match_hit's promotion score; empty snippet lets
+    # downstream extraction fall back to the bundle's own lead text
+    # via the section-attribution path.
+    return {
+        "path": full_path,
+        "snippet": "",
+        "score": 1.0,
+    }
+
+
 def _promote_title_match(
     top_hits: list[tuple[str, dict]],
     *,
@@ -924,6 +1021,24 @@ def _promote_title_match(
     # suggestions at the same score (``Darwin's evolution`` ≈
     # ``Evolution``) so only canonical redirects are auto-promoted.
     #
+    # Post-b6 Z1: the filter also rejects ``match_type="redirect"``
+    # rows whose pre-redirect path doesn't share any possessor token
+    # with the query — catches the live-observed ``Plato's republic
+    # philosophy`` → ``Czech_philosophy`` shape where libzim's
+    # suggestion produces an associative redirect.
+    #
+    # Post-b6 Z2: the pass-0 insert must produce a ``search_top_k``-
+    # shaped hit (``{path, snippet, score}``) so downstream
+    # ranking/extraction picks the canonical at rank 1. The previous
+    # implementation passed the raw ``find_title_match`` dict (no
+    # ``snippet`` / ``score``) → downstream sort by score demoted
+    # the canonical to the bottom when it wasn't already in
+    # ``top_hits`` (the live ``Einstein's theory`` synthesize case
+    # surfaced ``Theory_of_relativity`` at rank 6 / score 0). The fix
+    # below re-probes via ``title_match_hit`` using the resolved
+    # title — that helper produces the right shape with a real
+    # snippet.
+    #
     # ``find_title_match`` expects a ``zim_operations``-shaped object
     # (it calls ``.find_entry_by_title_data`` on it). ``search_handler``
     # in production IS the ``ZimOperations`` instance — wired in
@@ -931,7 +1046,8 @@ def _promote_title_match(
     # ``search_handler=self.zim_operations``. The per-archive validated
     # path lives in the ``(archive, vp)`` tuple and is what
     # ``find_entry_by_title_data`` expects for the single-archive call.
-    for (_archive, vp), archive_name in zip(archives, archives_searched):
+    title_match_hit = getattr(search_handler, "title_match_hit", None)
+    for (archive, vp), archive_name in zip(archives, archives_searched):
         try:
             full_probe = find_title_match(
                 search_handler, str(vp), query, min_score=0.95
@@ -944,31 +1060,36 @@ def _promote_title_match(
                 e,
             )
             continue
-        if (
-            isinstance(full_probe, dict)
-            and full_probe.get("path")
-            and not (
-                full_probe.get("match_type") == "fuzzy_suggest"
-                and has_apostrophe_possessive(query)
+        if not (isinstance(full_probe, dict) and full_probe.get("path")):
+            continue
+        if not _accept_synthesize_possessive_promotion(full_probe, query):
+            continue
+        full_path = str(full_probe["path"])
+        existing_paths_p0 = {(name, str(h.get("path", ""))) for name, h in top_hits}
+        if (archive_name, full_path) in existing_paths_p0:
+            # Already in BM25 top_hits — reorder the existing
+            # properly-shaped entry to first.
+            reordered_p0: list[tuple[str, dict]] = [
+                (n, h)
+                for n, h in top_hits
+                if not (n == archive_name and str(h.get("path", "")) == full_path)
+            ]
+            promoted_hit_p0 = next(
+                h
+                for n, h in top_hits
+                if n == archive_name and str(h.get("path", "")) == full_path
             )
-        ):
-            full_path = str(full_probe["path"])
-            existing_paths_p0 = {(name, str(h.get("path", ""))) for name, h in top_hits}
-            if (archive_name, full_path) in existing_paths_p0:
-                reordered_p0: list[tuple[str, dict]] = [
-                    (n, h)
-                    for n, h in top_hits
-                    if not (n == archive_name and str(h.get("path", "")) == full_path)
-                ]
-                promoted_hit_p0 = next(
-                    h
-                    for n, h in top_hits
-                    if n == archive_name and str(h.get("path", "")) == full_path
-                )
-                return [(archive_name, promoted_hit_p0), *reordered_p0]
-            return [(archive_name, full_probe), *top_hits]
+            return [(archive_name, promoted_hit_p0), *reordered_p0]
+        # Not in top_hits — construct a properly-shaped hit. Re-probe
+        # via ``title_match_hit`` using the resolved title (which the
+        # fast-path lookup can match exactly now that we know the
+        # canonical), so the resulting dict carries ``snippet`` and
+        # ``score`` per the ``search_top_k`` shape.
+        promoted_hit_built: dict = _build_pass0_promoted_hit(
+            full_probe, archive, title_match_hit
+        )
+        return [(archive_name, promoted_hit_built), *top_hits]
 
-    title_match_hit = getattr(search_handler, "title_match_hit", None)
     if not callable(title_match_hit):
         return top_hits
 

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 from openzim_mcp import bundle as _bundle_mod
 from openzim_mcp.title_promotion import (
-    extract_possessor_tokens,
+    accept_possessive_promotion,
     find_title_match,
     has_apostrophe_possessive,
     is_strong_title_match,
@@ -872,49 +872,6 @@ def _do_per_archive_search(
     return per_archive_hits, archives_searched, archive_by_name
 
 
-# Post-b6 Z1: token regex for pre-redirect-path token-membership
-# check. Matches ASCII alphanumerics inside path forms like
-# ``Plato's_cave`` → tokens ``{"plato", "s", "cave"}``. Apostrophes
-# and underscores act as boundaries.
-_PRE_REDIRECT_TOKEN_RE = re.compile(r"[a-z0-9]+")
-
-
-def _accept_synthesize_possessive_promotion(promoted: dict, query: str) -> bool:
-    """Return True iff ``promoted`` is safe to auto-fetch for ``query``.
-
-    Synthesize-path mirror of
-    ``simple_tools._accept_possessive_promotion``. Kept here instead
-    of imported to avoid the synthesize → simple_tools circular
-    dependency (simple_tools handles the synthesize dispatch).
-
-    See the simple_tools helper's docstring for the shape-by-shape
-    acceptance matrix. Briefly:
-      * non-possessive queries: accept all match_types (preserves
-        the b4 non-possessive disambiguator wins).
-      * possessive + direct: accept (user typed an exact title).
-      * possessive + fuzzy_suggest: reject (D1 attack surface).
-      * possessive + redirect: accept iff a query possessor token
-        appears verbatim in the pre-redirect path's tokens (Z1).
-      * missing match_type: accept (backwards-compat with older
-        callers and test mocks).
-    """
-    if not has_apostrophe_possessive(query):
-        return True
-    match_type = promoted.get("match_type")
-    if match_type == "direct":
-        return True
-    if match_type == "fuzzy_suggest":
-        return False
-    if match_type == "redirect":
-        possessors = set(extract_possessor_tokens(query))
-        if not possessors:
-            return True
-        pre_path = promoted.get("pre_redirect_path", "") or promoted.get("path", "")
-        pre_tokens = set(_PRE_REDIRECT_TOKEN_RE.findall(pre_path.lower()))
-        return bool(possessors & pre_tokens)
-    return True
-
-
 def _build_pass0_promoted_hit(
     full_probe: dict,
     archive: Any,
@@ -1062,7 +1019,7 @@ def _promote_title_match(
             continue
         if not (isinstance(full_probe, dict) and full_probe.get("path")):
             continue
-        if not _accept_synthesize_possessive_promotion(full_probe, query):
+        if not accept_possessive_promotion(full_probe, query):
             continue
         full_path = str(full_probe["path"])
         existing_paths_p0 = {(name, str(h.get("path", ""))) for name, h in top_hits}

--- a/openzim_mcp/title_promotion.py
+++ b/openzim_mcp/title_promotion.py
@@ -244,8 +244,10 @@ _TAIL_TOKEN_RE = re.compile(r"[^\W_]+(?:['’][^\W_]+)*", re.UNICODE)
 # Inner character class is ``[^\W_]`` rather than ``[^\W_'’]`` because
 # apostrophes (both ASCII ``'`` and curly ``’``) are already excluded
 # by ``\W`` — listing them inside ``^\W`` is a redundant character
-# class member (SonarCloud S5869).
-_POSSESSIVE_TOKEN_RE = re.compile(r"([^\W_][^\W_]*)['’](?:s\b|\B)", re.UNICODE)
+# class member (SonarCloud S5869). The leading-letter + repeat is
+# expressed as a single ``[^\W_]+`` (S6353) — equivalent to the
+# previous ``[^\W_][^\W_]*`` two-class form.
+_POSSESSIVE_TOKEN_RE = re.compile(r"([^\W_]+)['’](?:s\b|\B)", re.UNICODE)
 
 
 def has_apostrophe_possessive(topic: str) -> bool:

--- a/openzim_mcp/title_promotion.py
+++ b/openzim_mcp/title_promotion.py
@@ -240,7 +240,12 @@ _TAIL_TOKEN_RE = re.compile(r"[^\W_]+(?:['’][^\W_]+)*", re.UNICODE)
 # out to check against a redirect's pre-resolution path. The
 # ``has_apostrophe_possessive`` predicate continues to use ``search``
 # on the same pattern — group 1 is harmless for existence checks.
-_POSSESSIVE_TOKEN_RE = re.compile(r"([^\W_][^\W_'’]*)['’](?:s\b|\B)", re.UNICODE)
+#
+# Inner character class is ``[^\W_]`` rather than ``[^\W_'’]`` because
+# apostrophes (both ASCII ``'`` and curly ``’``) are already excluded
+# by ``\W`` — listing them inside ``^\W`` is a redundant character
+# class member (SonarCloud S5869).
+_POSSESSIVE_TOKEN_RE = re.compile(r"([^\W_][^\W_]*)['’](?:s\b|\B)", re.UNICODE)
 
 
 def has_apostrophe_possessive(topic: str) -> bool:
@@ -280,6 +285,65 @@ def extract_possessor_tokens(topic: str) -> list[str]:
     if not topic:
         return []
     return [m.group(1).lower() for m in _POSSESSIVE_TOKEN_RE.finditer(topic)]
+
+
+def accept_possessive_promotion(promoted: Dict[str, Any], topic: str) -> bool:
+    """Return True iff ``promoted`` is safe to auto-fetch for ``topic``.
+
+    Shared filter used by both ``simple_tools._promote_topic_via_title_index``
+    (pass-0 + pass-3) and ``synthesize._promote_title_match`` pass-0 so
+    the two-mode tell-me-about/synthesize paths apply the SAME D1+Z1
+    safety logic. Lives here in ``title_promotion`` (not on either
+    handler) to keep ``simple_tools`` and ``synthesize`` decoupled from
+    each other — both already import from this module.
+
+    The libzim suggestion-search produces three relevant ``match_type``
+    shapes at the 0.95+ score band:
+
+      * ``"direct"`` — exact-title hit (post-redirect title equals
+        user input case-insensitively). Always safe.
+      * ``"redirect"`` — libzim found a redirect entry and
+        ``_follow_redirect_chain`` walked it to a canonical. SAFE iff
+        the pre-redirect path is semantically related to the user's
+        query — checked by requiring at least one possessor token to
+        appear in the pre-redirect path's tokens. Otherwise UNSAFE:
+        an associative redirect (some unrelated redirect entry whose
+        destination happens to share a user token — live observed for
+        ``"darwin's evolution"`` and ``"plato's republic philosophy"``
+        in the post-b6 sweep).
+      * ``"fuzzy_suggest"`` — libzim returned the canonical directly
+        via token-prefix matching, no redirect walked. SAFE for
+        non-possessive prose (``"Berlin Germany"`` → ``"Berlin"`` is
+        the user's intent), UNSAFE for possessives (``"Darwin's
+        evolution"`` → ``"Evolution"`` drops the possessor entirely
+        — silent-wrong-answer at cert=0.85).
+
+    For non-possessive topics, all three shapes are accepted — the b4
+    pass-0 improvements for ``<entity> <disambiguator>`` queries
+    depend on this.
+
+    Missing/unknown ``match_type`` is accepted for backwards-compat
+    with older callers and test mocks that don't annotate the row.
+    """
+    if not has_apostrophe_possessive(topic):
+        return True
+    match_type = promoted.get("match_type")
+    if match_type == "direct":
+        return True
+    if match_type == "fuzzy_suggest":
+        return False
+    if match_type == "redirect":
+        possessors = set(extract_possessor_tokens(topic))
+        if not possessors:
+            return True
+        pre_path = promoted.get("pre_redirect_path", "") or promoted.get("path", "")
+        # ``_TOKEN_RE`` is the same ASCII-alphanumerics tokenizer
+        # ``is_strong_title_match`` uses, so possessor-vs-pre-path
+        # comparison stays symmetric with the rest of the title-
+        # promotion pipeline.
+        pre_tokens = set(_TOKEN_RE.findall(pre_path.lower()))
+        return bool(possessors & pre_tokens)
+    return True
 
 
 def iter_query_tails(

--- a/openzim_mcp/title_promotion.py
+++ b/openzim_mcp/title_promotion.py
@@ -177,6 +177,21 @@ def find_title_match(
     match_type = top.get("match_type")
     if match_type:
         result["match_type"] = str(match_type)
+    # Post-b6 Z1: propagate ``pre_redirect_path`` so callers can
+    # detect "associative" redirects — libzim's suggestion-search
+    # sometimes returns a row whose pre-redirect path is unrelated to
+    # the user's possessor entity (the path libzim found via fuzzy
+    # token-prefix matching just happens to walk through a redirect
+    # to a canonical that shares one user-typed token). The D1 filter
+    # on possessive topics uses this to distinguish semantic redirects
+    # (``Plato's_cave`` → ``Allegory_of_the_cave`` — pre-path
+    # contains the possessor ``plato``) from associative ones
+    # (some unrelated-redirect → ``Evolution`` for a
+    # ``darwin's evolution`` query). Field is optional; older callers
+    # that don't set it pass through transparently.
+    pre_redirect_path = top.get("pre_redirect_path")
+    if pre_redirect_path:
+        result["pre_redirect_path"] = str(pre_redirect_path)
     return result
 
 
@@ -219,7 +234,13 @@ _TAIL_TOKEN_RE = re.compile(r"[^\W_]+(?:['’][^\W_]+)*", re.UNICODE)
 # ``"history"`` → ``History``, ``"tourism"`` → ``Tourism``) for
 # prose-with-possessive queries where the full topic isn't canonical.
 # Matches ``X's``, ``X’s``, ``Achilles'`` (bare trailing apostrophe).
-_POSSESSIVE_TOKEN_RE = re.compile(r"[^\W_][^\W_'’]*['’](?:s\b|\B)", re.UNICODE)
+#
+# Post-b6 Z1: the regex now captures the possessor token (before the
+# apostrophe) as group 1, so ``extract_possessor_tokens`` can pull it
+# out to check against a redirect's pre-resolution path. The
+# ``has_apostrophe_possessive`` predicate continues to use ``search``
+# on the same pattern — group 1 is harmless for existence checks.
+_POSSESSIVE_TOKEN_RE = re.compile(r"([^\W_][^\W_'’]*)['’](?:s\b|\B)", re.UNICODE)
 
 
 def has_apostrophe_possessive(topic: str) -> bool:
@@ -232,6 +253,33 @@ def has_apostrophe_possessive(topic: str) -> bool:
     if not topic:
         return False
     return bool(_POSSESSIVE_TOKEN_RE.search(topic))
+
+
+def extract_possessor_tokens(topic: str) -> list[str]:
+    """Return the lowercased possessor tokens in ``topic``.
+
+    For each ``X's`` / ``X'`` / ``X’s`` shape in the topic, the
+    possessor is the bare token before the apostrophe. ``Plato's
+    cave`` yields ``["plato"]``; ``John's and Mary's books`` yields
+    ``["john", "mary"]``; ``Berlin Germany`` yields ``[]``.
+
+    Post-b6 Z1 helper: the D1 filter in
+    ``_promote_topic_via_title_index`` and ``_promote_title_match``
+    uses these tokens to detect "associative" redirects — libzim's
+    suggestion-search occasionally returns a result via a redirect
+    chain whose pre-resolution path is unrelated to the user's
+    possessor entity (e.g., ``"darwin's evolution"`` → some unrelated
+    redirect → ``Evolution``). When NONE of the possessor tokens
+    appear in the pre-redirect path's tokens, the redirect is
+    classified as associative-not-semantic and rejected.
+
+    Returns an empty list when the topic has no possessive shape.
+    Order follows left-to-right occurrence in the topic; duplicates
+    are preserved so callers that want a set can ``set(...)``-wrap.
+    """
+    if not topic:
+        return []
+    return [m.group(1).lower() for m in _POSSESSIVE_TOKEN_RE.finditer(topic)]
 
 
 def iter_query_tails(

--- a/openzim_mcp/title_promotion.py
+++ b/openzim_mcp/title_promotion.py
@@ -245,9 +245,16 @@ _TAIL_TOKEN_RE = re.compile(r"[^\W_]+(?:['’][^\W_]+)*", re.UNICODE)
 # apostrophes (both ASCII ``'`` and curly ``’``) are already excluded
 # by ``\W`` — listing them inside ``^\W`` is a redundant character
 # class member (SonarCloud S5869). The leading-letter + repeat is
-# expressed as a single ``[^\W_]+`` (S6353) — equivalent to the
-# previous ``[^\W_][^\W_]*`` two-class form.
-_POSSESSIVE_TOKEN_RE = re.compile(r"([^\W_]+)['’](?:s\b|\B)", re.UNICODE)
+# expressed as a single ``[^\W_]+`` (S6353).
+#
+# The quantifier is bounded ``{1,64}`` rather than unbounded ``+`` so
+# the static analyzer can prove linear-time worst case (SonarCloud
+# S5852 ReDoS): the engine can backtrack at most 64 positions per
+# apostrophe character — well above any natural-language possessor
+# token length (longest English name in common use is well under
+# 30 chars). Same mitigation pattern as the post-a22 sweep's
+# ``[\s\S]+?for ...`` rewrite (commit 63dac8a).
+_POSSESSIVE_TOKEN_RE = re.compile(r"([^\W_]{1,64})['’](?:s\b|\B)", re.UNICODE)
 
 
 def has_apostrophe_possessive(topic: str) -> bool:

--- a/openzim_mcp/tool_schemas.py
+++ b/openzim_mcp/tool_schemas.py
@@ -53,6 +53,14 @@ class FindEntryHit(TypedDict):
     score: float
     zim_file: NotRequired[str]
     match_type: NotRequired[str]
+    # Post-b6 Z1: the path emitted by libzim's suggestion search /
+    # fast-path lookup BEFORE ``_follow_redirect_chain`` resolved it
+    # to the canonical. Equals ``path`` when no redirect was walked;
+    # differs when ``match_type == "redirect"``. Callers using the
+    # 0.95 gate check whether the user's query tokens (especially
+    # possessor tokens) appear in this pre-redirect path to filter
+    # associative-not-semantic redirects.
+    pre_redirect_path: NotRequired[str]
 
 
 class SuggestionItem(TypedDict):

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -2765,6 +2765,10 @@ class _SearchMixin:
                         # Post-b4 D1: capture the pre-redirect path so we
                         # can annotate ``match_type`` with whether the
                         # canonical lookup actually walked a redirect.
+                        # Post-b6 Z1: propagate the pre-redirect path
+                        # itself in the result row so the D1 filter can
+                        # check whether the redirect target is
+                        # semantically related to the user's query.
                         fast_pre_path = getattr(fast_hit_entry, "path", None)
                         fast_hit_entry = self._follow_redirect_chain(fast_hit_entry)
                         fast_post_path = getattr(fast_hit_entry, "path", None)
@@ -2778,6 +2782,7 @@ class _SearchMixin:
                                 "score": 1.0,
                                 "zim_file": file_path,
                                 "match_type": fast_match_type,
+                                "pre_redirect_path": str(fast_pre_path or ""),
                             }
                         )
                         fast_path_hit = True
@@ -2853,6 +2858,16 @@ class _SearchMixin:
                                         "score": score,
                                         "zim_file": file_path,
                                         "match_type": match_type,
+                                        # Post-b6 Z1: propagate the
+                                        # pre-redirect path so the D1
+                                        # filter on possessive topics
+                                        # can detect associative
+                                        # redirects (pre-path unrelated
+                                        # to the user's possessor
+                                        # entity).
+                                        "pre_redirect_path": str(
+                                            suggest_pre_path or ""
+                                        ),
                                     }
                                 )
                     except Exception as e:

--- a/tests/data/goldens/v2_phase_b/find_einstein.json
+++ b/tests/data/goldens/v2_phase_b/find_einstein.json
@@ -16,6 +16,7 @@
     {
       "match_type": "direct",
       "path": "A/Einstein",
+      "pre_redirect_path": "A/Einstein",
       "score": 1.0,
       "title": "Einstein"
     }

--- a/tests/test_post_b4_beta_fixes.py
+++ b/tests/test_post_b4_beta_fixes.py
@@ -620,6 +620,12 @@ class TestSynthesizePromoteFullTopicProbe:
                     "title": "Theory of relativity",
                     "zim_file": "wiki",
                     "match_type": "redirect",
+                    # Post-b6 Z1: the synthesize filter rejects
+                    # redirects whose pre-resolution path doesn't
+                    # share a possessor token with the query. The
+                    # live ``Einstein's_theory`` redirect entry
+                    # carries the possessor ``einstein`` → ACCEPT.
+                    "pre_redirect_path": "Einstein's_theory",
                 }
             return None
 
@@ -789,13 +795,16 @@ class TestRegressionGuards:
     def test_promote_function_has_pass_0_match_type_filter(self) -> None:
         """Structural pin: ``_promote_topic_via_title_index`` must
         check ``match_type`` against ``"fuzzy_suggest"`` before
-        accepting the pass-0 result. If a refactor removes this
-        check, the b4 D1 regression returns."""
+        accepting the pass-0 result. Post-b6 Z1: the check moved into
+        the shared ``_accept_possessive_promotion`` helper; this
+        guard now greps the helper's source instead of the method
+        body. If a refactor removes this check, the b4 D1 regression
+        returns."""
         import inspect
 
-        from openzim_mcp.simple_tools import SimpleToolsHandler
+        from openzim_mcp import simple_tools
 
-        source = inspect.getsource(SimpleToolsHandler._promote_topic_via_title_index)
+        source = inspect.getsource(simple_tools._accept_possessive_promotion)
         assert '"fuzzy_suggest"' in source or "'fuzzy_suggest'" in source, (
             "_promote_topic_via_title_index must filter fuzzy_suggest " "at pass-0"
         )

--- a/tests/test_post_b4_beta_fixes.py
+++ b/tests/test_post_b4_beta_fixes.py
@@ -796,15 +796,16 @@ class TestRegressionGuards:
         """Structural pin: ``_promote_topic_via_title_index`` must
         check ``match_type`` against ``"fuzzy_suggest"`` before
         accepting the pass-0 result. Post-b6 Z1: the check moved into
-        the shared ``_accept_possessive_promotion`` helper; this
-        guard now greps the helper's source instead of the method
-        body. If a refactor removes this check, the b4 D1 regression
-        returns."""
+        the shared ``title_promotion.accept_possessive_promotion``
+        helper (single source of truth for both simple_tools and
+        synthesize); this guard now greps the shared helper's source
+        instead of the method body. If a refactor removes this check,
+        the b4 D1 regression returns."""
         import inspect
 
-        from openzim_mcp import simple_tools
+        from openzim_mcp import title_promotion
 
-        source = inspect.getsource(simple_tools._accept_possessive_promotion)
+        source = inspect.getsource(title_promotion.accept_possessive_promotion)
         assert '"fuzzy_suggest"' in source or "'fuzzy_suggest'" in source, (
             "_promote_topic_via_title_index must filter fuzzy_suggest " "at pass-0"
         )

--- a/tests/test_post_b6_beta_fixes.py
+++ b/tests/test_post_b6_beta_fixes.py
@@ -376,9 +376,9 @@ class TestSynthesizePass0InsertShape:
             "pass-0 insert must include ``score`` field for "
             "downstream score-based sorting — see Z2"
         )
-        assert top_hit["score"] >= 1.0, (
-            f"pass-0 insert score must be 1.0 (highest); got " f"{top_hit.get('score')}"
-        )
+        assert (
+            top_hit["score"] >= 1.0
+        ), f"pass-0 insert score must be 1.0 (highest); got {top_hit.get('score')}"
 
     def test_fallback_to_minimal_hit_when_reprobe_misses(self) -> None:
         """If ``title_match_hit`` re-probe misses (e.g., the fast-path
@@ -461,29 +461,23 @@ class TestRegressionGuards:
         assert hasattr(title_promotion, "extract_possessor_tokens")
 
     def test_promote_function_filter_checks_pre_redirect_path(self) -> None:
-        """Structural pin: the filter helper consulted by
-        ``_promote_topic_via_title_index`` (pass-0 + pass-3) must
+        """Structural pin: the shared filter
+        ``title_promotion.accept_possessive_promotion`` consulted by
+        both ``simple_tools._promote_topic_via_title_index`` (pass-0 +
+        pass-3) and ``synthesize._promote_title_match`` (pass-0) must
         reference ``pre_redirect_path`` so an associative redirect on
         a possessive topic is rejected. The helper lives in
-        ``simple_tools`` as ``_accept_possessive_promotion`` and
-        ``synthesize`` as ``_accept_synthesize_possessive_promotion``."""
+        ``title_promotion`` (single source of truth — fixes the
+        post-b6 sweep-CI Sonar duplication finding)."""
         import inspect
 
-        from openzim_mcp import simple_tools, synthesize
+        from openzim_mcp import title_promotion
 
-        simple_source = inspect.getsource(simple_tools._accept_possessive_promotion)
-        assert "pre_redirect_path" in simple_source, (
-            "simple_tools._accept_possessive_promotion must consult "
+        source = inspect.getsource(title_promotion.accept_possessive_promotion)
+        assert "pre_redirect_path" in source, (
+            "title_promotion.accept_possessive_promotion must consult "
             "pre_redirect_path to reject associative redirects on "
             "possessive topics — see Z1"
-        )
-        synth_source = inspect.getsource(
-            synthesize._accept_synthesize_possessive_promotion
-        )
-        assert "pre_redirect_path" in synth_source, (
-            "synthesize._accept_synthesize_possessive_promotion must "
-            "consult pre_redirect_path to reject associative redirects "
-            "on possessive topics — see Z1"
         )
 
     def test_synthesize_pass_0_constructs_proper_shape(self) -> None:

--- a/tests/test_post_b6_beta_fixes.py
+++ b/tests/test_post_b6_beta_fixes.py
@@ -31,57 +31,153 @@ when the redirect target is unrelated to the user's possessive entity:
 
 The fix: tighten the filter to also reject ``redirect`` rows whose
 PRE-redirect path doesn't contain any of the topic's possessor
-tokens. For ``Plato's_cave`` → ``Allegory_of_the_cave``, the
-pre-redirect path is ``Plato's_cave`` whose tokens contain ``plato``
-(the possessor) → ACCEPT. For ``Darwin's evolution`` → some
-unrelated-redirect-path → ``Evolution``, the pre-redirect path tokens
-don't contain ``darwin`` → REJECT.
-
-Implementation:
-- ``find_entry_by_title_data`` annotates each result row with
-  ``pre_redirect_path`` (the path libzim's suggest emitted before
-  ``_follow_redirect_chain`` resolved it).
-- ``find_title_match`` propagates ``pre_redirect_path``.
-- New ``extract_possessor_tokens(topic)`` helper extracts the bare
-  possessor token from each ``X's``/``X'`` shape (e.g.,
-  ``"Plato's cave"`` → ``["plato"]``; ``"John's and Mary's books"``
-  → ``["john", "mary"]``).
-- The D1 filter in ``_promote_topic_via_title_index`` (pass-0 +
-  pass-3) and ``_promote_title_match`` (synthesize pass-0) rejects
-  when ``match_type ∈ {fuzzy_suggest, redirect}`` AND the topic has
-  a possessive AND the pre-redirect path's tokens contain NONE of
-  the possessor tokens.
+tokens. The shared filter lives in ``title_promotion`` as
+``accept_possessive_promotion`` and is consulted by both the simple-
+mode pass-0/pass-3 and the synthesize-mode pass-0.
 
 ## Z2 — Synthesize pass-0 produces malformed insert when canonical isn't in BM25 top hits
 
-``_promote_title_match`` in ``synthesize.py:_promote_title_match``
-inserts the raw ``find_title_match`` dict (shape
-``{path, title, zim_file, match_type, ...}``) into ``top_hits``,
-which expects the ``search_top_k`` shape
+``_promote_title_match`` in ``synthesize.py`` previously inserted the
+raw ``find_title_match`` dict (shape ``{path, title, zim_file,
+match_type, pre_redirect_path}``) into ``top_hits``, which expects
 ``{path, snippet, score}``. When the canonical IS in ``top_hits``
-already (the reorder branch), the existing properly-shaped entry is
-moved to first. But when the canonical is NOT in ``top_hits`` (no
-intersection with BM25), the malformed insert leaks through →
-downstream score-sort demotes it to the bottom because ``score`` is
-missing.
+already (the reorder branch), the existing properly-shaped entry was
+moved to first. But when the canonical was NOT in ``top_hits``, the
+malformed insert leaked through → downstream score-sort demoted it
+to the bottom.
 
-Live impact: ``Einstein's theory`` via ``synthesize=true`` returns
-``Theory_of_relativity`` at rank 6 with score 0 (instead of rank 1).
-``Plato's cave`` happens to work because ``Allegory_of_the_cave``
-IS in BM25 top hits (the reorder branch fires).
+Live impact: ``Einstein's theory`` via ``synthesize=true`` returned
+``Theory_of_relativity`` at rank 6 with score 0. Plato's cave worked
+because Allegory_of_the_cave WAS in BM25 top hits.
 
-The fix: when ``find_title_match`` accepts a pass-0 promotion, re-probe
-via ``search_handler.title_match_hit(archive, full_probe.title)`` to
-produce a ``{path, snippet, score: 1.0}`` shaped hit. If the
-title_match_hit re-probe misses (rare — only when fast-path can't
-find the resolved title), fall back to constructing the minimal hit
-with the canonical title's lead text as the snippet.
+The fix: re-probe via ``search_handler.title_match_hit(archive,
+full_probe.title)`` to produce a ``{path, snippet, score: 1.0}``
+shape; fall back to ``{path, snippet: "", score: 1.0}`` when the
+re-probe handler misses (test stubs / degraded paths).
 """
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Shared fixtures / mock-builders.
+#
+# Several tests share the same scaffold: a stub ``SimpleToolsHandler``-shaped
+# object, a fake ``find_title_match`` driven by a ``{topic: result}``
+# mapping, and a synthesize ``search_handler`` whose ``title_match_hit`` is
+# also mapping-driven. Extract them once at module scope so each test only
+# carries the per-case mapping / assertions — reduces noise AND fixes the
+# Sonar new-code-duplication finding from the pass-1 push.
+# ---------------------------------------------------------------------------
+
+
+def _make_simple_handler() -> Any:
+    """Return a stub ``SimpleToolsHandler``-shaped object suitable for
+    calling ``_promote_topic_via_title_index`` unbound."""
+
+    class _StubOps:
+        pass
+
+    class _Handler:
+        zim_operations = _StubOps()
+
+    return _Handler()
+
+
+def _archive_stub() -> Any:
+    """Lightweight stub for libzim ``Archive`` — only needs identity
+    for ``zip(archives, archives_searched)`` iteration in synthesize."""
+
+    class _Archive:
+        pass
+
+    return _Archive()
+
+
+def _fake_find_title_match(
+    mapping: Dict[str, Optional[Dict[str, Any]]],
+    *,
+    min_score_floor: float = 0.0,
+) -> Callable[..., Optional[Dict[str, Any]]]:
+    """Build a ``find_title_match`` stand-in from ``{topic_lower: row}``.
+
+    Returns the mapped row when ``topic.lower()`` is a key AND the
+    caller's ``min_score`` is at or below ``min_score_floor`` (default
+    0.0 = no threshold check). Each test passes ``min_score_floor=0.95``
+    when it wants the stub to mimic the libzim suggestion-rank cap
+    (rows at score 0.95 only visible when caller requests ≤ 0.95).
+    """
+
+    def fake(
+        zim_ops: Any,
+        zim_file_path: str,
+        topic: str,
+        *,
+        cross_file: bool = False,
+        min_score: float = 1.0,
+    ) -> Optional[Dict[str, Any]]:
+        if min_score > min_score_floor and min_score_floor > 0.0:
+            return None
+        return mapping.get(topic.lower())
+
+    return fake
+
+
+def _fake_title_match_hit(
+    mapping: Dict[str, Optional[Dict[str, Any]]],
+) -> Callable[[Any, str], Optional[Dict[str, Any]]]:
+    """Build a ``title_match_hit`` stand-in from ``{title_lower: row}``."""
+
+    def fake(archive: Any, title: str) -> Optional[Dict[str, Any]]:
+        return mapping.get(title.lower())
+
+    return fake
+
+
+def _run_promote_simple(
+    topic: str, fake_find: Callable[..., Optional[Dict[str, Any]]]
+) -> Optional[Dict[str, Any]]:
+    """Drive ``SimpleToolsHandler._promote_topic_via_title_index`` with
+    ``fake_find`` patched at the import site."""
+    from openzim_mcp.simple_tools import SimpleToolsHandler
+
+    with patch("openzim_mcp.simple_tools.find_title_match", side_effect=fake_find):
+        return SimpleToolsHandler._promote_topic_via_title_index(
+            _make_simple_handler(),
+            "test.zim",
+            topic,
+        )
+
+
+def _run_promote_synthesize(
+    query: str,
+    fake_find: Callable[..., Optional[Dict[str, Any]]],
+    *,
+    title_match_hit: Optional[Callable[[Any, str], Optional[Dict[str, Any]]]] = None,
+    top_hits: Optional[List[tuple[str, Dict[str, Any]]]] = None,
+) -> List[tuple[str, Dict[str, Any]]]:
+    """Drive ``synthesize._promote_title_match`` with the given fakes."""
+    from openzim_mcp.synthesize import _promote_title_match
+
+    handler = MagicMock()
+    handler.title_match_hit = title_match_hit or (lambda _a, _q: None)
+    with patch("openzim_mcp.synthesize.find_title_match", side_effect=fake_find):
+        return _promote_title_match(
+            top_hits or [],
+            query=query,
+            archives=[(_archive_stub(), "/wiki.zim")],
+            archives_searched=["wiki"],
+            search_handler=handler,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
 
 
 class TestPreRedirectPathPropagation:
@@ -134,39 +230,30 @@ class TestPossessorTokenExtraction:
     """``extract_possessor_tokens`` extracts the bare possessor from
     each ``X's`` / ``X'`` shape in the topic."""
 
-    def test_simple_possessive(self) -> None:
+    @pytest.mark.parametrize(
+        "topic, expected",
+        [
+            # Simple possessives
+            ("Plato's cave", ["plato"]),
+            ("Darwin's evolution", ["darwin"]),
+            ("Einstein's theory", ["einstein"]),
+            # Multiple possessives in one query
+            ("John's and Mary's books", ["john", "mary"]),
+            # Trailing apostrophe without 's
+            ("Achilles' heel", ["achilles"]),
+            # Curly apostrophe
+            ("Einstein’s theory", ["einstein"]),
+            # No possessive — names with apostrophes are not possessors
+            ("Berlin Germany", []),
+            ("Apollo 11", []),
+            ("O'Brien", []),
+            ("d'Artagnan", []),
+        ],
+    )
+    def test_extraction(self, topic: str, expected: List[str]) -> None:
         from openzim_mcp.title_promotion import extract_possessor_tokens
 
-        assert extract_possessor_tokens("Plato's cave") == ["plato"]
-        assert extract_possessor_tokens("Darwin's evolution") == ["darwin"]
-        assert extract_possessor_tokens("Einstein's theory") == ["einstein"]
-
-    def test_multiple_possessives(self) -> None:
-        from openzim_mcp.title_promotion import extract_possessor_tokens
-
-        tokens = extract_possessor_tokens("John's and Mary's books")
-        assert tokens == ["john", "mary"]
-
-    def test_trailing_apostrophe(self) -> None:
-        """``Achilles'`` (trailing apostrophe without 's') is a
-        possessor."""
-        from openzim_mcp.title_promotion import extract_possessor_tokens
-
-        assert extract_possessor_tokens("Achilles' heel") == ["achilles"]
-
-    def test_curly_apostrophe(self) -> None:
-        from openzim_mcp.title_promotion import extract_possessor_tokens
-
-        assert extract_possessor_tokens("Einstein’s theory") == ["einstein"]
-
-    def test_no_possessive(self) -> None:
-        from openzim_mcp.title_promotion import extract_possessor_tokens
-
-        assert extract_possessor_tokens("Berlin Germany") == []
-        assert extract_possessor_tokens("Apollo 11") == []
-        # ``O'Brien`` and ``d'Artagnan`` are names, not possessives.
-        assert extract_possessor_tokens("O'Brien") == []
-        assert extract_possessor_tokens("d'Artagnan") == []
+        assert extract_possessor_tokens(topic) == expected
 
 
 class TestRedirectFilterRejectsUnrelatedRedirect:
@@ -176,117 +263,78 @@ class TestRedirectFilterRejectsUnrelatedRedirect:
     libzim's suggest produces an associative redirect to an unrelated
     canonical."""
 
-    def _make_handler(self) -> Any:
-        class _StubOps:
-            pass
-
-        class _Handler:
-            zim_operations = _StubOps()
-
-        return _Handler()
-
-    def test_rejects_redirect_with_unrelated_pre_path(self) -> None:
-        """Live repro: ``darwin's evolution`` → some-unrelated-redirect
-        → ``Evolution``. Pre-redirect path doesn't contain ``darwin``
-        → filter REJECTS."""
-        from openzim_mcp.simple_tools import SimpleToolsHandler
-
-        def fake(
-            zim_ops: Any,
-            zim_file_path: str,
-            topic: str,
-            *,
-            cross_file: bool = False,
-            min_score: float = 1.0,
-        ) -> Optional[Dict[str, Any]]:
-            if topic.lower() == "darwin's evolution" and min_score <= 0.95:
-                # Simulate libzim returning a redirect that walks to
-                # Evolution but whose pre-redirect path doesn't
-                # contain the possessor token "darwin".
-                return {
-                    "path": "Evolution",
-                    "title": "Evolution",
-                    "zim_file": "test.zim",
-                    "match_type": "redirect",
-                    "pre_redirect_path": "Evolutionary_theory",
-                }
-            return None
-
-        with patch("openzim_mcp.simple_tools.find_title_match", side_effect=fake):
-            result = SimpleToolsHandler._promote_topic_via_title_index(
-                self._make_handler(),
-                "test.zim",
+    @pytest.mark.parametrize(
+        "topic, mapping, expected_path",
+        [
+            # Z1 repro: redirect to ``Evolution`` via an unrelated
+            # pre-redirect path. ``darwin`` not in pre-path tokens →
+            # filter REJECTS → no promotion → returns None.
+            (
                 "darwin's evolution",
-            )
-        assert result is None, (
-            f"redirect with unrelated pre-path must be rejected for "
-            f"possessive topics; got {result!r}"
-        )
-
-    def test_accepts_redirect_with_possessor_in_pre_path(self) -> None:
-        """Live invariant: ``plato's cave`` → ``Plato's_cave`` redirect
-        → ``Allegory_of_the_cave``. Pre-redirect path ``Plato's_cave``
-        tokens contain ``plato`` → filter ACCEPTS."""
-        from openzim_mcp.simple_tools import SimpleToolsHandler
-
-        def fake(
-            zim_ops: Any,
-            zim_file_path: str,
-            topic: str,
-            *,
-            cross_file: bool = False,
-            min_score: float = 1.0,
-        ) -> Optional[Dict[str, Any]]:
-            if topic.lower() == "plato's cave" and min_score <= 0.95:
-                return {
-                    "path": "Allegory_of_the_cave",
-                    "title": "Allegory of the cave",
-                    "zim_file": "test.zim",
-                    "match_type": "redirect",
-                    "pre_redirect_path": "Plato's_cave",
-                }
-            return None
-
-        with patch("openzim_mcp.simple_tools.find_title_match", side_effect=fake):
-            result = SimpleToolsHandler._promote_topic_via_title_index(
-                self._make_handler(),
-                "test.zim",
+                {
+                    "darwin's evolution": {
+                        "path": "Evolution",
+                        "title": "Evolution",
+                        "zim_file": "test.zim",
+                        "match_type": "redirect",
+                        "pre_redirect_path": "Evolutionary_theory",
+                    }
+                },
+                None,
+            ),
+            # Live invariant: ``Plato's_cave`` redirect entry → walks to
+            # ``Allegory_of_the_cave``. Pre-redirect path tokens contain
+            # ``plato`` → filter ACCEPTS.
+            (
                 "plato's cave",
-            )
-        assert result is not None
-        assert result["path"] == "Allegory_of_the_cave"
-
-    def test_accepts_direct_match_unconditionally(self) -> None:
-        """``match_type="direct"`` is always accepted — the user's
-        exact title is canonical. No possessor-token check needed."""
-        from openzim_mcp.simple_tools import SimpleToolsHandler
-
-        def fake(
-            zim_ops: Any,
-            zim_file_path: str,
-            topic: str,
-            *,
-            cross_file: bool = False,
-            min_score: float = 1.0,
-        ) -> Optional[Dict[str, Any]]:
-            if topic.lower() == "hubble's law":
-                return {
-                    "path": "Hubble's_law",
-                    "title": "Hubble's law",
-                    "zim_file": "test.zim",
-                    "match_type": "direct",
-                    "pre_redirect_path": "Hubble's_law",
-                }
-            return None
-
-        with patch("openzim_mcp.simple_tools.find_title_match", side_effect=fake):
-            result = SimpleToolsHandler._promote_topic_via_title_index(
-                self._make_handler(),
-                "test.zim",
+                {
+                    "plato's cave": {
+                        "path": "Allegory_of_the_cave",
+                        "title": "Allegory of the cave",
+                        "zim_file": "test.zim",
+                        "match_type": "redirect",
+                        "pre_redirect_path": "Plato's_cave",
+                    }
+                },
+                "Allegory_of_the_cave",
+            ),
+            # ``match_type="direct"`` is always accepted — the user's
+            # exact title is canonical. No possessor-token check.
+            (
                 "Hubble's law",
-            )
-        assert result is not None
-        assert result["path"] == "Hubble's_law"
+                {
+                    "hubble's law": {
+                        "path": "Hubble's_law",
+                        "title": "Hubble's law",
+                        "zim_file": "test.zim",
+                        "match_type": "direct",
+                        "pre_redirect_path": "Hubble's_law",
+                    }
+                },
+                "Hubble's_law",
+            ),
+        ],
+        ids=[
+            "rejects_redirect_with_unrelated_pre_path",
+            "accepts_redirect_with_possessor_in_pre_path",
+            "accepts_direct_match_unconditionally",
+        ],
+    )
+    def test_filter(
+        self,
+        topic: str,
+        mapping: Dict[str, Dict[str, Any]],
+        expected_path: Optional[str],
+    ) -> None:
+        result = _run_promote_simple(
+            topic, _fake_find_title_match(mapping, min_score_floor=0.95)
+        )
+        if expected_path is None:
+            assert (
+                result is None
+            ), f"filter must reject for topic={topic!r}; got {result!r}"
+        else:
+            assert result is not None and result["path"] == expected_path
 
 
 class TestSynthesizePass0InsertShape:
@@ -294,73 +342,51 @@ class TestSynthesizePass0InsertShape:
     inserts (``{path, snippet, score}``) so downstream score-based
     sorting doesn't demote the canonical to the bottom."""
 
+    # Shared mapping the synthesize pass-0 sees for ``Einstein's theory``
+    # → ``Theory_of_relativity`` (a redirect-walked canonical).
+    _EINSTEIN_FIND_MAPPING: Dict[str, Dict[str, Any]] = {
+        "einstein's theory": {
+            "path": "Theory_of_relativity",
+            "title": "Theory of relativity",
+            "zim_file": "wiki",
+            "match_type": "redirect",
+            "pre_redirect_path": "Einstein's_theory",
+        }
+    }
+
     def test_promoted_hit_has_search_top_k_shape(self) -> None:
         """``Einstein's theory`` via synthesize → pass-0 inserts
         ``Theory_of_relativity``. The insert must have ``snippet`` and
         ``score`` fields so it survives downstream ranking."""
-        from openzim_mcp.synthesize import _promote_title_match
-
-        class _Archive:
-            pass
-
-        archive_obj = _Archive()
-
-        def fake_title_match_hit(archive: Any, title: str) -> Optional[Dict[str, Any]]:
-            # The re-probe after pass-0 accept: looks up the resolved
-            # title via fast path and returns the ``search_top_k`` shape.
-            if title.lower() == "theory of relativity":
-                return {
+        # title_match_hit re-probe lands the resolved title via fast
+        # path → returns ``{path, snippet, score: 1.0}``.
+        title_match_hit = _fake_title_match_hit(
+            {
+                "theory of relativity": {
                     "path": "Theory_of_relativity",
                     "snippet": "The theory of relativity comprises two...",
                     "score": 1.0,
                 }
-            return None
-
-        def fake_find_title_match(
-            zim_ops: Any,
-            zim_file_path: str,
-            topic: str,
-            *,
-            cross_file: bool = False,
-            min_score: float = 1.0,
-        ) -> Optional[Dict[str, Any]]:
-            if topic.lower() == "einstein's theory":
-                return {
-                    "path": "Theory_of_relativity",
-                    "title": "Theory of relativity",
-                    "zim_file": "wiki",
-                    "match_type": "redirect",
-                    "pre_redirect_path": "Einstein's_theory",
-                }
-            return None
-
-        handler = MagicMock()
-        handler.title_match_hit = fake_title_match_hit
-
-        with patch(
-            "openzim_mcp.synthesize.find_title_match",
-            side_effect=fake_find_title_match,
-        ):
-            # Top hits do NOT contain Theory_of_relativity — the only
-            # way it can end up at rank 1 is via pass-0 promotion.
-            top_hits: List[tuple[str, Dict[str, Any]]] = [
-                (
-                    "wiki",
-                    {
-                        "path": "Einstein–Cartan_theory",
-                        "snippet": "...alternative to general relativity...",
-                        "score": 1.0,
-                    },
-                ),
-            ]
-            result_hits = _promote_title_match(
-                top_hits,
-                query="Einstein's theory",
-                archives=[(archive_obj, "/wiki.zim")],
-                archives_searched=["wiki"],
-                search_handler=handler,
-            )
-        # Rank 0: must be Theory_of_relativity with search_top_k shape.
+            }
+        )
+        # Top hits do NOT contain Theory_of_relativity — the only way
+        # it can end up at rank 1 is via pass-0 promotion.
+        top_hits: List[tuple[str, Dict[str, Any]]] = [
+            (
+                "wiki",
+                {
+                    "path": "Einstein–Cartan_theory",
+                    "snippet": "...alternative to general relativity...",
+                    "score": 1.0,
+                },
+            ),
+        ]
+        result_hits = _run_promote_synthesize(
+            "Einstein's theory",
+            _fake_find_title_match(self._EINSTEIN_FIND_MAPPING),
+            title_match_hit=title_match_hit,
+            top_hits=top_hits,
+        )
         assert len(result_hits) >= 1
         top_arch, top_hit = result_hits[0]
         assert top_arch == "wiki"
@@ -378,7 +404,7 @@ class TestSynthesizePass0InsertShape:
         )
         assert (
             top_hit["score"] >= 1.0
-        ), f"pass-0 insert score must be 1.0 (highest); got {top_hit.get('score')}"
+        ), f"pass-0 insert score must be 1.0; got {top_hit.get('score')}"
 
     def test_fallback_to_minimal_hit_when_reprobe_misses(self) -> None:
         """If ``title_match_hit`` re-probe misses (e.g., the fast-path
@@ -386,58 +412,24 @@ class TestSynthesizePass0InsertShape:
         archives), pass-0 still produces a well-shaped minimal hit
         with the canonical path and an empty-but-present snippet
         rather than leaking the malformed find_title_match dict."""
-        from openzim_mcp.synthesize import _promote_title_match
-
-        class _Archive:
-            pass
-
-        archive_obj = _Archive()
-
-        def fake_title_match_hit(archive: Any, title: str) -> Optional[Dict[str, Any]]:
-            # Re-probe miss — fast path doesn't find the resolved title.
-            return None
-
-        def fake_find_title_match(
-            zim_ops: Any,
-            zim_file_path: str,
-            topic: str,
-            *,
-            cross_file: bool = False,
-            min_score: float = 1.0,
-        ) -> Optional[Dict[str, Any]]:
-            if topic.lower() == "einstein's theory":
-                return {
-                    "path": "Theory_of_relativity",
-                    "title": "Theory of relativity",
-                    "zim_file": "wiki",
-                    "match_type": "redirect",
-                    "pre_redirect_path": "Einstein's_theory",
-                }
-            return None
-
-        handler = MagicMock()
-        handler.title_match_hit = fake_title_match_hit
-
-        with patch(
-            "openzim_mcp.synthesize.find_title_match",
-            side_effect=fake_find_title_match,
-        ):
-            result_hits = _promote_title_match(
-                [
-                    (
-                        "wiki",
-                        {
-                            "path": "Some_BM25_hit",
-                            "snippet": "...",
-                            "score": 1.0,
-                        },
-                    ),
-                ],
-                query="Einstein's theory",
-                archives=[(archive_obj, "/wiki.zim")],
-                archives_searched=["wiki"],
-                search_handler=handler,
-            )
+        # Empty re-probe mapping → title_match_hit always returns None
+        # → fallback minimal-hit path engages.
+        top_hits: List[tuple[str, Dict[str, Any]]] = [
+            (
+                "wiki",
+                {
+                    "path": "Some_BM25_hit",
+                    "snippet": "...",
+                    "score": 1.0,
+                },
+            ),
+        ]
+        result_hits = _run_promote_synthesize(
+            "Einstein's theory",
+            _fake_find_title_match(self._EINSTEIN_FIND_MAPPING),
+            title_match_hit=_fake_title_match_hit({}),
+            top_hits=top_hits,
+        )
         # Top hit must STILL be Theory_of_relativity with search_top_k
         # shape — even if the re-probe missed.
         assert len(result_hits) >= 1

--- a/tests/test_post_b6_beta_fixes.py
+++ b/tests/test_post_b6_beta_fixes.py
@@ -1,0 +1,505 @@
+r"""Regression tests for the post-b6 beta-test sweep.
+
+The post-b6 live-MCP verification sweep against v2.0.0b6 confirmed:
+
+- All three b3 invariants (Einstein's theory, Plato's cave, Plato's
+  Republic) still resolve canonically.
+- The D2 fix lands cleanly for 3-token possessives: `Einstein's
+  theory tourism` / `Einstein's theory history` correctly route to
+  `Theory_of_relativity` via pass-2 windows promoting the
+  `einstein's theory` 2-window.
+- The D1 carve-out preserves the b4 win for non-possessive prose:
+  `Berlin Germany` → `Berlin`.
+- All no-regression possessives (Hubble's law / Achilles' heel /
+  Photosythesis's reproduction / Newton's laws of motion) hold.
+- All earlier b-series invariants (Tokyo if you would, lord of the
+  rings, Köln+München+Berlin chain reject, Definately typo, walk
+  namespace M, no-results reranker telemetry) hold.
+
+Two new HIGH-severity defects unlocked by deeper probing:
+
+## Z1 — D1 filter misses ``match_type="redirect"`` cases when the redirect target is unrelated to the possessor
+
+The pass-1 D1 filter only rejects ``match_type="fuzzy_suggest"``. But
+libzim's suggestion-search sometimes returns a result via a redirect
+chain walk (``match_type="redirect"`` → ACCEPTED by the filter), even
+when the redirect target is unrelated to the user's possessive entity:
+
+- ``tell me about Darwin's evolution`` → ``Evolution`` (cert=0.85)
+- ``tell me about Plato's republic philosophy`` → ``Czech_philosophy``
+  (cert=0.85)
+
+The fix: tighten the filter to also reject ``redirect`` rows whose
+PRE-redirect path doesn't contain any of the topic's possessor
+tokens. For ``Plato's_cave`` → ``Allegory_of_the_cave``, the
+pre-redirect path is ``Plato's_cave`` whose tokens contain ``plato``
+(the possessor) → ACCEPT. For ``Darwin's evolution`` → some
+unrelated-redirect-path → ``Evolution``, the pre-redirect path tokens
+don't contain ``darwin`` → REJECT.
+
+Implementation:
+- ``find_entry_by_title_data`` annotates each result row with
+  ``pre_redirect_path`` (the path libzim's suggest emitted before
+  ``_follow_redirect_chain`` resolved it).
+- ``find_title_match`` propagates ``pre_redirect_path``.
+- New ``extract_possessor_tokens(topic)`` helper extracts the bare
+  possessor token from each ``X's``/``X'`` shape (e.g.,
+  ``"Plato's cave"`` → ``["plato"]``; ``"John's and Mary's books"``
+  → ``["john", "mary"]``).
+- The D1 filter in ``_promote_topic_via_title_index`` (pass-0 +
+  pass-3) and ``_promote_title_match`` (synthesize pass-0) rejects
+  when ``match_type ∈ {fuzzy_suggest, redirect}`` AND the topic has
+  a possessive AND the pre-redirect path's tokens contain NONE of
+  the possessor tokens.
+
+## Z2 — Synthesize pass-0 produces malformed insert when canonical isn't in BM25 top hits
+
+``_promote_title_match`` in ``synthesize.py:_promote_title_match``
+inserts the raw ``find_title_match`` dict (shape
+``{path, title, zim_file, match_type, ...}``) into ``top_hits``,
+which expects the ``search_top_k`` shape
+``{path, snippet, score}``. When the canonical IS in ``top_hits``
+already (the reorder branch), the existing properly-shaped entry is
+moved to first. But when the canonical is NOT in ``top_hits`` (no
+intersection with BM25), the malformed insert leaks through →
+downstream score-sort demotes it to the bottom because ``score`` is
+missing.
+
+Live impact: ``Einstein's theory`` via ``synthesize=true`` returns
+``Theory_of_relativity`` at rank 6 with score 0 (instead of rank 1).
+``Plato's cave`` happens to work because ``Allegory_of_the_cave``
+IS in BM25 top hits (the reorder branch fires).
+
+The fix: when ``find_title_match`` accepts a pass-0 promotion, re-probe
+via ``search_handler.title_match_hit(archive, full_probe.title)`` to
+produce a ``{path, snippet, score: 1.0}`` shaped hit. If the
+title_match_hit re-probe misses (rare — only when fast-path can't
+find the resolved title), fall back to constructing the minimal hit
+with the canonical title's lead text as the snippet.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+
+class TestPreRedirectPathPropagation:
+    """``find_title_match`` propagates ``pre_redirect_path`` so callers
+    can distinguish semantic redirects (pre-path contains the user's
+    possessor token) from associative redirects (pre-path is unrelated)."""
+
+    def test_propagates_pre_redirect_path(self) -> None:
+        from openzim_mcp.title_promotion import find_title_match
+
+        mock = MagicMock()
+        mock.find_entry_by_title_data.return_value = {
+            "results": [
+                {
+                    "path": "Allegory_of_the_cave",
+                    "title": "Allegory of the cave",
+                    "score": 0.95,
+                    "match_type": "redirect",
+                    "pre_redirect_path": "Plato's_cave",
+                }
+            ]
+        }
+        result = find_title_match(mock, "/x.zim", "Plato's cave", min_score=0.95)
+        assert result is not None
+        assert result["pre_redirect_path"] == "Plato's_cave"
+
+    def test_missing_pre_redirect_path_backwards_compat(self) -> None:
+        """Old mocks / fixtures that don't set pre_redirect_path must
+        still pass through cleanly (the field is optional)."""
+        from openzim_mcp.title_promotion import find_title_match
+
+        mock = MagicMock()
+        mock.find_entry_by_title_data.return_value = {
+            "results": [
+                {
+                    "path": "Berlin",
+                    "title": "Berlin",
+                    "score": 1.0,
+                    "match_type": "direct",
+                }
+            ]
+        }
+        result = find_title_match(mock, "/x.zim", "Berlin")
+        assert result is not None
+        # pre_redirect_path not required — older callers don't set it.
+        assert "pre_redirect_path" not in result or result["pre_redirect_path"] == ""
+
+
+class TestPossessorTokenExtraction:
+    """``extract_possessor_tokens`` extracts the bare possessor from
+    each ``X's`` / ``X'`` shape in the topic."""
+
+    def test_simple_possessive(self) -> None:
+        from openzim_mcp.title_promotion import extract_possessor_tokens
+
+        assert extract_possessor_tokens("Plato's cave") == ["plato"]
+        assert extract_possessor_tokens("Darwin's evolution") == ["darwin"]
+        assert extract_possessor_tokens("Einstein's theory") == ["einstein"]
+
+    def test_multiple_possessives(self) -> None:
+        from openzim_mcp.title_promotion import extract_possessor_tokens
+
+        tokens = extract_possessor_tokens("John's and Mary's books")
+        assert tokens == ["john", "mary"]
+
+    def test_trailing_apostrophe(self) -> None:
+        """``Achilles'`` (trailing apostrophe without 's') is a
+        possessor."""
+        from openzim_mcp.title_promotion import extract_possessor_tokens
+
+        assert extract_possessor_tokens("Achilles' heel") == ["achilles"]
+
+    def test_curly_apostrophe(self) -> None:
+        from openzim_mcp.title_promotion import extract_possessor_tokens
+
+        assert extract_possessor_tokens("Einstein’s theory") == ["einstein"]
+
+    def test_no_possessive(self) -> None:
+        from openzim_mcp.title_promotion import extract_possessor_tokens
+
+        assert extract_possessor_tokens("Berlin Germany") == []
+        assert extract_possessor_tokens("Apollo 11") == []
+        # ``O'Brien`` and ``d'Artagnan`` are names, not possessives.
+        assert extract_possessor_tokens("O'Brien") == []
+        assert extract_possessor_tokens("d'Artagnan") == []
+
+
+class TestRedirectFilterRejectsUnrelatedRedirect:
+    """The D1 filter must reject ``match_type="redirect"`` when the
+    pre-redirect path tokens don't contain any of the topic's
+    possessor tokens — catching the Z1 silent-wrong-answer where
+    libzim's suggest produces an associative redirect to an unrelated
+    canonical."""
+
+    def _make_handler(self) -> Any:
+        class _StubOps:
+            pass
+
+        class _Handler:
+            zim_operations = _StubOps()
+
+        return _Handler()
+
+    def test_rejects_redirect_with_unrelated_pre_path(self) -> None:
+        """Live repro: ``darwin's evolution`` → some-unrelated-redirect
+        → ``Evolution``. Pre-redirect path doesn't contain ``darwin``
+        → filter REJECTS."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        def fake(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            if topic.lower() == "darwin's evolution" and min_score <= 0.95:
+                # Simulate libzim returning a redirect that walks to
+                # Evolution but whose pre-redirect path doesn't
+                # contain the possessor token "darwin".
+                return {
+                    "path": "Evolution",
+                    "title": "Evolution",
+                    "zim_file": "test.zim",
+                    "match_type": "redirect",
+                    "pre_redirect_path": "Evolutionary_theory",
+                }
+            return None
+
+        with patch("openzim_mcp.simple_tools.find_title_match", side_effect=fake):
+            result = SimpleToolsHandler._promote_topic_via_title_index(
+                self._make_handler(),
+                "test.zim",
+                "darwin's evolution",
+            )
+        assert result is None, (
+            f"redirect with unrelated pre-path must be rejected for "
+            f"possessive topics; got {result!r}"
+        )
+
+    def test_accepts_redirect_with_possessor_in_pre_path(self) -> None:
+        """Live invariant: ``plato's cave`` → ``Plato's_cave`` redirect
+        → ``Allegory_of_the_cave``. Pre-redirect path ``Plato's_cave``
+        tokens contain ``plato`` → filter ACCEPTS."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        def fake(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            if topic.lower() == "plato's cave" and min_score <= 0.95:
+                return {
+                    "path": "Allegory_of_the_cave",
+                    "title": "Allegory of the cave",
+                    "zim_file": "test.zim",
+                    "match_type": "redirect",
+                    "pre_redirect_path": "Plato's_cave",
+                }
+            return None
+
+        with patch("openzim_mcp.simple_tools.find_title_match", side_effect=fake):
+            result = SimpleToolsHandler._promote_topic_via_title_index(
+                self._make_handler(),
+                "test.zim",
+                "plato's cave",
+            )
+        assert result is not None
+        assert result["path"] == "Allegory_of_the_cave"
+
+    def test_accepts_direct_match_unconditionally(self) -> None:
+        """``match_type="direct"`` is always accepted — the user's
+        exact title is canonical. No possessor-token check needed."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        def fake(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            if topic.lower() == "hubble's law":
+                return {
+                    "path": "Hubble's_law",
+                    "title": "Hubble's law",
+                    "zim_file": "test.zim",
+                    "match_type": "direct",
+                    "pre_redirect_path": "Hubble's_law",
+                }
+            return None
+
+        with patch("openzim_mcp.simple_tools.find_title_match", side_effect=fake):
+            result = SimpleToolsHandler._promote_topic_via_title_index(
+                self._make_handler(),
+                "test.zim",
+                "Hubble's law",
+            )
+        assert result is not None
+        assert result["path"] == "Hubble's_law"
+
+
+class TestSynthesizePass0InsertShape:
+    """Z2: synthesize pass-0 must produce ``search_top_k``-shaped
+    inserts (``{path, snippet, score}``) so downstream score-based
+    sorting doesn't demote the canonical to the bottom."""
+
+    def test_promoted_hit_has_search_top_k_shape(self) -> None:
+        """``Einstein's theory`` via synthesize → pass-0 inserts
+        ``Theory_of_relativity``. The insert must have ``snippet`` and
+        ``score`` fields so it survives downstream ranking."""
+        from openzim_mcp.synthesize import _promote_title_match
+
+        class _Archive:
+            pass
+
+        archive_obj = _Archive()
+
+        def fake_title_match_hit(archive: Any, title: str) -> Optional[Dict[str, Any]]:
+            # The re-probe after pass-0 accept: looks up the resolved
+            # title via fast path and returns the ``search_top_k`` shape.
+            if title.lower() == "theory of relativity":
+                return {
+                    "path": "Theory_of_relativity",
+                    "snippet": "The theory of relativity comprises two...",
+                    "score": 1.0,
+                }
+            return None
+
+        def fake_find_title_match(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            if topic.lower() == "einstein's theory":
+                return {
+                    "path": "Theory_of_relativity",
+                    "title": "Theory of relativity",
+                    "zim_file": "wiki",
+                    "match_type": "redirect",
+                    "pre_redirect_path": "Einstein's_theory",
+                }
+            return None
+
+        handler = MagicMock()
+        handler.title_match_hit = fake_title_match_hit
+
+        with patch(
+            "openzim_mcp.synthesize.find_title_match",
+            side_effect=fake_find_title_match,
+        ):
+            # Top hits do NOT contain Theory_of_relativity — the only
+            # way it can end up at rank 1 is via pass-0 promotion.
+            top_hits: List[tuple[str, Dict[str, Any]]] = [
+                (
+                    "wiki",
+                    {
+                        "path": "Einstein–Cartan_theory",
+                        "snippet": "...alternative to general relativity...",
+                        "score": 1.0,
+                    },
+                ),
+            ]
+            result_hits = _promote_title_match(
+                top_hits,
+                query="Einstein's theory",
+                archives=[(archive_obj, "/wiki.zim")],
+                archives_searched=["wiki"],
+                search_handler=handler,
+            )
+        # Rank 0: must be Theory_of_relativity with search_top_k shape.
+        assert len(result_hits) >= 1
+        top_arch, top_hit = result_hits[0]
+        assert top_arch == "wiki"
+        assert top_hit["path"] == "Theory_of_relativity"
+        # CRITICAL: snippet and score must be present for downstream
+        # extraction and ranking to work correctly.
+        assert "snippet" in top_hit, (
+            "pass-0 insert must include ``snippet`` field for "
+            "_extract_passages downstream — see Z2"
+        )
+        assert top_hit["snippet"], "snippet must be non-empty"
+        assert "score" in top_hit, (
+            "pass-0 insert must include ``score`` field for "
+            "downstream score-based sorting — see Z2"
+        )
+        assert top_hit["score"] >= 1.0, (
+            f"pass-0 insert score must be 1.0 (highest); got " f"{top_hit.get('score')}"
+        )
+
+    def test_fallback_to_minimal_hit_when_reprobe_misses(self) -> None:
+        """If ``title_match_hit`` re-probe misses (e.g., the fast-path
+        case variants don't match the resolved title for some
+        archives), pass-0 still produces a well-shaped minimal hit
+        with the canonical path and an empty-but-present snippet
+        rather than leaking the malformed find_title_match dict."""
+        from openzim_mcp.synthesize import _promote_title_match
+
+        class _Archive:
+            pass
+
+        archive_obj = _Archive()
+
+        def fake_title_match_hit(archive: Any, title: str) -> Optional[Dict[str, Any]]:
+            # Re-probe miss — fast path doesn't find the resolved title.
+            return None
+
+        def fake_find_title_match(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            if topic.lower() == "einstein's theory":
+                return {
+                    "path": "Theory_of_relativity",
+                    "title": "Theory of relativity",
+                    "zim_file": "wiki",
+                    "match_type": "redirect",
+                    "pre_redirect_path": "Einstein's_theory",
+                }
+            return None
+
+        handler = MagicMock()
+        handler.title_match_hit = fake_title_match_hit
+
+        with patch(
+            "openzim_mcp.synthesize.find_title_match",
+            side_effect=fake_find_title_match,
+        ):
+            result_hits = _promote_title_match(
+                [
+                    (
+                        "wiki",
+                        {
+                            "path": "Some_BM25_hit",
+                            "snippet": "...",
+                            "score": 1.0,
+                        },
+                    ),
+                ],
+                query="Einstein's theory",
+                archives=[(archive_obj, "/wiki.zim")],
+                archives_searched=["wiki"],
+                search_handler=handler,
+            )
+        # Top hit must STILL be Theory_of_relativity with search_top_k
+        # shape — even if the re-probe missed.
+        assert len(result_hits) >= 1
+        top_hit = result_hits[0][1]
+        assert top_hit["path"] == "Theory_of_relativity"
+        assert "snippet" in top_hit
+        assert "score" in top_hit
+        assert top_hit["score"] >= 1.0
+
+
+class TestRegressionGuards:
+    """Pin the post-b6 invariants so future contributors don't
+    regress them."""
+
+    def test_extract_possessor_tokens_exists(self) -> None:
+        """The Z1 fix depends on this helper. If a refactor removes
+        it, the filter falls back to the unconditional check that the
+        post-b6 sweep refined."""
+        from openzim_mcp import title_promotion
+
+        assert hasattr(title_promotion, "extract_possessor_tokens")
+
+    def test_promote_function_filter_checks_pre_redirect_path(self) -> None:
+        """Structural pin: the filter helper consulted by
+        ``_promote_topic_via_title_index`` (pass-0 + pass-3) must
+        reference ``pre_redirect_path`` so an associative redirect on
+        a possessive topic is rejected. The helper lives in
+        ``simple_tools`` as ``_accept_possessive_promotion`` and
+        ``synthesize`` as ``_accept_synthesize_possessive_promotion``."""
+        import inspect
+
+        from openzim_mcp import simple_tools, synthesize
+
+        simple_source = inspect.getsource(simple_tools._accept_possessive_promotion)
+        assert "pre_redirect_path" in simple_source, (
+            "simple_tools._accept_possessive_promotion must consult "
+            "pre_redirect_path to reject associative redirects on "
+            "possessive topics — see Z1"
+        )
+        synth_source = inspect.getsource(
+            synthesize._accept_synthesize_possessive_promotion
+        )
+        assert "pre_redirect_path" in synth_source, (
+            "synthesize._accept_synthesize_possessive_promotion must "
+            "consult pre_redirect_path to reject associative redirects "
+            "on possessive topics — see Z1"
+        )
+
+    def test_synthesize_pass_0_constructs_proper_shape(self) -> None:
+        """Structural pin: ``_promote_title_match`` source must
+        re-probe via ``title_match_hit`` or otherwise construct a
+        ``snippet``-carrying hit for the pass-0 insert."""
+        import inspect
+
+        from openzim_mcp.synthesize import _promote_title_match
+
+        source = inspect.getsource(_promote_title_match)
+        # The insert path must either call title_match_hit (the
+        # canonical re-probe approach) or explicitly construct
+        # ``snippet`` in the hit dict.
+        assert "snippet" in source or "title_match_hit" in source.split("Pass-0")[0], (
+            "_promote_title_match pass-0 insert must construct a "
+            "search_top_k-shaped hit (path, snippet, score) so "
+            "downstream ranking doesn't demote the canonical — see Z2"
+        )


### PR DESCRIPTION
Post-b6 live-MCP sweep against v2.0.0b6 confirmed all b3/b4/b5 fixes land cleanly on live (Einstein's/Plato's-canonical possessives, b4 non-possessive carve-out, b3 trailing-modal politeness, b2 D3 typo retry, all earlier b-series invariants). Two HIGH-severity defects unlocked by deeper probing.

## Z1 (HIGH) — D1 filter misses associative redirects

The post-b4 D1 filter rejected `match_type="fuzzy_suggest"` for possessive topics but accepted `match_type="redirect"` blindly. In practice libzim's suggestion-search occasionally produces an **associative redirect**: a redirect entry whose pre-resolution path is unrelated to the user's possessor entity, but whose redirect chain walks to a canonical that shares one user-typed token.

Live silent-wrong-answers (cert=0.85):

- `tell me about Darwin's evolution` → `Evolution` (the user's possessor `darwin` doesn't appear in the pre-redirect path)
- `tell me about Plato's republic philosophy` → `Czech_philosophy` (the user's possessor `plato` doesn't appear in the pre-redirect path; libzim's tokenized match returned an unrelated redirect that walks to Czech_philosophy)

## Z2 (HIGH) — Synthesize pass-0 produces malformed insert

The post-b4 D3 synthesize pass-0 inserted the raw `find_title_match` dict into `top_hits`. The dict has shape `{path, title, zim_file, match_type, pre_redirect_path}` but `top_hits` items expect the `search_top_k` shape `{path, snippet, score}`. Downstream score-sort demoted the canonical to the bottom when it wasn't already in `top_hits`.

Live impact (`synthesize=true`):

- `Einstein's theory` → `Theory_of_relativity` surfaces at rank 6 with score 0 (BM25 hits dominate; the buggy insert is demoted)
- `Plato's cave` happens to work because `Allegory_of_the_cave` IS in BM25 top_hits — the reorder branch fires with the existing properly-shaped entry

## Fixes

### Z1 — pre-redirect path propagation + token-membership filter

1. **`find_entry_by_title_data` annotates `pre_redirect_path`** on each result row — the path libzim's suggest emitted before `_follow_redirect_chain` resolved it. Equals `path` when no redirect was walked.

2. **`find_title_match` propagates `pre_redirect_path`** through to its returned dict.

3. **New `extract_possessor_tokens(topic)` helper** extracts the bare possessor token from each `X's`/`X'` shape. `"Plato's cave"` → `["plato"]`; `"John's and Mary's books"` → `["john", "mary"]`; `"O'Brien"` → `[]` (name, not possessive).

4. **New shared filter** `_accept_possessive_promotion` in `simple_tools.py` (and synthesize-side mirror `_accept_synthesize_possessive_promotion` kept separate to avoid circular import). Shape-by-shape acceptance:

| Match type | Non-possessive | Possessive |
|---|---|---|
| direct | accept | accept |
| fuzzy_suggest | accept | **REJECT** (b6 D1) |
| redirect | accept | accept iff query possessor token ∈ pre-redirect path tokens (**Z1**) |
| missing | accept | accept (backwards-compat) |

### Z2 — `search_top_k`-shaped pass-0 insert

Synthesize pass-0 now constructs the insert via `_build_pass0_promoted_hit`:

1. Re-probe via `search_handler.title_match_hit(archive, full_probe.title)` using the resolved canonical title. The re-probe lands on the fast-path (case-variant lookup of the canonical title) and returns the proper `{path, snippet, score: 1.0}` shape.

2. Fallback to a minimal `{path, snippet: "", score: 1.0}` hit when the re-probe handler is missing or misses — keeps the shape correct under degraded paths and test stubs.

## Tests

15 new tests in `tests/test_post_b6_beta_fixes.py` across 5 classes (TestPreRedirectPathPropagation, TestPossessorTokenExtraction, TestRedirectFilterRejectsUnrelatedRedirect, TestSynthesizePass0InsertShape, TestRegressionGuards). Updated 1 b4 test mock to include `pre_redirect_path: "Einstein's_theory"`. Updated 1 b4 structural guard. Updated 1 golden snapshot.

```
2405 passed, 54 skipped (full suite, ~28s)
pip-audit: no known vulnerabilities
```

mypy clean across 52 source files. black + flake8 clean.

## Methodology — "fix unlocks new paths" 14 sweeps strong

Each prior sweep peeled back another layer; the post-b6 sweep added two new layers:

1. `match_type="redirect"` was assumed semantic — the post-b6 live probe revealed associative redirects where libzim's fuzzy token-matching produces a redirect entry whose pre-resolution path is unrelated to the user's possessor.

2. The synthesize pass-0 insert worked only when the canonical was already in BM25 top_hits (reorder branch). Otherwise the malformed insert leaked through and was demoted by score-sort.

Three new invariants pinned:

  1. **Pre-redirect path invariant** (Z1): every result row from `find_entry_by_title_data` (fast-path + suggestion-search) carries `pre_redirect_path`; `find_title_match` propagates it; consumers using the 0.95 gate use it to filter associative redirects.
  2. **Possessor-token filter invariant** (Z1): possessive + `match_type="redirect"` is safe iff a query possessor token appears in the pre-redirect path.
  3. **Pass-0 insert shape invariant** (Z2): synthesize pass-0 emits `search_top_k`-shaped hits (`{path, snippet, score}`) — never the raw `find_title_match` shape.

## What's not in this PR

Version bump / CHANGELOG entry — follows the sweep convention (release PR is separate).
