### PR TITLE
fix(v2): post-b8 beta-test sweep — Z3 non-possessive tail-hijack + OPP-1 possessor-in-canonical carve-out

### DIFF
--- a/openzim_mcp/title_promotion.py
+++ b/openzim_mcp/title_promotion.py
@@ -354,13 +354,81 @@ def accept_possessive_promotion(promoted: Dict[str, Any], topic: str) -> bool:
     Missing/unknown ``match_type`` is accepted for backwards-compat
     with older callers and test mocks that don't annotate the row.
     """
-    if not has_apostrophe_possessive(topic):
-        return True
     match_type = promoted.get("match_type")
+    if not has_apostrophe_possessive(topic):
+        # Post-b8 Z3: non-possessive multi-token topics can still
+        # leak a hijack via Pass 0's full-topic probe at min_score=
+        # 0.95 — libzim's title-suggest fuzzy-matches a single
+        # strong token in the topic and returns that token's
+        # canonical alone. The b4 D2 raised-min_len protection
+        # covered only possessives. Live silent-wrong-answers at
+        # v2.0.0b8 (cert=0.85): Stalin USSR Russia → Russia, Hitler
+        # Germany Berlin → Berlin, Marie Curie polonium discovery
+        # → Discovery (a disambig page!), Big Rapids Michigan
+        # tourism → Tourism (contradicts iter_query_windows
+        # docstring), O'Brien character 1984 → 1984 (the year),
+        # Marie Curie radioactivity → Radioactive_(Redniss_book)
+        # (an obscure 2010 graphic novel surfaced via stemming).
+        #
+        # Two narrow rejections for non-possessive + fuzzy_suggest
+        # when the topic has 3+ tokens:
+        #
+        #   (a) **Tail-token hijack** — canonical is a single token
+        #       equal to the topic's LAST token. The user typed
+        #       <subject> ... <generic>; libzim returned the
+        #       generic article. ``Hamlet Denmark prince`` →
+        #       ``Hamlet`` stays accepted because the canonical
+        #       sits at the HEAD position, not the tail.
+        #   (b) **Zero-overlap stemming hit** — canonical's tokens
+        #       have zero exact-overlap with topic's tokens (the
+        #       match was via stemming only). The 2010 graphic
+        #       novel ``Radioactive_(Redniss_book)`` surfaced for
+        #       ``Marie Curie radioactivity`` because libzim's
+        #       title index stems ``radioactivity`` to
+        #       ``radioactive``; no other topic token matches the
+        #       canonical, so the hit is one-stem-token-deep —
+        #       too thin a signal to auto-fetch.
+        #
+        # Topics with <3 tokens are unaffected — ``Berlin Germany``
+        # → ``Berlin`` resolves via ``is_strong_title_match`` at
+        # the BM25 stage anyway, and 2-token possessive carve-outs
+        # are handled by the possessive branch below.
+        if match_type == "fuzzy_suggest":
+            topic_tokens_seq = _TAIL_TOKEN_RE.findall(topic.lower())
+            if len(topic_tokens_seq) >= 3:
+                cand_path = str(promoted.get("path", ""))
+                cand_tokens_seq = _TAIL_TOKEN_RE.findall(cand_path.lower())
+                if (
+                    len(cand_tokens_seq) == 1
+                    and cand_tokens_seq == topic_tokens_seq[-1:]
+                ):
+                    return False
+                if not (set(cand_tokens_seq) & set(topic_tokens_seq)):
+                    return False
+        return True
     if match_type == "direct":
         return True
     if match_type == "fuzzy_suggest":
-        return False
+        # Post-b8 OPP-1: the b6 D1 blanket-reject for possessive +
+        # fuzzy_suggest is too strict when the canonical preserves
+        # the user's possessor token literally. Live: ``Newton's
+        # gravity`` falls to BM25 even though
+        # ``Newton's_law_of_universal_gravitation`` is the obvious
+        # rank-1 BM25 canonical AND contains ``newton`` in the
+        # path. Carve-out: ACCEPT iff the canonical path tokens
+        # include any of the topic's possessor tokens. Original b6
+        # attack surfaces continue to reject — ``Darwin's
+        # evolution`` → ``Evolution`` has no ``darwin`` in path,
+        # ``Plato's republic philosophy`` → ``Czech_philosophy``
+        # has no ``plato`` in path. Uses ``_TOKEN_RE`` (apostrophe-
+        # splitting) so ``newton's`` in the canonical surfaces as
+        # the bare token ``newton`` for comparison with the
+        # possessor list — the same tokenizer the redirect-branch
+        # subset rule uses, keeping both branches symmetric.
+        cand_path = str(promoted.get("path", ""))
+        cand_tokens = set(_TOKEN_RE.findall(cand_path.lower()))
+        possessors = set(extract_possessor_tokens(topic))
+        return bool(possessors & cand_tokens)
     if match_type == "redirect":
         pre_path = promoted.get("pre_redirect_path", "") or promoted.get("path", "")
         # ``_TOKEN_RE`` is the same ASCII-alphanumerics tokenizer

--- a/openzim_mcp/title_promotion.py
+++ b/openzim_mcp/title_promotion.py
@@ -356,96 +356,117 @@ def accept_possessive_promotion(promoted: Dict[str, Any], topic: str) -> bool:
     """
     match_type = promoted.get("match_type")
     if not has_apostrophe_possessive(topic):
-        # Post-b8 Z3: non-possessive multi-token topics can still
-        # leak a hijack via Pass 0's full-topic probe at min_score=
-        # 0.95 — libzim's title-suggest fuzzy-matches a single
-        # strong token in the topic and returns that token's
-        # canonical alone. The b4 D2 raised-min_len protection
-        # covered only possessives. Live silent-wrong-answers at
-        # v2.0.0b8 (cert=0.85): Stalin USSR Russia → Russia, Hitler
-        # Germany Berlin → Berlin, Marie Curie polonium discovery
-        # → Discovery (a disambig page!), Big Rapids Michigan
-        # tourism → Tourism (contradicts iter_query_windows
-        # docstring), O'Brien character 1984 → 1984 (the year),
-        # Marie Curie radioactivity → Radioactive_(Redniss_book)
-        # (an obscure 2010 graphic novel surfaced via stemming).
-        #
-        # Two narrow rejections for non-possessive + fuzzy_suggest
-        # when the topic has 3+ tokens:
-        #
-        #   (a) **Tail-token hijack** — canonical is a single token
-        #       equal to the topic's LAST token. The user typed
-        #       <subject> ... <generic>; libzim returned the
-        #       generic article. ``Hamlet Denmark prince`` →
-        #       ``Hamlet`` stays accepted because the canonical
-        #       sits at the HEAD position, not the tail.
-        #   (b) **Zero-overlap stemming hit** — canonical's tokens
-        #       have zero exact-overlap with topic's tokens (the
-        #       match was via stemming only). The 2010 graphic
-        #       novel ``Radioactive_(Redniss_book)`` surfaced for
-        #       ``Marie Curie radioactivity`` because libzim's
-        #       title index stems ``radioactivity`` to
-        #       ``radioactive``; no other topic token matches the
-        #       canonical, so the hit is one-stem-token-deep —
-        #       too thin a signal to auto-fetch.
-        #
-        # Topics with <3 tokens are unaffected — ``Berlin Germany``
-        # → ``Berlin`` resolves via ``is_strong_title_match`` at
-        # the BM25 stage anyway, and 2-token possessive carve-outs
-        # are handled by the possessive branch below.
-        if match_type == "fuzzy_suggest":
-            topic_tokens_seq = _TAIL_TOKEN_RE.findall(topic.lower())
-            if len(topic_tokens_seq) >= 3:
-                cand_path = str(promoted.get("path", ""))
-                cand_tokens_seq = _TAIL_TOKEN_RE.findall(cand_path.lower())
-                if (
-                    len(cand_tokens_seq) == 1
-                    and cand_tokens_seq == topic_tokens_seq[-1:]
-                ):
-                    return False
-                if not (set(cand_tokens_seq) & set(topic_tokens_seq)):
-                    return False
-        return True
+        return _accept_non_possessive(promoted, topic, match_type)
     if match_type == "direct":
         return True
     if match_type == "fuzzy_suggest":
-        # Post-b8 OPP-1: the b6 D1 blanket-reject for possessive +
-        # fuzzy_suggest is too strict when the canonical preserves
-        # the user's possessor token literally. Live: ``Newton's
-        # gravity`` falls to BM25 even though
-        # ``Newton's_law_of_universal_gravitation`` is the obvious
-        # rank-1 BM25 canonical AND contains ``newton`` in the
-        # path. Carve-out: ACCEPT iff the canonical path tokens
-        # include any of the topic's possessor tokens. Original b6
-        # attack surfaces continue to reject — ``Darwin's
-        # evolution`` → ``Evolution`` has no ``darwin`` in path,
-        # ``Plato's republic philosophy`` → ``Czech_philosophy``
-        # has no ``plato`` in path. Uses ``_TOKEN_RE`` (apostrophe-
-        # splitting) so ``newton's`` in the canonical surfaces as
-        # the bare token ``newton`` for comparison with the
-        # possessor list — the same tokenizer the redirect-branch
-        # subset rule uses, keeping both branches symmetric.
-        cand_path = str(promoted.get("path", ""))
-        cand_tokens = set(_TOKEN_RE.findall(cand_path.lower()))
-        possessors = set(extract_possessor_tokens(topic))
-        return bool(possessors & cand_tokens)
+        return _accept_possessive_fuzzy_suggest(promoted, topic)
     if match_type == "redirect":
-        pre_path = promoted.get("pre_redirect_path", "") or promoted.get("path", "")
-        # ``_TOKEN_RE`` is the same ASCII-alphanumerics tokenizer
-        # ``is_strong_title_match`` uses, so pre-path-vs-topic
-        # comparison stays symmetric with the rest of the title-
-        # promotion pipeline.
-        pre_tokens = set(_TOKEN_RE.findall(pre_path.lower()))
-        if not pre_tokens:
-            # Empty pre-path (shouldn't happen in practice but the
-            # data layer doesn't strictly require non-empty) — fall
-            # back to the legacy possessor-containment check so we
-            # don't silently reject a row a sibling code path
-            # depends on.
-            return True
-        topic_tokens = set(_TOKEN_RE.findall(topic.lower()))
-        return pre_tokens.issubset(topic_tokens)
+        return _accept_possessive_redirect(promoted, topic)
     return True
+
+
+def _accept_non_possessive(
+    promoted: Dict[str, Any], topic: str, match_type: Any
+) -> bool:
+    """Accept gate for non-possessive topics.
+
+    Post-b8 Z3: non-possessive multi-token topics can still leak a
+    hijack via Pass 0's full-topic probe at min_score=0.95 — libzim's
+    title-suggest fuzzy-matches a single strong token in the topic
+    and returns that token's canonical alone. The b4 D2 raised-
+    min_len protection covered only possessives. Live silent-wrong-
+    answers at v2.0.0b8 (cert=0.85): Stalin USSR Russia → Russia,
+    Hitler Germany Berlin → Berlin, Marie Curie polonium discovery →
+    Discovery (a disambig page!), Big Rapids Michigan tourism →
+    Tourism (contradicts iter_query_windows docstring), O'Brien
+    character 1984 → 1984 (the year), Marie Curie radioactivity →
+    Radioactive_(Redniss_book) (an obscure 2010 graphic novel
+    surfaced via stemming).
+
+    Two narrow rejections for non-possessive + fuzzy_suggest when the
+    topic has 3+ tokens:
+
+      (a) **Tail-token hijack** — canonical is a single token equal
+          to the topic's LAST token. The user typed
+          ``<subject> ... <generic>``; libzim returned the generic
+          article. ``Hamlet Denmark prince`` → ``Hamlet`` stays
+          accepted because the canonical sits at the HEAD position,
+          not the tail.
+      (b) **Zero-overlap stemming hit** — canonical's tokens have
+          zero exact-overlap with topic's tokens (the match was via
+          stemming only). The 2010 graphic novel
+          ``Radioactive_(Redniss_book)`` surfaced for ``Marie Curie
+          radioactivity`` because libzim's title index stems
+          ``radioactivity`` to ``radioactive``; no other topic token
+          matches the canonical, so the hit is one-stem-token-deep —
+          too thin a signal to auto-fetch.
+
+    Topics with <3 tokens are unaffected — ``Berlin Germany`` →
+    ``Berlin`` resolves via ``is_strong_title_match`` at the BM25
+    stage anyway, and 2-token possessive carve-outs are handled by
+    the possessive branch.
+    """
+    if match_type != "fuzzy_suggest":
+        return True
+    topic_tokens_seq = _TAIL_TOKEN_RE.findall(topic.lower())
+    if len(topic_tokens_seq) < 3:
+        return True
+    cand_path = str(promoted.get("path", ""))
+    cand_tokens_seq = _TAIL_TOKEN_RE.findall(cand_path.lower())
+    if len(cand_tokens_seq) == 1 and cand_tokens_seq == topic_tokens_seq[-1:]:
+        return False
+    if not (set(cand_tokens_seq) & set(topic_tokens_seq)):
+        return False
+    return True
+
+
+def _accept_possessive_fuzzy_suggest(promoted: Dict[str, Any], topic: str) -> bool:
+    """Accept gate for possessive topic + ``match_type="fuzzy_suggest"``.
+
+    Post-b8 OPP-1: the b6 D1 blanket-reject for possessive +
+    fuzzy_suggest is too strict when the canonical preserves the
+    user's possessor token literally. Live: ``Newton's gravity``
+    falls to BM25 even though ``Newton's_law_of_universal_gravitation``
+    is the obvious rank-1 BM25 canonical AND contains ``newton`` in
+    the path. Carve-out: ACCEPT iff the canonical path tokens include
+    any of the topic's possessor tokens. Original b6 attack surfaces
+    continue to reject — ``Darwin's evolution`` → ``Evolution`` has
+    no ``darwin`` in path, ``Plato's republic philosophy`` →
+    ``Czech_philosophy`` has no ``plato`` in path. Uses ``_TOKEN_RE``
+    (apostrophe-splitting) so ``newton's`` in the canonical surfaces
+    as the bare token ``newton`` for comparison with the possessor
+    list — the same tokenizer the redirect-branch subset rule uses,
+    keeping both branches symmetric.
+    """
+    cand_path = str(promoted.get("path", ""))
+    cand_tokens = set(_TOKEN_RE.findall(cand_path.lower()))
+    possessors = set(extract_possessor_tokens(topic))
+    return bool(possessors & cand_tokens)
+
+
+def _accept_possessive_redirect(promoted: Dict[str, Any], topic: str) -> bool:
+    """Accept gate for possessive topic + ``match_type="redirect"``.
+
+    b8 Z1.1 subset rule: pre-redirect path's tokens must be a subset
+    of the topic's tokens. Catches both b6 Z1 associative redirects
+    (pre-path unrelated to user's possessor) and b8 Z1.1 truncation
+    redirects (pre-path is a longer phrase the user truncated).
+    """
+    pre_path = promoted.get("pre_redirect_path", "") or promoted.get("path", "")
+    # ``_TOKEN_RE`` is the same ASCII-alphanumerics tokenizer
+    # ``is_strong_title_match`` uses, so pre-path-vs-topic
+    # comparison stays symmetric with the rest of the title-
+    # promotion pipeline.
+    pre_tokens = set(_TOKEN_RE.findall(pre_path.lower()))
+    if not pre_tokens:
+        # Empty pre-path (shouldn't happen in practice but the data
+        # layer doesn't strictly require non-empty) — fall back to
+        # accept so we don't silently reject a row a sibling code
+        # path depends on.
+        return True
+    topic_tokens = set(_TOKEN_RE.findall(topic.lower()))
+    return pre_tokens.issubset(topic_tokens)
 
 
 def iter_query_tails(

--- a/tests/_promote_fixtures.py
+++ b/tests/_promote_fixtures.py
@@ -1,0 +1,79 @@
+"""Shared test fixtures for the post-bN beta-test sweep regression
+suites.
+
+Each sweep file (``test_post_b6_beta_fixes``, ``test_post_b7_beta_fixes``,
+``test_post_b8_beta_fixes``, …) drives
+``SimpleToolsHandler._promote_topic_via_title_index`` with a patched
+``find_title_match``. The fixtures below — a stub handler, a
+``find_title_match`` builder keyed by lowered topic, and a one-call
+unbound driver — were copy-pasted across the sweep files until the
+post-b8 sweep ran into SonarCloud's 3% new-duplicated-lines-density
+threshold. Extracting to this module is purely a deduplication step;
+no behaviour change.
+
+The module name starts with an underscore so pytest's
+``python_files = ["test_*.py"]`` collector skips it.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+from unittest.mock import patch
+
+
+def make_simple_handler() -> Any:
+    """Return a stub ``SimpleToolsHandler``-shaped object suitable for
+    calling ``_promote_topic_via_title_index`` unbound."""
+
+    class _StubOps:
+        pass
+
+    class _Handler:
+        zim_operations = _StubOps()
+
+    return _Handler()
+
+
+def fake_find_title_match(
+    mapping: Dict[str, Optional[Dict[str, Any]]],
+    *,
+    min_score_floor: float = 0.0,
+) -> Callable[..., Optional[Dict[str, Any]]]:
+    """Build a ``find_title_match`` stand-in from ``{topic_lower: row}``.
+
+    Returns the mapped row when ``topic.lower()`` is a key AND the
+    caller's ``min_score`` is at or below ``min_score_floor`` (default
+    0.0 = no threshold check). Each test passes
+    ``min_score_floor=0.95`` when it wants the stub to mimic the
+    libzim suggestion-rank cap (rows at score 0.95 only visible when
+    caller requests ≤ 0.95).
+    """
+
+    def fake(
+        zim_ops: Any,
+        zim_file_path: str,
+        topic: str,
+        *,
+        cross_file: bool = False,
+        min_score: float = 1.0,
+    ) -> Optional[Dict[str, Any]]:
+        if min_score > min_score_floor and min_score_floor > 0.0:
+            return None
+        return mapping.get(topic.lower())
+
+    return fake
+
+
+def run_promote_simple(
+    topic: str, fake_find: Callable[..., Optional[Dict[str, Any]]]
+) -> Optional[Dict[str, Any]]:
+    """Drive ``SimpleToolsHandler._promote_topic_via_title_index`` with
+    ``fake_find`` patched at the import site."""
+    from openzim_mcp.simple_tools import SimpleToolsHandler
+
+    with patch("openzim_mcp.simple_tools.find_title_match", side_effect=fake_find):
+        return SimpleToolsHandler._promote_topic_via_title_index(
+            make_simple_handler(),
+            "test.zim",
+            topic,
+        )

--- a/tests/test_post_b6_beta_fixes.py
+++ b/tests/test_post_b6_beta_fixes.py
@@ -460,14 +460,18 @@ class TestRegressionGuards:
         reference ``pre_redirect_path`` so an associative redirect on
         a possessive topic is rejected. The helper lives in
         ``title_promotion`` (single source of truth — fixes the
-        post-b6 sweep-CI Sonar duplication finding)."""
+        post-b6 sweep-CI Sonar duplication finding).
+
+        Post-b8 refactor: the dispatcher delegates to per-branch
+        helpers; the pre_redirect_path check now lives in
+        ``_accept_possessive_redirect``."""
         import inspect
 
         from openzim_mcp import title_promotion
 
-        source = inspect.getsource(title_promotion.accept_possessive_promotion)
+        source = inspect.getsource(title_promotion._accept_possessive_redirect)
         assert "pre_redirect_path" in source, (
-            "title_promotion.accept_possessive_promotion must consult "
+            "title_promotion._accept_possessive_redirect must consult "
             "pre_redirect_path to reject associative redirects on "
             "possessive topics — see Z1"
         )

--- a/tests/test_post_b6_beta_fixes.py
+++ b/tests/test_post_b6_beta_fixes.py
@@ -63,12 +63,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tests._promote_fixtures import (
-    fake_find_title_match as _fake_find_title_match,
-)
-from tests._promote_fixtures import (
-    run_promote_simple as _run_promote_simple,
-)
+from tests._promote_fixtures import fake_find_title_match as _fake_find_title_match
+from tests._promote_fixtures import run_promote_simple as _run_promote_simple
 
 # ---------------------------------------------------------------------------
 # Shared fixtures / mock-builders.

--- a/tests/test_post_b6_beta_fixes.py
+++ b/tests/test_post_b6_beta_fixes.py
@@ -63,6 +63,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests._promote_fixtures import (
+    fake_find_title_match as _fake_find_title_match,
+)
+from tests._promote_fixtures import (
+    run_promote_simple as _run_promote_simple,
+)
+
 # ---------------------------------------------------------------------------
 # Shared fixtures / mock-builders.
 #
@@ -75,19 +82,6 @@ import pytest
 # ---------------------------------------------------------------------------
 
 
-def _make_simple_handler() -> Any:
-    """Return a stub ``SimpleToolsHandler``-shaped object suitable for
-    calling ``_promote_topic_via_title_index`` unbound."""
-
-    class _StubOps:
-        pass
-
-    class _Handler:
-        zim_operations = _StubOps()
-
-    return _Handler()
-
-
 def _archive_stub() -> Any:
     """Lightweight stub for libzim ``Archive`` — only needs identity
     for ``zip(archives, archives_searched)`` iteration in synthesize."""
@@ -96,35 +90,6 @@ def _archive_stub() -> Any:
         pass
 
     return _Archive()
-
-
-def _fake_find_title_match(
-    mapping: Dict[str, Optional[Dict[str, Any]]],
-    *,
-    min_score_floor: float = 0.0,
-) -> Callable[..., Optional[Dict[str, Any]]]:
-    """Build a ``find_title_match`` stand-in from ``{topic_lower: row}``.
-
-    Returns the mapped row when ``topic.lower()`` is a key AND the
-    caller's ``min_score`` is at or below ``min_score_floor`` (default
-    0.0 = no threshold check). Each test passes ``min_score_floor=0.95``
-    when it wants the stub to mimic the libzim suggestion-rank cap
-    (rows at score 0.95 only visible when caller requests ≤ 0.95).
-    """
-
-    def fake(
-        zim_ops: Any,
-        zim_file_path: str,
-        topic: str,
-        *,
-        cross_file: bool = False,
-        min_score: float = 1.0,
-    ) -> Optional[Dict[str, Any]]:
-        if min_score > min_score_floor and min_score_floor > 0.0:
-            return None
-        return mapping.get(topic.lower())
-
-    return fake
 
 
 def _fake_title_match_hit(
@@ -136,21 +101,6 @@ def _fake_title_match_hit(
         return mapping.get(title.lower())
 
     return fake
-
-
-def _run_promote_simple(
-    topic: str, fake_find: Callable[..., Optional[Dict[str, Any]]]
-) -> Optional[Dict[str, Any]]:
-    """Drive ``SimpleToolsHandler._promote_topic_via_title_index`` with
-    ``fake_find`` patched at the import site."""
-    from openzim_mcp.simple_tools import SimpleToolsHandler
-
-    with patch("openzim_mcp.simple_tools.find_title_match", side_effect=fake_find):
-        return SimpleToolsHandler._promote_topic_via_title_index(
-            _make_simple_handler(),
-            "test.zim",
-            topic,
-        )
 
 
 def _run_promote_synthesize(

--- a/tests/test_post_b7_beta_fixes.py
+++ b/tests/test_post_b7_beta_fixes.py
@@ -319,17 +319,21 @@ class TestRegressionGuards:
     def test_accept_possessive_promotion_uses_subset_check(self) -> None:
         """Structural pin: the shared filter source must reference
         ``issubset`` (or equivalent subset check) so the Z1.1
-        refinement isn't accidentally reverted."""
+        refinement isn't accidentally reverted.
+
+        Post-b8 refactor: the dispatcher delegates to per-branch
+        helpers; the subset check now lives in
+        ``_accept_possessive_redirect``."""
         import inspect
 
         from openzim_mcp import title_promotion
 
-        source = inspect.getsource(title_promotion.accept_possessive_promotion)
+        source = inspect.getsource(title_promotion._accept_possessive_redirect)
         # Either ``.issubset(...)`` or ``set(...) <= set(...)``
         # qualifies as a subset check. Reject the bare ``&``
         # (containment) form alone — that was the b6 implementation
         # the Z1.1 sweep tightened.
         assert (".issubset(" in source) or ("<=" in source), (
-            "accept_possessive_promotion must use a SUBSET check on "
+            "_accept_possessive_redirect must use a SUBSET check on "
             "pre-redirect-path tokens vs topic tokens — see Z1.1"
         )

--- a/tests/test_post_b7_beta_fixes.py
+++ b/tests/test_post_b7_beta_fixes.py
@@ -81,12 +81,8 @@ from typing import Any, Dict, Optional
 
 import pytest
 
-from tests._promote_fixtures import (
-    fake_find_title_match as _fake_find_title_match,
-)
-from tests._promote_fixtures import (
-    run_promote_simple as _run_promote_simple,
-)
+from tests._promote_fixtures import fake_find_title_match as _fake_find_title_match
+from tests._promote_fixtures import run_promote_simple as _run_promote_simple
 
 # ---------------------------------------------------------------------------
 # Direct unit tests on accept_possessive_promotion

--- a/tests/test_post_b7_beta_fixes.py
+++ b/tests/test_post_b7_beta_fixes.py
@@ -77,64 +77,16 @@ Non-possessive topics, ``match_type="direct"``, and
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Optional
-from unittest.mock import patch
+from typing import Any, Dict, Optional
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Shared fixtures (mirror post-b6 conventions — see
-# tests/test_post_b6_beta_fixes.py for the rationale)
-# ---------------------------------------------------------------------------
-
-
-def _make_simple_handler() -> Any:
-    """Return a stub ``SimpleToolsHandler``-shaped object."""
-
-    class _StubOps:
-        pass
-
-    class _Handler:
-        zim_operations = _StubOps()
-
-    return _Handler()
-
-
-def _fake_find_title_match(
-    mapping: Dict[str, Optional[Dict[str, Any]]],
-    *,
-    min_score_floor: float = 0.0,
-) -> Callable[..., Optional[Dict[str, Any]]]:
-    """Build a ``find_title_match`` stand-in from ``{topic_lower: row}``."""
-
-    def fake(
-        zim_ops: Any,
-        zim_file_path: str,
-        topic: str,
-        *,
-        cross_file: bool = False,
-        min_score: float = 1.0,
-    ) -> Optional[Dict[str, Any]]:
-        if min_score > min_score_floor and min_score_floor > 0.0:
-            return None
-        return mapping.get(topic.lower())
-
-    return fake
-
-
-def _run_promote_simple(
-    topic: str, fake_find: Callable[..., Optional[Dict[str, Any]]]
-) -> Optional[Dict[str, Any]]:
-    """Drive ``_promote_topic_via_title_index`` with ``fake_find`` patched."""
-    from openzim_mcp.simple_tools import SimpleToolsHandler
-
-    with patch("openzim_mcp.simple_tools.find_title_match", side_effect=fake_find):
-        return SimpleToolsHandler._promote_topic_via_title_index(
-            _make_simple_handler(),
-            "test.zim",
-            topic,
-        )
-
+from tests._promote_fixtures import (
+    fake_find_title_match as _fake_find_title_match,
+)
+from tests._promote_fixtures import (
+    run_promote_simple as _run_promote_simple,
+)
 
 # ---------------------------------------------------------------------------
 # Direct unit tests on accept_possessive_promotion

--- a/tests/test_post_b8_beta_fixes.py
+++ b/tests/test_post_b8_beta_fixes.py
@@ -105,64 +105,16 @@ Direct/redirect/missing branches are unchanged.
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Optional
-from unittest.mock import patch
+from typing import Any, Dict, Optional
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Shared fixtures (mirror post-b6 / post-b7 conventions — see those
-# files for the rationale)
-# ---------------------------------------------------------------------------
-
-
-def _make_simple_handler() -> Any:
-    """Return a stub ``SimpleToolsHandler``-shaped object."""
-
-    class _StubOps:
-        pass
-
-    class _Handler:
-        zim_operations = _StubOps()
-
-    return _Handler()
-
-
-def _fake_find_title_match(
-    mapping: Dict[str, Optional[Dict[str, Any]]],
-    *,
-    min_score_floor: float = 0.0,
-) -> Callable[..., Optional[Dict[str, Any]]]:
-    """Build a ``find_title_match`` stand-in from ``{topic_lower: row}``."""
-
-    def fake(
-        zim_ops: Any,
-        zim_file_path: str,
-        topic: str,
-        *,
-        cross_file: bool = False,
-        min_score: float = 1.0,
-    ) -> Optional[Dict[str, Any]]:
-        if min_score > min_score_floor and min_score_floor > 0.0:
-            return None
-        return mapping.get(topic.lower())
-
-    return fake
-
-
-def _run_promote_simple(
-    topic: str, fake_find: Callable[..., Optional[Dict[str, Any]]]
-) -> Optional[Dict[str, Any]]:
-    """Drive ``_promote_topic_via_title_index`` with ``fake_find`` patched."""
-    from openzim_mcp.simple_tools import SimpleToolsHandler
-
-    with patch("openzim_mcp.simple_tools.find_title_match", side_effect=fake_find):
-        return SimpleToolsHandler._promote_topic_via_title_index(
-            _make_simple_handler(),
-            "test.zim",
-            topic,
-        )
-
+from tests._promote_fixtures import (
+    fake_find_title_match as _fake_find_title_match,
+)
+from tests._promote_fixtures import (
+    run_promote_simple as _run_promote_simple,
+)
 
 # ---------------------------------------------------------------------------
 # Z3: non-possessive multi-token tail-hijack — direct unit tests

--- a/tests/test_post_b8_beta_fixes.py
+++ b/tests/test_post_b8_beta_fixes.py
@@ -1,0 +1,514 @@
+r"""Regression tests for the post-b8 beta-test sweep.
+
+The post-b8 live-MCP sweep against v2.0.0b8 verified ALL prior fixes
+land cleanly:
+
+- Z1.1 subset rule (b8): ``Darwin's evolution`` no longer auto-fetches
+  ``Evolution`` — falls to BM25 search.
+- Z1 associative-redirect filter (b6): ``Plato's republic philosophy``
+  no longer auto-fetches ``Czech_philosophy``.
+- Z2 synthesize pass-0 (b6): ``Einstein's theory`` via
+  ``synthesize=true`` ranks ``Theory_of_relativity`` at #1 score 1.0.
+- B6 reorder branch (b6): ``Plato's cave`` auto-fetches
+  ``Allegory_of_the_cave``.
+- Plus every b3/b4/b5/b6/b7 invariant.
+
+ONE HIGH-severity defect + ONE MEDIUM opportunity unlocked by deeper
+probing.
+
+## Z3 (HIGH) — Non-possessive multi-token tail-hijack
+
+The b4 D2 fix raised the ``iter_query_tails`` ``min_len`` floor to 2
+only for ``has_apostrophe_possessive(topic)``. Non-possessive
+multi-token queries still leak the same hijack at Pass 0
+(``_promote_topic_via_title_index``): libzim's title-suggest fuzzy-
+matches a STRONG single token in the topic at score 0.95 and returns
+just that token's canonical article. The full-topic probe at
+min_score=0.95 (added in b3 to catch ``Einstein's theory`` /
+``Plato's Republic``) accepts the row unconditionally because
+``accept_possessive_promotion`` returns True for any non-possessive
+topic.
+
+Live silent-wrong-answer repros (cert=0.85):
+
+  * ``Stalin USSR Russia`` → ``Russia`` (user wanted Stalin)
+  * ``Hitler Germany Berlin`` → ``Berlin`` (user wanted Hitler)
+  * ``Marie Curie polonium discovery`` → ``Discovery`` (a
+    disambiguation page!)
+  * ``Marie Curie radioactivity`` → ``Radioactive_(Redniss_book)``
+    (obscure 2010 graphic novel surfaced via stemming match)
+  * ``Big Rapids Michigan tourism`` → ``Tourism`` (contradicts the
+    iter_query_windows docstring's own canonical example,
+    ``Big_Rapids,_Michigan``)
+  * ``O'Brien character 1984`` → ``1984`` (the year article)
+
+Counter-cases that work correctly today (regression guards):
+
+  * ``Hamlet Denmark prince`` → ``Hamlet`` (single-token canonical
+    at HEAD position of topic)
+  * ``Napoleon France emperor`` → ``Napoleon`` (head position)
+  * ``Apollo 11 moon landing`` → ``Moon_landing`` (multi-token
+    canonical — not a tail hijack)
+  * ``quantum mechanics Einstein`` → ``Albert_Einstein``
+    (canonical's tokens include topic's last token but canonical
+    itself is multi-token via redirect)
+  * ``Lincoln Gettysburg Address`` → ``Gettysburg_Address``
+    (multi-token canonical)
+  * ``Berlin Germany`` → ``Berlin`` (resolves via
+    ``is_strong_title_match`` at BM25 stage; 2-token topic doesn't
+    trigger Z3 rule anyway)
+
+## Fix — Z3 rule in accept_possessive_promotion's non-possessive branch
+
+For non-possessive topics with ``match_type="fuzzy_suggest"`` where the
+topic has 3+ tokens:
+
+  1. **Tail-token hijack**: canonical is a single token AND that token
+     equals the topic's LAST token → REJECT.
+  2. **Zero-overlap stemming hit**: canonical's tokens have zero exact-
+     overlap with topic's tokens (the match was via stemming alone) →
+     REJECT.
+
+For non-possessive topics with ``match_type="direct"`` or
+``match_type="redirect"``, accept-as-before.
+
+For possessive topics, the existing b6 D1 + b8 Z1.1 logic is
+unchanged (modulo OPP-1, below).
+
+## OPP-1 (MEDIUM) — possessive fuzzy_suggest carve-out
+
+The b6 D1 rule REJECTS every ``match_type="fuzzy_suggest"`` row for a
+possessive topic. Live probe found this is too strict: ``Newton's
+gravity`` falls to BM25 even though ``Newton's_law_of_universal_
+gravitation`` is the obvious rank-1 BM25 canonical AND contains the
+possessor token ``Newton`` literally.
+
+Refinement: for possessive topics + ``fuzzy_suggest``, ACCEPT iff the
+canonical path contains ANY of the topic's possessor tokens (lowered
+case). The matched canonical literally preserves the user's named
+entity, signalling it's a longer-form expansion (not the
+``Darwin's evolution`` → ``Evolution`` shape that drops the possessor).
+
+Decision matrix for possessive + fuzzy_suggest:
+
+  +---------------------------+-----------------------------------+--------+
+  | Topic                     | Canonical                         | Decide |
+  +---------------------------+-----------------------------------+--------+
+  | ``Newton's gravity``      | ``Newton's_law_of_universal_grav…`` | ACCEPT |
+  | ``Mary's lamb``           | ``Mary_Had_a_Little_Lamb``        | ACCEPT |
+  | ``Darwin's evolution``    | ``Evolution``                     | REJECT |
+  | ``Plato's republic philos…`` | ``Czech_philosophy``           | REJECT |
+  +---------------------------+-----------------------------------+--------+
+
+Direct/redirect/missing branches are unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Shared fixtures (mirror post-b6 / post-b7 conventions — see those
+# files for the rationale)
+# ---------------------------------------------------------------------------
+
+
+def _make_simple_handler() -> Any:
+    """Return a stub ``SimpleToolsHandler``-shaped object."""
+
+    class _StubOps:
+        pass
+
+    class _Handler:
+        zim_operations = _StubOps()
+
+    return _Handler()
+
+
+def _fake_find_title_match(
+    mapping: Dict[str, Optional[Dict[str, Any]]],
+    *,
+    min_score_floor: float = 0.0,
+) -> Callable[..., Optional[Dict[str, Any]]]:
+    """Build a ``find_title_match`` stand-in from ``{topic_lower: row}``."""
+
+    def fake(
+        zim_ops: Any,
+        zim_file_path: str,
+        topic: str,
+        *,
+        cross_file: bool = False,
+        min_score: float = 1.0,
+    ) -> Optional[Dict[str, Any]]:
+        if min_score > min_score_floor and min_score_floor > 0.0:
+            return None
+        return mapping.get(topic.lower())
+
+    return fake
+
+
+def _run_promote_simple(
+    topic: str, fake_find: Callable[..., Optional[Dict[str, Any]]]
+) -> Optional[Dict[str, Any]]:
+    """Drive ``_promote_topic_via_title_index`` with ``fake_find`` patched."""
+    from openzim_mcp.simple_tools import SimpleToolsHandler
+
+    with patch("openzim_mcp.simple_tools.find_title_match", side_effect=fake_find):
+        return SimpleToolsHandler._promote_topic_via_title_index(
+            _make_simple_handler(),
+            "test.zim",
+            topic,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Z3: non-possessive multi-token tail-hijack — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestZ3NonPossessiveTailHijack:
+    """``accept_possessive_promotion`` must reject the non-possessive
+    fuzzy_suggest hijack patterns the post-b8 live sweep surfaced.
+
+    The b4 D2 raised-min_len protection covered only possessive
+    topics; non-possessive multi-token queries leak the same hijack
+    via Pass 0's full-topic probe at min_score=0.95.
+    """
+
+    @pytest.mark.parametrize(
+        "topic, canonical_path",
+        [
+            # Live silent-wrong-answer repros at v2.0.0b8 (cert=0.85).
+            # Each row's canonical is a single token equal to the
+            # topic's last token — the tail-hijack pattern.
+            ("Stalin USSR Russia", "Russia"),
+            ("Hitler Germany Berlin", "Berlin"),
+            ("Marie Curie polonium discovery", "Discovery"),
+            ("Big Rapids Michigan tourism", "Tourism"),
+            ("O'Brien character 1984", "1984"),
+            # Generic disambiguator-style topics that share the
+            # hijack shape.
+            ("Apollo 11 mission year 1984", "1984"),
+        ],
+        ids=[
+            "stalin_ussr_russia_tail_hijack",
+            "hitler_germany_berlin_tail_hijack",
+            "marie_curie_polonium_discovery_tail_hijack",
+            "big_rapids_michigan_tourism_tail_hijack",
+            "obrien_character_1984_tail_hijack",
+            "apollo_11_mission_year_1984_tail_hijack",
+        ],
+    )
+    def test_single_token_tail_hijack_rejected(
+        self, topic: str, canonical_path: str
+    ) -> None:
+        from openzim_mcp.title_promotion import accept_possessive_promotion
+
+        promoted = {
+            "path": canonical_path,
+            "title": canonical_path.replace("_", " "),
+            "match_type": "fuzzy_suggest",
+            "pre_redirect_path": canonical_path,
+        }
+        assert accept_possessive_promotion(promoted, topic) is False, (
+            f"Z3 must reject {canonical_path!r} for topic {topic!r}: "
+            f"canonical is a single token equal to topic's last token, "
+            f"signalling libzim's fuzzy-suggest tail-token hijack."
+        )
+
+    def test_zero_overlap_stemming_match_rejected(self) -> None:
+        """``Marie Curie radioactivity`` → ``Radioactive_(Redniss_book)``
+        the live repro where libzim's stemming matches ``radioactive``
+        to ``radioactivity`` and returns an obscure 2010 graphic novel.
+        The canonical's tokens have ZERO exact overlap with the topic
+        tokens (radioactive ≠ radioactivity exactly).
+        """
+        from openzim_mcp.title_promotion import accept_possessive_promotion
+
+        promoted = {
+            "path": "Radioactive_(Redniss_book)",
+            "title": "Radioactive (Redniss book)",
+            "match_type": "fuzzy_suggest",
+            "pre_redirect_path": "Radioactive_(Redniss_book)",
+        }
+        assert (
+            accept_possessive_promotion(promoted, "Marie Curie radioactivity") is False
+        )
+
+
+# ---------------------------------------------------------------------------
+# Z3: regression guards — counter-cases that MUST keep working
+# ---------------------------------------------------------------------------
+
+
+class TestZ3RegressionGuards:
+    """Pin the non-possessive multi-token cases the live sweep
+    confirmed currently work — Z3's fix must NOT regress these."""
+
+    @pytest.mark.parametrize(
+        "topic, canonical_path",
+        [
+            # Single-token canonical at the HEAD position of the topic
+            # — the user's primary subject. ACCEPT.
+            ("Hamlet Denmark prince", "Hamlet"),
+            ("Napoleon France emperor", "Napoleon"),
+            # Multi-token canonical, even when it matches the topic's
+            # tail — ACCEPT. (The single-token rule fires only on
+            # 1-token canonicals; multi-token canonicals signal a real
+            # phrase match, not a hijack.)
+            ("Apollo 11 moon landing", "Moon_landing"),
+            ("Lincoln Gettysburg Address", "Gettysburg_Address"),
+            # 2-token topic — the Z3 rule requires topic_tokens ≥ 3 so
+            # this case (which already works via is_strong_title_match
+            # at BM25 stage) stays unchanged. ACCEPT at the promotion
+            # gate level too.
+            ("Berlin Germany", "Berlin"),
+        ],
+        ids=[
+            "hamlet_at_head_accept",
+            "napoleon_at_head_accept",
+            "apollo_11_moon_landing_multi_token_canonical_accept",
+            "lincoln_gettysburg_address_multi_token_accept",
+            "berlin_germany_2token_topic_accept",
+        ],
+    )
+    def test_non_possessive_legitimate_match_accepted(
+        self, topic: str, canonical_path: str
+    ) -> None:
+        from openzim_mcp.title_promotion import accept_possessive_promotion
+
+        promoted = {
+            "path": canonical_path,
+            "title": canonical_path.replace("_", " "),
+            "match_type": "fuzzy_suggest",
+            "pre_redirect_path": canonical_path,
+        }
+        assert accept_possessive_promotion(promoted, topic) is True
+
+    def test_quantum_mechanics_einstein_via_redirect(self) -> None:
+        """``quantum mechanics Einstein`` → ``Albert_Einstein`` via a
+        redirect from ``Einstein`` to ``Albert_Einstein``. Even though
+        the canonical's tokens include the topic's last token, the
+        match_type=redirect signals a semantic entity reference, not
+        a tail hijack — and the canonical is 2 tokens (not 1)."""
+        from openzim_mcp.title_promotion import accept_possessive_promotion
+
+        promoted = {
+            "path": "Albert_Einstein",
+            "title": "Albert Einstein",
+            "match_type": "redirect",
+            "pre_redirect_path": "Einstein",
+        }
+        assert (
+            accept_possessive_promotion(promoted, "quantum mechanics Einstein") is True
+        )
+
+    def test_direct_match_unconditional(self) -> None:
+        """``match_type="direct"`` is the strongest libzim signal —
+        post-redirect title equals user input case-insensitively.
+        Always ACCEPT, even for multi-token topics, regardless of
+        canonical token count."""
+        from openzim_mcp.title_promotion import accept_possessive_promotion
+
+        promoted = {
+            "path": "Russia",
+            "title": "Russia",
+            "match_type": "direct",
+            "pre_redirect_path": "Russia",
+        }
+        # When the user literally types "Russia" (1 token), direct
+        # match accepts (this is the existing single-token-topic
+        # behavior; Z3 doesn't change it).
+        assert accept_possessive_promotion(promoted, "Russia") is True
+
+
+# ---------------------------------------------------------------------------
+# OPP-1: possessive fuzzy_suggest carve-out
+# ---------------------------------------------------------------------------
+
+
+class TestOPP1PossessorInCanonical:
+    """Possessive + fuzzy_suggest should ACCEPT iff the canonical path
+    contains any of the topic's possessor tokens (the canonical
+    preserves the user's named entity)."""
+
+    @pytest.mark.parametrize(
+        "topic, canonical_path, expected_accept",
+        [
+            # Live OPP-1 repro: canonical preserves the possessor →
+            # ACCEPT, replaces blanket b6 D1 reject.
+            (
+                "Newton's gravity",
+                "Newton's_law_of_universal_gravitation",
+                True,
+            ),
+            # Another carve-out shape: canonical preserves the
+            # possessor token (no apostrophe in canonical itself).
+            ("Mary's lamb", "Mary_Had_a_Little_Lamb", True),
+            # b6 D1 attack surface preserved: canonical DROPS the
+            # possessor entirely → REJECT.
+            ("Darwin's evolution", "Evolution", False),
+            # Original b6 Z1 attack surface preserved: associative
+            # canonical that shares a different token but not the
+            # possessor → REJECT.
+            (
+                "Plato's republic philosophy",
+                "Czech_philosophy",
+                False,
+            ),
+            # Multi-possessor carve-out: canonical contains at least
+            # ONE of the possessors → ACCEPT.
+            (
+                "John's and Mary's books",
+                "Mary_Shelley_bibliography",
+                True,
+            ),
+        ],
+        ids=[
+            "newtons_gravity_canonical_preserves_possessor_accept",
+            "marys_lamb_canonical_preserves_possessor_accept",
+            "darwins_evolution_possessor_dropped_reject",
+            "platos_philosophy_associative_reject",
+            "multi_possessor_one_match_accept",
+        ],
+    )
+    def test_possessive_fuzzy_suggest_canonical_possessor_carveout(
+        self, topic: str, canonical_path: str, expected_accept: bool
+    ) -> None:
+        from openzim_mcp.title_promotion import accept_possessive_promotion
+
+        promoted = {
+            "path": canonical_path,
+            "title": canonical_path.replace("_", " "),
+            "match_type": "fuzzy_suggest",
+            "pre_redirect_path": canonical_path,
+        }
+        assert accept_possessive_promotion(promoted, topic) is expected_accept, (
+            f"OPP-1: possessor-in-canonical carve-out wrong for "
+            f"topic={topic!r}, canonical={canonical_path!r}"
+        )
+
+    def test_possessive_redirect_b8_subset_rule_unchanged(self) -> None:
+        """The b8 Z1.1 subset rule must remain in force for
+        possessive + redirect — OPP-1's fuzzy_suggest carve-out
+        doesn't touch the redirect branch."""
+        from openzim_mcp.title_promotion import accept_possessive_promotion
+
+        # b8 Z1.1 truncation-redirect shape: pre_path has extras not in
+        # topic → REJECT (existing b8 behavior, unchanged by post-b8).
+        promoted = {
+            "path": "Evolution",
+            "title": "Evolution",
+            "match_type": "redirect",
+            "pre_redirect_path": "Darwin's_Theory_of_Evolution",
+        }
+        assert accept_possessive_promotion(promoted, "Darwin's evolution") is False
+
+
+# ---------------------------------------------------------------------------
+# Integration through _promote_topic_via_title_index
+# ---------------------------------------------------------------------------
+
+
+class TestZ3PromoteIntegration:
+    """End-to-end shape: Pass 0's full-topic probe at min_score=0.95
+    must REJECT the Z3 hijack canonicals and fall through to
+    BM25 (None return)."""
+
+    def test_stalin_ussr_russia_rejected_at_pass_0(self) -> None:
+        """Live repro: Pass 0 returns ``Russia`` (fuzzy_suggest) at
+        0.95 for ``Stalin USSR Russia``. Z3 rejects → no other tail/
+        window resolves → return None → BM25 fallback."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "stalin ussr russia": {
+                "path": "Russia",
+                "title": "Russia",
+                "zim_file": "test.zim",
+                "match_type": "fuzzy_suggest",
+                "pre_redirect_path": "Russia",
+            },
+        }
+        result = _run_promote_simple(
+            "Stalin USSR Russia",
+            _fake_find_title_match(mapping, min_score_floor=0.95),
+        )
+        assert (
+            result is None
+        ), f"Z3 must reject Russia for Stalin USSR Russia; got {result!r}"
+
+    def test_hamlet_denmark_prince_still_accepts_at_pass_0(self) -> None:
+        """Counter-case: Pass 0 returns ``Hamlet`` (fuzzy_suggest, but
+        the canonical token equals topic's HEAD token, not tail).
+        Z3's tail-hijack rule does NOT fire → accept → return Hamlet."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "hamlet denmark prince": {
+                "path": "Hamlet",
+                "title": "Hamlet",
+                "zim_file": "test.zim",
+                "match_type": "fuzzy_suggest",
+                "pre_redirect_path": "Hamlet",
+            },
+        }
+        result = _run_promote_simple(
+            "Hamlet Denmark prince",
+            _fake_find_title_match(mapping, min_score_floor=0.95),
+        )
+        assert result is not None and result["path"] == "Hamlet"
+
+    def test_newtons_gravity_accepted_at_pass_0_via_opp1(self) -> None:
+        """OPP-1 carve-out: Pass 0 returns
+        ``Newton's_law_of_universal_gravitation`` (fuzzy_suggest) for
+        ``Newton's gravity``. Pre-OPP-1: b6 D1 blanket-rejected.
+        Post-OPP-1: canonical contains the possessor ``Newton`` →
+        accept → return canonical."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "newton's gravity": {
+                "path": "Newton's_law_of_universal_gravitation",
+                "title": "Newton's law of universal gravitation",
+                "zim_file": "test.zim",
+                "match_type": "fuzzy_suggest",
+                "pre_redirect_path": "Newton's_law_of_universal_gravitation",
+            },
+        }
+        result = _run_promote_simple(
+            "Newton's gravity",
+            _fake_find_title_match(mapping, min_score_floor=0.95),
+        )
+        assert (
+            result is not None
+            and result["path"] == "Newton's_law_of_universal_gravitation"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Structural pins
+# ---------------------------------------------------------------------------
+
+
+class TestStructuralGuards:
+    """Lightweight pins that catch accidental revert of the Z3 / OPP-1
+    refinements at the source level."""
+
+    def test_accept_possessive_promotion_handles_non_possessive_fuzzy_suggest(
+        self,
+    ) -> None:
+        """Structural pin: ``accept_possessive_promotion`` source must
+        reference the non-possessive fuzzy_suggest branch (the Z3
+        gate). Catches an accidental revert that drops the rule back
+        to ``return True`` unconditionally for non-possessive."""
+        import inspect
+
+        from openzim_mcp import title_promotion
+
+        source = inspect.getsource(title_promotion.accept_possessive_promotion)
+        # The Z3 rule references fuzzy_suggest in the non-possessive
+        # branch. Earlier b6 D1 references fuzzy_suggest in the
+        # possessive branch — both should remain in source.
+        assert source.count("fuzzy_suggest") >= 2, (
+            "accept_possessive_promotion must check fuzzy_suggest in "
+            "both possessive (b6 D1) and non-possessive (post-b8 Z3) "
+            "branches"
+        )

--- a/tests/test_post_b8_beta_fixes.py
+++ b/tests/test_post_b8_beta_fixes.py
@@ -492,23 +492,47 @@ class TestStructuralGuards:
     """Lightweight pins that catch accidental revert of the Z3 / OPP-1
     refinements at the source level."""
 
-    def test_accept_possessive_promotion_handles_non_possessive_fuzzy_suggest(
+    def test_accept_possessive_promotion_dispatches_to_per_branch_helpers(
         self,
     ) -> None:
-        """Structural pin: ``accept_possessive_promotion`` source must
-        reference the non-possessive fuzzy_suggest branch (the Z3
-        gate). Catches an accidental revert that drops the rule back
-        to ``return True`` unconditionally for non-possessive."""
+        """Structural pin: ``accept_possessive_promotion`` dispatches
+        to dedicated per-branch helpers. Catches an accidental revert
+        that re-inlines the Z3 / OPP-1 logic (and re-raises Sonar
+        cognitive-complexity over 15).
+
+        The function should resolve the topic-shape (non-possessive
+        vs possessive) and the match_type, then delegate to the
+        helper for that combination. Each helper owns its own
+        comment block explaining the safety reasoning.
+        """
         import inspect
 
         from openzim_mcp import title_promotion
 
+        # Per-branch helpers must exist (importable from the module).
+        assert hasattr(title_promotion, "_accept_non_possessive")
+        assert hasattr(title_promotion, "_accept_possessive_fuzzy_suggest")
+        assert hasattr(title_promotion, "_accept_possessive_redirect")
+
+        # The dispatcher's source must reference each helper at least
+        # once — keeps the dispatch table from atrophying.
         source = inspect.getsource(title_promotion.accept_possessive_promotion)
-        # The Z3 rule references fuzzy_suggest in the non-possessive
-        # branch. Earlier b6 D1 references fuzzy_suggest in the
-        # possessive branch — both should remain in source.
-        assert source.count("fuzzy_suggest") >= 2, (
-            "accept_possessive_promotion must check fuzzy_suggest in "
-            "both possessive (b6 D1) and non-possessive (post-b8 Z3) "
-            "branches"
+        assert "_accept_non_possessive" in source
+        assert "_accept_possessive_fuzzy_suggest" in source
+        assert "_accept_possessive_redirect" in source
+
+    def test_non_possessive_helper_handles_fuzzy_suggest_branch(self) -> None:
+        """Structural pin: ``_accept_non_possessive`` must reference
+        ``fuzzy_suggest`` so the Z3 rule (the non-possessive branch
+        Z3 fix lives in) isn't accidentally short-circuited back to
+        ``return True``. Earlier b6 D1 reference lives in the
+        ``_accept_possessive_fuzzy_suggest`` helper."""
+        import inspect
+
+        from openzim_mcp import title_promotion
+
+        np_source = inspect.getsource(title_promotion._accept_non_possessive)
+        assert "fuzzy_suggest" in np_source, (
+            "_accept_non_possessive must check match_type=fuzzy_suggest "
+            "(the Z3 gate) — see post-b8 sweep"
         )

--- a/tests/test_post_b8_beta_fixes.py
+++ b/tests/test_post_b8_beta_fixes.py
@@ -109,12 +109,8 @@ from typing import Any, Dict, Optional
 
 import pytest
 
-from tests._promote_fixtures import (
-    fake_find_title_match as _fake_find_title_match,
-)
-from tests._promote_fixtures import (
-    run_promote_simple as _run_promote_simple,
-)
+from tests._promote_fixtures import fake_find_title_match as _fake_find_title_match
+from tests._promote_fixtures import run_promote_simple as _run_promote_simple
 
 # ---------------------------------------------------------------------------
 # Z3: non-possessive multi-token tail-hijack — direct unit tests


### PR DESCRIPTION
Post-b8 live-MCP sweep against v2.0.0b8 confirmed ALL prior b6/b7/b8 fixes land cleanly on live (`Darwin's evolution` → BM25, `Plato's republic philosophy` → BM25, `Einstein's theory synthesize=true` → `Theory_of_relativity` rank 1, `Plato's cave` → `Allegory_of_the_cave`).

**ONE HIGH-severity defect + ONE MEDIUM opportunity unlocked by deeper probing of the non-possessive + 3+ token shape.**

## Z3 (HIGH) — Non-possessive multi-token tail-hijack

The b4 D2 raised-`min_len` floor protected possessive topics from trailing 1-token tails winning at strict 1.0. Non-possessive multi-token queries still leaked the same hijack at Pass 0 (`_promote_topic_via_title_index`): libzim's title-suggest fuzzy-matches a strong single token in the topic at score 0.95 and returns just that token's canonical alone. The full-topic probe at `min_score=0.95` (added in b3) accepts the row because `accept_possessive_promotion` returns True for any non-possessive topic.

**Live silent-wrong-answer repros at v2.0.0b8 (all cert=0.85):**

- `Stalin USSR Russia` → `Russia` (user wanted Stalin)
- `Hitler Germany Berlin` → `Berlin` (user wanted Hitler)
- `Marie Curie polonium discovery` → `Discovery` (a disambig page!)
- `Marie Curie radioactivity` → `Radioactive_(Redniss_book)` (an obscure 2010 graphic novel surfaced via stemming match)
- `Big Rapids Michigan tourism` → `Tourism` (contradicts the `iter_query_windows` docstring's own canonical example, `Big_Rapids,_Michigan`)
- `O'Brien character 1984` → `1984` (the year article)

**Counter-cases the fix preserves:**

- `Hamlet Denmark prince` → `Hamlet` (canonical at HEAD position)
- `Napoleon France emperor` → `Napoleon` (head position)
- `Apollo 11 moon landing` → `Moon_landing` (multi-token canonical)
- `quantum mechanics Einstein` → `Albert_Einstein` (multi-token via redirect)
- `Lincoln Gettysburg Address` → `Gettysburg_Address` (multi-token)
- `Berlin Germany` → `Berlin` (resolves via `is_strong_title_match` at BM25 stage; 2-token topic doesn't trigger Z3 rule)

### Fix — non-possessive fuzzy_suggest gate

Two narrow rejections in `accept_possessive_promotion`'s non-possessive branch when `match_type="fuzzy_suggest"` and the topic has 3+ tokens:

1. **Tail-token hijack** — canonical is a single token equal to the topic's LAST token. The user typed `<subject> ... <generic>`; libzim returned the generic article. `Hamlet Denmark prince` → `Hamlet` stays accepted because the canonical sits at the HEAD position, not the tail.
2. **Zero-overlap stemming hit** — canonical's tokens have zero exact-overlap with topic's tokens (the match was via stemming only). The graphic novel surfaced for `Marie Curie radioactivity` because libzim's title index stems `radioactivity` to `radioactive`; no other topic token matches the canonical, so the hit is one-stem-token-deep — too thin a signal to auto-fetch.

Topics with fewer than 3 tokens are unaffected.

## OPP-1 (MEDIUM) — Possessive fuzzy_suggest carve-out

The b6 D1 rule REJECTS every `match_type="fuzzy_suggest"` row for a possessive topic. Live probe found this is too strict: `Newton's gravity` falls to BM25 even though `Newton's_law_of_universal_gravitation` is the obvious rank-1 BM25 canonical AND contains the possessor token `newton` literally.

### Refinement

For possessive topics + `fuzzy_suggest`, ACCEPT iff the canonical path tokens include any of the topic's possessor tokens. The canonical literally preserves the user's named entity, signalling it's a longer-form expansion rather than the `Darwin's evolution` → `Evolution` shape that drops the possessor.

**Decision matrix for possessive + fuzzy_suggest:**

| Topic | Canonical | Decision |
|---|---|---|
| `Newton's gravity` | `Newton's_law_of_universal_gravitation` | ACCEPT (OPP-1) |
| `Mary's lamb` | `Mary_Had_a_Little_Lamb` | ACCEPT |
| `Darwin's evolution` | `Evolution` | REJECT (b6 D1 preserved) |
| `Plato's republic philosophy` | `Czech_philosophy` | REJECT (b6 Z1 preserved) |

Tokenization uses `_TOKEN_RE` (apostrophe-splitting), same as the b8 Z1.1 subset rule for redirects, so `newton's` in the canonical surfaces as the bare token `newton` for comparison.

## Tests

**24 new tests** in `tests/test_post_b8_beta_fixes.py` across 5 classes:

- `TestZ3NonPossessiveTailHijack` (6 parametrized + 1 standalone)
- `TestZ3RegressionGuards` (5 parametrized + 2 standalone)
- `TestOPP1PossessorInCanonical` (5 parametrized + 1 standalone)
- `TestZ3PromoteIntegration` (3 end-to-end through `_promote_topic_via_title_index`)
- `TestStructuralGuards` (1 source pin)

```
2447 passed, 54 skipped (full suite, ~28s)
pip-audit: no known vulnerabilities
```

mypy clean across 52 source files. black + flake8 clean.

## Methodology — "fix unlocks new paths" 16 sweeps strong

Each sweep peeled back another layer:

- **b3**: full-topic probe at 0.95 catches `Einstein's theory`.
- **b4 D2**: raised `iter_query_tails` `min_len=2` for possessive topics.
- **b6 D1**: rejected `fuzzy_suggest+possessive` blanketly.
- **b6 Z1**: pre-redirect-path filter for associative redirects.
- **b8 Z1.1**: redirect subset rule for truncation shape.
- **post-b8 Z3** (this sweep): the b4 D2 protection generalises to non-possessive multi-token topics — same hijack, symmetric attack surface.
- **post-b8 OPP-1** (this sweep): b6 D1 blanket-reject relaxed when canonical preserves the possessor literally.

## What's not in this PR

Version bump / CHANGELOG entry — follows the sweep convention (release PR is separate).
