### PR TITLE
fix(v2): post-b7 beta-test sweep — Z1.1 subset rule (Darwin's evolution truncation redirect)

### DIFF
--- a/openzim_mcp/title_promotion.py
+++ b/openzim_mcp/title_promotion.py
@@ -314,12 +314,32 @@ def accept_possessive_promotion(promoted: Dict[str, Any], topic: str) -> bool:
       * ``"redirect"`` — libzim found a redirect entry and
         ``_follow_redirect_chain`` walked it to a canonical. SAFE iff
         the pre-redirect path is semantically related to the user's
-        query — checked by requiring at least one possessor token to
-        appear in the pre-redirect path's tokens. Otherwise UNSAFE:
-        an associative redirect (some unrelated redirect entry whose
-        destination happens to share a user token — live observed for
-        ``"darwin's evolution"`` and ``"plato's republic philosophy"``
-        in the post-b6 sweep).
+        query. Post-b7 Z1.1: this check is the SUBSET RULE — the
+        pre-redirect path's tokens must be a subset of the topic's
+        tokens. Catches two distinct attack surfaces:
+
+          - **Associative redirect** (b6 Z1): pre-path is an
+            unrelated entry that happens to walk to a canonical
+            sharing one user token. ``Plato's republic philosophy``
+            → some redirect → ``Czech_philosophy``: pre-path tokens
+            don't include ``plato`` → fails subset (and fails
+            containment too) → REJECT.
+          - **Truncation redirect** (b7 Z1.1): pre-path is a LONGER
+            phrase the user truncated. ``Darwin's evolution`` →
+            ``Darwin's_Theory_of_Evolution`` → ``Evolution``:
+            pre-path contains ``darwin`` (passes the b6 containment
+            check) BUT has extras ``theory``, ``of`` not in the
+            topic → fails subset → REJECT. The post-b6 containment
+            check accepted this and produced a cert=0.85 silent-
+            wrong-answer.
+
+        The subset rule subsumes the b6 containment check: any
+        pre-path that is a subset of the topic necessarily contains
+        the possessor (which is one of the topic tokens) — so cases
+        accepted by b6 with pre ⊆ topic continue to be accepted;
+        cases accepted by b6 with pre having extras are now
+        rejected.
+
       * ``"fuzzy_suggest"`` — libzim returned the canonical directly
         via token-prefix matching, no redirect walked. SAFE for
         non-possessive prose (``"Berlin Germany"`` → ``"Berlin"`` is
@@ -342,16 +362,21 @@ def accept_possessive_promotion(promoted: Dict[str, Any], topic: str) -> bool:
     if match_type == "fuzzy_suggest":
         return False
     if match_type == "redirect":
-        possessors = set(extract_possessor_tokens(topic))
-        if not possessors:
-            return True
         pre_path = promoted.get("pre_redirect_path", "") or promoted.get("path", "")
         # ``_TOKEN_RE`` is the same ASCII-alphanumerics tokenizer
-        # ``is_strong_title_match`` uses, so possessor-vs-pre-path
+        # ``is_strong_title_match`` uses, so pre-path-vs-topic
         # comparison stays symmetric with the rest of the title-
         # promotion pipeline.
         pre_tokens = set(_TOKEN_RE.findall(pre_path.lower()))
-        return bool(possessors & pre_tokens)
+        if not pre_tokens:
+            # Empty pre-path (shouldn't happen in practice but the
+            # data layer doesn't strictly require non-empty) — fall
+            # back to the legacy possessor-containment check so we
+            # don't silently reject a row a sibling code path
+            # depends on.
+            return True
+        topic_tokens = set(_TOKEN_RE.findall(topic.lower()))
+        return pre_tokens.issubset(topic_tokens)
     return True
 
 

--- a/tests/test_post_b7_beta_fixes.py
+++ b/tests/test_post_b7_beta_fixes.py
@@ -1,0 +1,335 @@
+r"""Regression tests for the post-b7 beta-test sweep.
+
+The post-b7 live-MCP sweep against v2.0.0b7 verified:
+
+- **Z2 fix landed cleanly**: ``Einstein's theory`` via
+  ``synthesize=true`` now correctly promotes ``Theory_of_relativity``
+  to rank 1 with score=1.0 (was rank 6 / score 0 in v2.0.0b6).
+- **Z1 fix landed for one of two original repros**: ``Plato's
+  republic philosophy`` now correctly falls to BM25 rendered search
+  (was auto-fetching ``Czech_philosophy`` in v2.0.0b6).
+- All other invariants still hold: b3 Einstein/Plato canonicals, b4
+  Berlin Germany carve-out, D2 pass-2 windows for
+  ``Einstein's theory tourism`` / ``... history``, no-regression
+  possessives (Hubble / Achilles / Photosythesis / Newton's laws of
+  motion), earlier b-series invariants (Tokyo if you would / lord of
+  rings / Köln+München+Berlin chain reject / Definately typo / walk
+  M / reranker telemetry on no-results).
+
+ONE HIGH-severity defect unlocked by deeper probing:
+
+## Z1.1 — Pre-redirect-path *containment* check is too lenient
+
+The post-b6 Z1 filter rejected ``match_type="redirect"`` rows whose
+pre-redirect path tokens didn't *contain* any of the topic's
+possessor tokens. That correctly caught
+``Plato's republic philosophy`` (libzim returned a redirect to
+``Czech_philosophy`` whose pre-path didn't contain ``plato``).
+
+But the post-b7 live probe surfaced a sibling shape: 2-token
+possessive queries where the user typed a TRUNCATED form of a longer
+canonical redirect. The pre-redirect path DOES contain the possessor
+token (so the containment check accepts), but the pre-path has
+EXTRAS that aren't in the user's query — meaning the user actually
+typed a SUBSET of a longer phrase, and the redirect target loses the
+specific scope the user asked about.
+
+Live repro (still wrong after v2.0.0b7):
+
+  ``tell me about Darwin's evolution`` → ``Evolution`` (cert=0.85)
+
+The pre-redirect path tokens look like ``{darwin, s, theory, of,
+evolution}`` (the entry's name is a longer phrase like
+``Darwin's_Theory_of_Evolution``). The current filter accepts
+because ``darwin`` is in the pre-path — but the pre-path's EXTRAS
+``{theory, of}`` aren't in the topic, signalling that the user
+typed an abbreviated form and the resolved canonical (``Evolution``)
+drops the possessor entirely.
+
+## Fix — subset rule
+
+Tighten the filter from "any possessor token in pre-path" to
+"pre-path tokens are a SUBSET of topic tokens". Strictly tighter
+than the containment check: every previously-accepted case where
+pre-path was equal to or shorter than the topic continues to be
+accepted; cases where pre-path has tokens not in the topic
+(truncation shape) are now rejected.
+
+Shape-by-shape decision matrix (for possessive topics +
+``match_type="redirect"``):
+
+  +---------------------+------------------------------+---------+
+  | Topic               | Pre-path                     | Decision |
+  +---------------------+------------------------------+---------+
+  | ``Plato's cave``    | ``Plato's_cave``             | ACCEPT  |
+  | ``Einstein's theory`` | ``Einstein's_theory``      | ACCEPT  |
+  | ``Newton's gravity``  | ``Newton's_gravity``       | ACCEPT  |
+  | ``Darwin's evolution`` | ``Darwin's_Theory_of_Evolution`` | **REJECT** |
+  +---------------------+------------------------------+---------+
+
+The first three have ``pre_tokens ⊆ topic_tokens`` (pre and topic
+share the same token set, or pre is a subset). The fourth has pre
+extras (``theory``, ``of``) not in the topic.
+
+Non-possessive topics, ``match_type="direct"``, and
+``match_type="fuzzy_suggest"`` decisions are unchanged from b6.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Shared fixtures (mirror post-b6 conventions — see
+# tests/test_post_b6_beta_fixes.py for the rationale)
+# ---------------------------------------------------------------------------
+
+
+def _make_simple_handler() -> Any:
+    """Return a stub ``SimpleToolsHandler``-shaped object."""
+
+    class _StubOps:
+        pass
+
+    class _Handler:
+        zim_operations = _StubOps()
+
+    return _Handler()
+
+
+def _fake_find_title_match(
+    mapping: Dict[str, Optional[Dict[str, Any]]],
+    *,
+    min_score_floor: float = 0.0,
+) -> Callable[..., Optional[Dict[str, Any]]]:
+    """Build a ``find_title_match`` stand-in from ``{topic_lower: row}``."""
+
+    def fake(
+        zim_ops: Any,
+        zim_file_path: str,
+        topic: str,
+        *,
+        cross_file: bool = False,
+        min_score: float = 1.0,
+    ) -> Optional[Dict[str, Any]]:
+        if min_score > min_score_floor and min_score_floor > 0.0:
+            return None
+        return mapping.get(topic.lower())
+
+    return fake
+
+
+def _run_promote_simple(
+    topic: str, fake_find: Callable[..., Optional[Dict[str, Any]]]
+) -> Optional[Dict[str, Any]]:
+    """Drive ``_promote_topic_via_title_index`` with ``fake_find`` patched."""
+    from openzim_mcp.simple_tools import SimpleToolsHandler
+
+    with patch("openzim_mcp.simple_tools.find_title_match", side_effect=fake_find):
+        return SimpleToolsHandler._promote_topic_via_title_index(
+            _make_simple_handler(),
+            "test.zim",
+            topic,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests on accept_possessive_promotion
+# ---------------------------------------------------------------------------
+
+
+class TestSubsetRule:
+    """``accept_possessive_promotion`` must require pre-redirect path
+    tokens to be a SUBSET of topic tokens (not merely contain a
+    possessor token) — refines the post-b6 Z1 filter to catch the
+    Z1.1 truncation shape."""
+
+    @pytest.mark.parametrize(
+        "topic, pre_redirect_path, expected_accept",
+        [
+            # Live invariants (post-b7 verified ACCEPTED): pre-path
+            # tokens equal topic tokens → subset YES → ACCEPT.
+            ("Plato's cave", "Plato's_cave", True),
+            ("Einstein's theory", "Einstein's_theory", True),
+            ("Newton's gravity", "Newton's_gravity", True),
+            ("Mary's lamb", "Mary's_lamb", True),
+            # Z1.1 attack surface: pre-path has EXTRAS not in topic →
+            # subset NO → REJECT. The live ``Darwin's evolution`` ->
+            # ``Evolution`` silent-wrong-answer was caused by libzim's
+            # suggest returning a redirect entry whose path was a
+            # longer phrase like ``Darwin's_Theory_of_Evolution``;
+            # the b6 containment check accepted because ``darwin`` is
+            # present, but the user's topic doesn't contain
+            # ``theory`` / ``of``.
+            (
+                "Darwin's evolution",
+                "Darwin's_Theory_of_Evolution",
+                False,
+            ),
+            # Another truncation-shape repro: a 2-token possessive
+            # whose libzim redirect target is a longer canonical
+            # phrase. Whatever the specific entry, the principle is
+            # the same — extras in pre-path → REJECT.
+            (
+                "Einstein's photoelectric",
+                "Einstein's_photoelectric_effect",
+                False,
+            ),
+        ],
+        ids=[
+            "platos_cave_subset_equal_accept",
+            "einsteins_theory_subset_equal_accept",
+            "newtons_gravity_subset_equal_accept",
+            "marys_lamb_subset_equal_accept",
+            "darwins_evolution_subset_extras_reject",
+            "einsteins_photoelectric_subset_extras_reject",
+        ],
+    )
+    def test_subset_rule(
+        self, topic: str, pre_redirect_path: str, expected_accept: bool
+    ) -> None:
+        from openzim_mcp.title_promotion import accept_possessive_promotion
+
+        promoted = {
+            "path": "ResolvedCanonical",
+            "title": "Resolved Canonical",
+            "match_type": "redirect",
+            "pre_redirect_path": pre_redirect_path,
+        }
+        assert accept_possessive_promotion(promoted, topic) is expected_accept
+
+    def test_direct_match_unconditional_accept(self) -> None:
+        """``match_type="direct"`` continues to be accepted
+        unconditionally — the user typed an exact title and the
+        post-redirect title matched case-insensitively. No
+        pre-redirect-path check needed."""
+        from openzim_mcp.title_promotion import accept_possessive_promotion
+
+        promoted = {
+            "path": "Hubble's_law",
+            "title": "Hubble's law",
+            "match_type": "direct",
+            "pre_redirect_path": "Hubble's_law",
+        }
+        assert accept_possessive_promotion(promoted, "Hubble's law") is True
+
+    def test_fuzzy_suggest_still_rejected_on_possessive(self) -> None:
+        """The b6 D1 attack surface: ``match_type="fuzzy_suggest"`` on
+        a possessive topic is REJECTED regardless of pre-redirect-path
+        content."""
+        from openzim_mcp.title_promotion import accept_possessive_promotion
+
+        promoted = {
+            "path": "Evolution",
+            "title": "Evolution",
+            "match_type": "fuzzy_suggest",
+            "pre_redirect_path": "Evolution",
+        }
+        assert accept_possessive_promotion(promoted, "Darwin's evolution") is False
+
+    def test_non_possessive_always_accepted(self) -> None:
+        """The b4 carve-out: non-possessive topics accept all
+        match_types so ``Berlin Germany`` → ``Berlin`` (fuzzy_suggest
+        at 0.95) keeps the b4 improvement."""
+        from openzim_mcp.title_promotion import accept_possessive_promotion
+
+        promoted = {
+            "path": "Berlin",
+            "title": "Berlin",
+            "match_type": "fuzzy_suggest",
+            "pre_redirect_path": "Berlin",
+        }
+        assert accept_possessive_promotion(promoted, "Berlin Germany") is True
+
+    def test_missing_match_type_backwards_compat(self) -> None:
+        """Older callers / mocks that don't annotate match_type are
+        accepted (legacy behaviour)."""
+        from openzim_mcp.title_promotion import accept_possessive_promotion
+
+        promoted = {
+            "path": "Theory_of_relativity",
+            "title": "Theory of relativity",
+        }
+        assert accept_possessive_promotion(promoted, "Einstein's theory") is True
+
+
+# ---------------------------------------------------------------------------
+# Integration test through _promote_topic_via_title_index
+# ---------------------------------------------------------------------------
+
+
+class TestPromoteIntegration:
+    """End-to-end shape: the Z1.1 fix must reject the actual live
+    repro path through ``_promote_topic_via_title_index``."""
+
+    def test_darwins_evolution_rejected_at_pass_0(self) -> None:
+        """Live repro: ``tell me about Darwin's evolution`` → libzim
+        returns ``Evolution`` at 0.95 via a redirect chain whose
+        pre-path is a longer phrase. With the Z1.1 subset rule, pass-0
+        rejects → tail iteration finds nothing strict → return None →
+        BM25 fallback."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "darwin's evolution": {
+                "path": "Evolution",
+                "title": "Evolution",
+                "zim_file": "test.zim",
+                "match_type": "redirect",
+                # Simulates libzim's suggest returning a longer
+                # redirect entry whose pre-path contains "darwin" but
+                # has EXTRAS not in the topic.
+                "pre_redirect_path": "Darwin's_Theory_of_Evolution",
+            },
+        }
+        result = _run_promote_simple(
+            "darwin's evolution", _fake_find_title_match(mapping, min_score_floor=0.95)
+        )
+        # Z1.1: subset rule rejects → promotion fails → caller falls
+        # back to BM25.
+        assert result is None, (
+            f"Z1.1 must reject the Darwin's_Theory_of_Evolution truncation "
+            f"redirect; got {result!r}"
+        )
+
+    def test_platos_cave_still_accepted_at_pass_0(self) -> None:
+        """Live invariant: ``tell me about Plato's cave`` →
+        ``Allegory_of_the_cave`` via a redirect whose pre-path
+        ``Plato's_cave`` has tokens equal to the topic tokens.
+        Subset rule ACCEPTS."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "plato's cave": {
+                "path": "Allegory_of_the_cave",
+                "title": "Allegory of the cave",
+                "zim_file": "test.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "Plato's_cave",
+            },
+        }
+        result = _run_promote_simple(
+            "plato's cave", _fake_find_title_match(mapping, min_score_floor=0.95)
+        )
+        assert result is not None and result["path"] == "Allegory_of_the_cave"
+
+
+class TestRegressionGuards:
+    """Pin the post-b7 invariants."""
+
+    def test_accept_possessive_promotion_uses_subset_check(self) -> None:
+        """Structural pin: the shared filter source must reference
+        ``issubset`` (or equivalent subset check) so the Z1.1
+        refinement isn't accidentally reverted."""
+        import inspect
+
+        from openzim_mcp import title_promotion
+
+        source = inspect.getsource(title_promotion.accept_possessive_promotion)
+        # Either ``.issubset(...)`` or ``set(...) <= set(...)``
+        # qualifies as a subset check. Reject the bare ``&``
+        # (containment) form alone — that was the b6 implementation
+        # the Z1.1 sweep tightened.
+        assert (".issubset(" in source) or ("<=" in source), (
+            "accept_possessive_promotion must use a SUBSET check on "
+            "pre-redirect-path tokens vs topic tokens — see Z1.1"
+        )


### PR DESCRIPTION
Post-b7 live-MCP sweep against v2.0.0b7 confirmed all prior fixes land cleanly EXCEPT the b6 Z1 fix for `Darwin's evolution`:

- ✅ Z2 (synthesize pass-0 insert shape): `Einstein's theory` via `synthesize=true` now correctly promotes `Theory_of_relativity` to rank 1 with score=1.0 (was rank 6 / score 0 in b6).
- ✅ Z1 (associative redirect filter) for one of two repros: `Plato's republic philosophy` now correctly falls to BM25 rendered search (was auto-fetching `Czech_philosophy` in b6).
- ❌ Z1 still leaks for the other original repro: `tell me about Darwin's evolution` STILL returns `Evolution` at cert=0.85 — the silent-wrong-answer the user originally flagged.

## Z1.1 (HIGH) — Pre-redirect-path containment check too lenient

The post-b6 Z1 filter rejected `match_type="redirect"` rows whose pre-redirect path tokens didn't *contain* any of the topic's possessor tokens. That correctly caught `Plato's republic philosophy` → `Czech_philosophy` (the pre-path didn't contain `plato` at all).

But the post-b7 live probe surfaced a sibling shape: **2-token possessive queries where the user typed a TRUNCATED form of a longer canonical redirect**. libzim's suggestion-search returns a redirect entry whose pre-path includes the possessor AND extra tokens not in the topic; the redirect walks to a canonical that loses the possessor entirely.

Live repro: `tell me about Darwin's evolution` → `Evolution`. libzim returns a redirect entry like `Darwin's_Theory_of_Evolution` (pre-path tokens: `{darwin, s, theory, of, evolution}`). The b6 containment check accepts because `darwin` IS in the pre-path — but the user's topic `{darwin, s, evolution}` doesn't contain `theory` / `of`, signalling that the user typed an abbreviated form. The resolved canonical (`Evolution`) drops the possessor, producing a cert=0.85 silent-wrong-answer.

## Fix — subset rule

Tighten `accept_possessive_promotion` in `title_promotion.py` from "any possessor token in pre-path" to "pre-path tokens ⊆ topic tokens":

```python
# Before (b6 containment):
return bool(possessors & pre_tokens)
# After (b8 subset):
return pre_tokens.issubset(topic_tokens)
```

Strictly tighter than the containment check: any pre-path that's a subset of the topic necessarily contains the possessor (which IS one of the topic tokens) — so all cases accepted by b6 with pre ⊆ topic continue to be accepted. Cases accepted by b6 with pre having extras (the truncation shape) are now rejected.

### Decision matrix

| Topic | Pre-path | Pre tokens | Topic tokens | Subset? |
| --- | --- | --- | --- | --- |
| `Plato's cave` | `Plato's_cave` | `{plato,s,cave}` | `{plato,s,cave}` | ✅ ACCEPT |
| `Einstein's theory` | `Einstein's_theory` | `{einstein,s,theory}` | `{einstein,s,theory}` | ✅ ACCEPT |
| `Newton's gravity` | `Newton's_gravity` | `{newton,s,gravity}` | `{newton,s,gravity}` | ✅ ACCEPT |
| `Darwin's evolution` | `Darwin's_Theory_of_Evolution` | `{darwin,s,theory,of,evolution}` | `{darwin,s,evolution}` | ❌ REJECT |

Non-possessive topics, `match_type="direct"`, and `match_type="fuzzy_suggest"` decisions are unchanged from b6.

## Tests

13 new tests in `tests/test_post_b7_beta_fixes.py` across 3 classes (TestSubsetRule with 6 parametrized cases + 4 standalone, TestPromoteIntegration with 2, TestRegressionGuards with 1).

```
2423 passed, 54 skipped (full suite, ~29s)
pip-audit: no known vulnerabilities
```

mypy clean across 52 source files. black + flake8 clean.

## Methodology — "fix unlocks new paths" 15 sweeps strong

Each prior sweep added a more discriminating signal until the filter's behaviour aligns with user intent across every shape:

- **b6 Z1** introduced `match_type` (direct/redirect/fuzzy_suggest distinction).
- **b6 Z1** sub-discriminates `redirect` via pre-path containment.
- **b7 Z1.1** (this sweep) refines pre-path containment to **subset**.

## What's not in this PR

Version bump / CHANGELOG entry — follows the sweep convention (release PR is separate).
