### PR TITLE
fix(v2): post-b9 beta-test sweep — Z3 all match_types + Pass 1/2 gate + OPP-1 redirect extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ yarn.lock
 
 # Prettier cache (configured via --cache-location in pre-commit)
 .cache/
+.claude/

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -3941,9 +3941,16 @@ class SimpleToolsHandler:
         # Pass 1: strict 1.0-score gate across every trailing tail.
         # Prefer an exact title match on any tail (even a short one)
         # over a typo-tolerant fuzzy match on a longer noisier tail.
+        # Post-b9 Z3: gate every pass through accept_possessive_promotion
+        # so the non-possessive tail-token-hijack rule fires here too.
+        # The b9 Z3 rule was wired into accept_possessive_promotion but
+        # Pass 1 (and Pass 2) returned ``promoted`` directly without
+        # consulting the gate, so the live Stalin USSR Russia → Russia
+        # silent-wrong-answer (Pass 1's 1-token tail ``"russia"`` →
+        # direct match) sailed past unchecked.
         for tail in iter_query_tails(topic, min_len=pass_tail_min_len):
             promoted = find_title_match(self.zim_operations, zim_file_path, tail)
-            if promoted is not None:
+            if promoted is not None and accept_possessive_promotion(promoted, topic):
                 return promoted
         # Pass 2: strict 1.0-score gate across non-trailing windows.
         # Catches head/middle-positioned entities like
@@ -3951,7 +3958,7 @@ class SimpleToolsHandler:
         # (more specific) windows win.
         for window in iter_query_windows(topic, min_len=pass_tail_min_len):
             promoted = find_title_match(self.zim_operations, zim_file_path, window)
-            if promoted is not None:
+            if promoted is not None and accept_possessive_promotion(promoted, topic):
                 return promoted
         # Pass 3: 0.8 typo-tolerant gate. Only fires when no strict
         # match exists at all — catches single-edit typos.

--- a/openzim_mcp/title_promotion.py
+++ b/openzim_mcp/title_promotion.py
@@ -406,19 +406,71 @@ def _accept_non_possessive(
     ``Berlin`` resolves via ``is_strong_title_match`` at the BM25
     stage anyway, and 2-token possessive carve-outs are handled by
     the possessive branch.
+
+    Post-b9 Z3 extension: the b9 rule gated the tail-hijack check on
+    ``match_type == "fuzzy_suggest"``. Live post-b9 sweep against
+    v2.0.0b9 revealed every Z3 silent-wrong-answer actually routes
+    through ``_promote_topic_via_title_index`` Pass 1's
+    ``iter_query_tails`` 1-token tail probe, where the tail string
+    (``"russia"``, ``"berlin"``, ``"discovery"``, etc.) is passed to
+    ``find_title_match``. libzim sees the tail string as a
+    case-insensitive title equal → returns ``match_type="direct"``
+    at score 1.0. The b9 short-circuit ``if match_type !=
+    "fuzzy_suggest": return True`` bypassed the Z3 check entirely.
+
+    The tail-hijack premise is purely about the topic↔canonical
+    token relationship; it doesn't depend on how libzim resolved
+    the match. Apply it regardless of match_type. The zero-overlap
+    stemming sub-rule stays gated on ``fuzzy_suggest`` (a direct or
+    redirect match by definition shares at least the matched token,
+    so the rule is moot for those branches).
+
+    Discriminator — multi-entity vs filler-prose: the documented
+    Pass 1 1-token-tail feature MUST keep working for queries like
+    ``what is the population of detroit`` → ``Detroit`` and
+    ``people who live in michigan`` → ``Michigan`` (lowercase prose
+    + entity at tail). Only reject the tail-hijack when the topic
+    has 2+ "specific" tokens — tokens that are capitalized in the
+    original case OR digit-only. The silent-wrong-answer pattern is
+    distinguished by stacking multiple proper-noun-shaped tokens
+    (``Stalin USSR Russia``, ``Hitler Germany Berlin``, ``O'Brien
+    character 1984``); legitimate filler-prose queries have at most
+    one capitalized entity (the tail itself).
     """
-    if match_type != "fuzzy_suggest":
-        return True
     topic_tokens_seq = _TAIL_TOKEN_RE.findall(topic.lower())
     if len(topic_tokens_seq) < 3:
         return True
     cand_path = str(promoted.get("path", ""))
     cand_tokens_seq = _TAIL_TOKEN_RE.findall(cand_path.lower())
     if len(cand_tokens_seq) == 1 and cand_tokens_seq == topic_tokens_seq[-1:]:
-        return False
-    if not (set(cand_tokens_seq) & set(topic_tokens_seq)):
+        original_tokens = _TAIL_TOKEN_RE.findall(topic)
+        specific_count = sum(1 for tok in original_tokens if _is_specific_token(tok))
+        if specific_count >= 2:
+            return False
+    if match_type == "fuzzy_suggest" and not (
+        set(cand_tokens_seq) & set(topic_tokens_seq)
+    ):
         return False
     return True
+
+
+def _is_specific_token(token: str) -> bool:
+    """True iff ``token`` looks like a specific entity / identifier
+    (capitalized word OR digit-only run) rather than filler prose.
+
+    Used by the Z3 tail-hijack discriminator to count how many
+    proper-noun-shaped tokens the topic carries before rejecting a
+    1-token-tail-equals-last-topic-token canonical. Two or more
+    "specific" tokens signal a multi-entity stack the user is
+    asking about jointly — making the trailing-tail auto-fetch a
+    silent-wrong-answer. Zero or one signals filler prose + a
+    single entity reference — making the trailing-tail auto-fetch
+    the user's actual subject.
+    """
+    if not token:
+        return False
+    first = token[0]
+    return first.isupper() or token.isdigit()
 
 
 def _accept_possessive_fuzzy_suggest(promoted: Dict[str, Any], topic: str) -> bool:
@@ -452,6 +504,23 @@ def _accept_possessive_redirect(promoted: Dict[str, Any], topic: str) -> bool:
     of the topic's tokens. Catches both b6 Z1 associative redirects
     (pre-path unrelated to user's possessor) and b8 Z1.1 truncation
     redirects (pre-path is a longer phrase the user truncated).
+
+    Post-b9 OPP-1 redirect extension: when the subset rule rejects
+    (pre-path has tokens not in the topic), STILL accept if the
+    post-redirect canonical path preserves the user's possessor
+    token literally. Live: ``Newton's gravity`` resolves through
+    libzim's redirect chain ``Newton_Laws_of_Gravity`` →
+    ``Newton's_law_of_universal_gravitation``; pre-path
+    ``{newton, laws, of, gravity} ⊄ {newton, s, gravity}`` would
+    reject under b8 Z1.1, but the post-redirect canonical literally
+    contains ``newton`` — the redirect IS semantic, just one that
+    libzim happened to route via a non-subset stem path.
+
+    The b6 Z1 ``Plato's republic philosophy`` → ``Czech_philosophy``
+    attack surface continues to reject because ``plato`` is not in
+    ``Czech_philosophy``. The b7 Z1.1 ``Darwin's evolution`` →
+    ``Evolution`` attack surface continues to reject because
+    ``darwin`` is not in ``Evolution``.
     """
     pre_path = promoted.get("pre_redirect_path", "") or promoted.get("path", "")
     # ``_TOKEN_RE`` is the same ASCII-alphanumerics tokenizer
@@ -466,7 +535,12 @@ def _accept_possessive_redirect(promoted: Dict[str, Any], topic: str) -> bool:
         # path depends on.
         return True
     topic_tokens = set(_TOKEN_RE.findall(topic.lower()))
-    return pre_tokens.issubset(topic_tokens)
+    if pre_tokens.issubset(topic_tokens):
+        return True
+    cand_path = str(promoted.get("path", ""))
+    cand_tokens = set(_TOKEN_RE.findall(cand_path.lower()))
+    possessors = set(extract_possessor_tokens(topic))
+    return bool(possessors & cand_tokens)
 
 
 def iter_query_tails(

--- a/tests/test_post_b4_beta_fixes.py
+++ b/tests/test_post_b4_beta_fixes.py
@@ -251,6 +251,16 @@ class TestFuzzySuggestGateReject:
                     "title": "Allegory of the cave",
                     "zim_file": "test.zim",
                     "match_type": "redirect",
+                    # Post-b6 Z1 / b8 Z1.1 require pre_redirect_path
+                    # to evaluate the redirect's semantic
+                    # relatedness. The live row libzim emits for
+                    # ``plato's cave`` carries this; the test
+                    # originally omitted it and incidentally passed
+                    # because Pass 1's no-gate fall-through
+                    # compensated. Post-b10 Z3 adds the gate to
+                    # Pass 1 / Pass 2 too, so the mock now reflects
+                    # the actual live shape.
+                    "pre_redirect_path": "Plato's_cave",
                 }
             return None
 

--- a/tests/test_post_b9_beta_fixes.py
+++ b/tests/test_post_b9_beta_fixes.py
@@ -1,0 +1,471 @@
+r"""Regression tests for the post-b9 beta-test sweep.
+
+The post-b9 live-MCP sweep against v2.0.0b9 confirmed the b9 Z3 +
+OPP-1 fixes land at the unit-test level but BOTH bypass the actual
+live silent-wrong-answer code paths because b9 gated on the wrong
+``match_type``.
+
+## Z3-bypass (HIGH) — tail-hijack lives on the direct/redirect branches
+
+The b9 Z3 rule only fires inside ``_accept_non_possessive`` when
+``match_type == "fuzzy_suggest"``. The live ``Stalin USSR Russia`` →
+``Russia`` silent-wrong-answer routes through Pass 1
+``iter_query_tails`` (full topic returns ``None`` from
+``find_title_match``, so the next pass kicks in), where the
+1-token tail ``"russia"`` is passed to ``find_title_match``.
+libzim sees ``"russia" == "Russia"`` case-insensitively → returns
+``match_type="direct"`` at score 1.0. The accept gate routes to
+``_accept_non_possessive`` with ``match_type="direct"`` →
+``if match_type != "fuzzy_suggest": return True`` → immediate
+ACCEPT → silently returns Russia.
+
+The same shape applies to every Z3 repro at the live deployment:
+
+  * ``Stalin USSR Russia`` → Pass 1 ``"russia"`` direct
+  * ``Hitler Germany Berlin`` → Pass 1 ``"berlin"`` direct
+  * ``Marie Curie polonium discovery`` → Pass 1 ``"discovery"`` direct
+  * ``Big Rapids Michigan tourism`` → Pass 1 ``"tourism"`` direct
+  * ``O'Brien character 1984`` → Pass 1 ``"1984"`` direct
+  * ``Marie Curie radioactivity`` → Pass 1 ``"radioactivity"`` direct
+    (libzim's title-suggest happens to fuzzy-match
+    ``Radioactive_(Redniss_book)`` via stemming, but for the
+    direct-match path against the ZIM corpus the canonical token
+    equals the topic tail — same shape)
+
+The fix is to generalise the b9 tail-token-hijack rule to apply to
+ALL match_types (direct, redirect, fuzzy_suggest, missing), not just
+fuzzy_suggest. The rule's premise — "for a non-possessive multi-
+token topic, a single-token canonical equal to the topic's LAST
+token is the trailing-tail-hijack pattern" — is purely about the
+topic↔canonical token relationship; it doesn't depend on how libzim
+resolved the match.
+
+The zero-overlap stemming sub-rule stays gated on fuzzy_suggest
+(direct matches by definition share at least the matched token, so
+the rule is moot for direct/redirect).
+
+## OPP-1-bypass (MEDIUM) — Newton's gravity redirect canonical preserves possessor
+
+The b9 OPP-1 carve-out only fires inside
+``_accept_possessive_fuzzy_suggest``. The live ``Newton's gravity``
+case routes through ``_accept_possessive_redirect``: libzim returns
+``Newton's_law_of_universal_gravitation`` with
+``match_type="redirect"`` and
+``pre_redirect_path="Newton_Laws_of_Gravity"``. The b7 Z1.1 subset
+rule then rejects because ``{newton, laws, of, gravity} ⊄ {newton,
+s, gravity}`` — pre-path has extras ``laws`` / ``of`` not in the
+topic. OPP-1's possessor-in-canonical check never runs.
+
+The fix is to extend OPP-1's possessor-in-canonical carve-out to
+``_accept_possessive_redirect`` as a fallback after the subset rule
+rejects: when ``pre_tokens ⊄ topic_tokens``, STILL accept if the
+post-redirect canonical path contains any of the topic's possessor
+tokens. The b6 Z1 ``Plato's republic philosophy`` →
+``Czech_philosophy`` attack surface continues to reject because
+``plato`` is not in ``Czech_philosophy``. The b7 Z1.1
+``Darwin's evolution`` → ``Evolution`` attack surface continues to
+reject because ``darwin`` is not in ``Evolution``.
+
+Decision matrix for possessive + redirect:
+
+  +----------------------+-------------------------------+--------+
+  | Topic                | Resolved canonical            | Decide |
+  +----------------------+-------------------------------+--------+
+  | ``Plato's cave``     | ``Allegory_of_the_cave`` via  | ACCEPT |
+  |                      | pre=``Plato's_cave``          | (b8)   |
+  | ``Einstein's theory``| ``Theory_of_relativity`` via  | ACCEPT |
+  |                      | pre=``Einstein's_theory``     | (b8)   |
+  | ``Newton's gravity`` | ``Newton's_law_of_…`` via     | ACCEPT |
+  |                      | pre=``Newton_Laws_of_Gravity``| (OPP-1)|
+  | ``Darwin's evolution``| ``Evolution`` via            | REJECT |
+  |                      | pre=``Darwin's_Theory_of_…``  | (b7)   |
+  | ``Plato's republic … ``| ``Czech_philosophy``        | REJECT |
+  |                      |                               | (b6)   |
+  +----------------------+-------------------------------+--------+
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import pytest
+
+from tests._promote_fixtures import fake_find_title_match as _fake_find_title_match
+from tests._promote_fixtures import run_promote_simple as _run_promote_simple
+
+# ---------------------------------------------------------------------------
+# Z3-bypass: tail-token hijack must fire on direct + redirect match_types
+# ---------------------------------------------------------------------------
+
+
+class TestZ3TailHijackAllMatchTypes:
+    """The b9 Z3 rule only fired on ``match_type="fuzzy_suggest"``.
+    The live silent-wrong-answers route through ``direct`` (the Pass
+    1 tail-probe path). The rule must fire regardless of match_type."""
+
+    @pytest.mark.parametrize(
+        "match_type",
+        ["direct", "redirect", "fuzzy_suggest"],
+        ids=["direct", "redirect", "fuzzy_suggest"],
+    )
+    @pytest.mark.parametrize(
+        "topic, canonical_path",
+        [
+            ("Stalin USSR Russia", "Russia"),
+            ("Hitler Germany Berlin", "Berlin"),
+            ("Marie Curie polonium discovery", "Discovery"),
+            ("Big Rapids Michigan tourism", "Tourism"),
+            ("O'Brien character 1984", "1984"),
+        ],
+        ids=[
+            "stalin_ussr_russia",
+            "hitler_germany_berlin",
+            "marie_curie_polonium_discovery",
+            "big_rapids_michigan_tourism",
+            "obrien_character_1984",
+        ],
+    )
+    def test_tail_hijack_rejected_regardless_of_match_type(
+        self, topic: str, canonical_path: str, match_type: str
+    ) -> None:
+        from openzim_mcp.title_promotion import accept_possessive_promotion
+
+        promoted = {
+            "path": canonical_path,
+            "title": canonical_path.replace("_", " "),
+            "match_type": match_type,
+            "pre_redirect_path": canonical_path,
+        }
+        assert accept_possessive_promotion(promoted, topic) is False, (
+            f"Z3 must reject {canonical_path!r} for topic {topic!r} when "
+            f"match_type={match_type!r}: canonical is a single token equal "
+            f"to topic's last token — the tail-hijack pattern, regardless "
+            f"of how libzim resolved the match."
+        )
+
+
+class TestZ3TailHijackRegressionGuards:
+    """Counter-cases that MUST keep working under the extended Z3 rule."""
+
+    @pytest.mark.parametrize(
+        "match_type",
+        ["direct", "redirect", "fuzzy_suggest"],
+        ids=["direct", "redirect", "fuzzy_suggest"],
+    )
+    @pytest.mark.parametrize(
+        "topic, canonical_path",
+        [
+            # HEAD position: canonical's single token matches topic's
+            # FIRST token, not last. Must ACCEPT — the user's primary
+            # subject is at the head.
+            ("Hamlet Denmark prince", "Hamlet"),
+            ("Napoleon France emperor", "Napoleon"),
+            ("Stalin USSR Russia", "Stalin"),
+            ("Hitler Germany Berlin", "Hitler"),
+        ],
+        ids=[
+            "hamlet_at_head",
+            "napoleon_at_head",
+            "stalin_at_head",
+            "hitler_at_head",
+        ],
+    )
+    def test_head_position_canonical_accepted(
+        self, topic: str, canonical_path: str, match_type: str
+    ) -> None:
+        from openzim_mcp.title_promotion import accept_possessive_promotion
+
+        promoted = {
+            "path": canonical_path,
+            "title": canonical_path.replace("_", " "),
+            "match_type": match_type,
+            "pre_redirect_path": canonical_path,
+        }
+        assert accept_possessive_promotion(promoted, topic) is True, (
+            f"Z3 must NOT reject {canonical_path!r} for topic {topic!r}: "
+            f"canonical at HEAD position is the user's subject, not "
+            f"a noisy tail hijack."
+        )
+
+    def test_multi_token_canonical_accepted(self) -> None:
+        """Multi-token canonical = real phrase match, never a tail
+        hijack. Apollo 11 moon landing → Moon_landing is the
+        canonical Pass-0 example."""
+        from openzim_mcp.title_promotion import accept_possessive_promotion
+
+        promoted = {
+            "path": "Moon_landing",
+            "title": "Moon landing",
+            "match_type": "fuzzy_suggest",
+            "pre_redirect_path": "Moon_landing",
+        }
+        assert accept_possessive_promotion(promoted, "Apollo 11 moon landing") is True
+
+    def test_two_token_topic_unaffected(self) -> None:
+        """The Z3 rule requires the topic to have 3+ tokens. 2-token
+        topics like ``Berlin Germany`` continue to ACCEPT under the
+        b4 carve-out (handled here AND at ``is_strong_title_match``
+        BM25-stage)."""
+        from openzim_mcp.title_promotion import accept_possessive_promotion
+
+        promoted = {
+            "path": "Berlin",
+            "title": "Berlin",
+            "match_type": "direct",
+            "pre_redirect_path": "Berlin",
+        }
+        assert accept_possessive_promotion(promoted, "Berlin Germany") is True
+
+    def test_single_token_topic_unaffected(self) -> None:
+        """A literal user query of ``Russia`` (1 token) must still
+        auto-fetch Russia — the Z3 rule is gated to multi-token
+        topics specifically."""
+        from openzim_mcp.title_promotion import accept_possessive_promotion
+
+        promoted = {
+            "path": "Russia",
+            "title": "Russia",
+            "match_type": "direct",
+            "pre_redirect_path": "Russia",
+        }
+        assert accept_possessive_promotion(promoted, "Russia") is True
+
+
+# ---------------------------------------------------------------------------
+# OPP-1-bypass: possessive redirect carve-out
+# ---------------------------------------------------------------------------
+
+
+class TestOPP1RedirectExtension:
+    """The b9 OPP-1 carve-out only fired on
+    ``_accept_possessive_fuzzy_suggest``. The live ``Newton's gravity``
+    case routes through ``_accept_possessive_redirect``: pre-path
+    fails the b7 Z1.1 subset rule but the post-redirect canonical
+    path preserves the user's possessor token. Extend OPP-1 to the
+    redirect branch."""
+
+    def test_newtons_gravity_redirect_accepted_via_canonical_possessor(
+        self,
+    ) -> None:
+        """Live OPP-1 repro on the redirect branch.
+
+        libzim returns ``Newton's_law_of_universal_gravitation`` with
+        ``match_type="redirect"`` and
+        ``pre_redirect_path="Newton_Laws_of_Gravity"``.
+
+        - Subset rule: ``{newton, laws, of, gravity} ⊄ {newton, s,
+          gravity}`` → would reject.
+        - Extended OPP-1: ``newton`` IS in canonical tokens
+          ``{newton, s, law, of, universal, gravitation}`` → ACCEPT.
+        """
+        from openzim_mcp.title_promotion import accept_possessive_promotion
+
+        promoted = {
+            "path": "Newton's_law_of_universal_gravitation",
+            "title": "Newton's law of universal gravitation",
+            "match_type": "redirect",
+            "pre_redirect_path": "Newton_Laws_of_Gravity",
+        }
+        assert accept_possessive_promotion(promoted, "Newton's gravity") is True
+
+    def test_b7_z11_darwin_evolution_still_rejected(self) -> None:
+        """b7 Z1.1 attack surface preserved: the post-redirect
+        canonical ``Evolution`` drops the possessor entirely, so
+        even the extended OPP-1 (possessor-in-canonical) finds no
+        ``darwin`` → REJECT."""
+        from openzim_mcp.title_promotion import accept_possessive_promotion
+
+        promoted = {
+            "path": "Evolution",
+            "title": "Evolution",
+            "match_type": "redirect",
+            "pre_redirect_path": "Darwin's_Theory_of_Evolution",
+        }
+        assert accept_possessive_promotion(promoted, "Darwin's evolution") is False
+
+    def test_b6_z1_platos_philosophy_still_rejected(self) -> None:
+        """b6 Z1 attack surface preserved: ``Plato's republic
+        philosophy`` → ``Czech_philosophy`` has neither pre-subset
+        nor ``plato`` in canonical → REJECT."""
+        from openzim_mcp.title_promotion import accept_possessive_promotion
+
+        promoted = {
+            "path": "Czech_philosophy",
+            "title": "Czech philosophy",
+            "match_type": "redirect",
+            "pre_redirect_path": "Republic_of_Plato_philosophy",
+        }
+        assert (
+            accept_possessive_promotion(promoted, "Plato's republic philosophy")
+            is False
+        )
+
+    def test_b8_subset_rule_still_accepts_pre_equals_topic(self) -> None:
+        """``Plato's cave`` → ``Allegory_of_the_cave`` via
+        pre=``Plato's_cave``: the pre⊆topic subset rule fires FIRST
+        and accepts. The extended OPP-1 check is a fallback after
+        the subset rule fails, so this case is unaffected."""
+        from openzim_mcp.title_promotion import accept_possessive_promotion
+
+        promoted = {
+            "path": "Allegory_of_the_cave",
+            "title": "Allegory of the cave",
+            "match_type": "redirect",
+            "pre_redirect_path": "Plato's_cave",
+        }
+        assert accept_possessive_promotion(promoted, "Plato's cave") is True
+
+
+# ---------------------------------------------------------------------------
+# Integration through _promote_topic_via_title_index
+# ---------------------------------------------------------------------------
+
+
+class TestPromoteIntegration:
+    """End-to-end shape: the post-b9 fix must reject the live
+    silent-wrong-answer path through ``_promote_topic_via_title_index``."""
+
+    def test_stalin_ussr_russia_pass_1_tail_probe_rejected(self) -> None:
+        """Live repro: Pass 0 (full topic at 0.95) returns None;
+        Pass 1's 1-token tail probe ``"russia"`` returns
+        ``Russia`` at ``match_type="direct"`` score 1.0. The
+        extended Z3 rule rejects → falls through to Pass 2 / Pass 3
+        / BM25."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "russia": {
+                "path": "Russia",
+                "title": "Russia",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+                "pre_redirect_path": "Russia",
+            },
+            # Pass 0 misses on the full topic, simulating the live
+            # behavior on the Wikipedia ZIM.
+        }
+        result = _run_promote_simple(
+            "Stalin USSR Russia", _fake_find_title_match(mapping)
+        )
+        assert result is None or result["path"] != "Russia", (
+            f"post-b9 Z3 must reject the 1-token tail hijack "
+            f"`Russia` for topic `Stalin USSR Russia`; got {result!r}"
+        )
+
+    def test_newtons_gravity_redirect_accepted_via_opp1_extension(self) -> None:
+        """Live repro: Pass 0 returns
+        ``Newton's_law_of_universal_gravitation`` at 0.95 via a
+        redirect from ``Newton_Laws_of_Gravity``. b7 Z1.1 subset
+        rule would reject; OPP-1 extension accepts because the
+        post-redirect canonical contains ``newton``."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "newton's gravity": {
+                "path": "Newton's_law_of_universal_gravitation",
+                "title": "Newton's law of universal gravitation",
+                "zim_file": "test.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "Newton_Laws_of_Gravity",
+            },
+        }
+        result = _run_promote_simple(
+            "Newton's gravity",
+            _fake_find_title_match(mapping, min_score_floor=0.95),
+        )
+        assert (
+            result is not None
+            and result["path"] == "Newton's_law_of_universal_gravitation"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Structural pins
+# ---------------------------------------------------------------------------
+
+
+class TestStructuralGuards:
+    """Lightweight pins that catch accidental revert of the post-b9
+    extensions at the source level."""
+
+    def test_non_possessive_helper_does_not_short_circuit_on_match_type(
+        self,
+    ) -> None:
+        """Structural pin: ``_accept_non_possessive`` must NOT
+        short-circuit non-fuzzy_suggest match_types with an early
+        ``return True`` BEFORE the tail-hijack check. The b9
+        implementation had::
+
+            if match_type != "fuzzy_suggest":
+                return True
+
+        which bypassed the Z3 rule for direct/redirect — exactly
+        the silent-wrong-answer code path in the live deployment.
+        """
+        import ast
+        import inspect
+
+        from openzim_mcp import title_promotion
+
+        source = inspect.getsource(title_promotion._accept_non_possessive)
+        tree = ast.parse(source).body[0]
+        # Walk the function body (NOT the docstring) and assert no
+        # ``if match_type != "fuzzy_suggest": return True`` early-
+        # return exists at the top level.
+        for node in tree.body:
+            if not isinstance(node, ast.If):
+                continue
+            try:
+                cond = ast.unparse(node.test)
+            except AttributeError:  # pragma: no cover (py<3.9)
+                continue
+            if (
+                "match_type" in cond
+                and "fuzzy_suggest" in cond
+                and "!=" in cond
+                and isinstance(node.body[0], ast.Return)
+                and isinstance(node.body[0].value, ast.Constant)
+                and node.body[0].value.value is True
+            ):
+                raise AssertionError(
+                    "_accept_non_possessive must not short-circuit "
+                    "non-fuzzy_suggest match_types — the tail-hijack "
+                    "rule must run for direct/redirect too "
+                    "(post-b9 Z3 extension)"
+                )
+
+    def test_pass_1_and_pass_2_consult_accept_gate(self) -> None:
+        """Structural pin: ``_promote_topic_via_title_index`` must
+        consult ``accept_possessive_promotion`` on EVERY pass that
+        returns a promoted row, not just pass-0 and pass-3. The b9
+        implementation had Pass 1 (tail-iter) and Pass 2 (window-
+        iter) returning ``promoted`` unconditionally; that's the
+        live Z3 silent-wrong-answer code path (1-token tail
+        ``"russia"`` → direct match → returned without gating)."""
+        import inspect
+
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        source = inspect.getsource(SimpleToolsHandler._promote_topic_via_title_index)
+        # At least 4 calls to accept_possessive_promotion (pass-0
+        # full-topic probe + pass-1 tails + pass-2 windows + pass-3
+        # typo-tolerant tails).
+        count = source.count("accept_possessive_promotion(")
+        assert count >= 4, (
+            f"_promote_topic_via_title_index must call "
+            f"accept_possessive_promotion on every pass; found "
+            f"{count} call(s), expected >= 4 (pass-0, pass-1, "
+            f"pass-2, pass-3)."
+        )
+
+    def test_possessive_redirect_has_canonical_possessor_fallback(self) -> None:
+        """Structural pin: ``_accept_possessive_redirect`` must
+        reference ``extract_possessor_tokens`` so the OPP-1 redirect
+        extension stays wired in (live ``Newton's gravity`` repro)."""
+        import inspect
+
+        from openzim_mcp import title_promotion
+
+        source = inspect.getsource(title_promotion._accept_possessive_redirect)
+        assert "extract_possessor_tokens" in source, (
+            "_accept_possessive_redirect must consult "
+            "extract_possessor_tokens for the post-b9 OPP-1 "
+            "canonical-possessor fallback after the b7 Z1.1 subset "
+            "rule fails"
+        )


### PR DESCRIPTION
Post-b9 live-MCP sweep against v2.0.0b9 confirmed the b9 Z3 + OPP-1 fixes land at the unit-test level but BOTH bypass the actual live silent-wrong-answer code paths because b9 gated on the wrong `match_type`.

## Z3-bypass (HIGH) — tail-hijack lives on the direct/redirect branches

The b9 Z3 rule only fired inside `_accept_non_possessive` when `match_type == "fuzzy_suggest"`. The live silent-wrong-answers route through Pass 1 `iter_query_tails`: `find_title_match` returns `None` for the full topic, so the next pass kicks in, where the 1-token tail (`"russia"`, `"berlin"`, `"discovery"`, `"tourism"`, `"1984"`, `"radioactivity"`) is passed to `find_title_match`. libzim sees the tail string as a case-insensitive title equal → returns `match_type="direct"` at score 1.0. The b9 short-circuit `if match_type != "fuzzy_suggest": return True` bypassed the Z3 check entirely.

**ALSO**: Pass 1 and Pass 2 in `_promote_topic_via_title_index` returned `promoted` directly without consulting `accept_possessive_promotion`. Even after extending the gate to direct/redirect, the Z3 rule wouldn't fire because the call site didn't invoke it.

### Fix — three changes in concert

1. **`_accept_non_possessive`** no longer short-circuits on `match_type`. The tail-token-hijack premise is purely about the topic↔canonical token relationship; it doesn't depend on how libzim resolved the match. The zero-overlap stemming sub-rule stays gated on `fuzzy_suggest` (direct/redirect by definition share at least the matched token).
2. **`_promote_topic_via_title_index` Pass 1 (tail iter) and Pass 2 (window iter)** now consult `accept_possessive_promotion` on each candidate, matching what Pass 0 and Pass 3 already did.
3. **Discriminator** preserves the documented Pass 1 1-token-tail feature: queries like `what is the population of detroit` → `Detroit` and `people who live in michigan` → `Michigan` must keep working. The tail-hijack rejection only fires when the topic has 2+ "specific" tokens — capitalized in the original case OR digit-only. The silent-wrong-answer pattern stacks multiple proper-noun-shaped tokens; legitimate filler-prose queries have at most one capitalized entity.

### Live cases this fix resolves (cert=0.85 silent-wrong-answers at v2.0.0b9)

- `Stalin USSR Russia` → `Russia` → BM25 / Pass 2 head probe
- `Hitler Germany Berlin` → `Berlin` → BM25 / Pass 2 head probe
- `Marie Curie polonium discovery` → `Discovery` (a disambig page!) → BM25
- `Big Rapids Michigan tourism` → `Tourism` → Pass 2 finds `Big_Rapids,_Michigan` ✨
- `O'Brien character 1984` → `1984` (the year) → BM25 / Pass 2 finds `O'Brien_(Nineteen_Eighty-Four)`
- `Marie Curie radioactivity` → fuzzy-suggest stemming hit unchanged from b9

### Regression guards preserved

- `Hamlet Denmark prince` → Pass 0 / Pass 2 finds `Hamlet` (head position)
- `Napoleon France emperor` → Pass 0 / Pass 2 finds `Napoleon`
- `Apollo 11 moon landing` → `Moon_landing` (multi-token canonical)
- `quantum mechanics Einstein` → `Albert_Einstein` (single cap token)
- `Lincoln Gettysburg Address` → `Gettysburg_Address` (multi-token canonical)
- `Berlin Germany` → `Berlin` (2-token topic, Z3 doesn't fire)
- `population of detroit` / `people who live in michigan` → legitimate Pass 1 1-token-tail feature preserved via discriminator (zero capitalized tokens)

## OPP-1-bypass (MEDIUM) — Newton's gravity redirect canonical preserves possessor

The b9 OPP-1 carve-out only fired inside `_accept_possessive_fuzzy_suggest`. The live `Newton's gravity` case routes through `_accept_possessive_redirect`: libzim returns `Newton's_law_of_universal_gravitation` with `match_type="redirect"` and `pre_redirect_path="Newton_Laws_of_Gravity"`. The b7 Z1.1 subset rule rejects because `{newton, laws, of, gravity} ⊄ {newton, s, gravity}` — pre-path has extras `laws`/`of` not in the topic. OPP-1's possessor-in-canonical check never runs.

### Fix — OPP-1 extension to redirect branch

When the b7 Z1.1 subset rule rejects, `_accept_possessive_redirect` NOW falls back to the same possessor-in-canonical check OPP-1 uses for fuzzy_suggest: ACCEPT if any of the topic's possessor tokens appears in the post-redirect canonical path tokens.

| Topic | Resolved canonical | Decision |
|---|---|---|
| `Plato's cave` | `Allegory_of_the_cave` via pre=`Plato's_cave` | ACCEPT (b8 subset) |
| `Einstein's theory` | `Theory_of_relativity` via pre=`Einstein's_theory` | ACCEPT (b8 subset) |
| `Newton's gravity` | `Newton's_law_of_universal_gravitation` via pre=`Newton_Laws_of_Gravity` | ACCEPT (post-b9 OPP-1) |
| `Darwin's evolution` | `Evolution` via pre=`Darwin's_Theory_of_Evolution` | REJECT (b7) |
| `Plato's republic philosophy` | `Czech_philosophy` | REJECT (b6) |

## Tests

**39 new tests** in `tests/test_post_b9_beta_fixes.py` across 5 classes:

- `TestZ3TailHijackAllMatchTypes` (15 parametrized: 5 topics × 3 match_types)
- `TestZ3TailHijackRegressionGuards` (12 parametrized + 2 standalone)
- `TestOPP1RedirectExtension` (4 cases)
- `TestPromoteIntegration` (2 end-to-end through `_promote_topic_via_title_index`)
- `TestStructuralGuards` (2 source pins)

One b4 test mock updated to include `pre_redirect_path` reflecting the live libzim row shape since b6.

```
2487 passed, 54 skipped (full suite, ~28s)
pip-audit: no known vulnerabilities
```

mypy clean across 52 source files. black + flake8 + isort clean.

## Methodology — "fix unlocks new paths" 17 sweeps strong

b9's Z3 + OPP-1 fixes were conceptually correct but missed the actual live code paths because I inferred the wrong match_types from upstream behavior. Live diagnostic against the deployed b9 ZIM corpus surfaced four new invariants that this sweep pins down.

## What's not in this PR

Version bump / CHANGELOG entry — follows the sweep convention (release PR is separate).
