### PR TITLE
fix(v2): post-b10 beta-test sweep — probe-based multi-entity discriminator (case-independent Z3)

### DIFF
--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -28,9 +28,11 @@ from .security import sanitize_context_for_error
 from .title_promotion import (
     _TOKEN_RE,
     accept_possessive_promotion,
+    count_non_tail_strong_entities,
     find_title_match,
     has_apostrophe_possessive,
     is_strong_title_match,
+    is_tail_hijack_shape,
     iter_query_tails,
     iter_query_windows,
 )
@@ -3938,19 +3940,50 @@ class SimpleToolsHandler:
         # canonical" case; further 1-token tail iteration just risks
         # picking a generic Wikipedia title that shares the word.
         pass_tail_min_len = 2 if has_apostrophe_possessive(topic) else 1
+
+        # Post-b10 Z3 multi-entity discriminator: the b9/b10 Z3 rule
+        # rejected the tail-hijack shape unconditionally in
+        # ``accept_possessive_promotion``. That correctly catches
+        # the silent-wrong-answer pattern (``stalin ussr russia`` →
+        # ``Russia``) but over-rejects the legitimate filler-prose +
+        # tail-entity case (``what is the population of detroit`` →
+        # ``Detroit``). The case-based discriminator b10 used broke
+        # because ``IntentParser._normalize_topic_case`` lowercases
+        # the topic upstream. The probe-based replacement counts how
+        # many non-tail topic tokens individually resolve to strong
+        # title matches; 2+ signals a multi-entity stack the user is
+        # querying jointly, < 2 signals filler-prose + entity-at-tail.
+        # The probe is wrapped once and reused across Pass 1 / Pass 2
+        # to keep the cost bounded.
+        def _probe(token_str: str) -> Optional[Dict[str, Any]]:
+            return find_title_match(self.zim_operations, zim_file_path, token_str)
+
+        def _accept_with_multi_entity_check(
+            promoted: Dict[str, Any],
+        ) -> bool:
+            """Run the standard accept gate; for non-possessive
+            tail-hijack rejections, probe non-tail tokens and
+            override the rejection when single-entity is confirmed.
+            """
+            if accept_possessive_promotion(promoted, topic):
+                return True
+            if has_apostrophe_possessive(topic):
+                return False
+            if not is_tail_hijack_shape(promoted, topic):
+                return False
+            return count_non_tail_strong_entities(topic, _probe, limit=2) < 2
+
         # Pass 1: strict 1.0-score gate across every trailing tail.
         # Prefer an exact title match on any tail (even a short one)
         # over a typo-tolerant fuzzy match on a longer noisier tail.
-        # Post-b9 Z3: gate every pass through accept_possessive_promotion
-        # so the non-possessive tail-token-hijack rule fires here too.
-        # The b9 Z3 rule was wired into accept_possessive_promotion but
-        # Pass 1 (and Pass 2) returned ``promoted`` directly without
-        # consulting the gate, so the live Stalin USSR Russia → Russia
-        # silent-wrong-answer (Pass 1's 1-token tail ``"russia"`` →
-        # direct match) sailed past unchecked.
+        # Post-b9 Z3 wired the accept gate into Pass 1 / Pass 2;
+        # post-b10 layers the multi-entity discriminator on top so
+        # the documented Pass 1 1-token-tail feature
+        # (``what is the population of detroit`` → ``Detroit``) keeps
+        # working when the non-tail tokens probe as single-entity.
         for tail in iter_query_tails(topic, min_len=pass_tail_min_len):
             promoted = find_title_match(self.zim_operations, zim_file_path, tail)
-            if promoted is not None and accept_possessive_promotion(promoted, topic):
+            if promoted is not None and _accept_with_multi_entity_check(promoted):
                 return promoted
         # Pass 2: strict 1.0-score gate across non-trailing windows.
         # Catches head/middle-positioned entities like
@@ -3958,7 +3991,7 @@ class SimpleToolsHandler:
         # (more specific) windows win.
         for window in iter_query_windows(topic, min_len=pass_tail_min_len):
             promoted = find_title_match(self.zim_operations, zim_file_path, window)
-            if promoted is not None and accept_possessive_promotion(promoted, topic):
+            if promoted is not None and _accept_with_multi_entity_check(promoted):
                 return promoted
         # Pass 3: 0.8 typo-tolerant gate. Only fires when no strict
         # match exists at all — catches single-edit typos.

--- a/openzim_mcp/title_promotion.py
+++ b/openzim_mcp/title_promotion.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Callable, Dict, Iterator, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -425,17 +425,17 @@ def _accept_non_possessive(
     redirect match by definition shares at least the matched token,
     so the rule is moot for those branches).
 
-    Discriminator — multi-entity vs filler-prose: the documented
-    Pass 1 1-token-tail feature MUST keep working for queries like
-    ``what is the population of detroit`` → ``Detroit`` and
-    ``people who live in michigan`` → ``Michigan`` (lowercase prose
-    + entity at tail). Only reject the tail-hijack when the topic
-    has 2+ "specific" tokens — tokens that are capitalized in the
-    original case OR digit-only. The silent-wrong-answer pattern is
-    distinguished by stacking multiple proper-noun-shaped tokens
-    (``Stalin USSR Russia``, ``Hitler Germany Berlin``, ``O'Brien
-    character 1984``); legitimate filler-prose queries have at most
-    one capitalized entity (the tail itself).
+    Post-b10 invariant: the b10 case-based discriminator (counting
+    capitalized + digit tokens in the original-case topic) was
+    fundamentally broken because ``IntentParser._normalize_topic_case``
+    (Tier 1 Rule 1) lowercases the query BEFORE topic extraction. By
+    the time this gate runs, the topic is uniformly lowercase — the
+    discriminator counted zero capitalized tokens and never fired on
+    live data. The multi-entity discriminator now lives at the call
+    site in ``_promote_topic_via_title_index`` as a probe-based check
+    (see ``count_non_tail_strong_entities``); this gate just emits
+    the unconditional tail-hijack rejection and lets the caller
+    override when its probe confirms the topic is single-entity.
     """
     topic_tokens_seq = _TAIL_TOKEN_RE.findall(topic.lower())
     if len(topic_tokens_seq) < 3:
@@ -443,10 +443,7 @@ def _accept_non_possessive(
     cand_path = str(promoted.get("path", ""))
     cand_tokens_seq = _TAIL_TOKEN_RE.findall(cand_path.lower())
     if len(cand_tokens_seq) == 1 and cand_tokens_seq == topic_tokens_seq[-1:]:
-        original_tokens = _TAIL_TOKEN_RE.findall(topic)
-        specific_count = sum(1 for tok in original_tokens if _is_specific_token(tok))
-        if specific_count >= 2:
-            return False
+        return False
     if match_type == "fuzzy_suggest" and not (
         set(cand_tokens_seq) & set(topic_tokens_seq)
     ):
@@ -454,23 +451,224 @@ def _accept_non_possessive(
     return True
 
 
-def _is_specific_token(token: str) -> bool:
-    """True iff ``token`` looks like a specific entity / identifier
-    (capitalized word OR digit-only run) rather than filler prose.
+def is_tail_hijack_shape(promoted: Dict[str, Any], topic: str) -> bool:
+    """Pure-logic check: ``promoted`` is a single-token canonical
+    equal to the topic's LAST token, AND the topic has 3+ tokens.
 
-    Used by the Z3 tail-hijack discriminator to count how many
-    proper-noun-shaped tokens the topic carries before rejecting a
-    1-token-tail-equals-last-topic-token canonical. Two or more
-    "specific" tokens signal a multi-entity stack the user is
-    asking about jointly — making the trailing-tail auto-fetch a
-    silent-wrong-answer. Zero or one signals filler prose + a
-    single entity reference — making the trailing-tail auto-fetch
-    the user's actual subject.
+    The tail-hijack shape distinguishes the silent-wrong-answer
+    pattern from legitimate multi-token matches:
+
+      * ``Stalin USSR Russia`` → ``Russia``: single-token canonical
+        equal to topic[-1:] → tail-hijack shape.
+      * ``Hamlet Denmark prince`` → ``Hamlet``: single-token
+        canonical at HEAD position → NOT a tail-hijack shape.
+      * ``Apollo 11 moon landing`` → ``Moon_landing``: multi-token
+        canonical → NOT a tail-hijack shape.
+      * ``Berlin Germany`` → ``Berlin``: 2-token topic → NOT a
+        tail-hijack shape (the b4 carve-out invariant).
+
+    Callers that want the rejection to fire conditionally
+    (e.g., only when the topic ALSO probes as multi-entity) check
+    this shape predicate first and then layer on the probe.
     """
-    if not token:
+    topic_tokens_seq = _TAIL_TOKEN_RE.findall(topic.lower())
+    if len(topic_tokens_seq) < 3:
         return False
-    first = token[0]
-    return first.isupper() or token.isdigit()
+    cand_path = str(promoted.get("path", ""))
+    cand_tokens_seq = _TAIL_TOKEN_RE.findall(cand_path.lower())
+    return len(cand_tokens_seq) == 1 and cand_tokens_seq == topic_tokens_seq[-1:]
+
+
+# English stop-word inventory used by the multi-entity discriminator
+# to skip tokens that are not entities even when libzim's title index
+# happens to resolve them (``What``, ``Is``, ``The``, ``Of`` all exist
+# as articles or disambiguation pages on Wikipedia). The list is
+# conservative — only words that are clearly non-content in a
+# tell-me-about query. Domain-specific common words (``population``,
+# ``character``, ``radioactivity``) deliberately stay OUT so the
+# discriminator still catches multi-entity queries that happen to
+# include those words.
+_DISCRIMINATOR_STOP_WORDS: frozenset[str] = frozenset(
+    {
+        # Question words
+        "what",
+        "when",
+        "where",
+        "who",
+        "whom",
+        "whose",
+        "which",
+        "why",
+        "how",
+        # Articles
+        "a",
+        "an",
+        "the",
+        # Conjunctions
+        "and",
+        "or",
+        "but",
+        "nor",
+        "yet",
+        # Prepositions
+        "of",
+        "in",
+        "on",
+        "at",
+        "to",
+        "from",
+        "by",
+        "with",
+        "as",
+        "into",
+        "onto",
+        "over",
+        "under",
+        "about",
+        # Auxiliary verbs
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "being",
+        "have",
+        "has",
+        "had",
+        "do",
+        "does",
+        "did",
+        "will",
+        "would",
+        "shall",
+        "should",
+        "may",
+        "might",
+        "can",
+        "could",
+        # Pronouns / determiners
+        "i",
+        "me",
+        "my",
+        "we",
+        "us",
+        "our",
+        "you",
+        "your",
+        "he",
+        "him",
+        "his",
+        "she",
+        "her",
+        "it",
+        "its",
+        "they",
+        "them",
+        "their",
+        "this",
+        "that",
+        "these",
+        "those",
+        # Politeness
+        "please",
+        "kindly",
+        # Filler adverbs
+        "also",
+        "too",
+        "very",
+        "just",
+        "really",
+        # Generic verbs that appear in pure-filler prose contexts
+        # ("people who live in michigan"). Kept narrow to verbs that
+        # are pure structural connectors; nouns stay OUT.
+        "live",
+        "lived",
+        "lives",
+        "make",
+        "makes",
+        "made",
+    }
+)
+
+
+def count_non_tail_strong_entities(
+    topic: str,
+    title_probe: Callable[[str], Optional[Dict[str, Any]]],
+    *,
+    limit: int = 2,
+) -> int:
+    """Probe each non-tail topic token; count how many resolve to a
+    strong title match where the probed token actually appears in
+    the resolved canonical or pre-redirect path tokens.
+
+    Case-independent multi-entity discriminator — used by
+    ``_promote_topic_via_title_index`` to distinguish the
+    silent-wrong-answer pattern (multiple stacked proper-noun-
+    shaped tokens like ``Stalin USSR Russia``, ``Hitler Germany
+    Berlin``, ``O'Brien character 1984``) from filler-prose +
+    tail-entity (``what is the population of detroit``, ``musicians
+    from tokyo``, ``people who live in michigan``).
+
+    Two refinements over a raw probe-counting check:
+
+      1. **Stop-word filter** — non-entity tokens (``what``, ``is``,
+         ``the``, ``of``, common pronouns/auxiliaries) are skipped
+         even though they often resolve to a real Wikipedia
+         disambiguation page. Without the filter, ``what is the
+         population of detroit`` would probe to four+ false-positive
+         matches and over-reject the documented Pass 1 1-token-tail
+         feature.
+      2. **Probed-token-in-canonical check** — the probe result is
+         only counted when the probed token (lowercased) appears in
+         the canonical path tokens OR the pre-redirect-path tokens.
+         This filters out fuzzy/stemming hits where libzim's
+         suggestion-search lands on an unrelated article AND defends
+         against overly-permissive test mocks that return the same
+         row regardless of input.
+
+    The b10 discriminator counted capitalized tokens in the original-
+    case topic but ``IntentParser._normalize_topic_case`` (Tier 1
+    Rule 1, ``intent_parser.py``) lowercases the query upstream, so
+    the gate never saw any capitalized tokens on live data. Probing
+    sidesteps the case-sensitivity assumption entirely.
+
+    Stops counting at ``limit`` (default 2) to avoid wasted probes
+    when the discriminator's decision is already made.
+
+    Topics with fewer than 3 tokens return 0 immediately — the
+    tail-hijack rule those topics interact with doesn't fire for
+    them either, so probing is wasted work.
+
+    Exceptions from individual probe calls are swallowed (treated
+    as "no match") so a transient libzim error on one token doesn't
+    blow up the gate.
+    """
+    tokens = _TAIL_TOKEN_RE.findall(topic.lower())
+    if len(tokens) < 3:
+        return 0
+    non_tail = tokens[:-1]
+    count = 0
+    for tok in non_tail:
+        if tok in _DISCRIMINATOR_STOP_WORDS:
+            continue
+        try:
+            result = title_probe(tok)
+        except Exception:
+            continue
+        if result is None:
+            continue
+        cand_path = str(result.get("path", "")).lower()
+        pre_path = str(result.get("pre_redirect_path", "")).lower()
+        haystack_tokens = set(_TAIL_TOKEN_RE.findall(cand_path)) | set(
+            _TAIL_TOKEN_RE.findall(pre_path)
+        )
+        if tok not in haystack_tokens:
+            continue
+        count += 1
+        if count >= limit:
+            break
+    return count
 
 
 def _accept_possessive_fuzzy_suggest(promoted: Dict[str, Any], topic: str) -> bool:

--- a/tests/test_post_b10_beta_fixes.py
+++ b/tests/test_post_b10_beta_fixes.py
@@ -1,0 +1,401 @@
+r"""Regression tests for the post-b10 beta-test sweep.
+
+The post-b10 live-MCP sweep against v2.0.0b10 confirmed OPP-1's
+redirect extension lands cleanly (``Newton's gravity`` now auto-
+fetches ``Newton's_law_of_universal_gravitation``) but ALL SIX Z3
+silent-wrong-answer repros STILL fire.
+
+## Root cause — Tier 1 Rule 1 lowercases the topic upstream
+
+The b10 Z3 discriminator (``_is_specific_token`` counting
+capitalized + digit tokens) was designed to distinguish multi-
+entity proper-noun queries (``Stalin USSR Russia``) from filler-
+prose + tail-entity (``what is the population of detroit``). It
+counted capitalized tokens in the ORIGINAL-case topic.
+
+But ``IntentParser._normalize_topic_case`` (Tier 1 Rule 1,
+``intent_parser.py:1540``) lowercases the query BEFORE topic
+extraction. By the time the discriminator sees the topic string,
+``"Stalin USSR Russia"`` is ``"stalin ussr russia"`` — zero
+capitalized tokens — the discriminator doesn't fire — tail-hijack
+escapes.
+
+## Fix — case-independent probe-based discriminator
+
+The discriminator must use a signal that survives Tier 1's case
+normalization. Probe each non-tail topic token via
+``find_title_match``. The silent-wrong-answer pattern stacks
+multiple individually-strong title-index tokens (``Stalin``,
+``USSR``, ``Russia`` all resolve standalone); legitimate filler-
+prose queries have at most one (``population`` resolves, ``what``
+/ ``is`` / ``the`` / ``of`` do not).
+
+Two new helpers in ``title_promotion``:
+
+  * ``is_tail_hijack_shape(promoted, topic)`` — pure-logic check
+    for the 1-token-canonical-equals-topic-last-token shape (no
+    discriminator).
+  * ``count_non_tail_strong_entities(topic, title_probe, limit=2)``
+    — probes each non-tail token via the supplied callback;
+    returns the count, short-circuiting at ``limit``.
+
+``_promote_topic_via_title_index`` Pass 1 / Pass 2 now consult
+both: when the candidate is a tail-hijack shape AND the topic
+probes as multi-entity (2+ strong non-tail matches), the
+candidate is skipped. When it's a tail-hijack shape but the
+topic probes as single-entity (filler-prose), the candidate is
+accepted — preserving the documented ``population of detroit``
+behavior.
+
+``_accept_non_possessive`` no longer carries the case-based
+discriminator; its tail-hijack rejection is unconditional (any
+match_type, regardless of case). The call site overrides the
+rejection when single-entity is confirmed.
+
+## Decision matrix
+
+  +---------------------------------+----------+------------+----------+
+  | Topic                           | Tail-    | Multi-     | Decision |
+  |                                 | hijack   | entity     |          |
+  |                                 | shape?   | probe ≥2?  |          |
+  +---------------------------------+----------+------------+----------+
+  | Stalin USSR Russia              | yes      | yes        | REJECT   |
+  | Hitler Germany Berlin           | yes      | yes        | REJECT   |
+  | Marie Curie polonium discovery  | yes      | yes        | REJECT   |
+  | Big Rapids Michigan tourism     | yes      | yes        | REJECT   |
+  | O'Brien character 1984          | yes      | yes        | REJECT   |
+  | what is the population of detroit| yes      | no (1 match)| ACCEPT |
+  | people who live in michigan     | yes      | no         | ACCEPT   |
+  | Berlin Germany                  | no (<3 tk)| -         | ACCEPT   |
+  +---------------------------------+----------+------------+----------+
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from unittest.mock import patch
+
+from tests._promote_fixtures import fake_find_title_match as _fake_find_title_match
+from tests._promote_fixtures import make_simple_handler as _make_simple_handler
+
+
+def _run_promote(
+    topic: str, mapping: Dict[str, Optional[Dict[str, Any]]]
+) -> Optional[Dict[str, Any]]:
+    """Drive ``_promote_topic_via_title_index`` with the mapping
+    serving as the find_title_match stand-in for every probe."""
+    from openzim_mcp.simple_tools import SimpleToolsHandler
+
+    fake = _fake_find_title_match(mapping)
+    with patch("openzim_mcp.simple_tools.find_title_match", side_effect=fake):
+        return SimpleToolsHandler._promote_topic_via_title_index(
+            _make_simple_handler(),
+            "test.zim",
+            topic,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Live Z3 silent-wrong-answer cases — must reject tail-hijack when
+# multi-entity probing succeeds.
+# ---------------------------------------------------------------------------
+
+
+class TestZ3TailHijackMultiEntityRejected:
+    """When the topic probes as multi-entity (2+ non-tail tokens
+    individually resolve to strong title matches), the tail-hijack
+    candidate must be rejected. Pass 2 then tries head-token windows;
+    when those resolve cleanly to a HEAD entity, that's the auto-
+    fetched result instead."""
+
+    def test_stalin_ussr_russia_rejects_tail_accepts_head(self) -> None:
+        """Live repro: topic arrives lowercased as ``stalin ussr
+        russia``. Pass 1 tail ``russia`` returns Russia direct (tail-
+        hijack). Probing ``stalin`` and ``ussr`` returns strong
+        matches → multi-entity → reject Russia. Pass 2 head probes
+        ``stalin`` → Stalin → auto-fetched."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "russia": {
+                "path": "Russia",
+                "title": "Russia",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "stalin": {
+                "path": "Stalin",
+                "title": "Stalin",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "ussr": {
+                "path": "Soviet_Union",
+                "title": "Soviet Union",
+                "zim_file": "test.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "USSR",
+            },
+        }
+        result = _run_promote("stalin ussr russia", mapping)
+        # Russia must be rejected (it's the tail-hijack); Pass 2 should
+        # find Stalin via head-position window probe.
+        assert result is None or result["path"] != "Russia", (
+            f"Z3 post-b10 must reject tail-hijack `Russia` when "
+            f"non-tail tokens probe as multi-entity. Got: {result!r}"
+        )
+
+    def test_hitler_germany_berlin_rejects_tail(self) -> None:
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "berlin": {
+                "path": "Berlin",
+                "title": "Berlin",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "hitler": {
+                "path": "Adolf_Hitler",
+                "title": "Adolf Hitler",
+                "zim_file": "test.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "Hitler",
+            },
+            "germany": {
+                "path": "Germany",
+                "title": "Germany",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+        }
+        result = _run_promote("hitler germany berlin", mapping)
+        assert result is None or result["path"] != "Berlin"
+
+    def test_marie_curie_polonium_discovery_rejects_tail(self) -> None:
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "discovery": {
+                "path": "Discovery",
+                "title": "Discovery",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "marie": {
+                "path": "Marie",
+                "title": "Marie",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "curie": {
+                "path": "Curie",
+                "title": "Curie",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "polonium": {
+                "path": "Polonium",
+                "title": "Polonium",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+        }
+        result = _run_promote("marie curie polonium discovery", mapping)
+        assert result is None or result["path"] != "Discovery"
+
+    def test_obrien_character_1984_rejects_tail(self) -> None:
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "1984": {
+                "path": "1984",
+                "title": "1984",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "o'brien": {
+                "path": "O'Brien",
+                "title": "O'Brien",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "character": {
+                "path": "Character",
+                "title": "Character",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+        }
+        result = _run_promote("o'brien character 1984", mapping)
+        assert result is None or result["path"] != "1984"
+
+
+# ---------------------------------------------------------------------------
+# Counter-cases: filler-prose queries with a single non-tail entity
+# must keep the documented Pass 1 1-token-tail auto-fetch behavior.
+# ---------------------------------------------------------------------------
+
+
+class TestFillerProseSingleEntityPreserved:
+    """When the topic probes as single-entity (only one non-tail
+    token resolves), the tail-hijack rule is a false positive; the
+    candidate must be accepted."""
+
+    def test_population_of_detroit_accepts_tail(self) -> None:
+        """Documented Pass 1 1-token-tail feature: filler prose +
+        entity at tail. ``what`` / ``is`` / ``the`` / ``of`` don't
+        resolve; only ``population`` does (1 non-tail match) →
+        single-entity → accept tail ``detroit``."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "detroit": {
+                "path": "Detroit",
+                "title": "Detroit",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "population": {
+                "path": "Population",
+                "title": "Population",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            # Others (what, is, the, of) deliberately absent from
+            # mapping → probe returns None → not counted.
+        }
+        result = _run_promote("what is the population of detroit", mapping)
+        assert result is not None and result["path"] == "Detroit"
+
+    def test_people_who_live_in_michigan_accepts_tail(self) -> None:
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "michigan": {
+                "path": "Michigan",
+                "title": "Michigan",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            # who / live / in / people deliberately absent → single
+            # entity (only michigan probes positively).
+        }
+        result = _run_promote("people who live in michigan", mapping)
+        assert result is not None and result["path"] == "Michigan"
+
+    def test_zero_strong_non_tail_entities_accepts_tail(self) -> None:
+        """Defensive: when ZERO non-tail tokens resolve, the topic
+        is pure filler; the tail-entity must be accepted."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "detroit": {
+                "path": "Detroit",
+                "title": "Detroit",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+        }
+        result = _run_promote("info about detroit ok", mapping)
+        assert result is not None and result["path"] == "Detroit"
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests on the new helpers
+# ---------------------------------------------------------------------------
+
+
+class TestIsTailHijackShape:
+    """Pure-logic check (no probing): canonical is single token
+    equal to topic's LAST token, topic has 3+ tokens."""
+
+    def test_tail_hijack_3_token_topic(self) -> None:
+        from openzim_mcp.title_promotion import is_tail_hijack_shape
+
+        promoted = {"path": "Russia", "match_type": "direct"}
+        assert is_tail_hijack_shape(promoted, "stalin ussr russia") is True
+
+    def test_not_tail_hijack_head_position(self) -> None:
+        """Canonical at HEAD position (not tail) is NOT a hijack."""
+        from openzim_mcp.title_promotion import is_tail_hijack_shape
+
+        promoted = {"path": "Hamlet"}
+        assert is_tail_hijack_shape(promoted, "hamlet denmark prince") is False
+
+    def test_not_tail_hijack_multi_token_canonical(self) -> None:
+        """Multi-token canonical is never a 1-token-tail hijack."""
+        from openzim_mcp.title_promotion import is_tail_hijack_shape
+
+        promoted = {"path": "Moon_landing"}
+        assert is_tail_hijack_shape(promoted, "apollo 11 moon landing") is False
+
+    def test_not_tail_hijack_2_token_topic(self) -> None:
+        """Topics with <3 tokens are exempt (b4 carve-out invariant)."""
+        from openzim_mcp.title_promotion import is_tail_hijack_shape
+
+        promoted = {"path": "Berlin"}
+        assert is_tail_hijack_shape(promoted, "berlin germany") is False
+
+
+class TestCountNonTailStrongEntities:
+    """Probe-based multi-entity discriminator — case-independent."""
+
+    def test_multi_entity_counts(self) -> None:
+        """Stalin USSR Russia: non-tail ``stalin`` + ``ussr`` both
+        resolve → count = 2."""
+        from openzim_mcp.title_promotion import count_non_tail_strong_entities
+
+        def probe(token: str) -> Optional[Dict[str, Any]]:
+            return {"stalin": {"path": "Stalin"}, "ussr": {"path": "USSR"}}.get(token)
+
+        assert count_non_tail_strong_entities("stalin ussr russia", probe) == 2
+
+    def test_filler_prose_counts(self) -> None:
+        """population of detroit: only ``population`` resolves of
+        non-tail tokens → count = 1."""
+        from openzim_mcp.title_promotion import count_non_tail_strong_entities
+
+        def probe(token: str) -> Optional[Dict[str, Any]]:
+            return {"population": {"path": "Population"}}.get(token)
+
+        assert (
+            count_non_tail_strong_entities("what is the population of detroit", probe)
+            == 1
+        )
+
+    def test_short_circuits_at_limit(self) -> None:
+        """Probe stops counting at ``limit`` to avoid wasted probes.
+
+        Uses entity-shaped tokens (not stop-words) so the filter
+        doesn't drop them, and returns a canonical that contains
+        the probed token so the in-canonical check counts the hit.
+        """
+        from openzim_mcp.title_promotion import count_non_tail_strong_entities
+
+        calls = []
+
+        def probe(token: str) -> Optional[Dict[str, Any]]:
+            calls.append(token)
+            return {"path": token}  # canonical = probed token
+
+        # 4-token topic "alpha beta gamma delta": 3 non-tail tokens,
+        # limit=2, should stop after counting the first 2.
+        result = count_non_tail_strong_entities(
+            "alpha beta gamma delta", probe, limit=2
+        )
+        assert result == 2
+        assert len(calls) == 2
+
+    def test_two_token_topic_returns_zero(self) -> None:
+        """Topics with <3 tokens: the discriminator is moot (the
+        tail-hijack rule doesn't fire either). Return 0."""
+        from openzim_mcp.title_promotion import count_non_tail_strong_entities
+
+        def probe(token: str) -> Optional[Dict[str, Any]]:
+            return {"path": "X"}
+
+        assert count_non_tail_strong_entities("berlin germany", probe) == 0
+
+
+class TestProbeExceptionsSwallowed:
+    """If a probe raises (transient libzim error), the count
+    keeps going. A flaky probe must not blow up the gate."""
+
+    def test_probe_exception_treated_as_no_match(self) -> None:
+        from openzim_mcp.title_promotion import count_non_tail_strong_entities
+
+        def probe(token: str) -> Optional[Dict[str, Any]]:
+            if token == "ussr":
+                raise RuntimeError("transient")
+            return {"stalin": {"path": "Stalin"}}.get(token)
+
+        # stalin resolves, ussr raises (skipped), russia is tail (not probed).
+        # Only stalin counts → 1.
+        assert count_non_tail_strong_entities("stalin ussr russia", probe) == 1

--- a/tests/test_post_b9_beta_fixes.py
+++ b/tests/test_post_b9_beta_fixes.py
@@ -329,8 +329,14 @@ class TestPromoteIntegration:
         """Live repro: Pass 0 (full topic at 0.95) returns None;
         Pass 1's 1-token tail probe ``"russia"`` returns
         ``Russia`` at ``match_type="direct"`` score 1.0. The
-        extended Z3 rule rejects → falls through to Pass 2 / Pass 3
-        / BM25."""
+        post-b10 multi-entity discriminator probes non-tail tokens
+        ``stalin`` + ``ussr``; both resolve strong → 2 → reject
+        Russia → falls through to Pass 2 / Pass 3 / BM25.
+
+        Post-b10 update: the mock now includes the multi-entity
+        probe entries reflecting what the live Wikipedia ZIM returns
+        for those token probes.
+        """
         mapping: Dict[str, Optional[Dict[str, Any]]] = {
             "russia": {
                 "path": "Russia",
@@ -339,15 +345,27 @@ class TestPromoteIntegration:
                 "match_type": "direct",
                 "pre_redirect_path": "Russia",
             },
-            # Pass 0 misses on the full topic, simulating the live
-            # behavior on the Wikipedia ZIM.
+            "stalin": {
+                "path": "Stalin",
+                "title": "Stalin",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "ussr": {
+                "path": "Soviet_Union",
+                "title": "Soviet Union",
+                "zim_file": "test.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "USSR",
+            },
         }
         result = _run_promote_simple(
             "Stalin USSR Russia", _fake_find_title_match(mapping)
         )
         assert result is None or result["path"] != "Russia", (
-            f"post-b9 Z3 must reject the 1-token tail hijack "
-            f"`Russia` for topic `Stalin USSR Russia`; got {result!r}"
+            f"post-b10 Z3 multi-entity discriminator must reject "
+            f"the 1-token tail hijack `Russia` for `Stalin USSR Russia` "
+            f"when non-tail tokens probe as multi-entity; got {result!r}"
         )
 
     def test_newtons_gravity_redirect_accepted_via_opp1_extension(self) -> None:
@@ -437,21 +455,38 @@ class TestStructuralGuards:
         implementation had Pass 1 (tail-iter) and Pass 2 (window-
         iter) returning ``promoted`` unconditionally; that's the
         live Z3 silent-wrong-answer code path (1-token tail
-        ``"russia"`` → direct match → returned without gating)."""
+        ``"russia"`` → direct match → returned without gating).
+
+        Post-b10 update: Pass 1 / Pass 2 now go through the
+        ``_accept_with_multi_entity_check`` wrapper (defined inside
+        ``_promote_topic_via_title_index``) which calls
+        ``accept_possessive_promotion`` once. So the dispatcher
+        source has three direct ``accept_possessive_promotion(`` call
+        sites — Pass 0, the wrapper, and Pass 3 — plus the helper
+        invocation. The pin asserts the wrapper is wired by name AND
+        every gate path is present.
+        """
         import inspect
 
         from openzim_mcp.simple_tools import SimpleToolsHandler
 
         source = inspect.getsource(SimpleToolsHandler._promote_topic_via_title_index)
-        # At least 4 calls to accept_possessive_promotion (pass-0
-        # full-topic probe + pass-1 tails + pass-2 windows + pass-3
-        # typo-tolerant tails).
+        # Pass 0, the multi-entity wrapper (which calls
+        # accept_possessive_promotion once), and Pass 3 → 3 direct
+        # ``accept_possessive_promotion(`` callsites.
         count = source.count("accept_possessive_promotion(")
-        assert count >= 4, (
+        assert count >= 3, (
             f"_promote_topic_via_title_index must call "
             f"accept_possessive_promotion on every pass; found "
-            f"{count} call(s), expected >= 4 (pass-0, pass-1, "
-            f"pass-2, pass-3)."
+            f"{count} call(s), expected >= 3 (pass-0, multi-entity "
+            f"wrapper covering pass-1 + pass-2, pass-3)."
+        )
+        # The multi-entity wrapper must be wired by name into both
+        # Pass 1 (iter_query_tails) and Pass 2 (iter_query_windows).
+        assert "_accept_with_multi_entity_check" in source, (
+            "_promote_topic_via_title_index must define + use the "
+            "_accept_with_multi_entity_check wrapper to gate Pass 1 "
+            "and Pass 2 with the post-b10 multi-entity discriminator"
         )
 
     def test_possessive_redirect_has_canonical_possessor_fallback(self) -> None:


### PR DESCRIPTION
Post-b10 live-MCP sweep against v2.0.0b10 confirmed OPP-1's redirect extension lands cleanly (`Newton's gravity` now auto-fetches `Newton's_law_of_universal_gravitation`) but ALL SIX Z3 silent-wrong-answer repros STILL fire identically to b9.

## Root cause — Tier 1 Rule 1 lowercases the topic upstream

The b10 Z3 discriminator counted capitalized + digit tokens in the ORIGINAL-case topic. But `IntentParser._normalize_topic_case` (Tier 1 Rule 1) lowercases the query BEFORE topic extraction. By the time the discriminator sees the topic, `"Stalin USSR Russia"` is `"stalin ussr russia"` — zero capitalized tokens — the discriminator never fired on live data.

## Fix — case-independent probe-based discriminator

Two new helpers in `title_promotion`:

- **`is_tail_hijack_shape(promoted, topic)`** — pure-logic shape check.
- **`count_non_tail_strong_entities(topic, title_probe, limit=2)`** — probe-based multi-entity counter with two refinements:
  - **Stop-word filter**: skip non-entity tokens (`what`, `is`, `the`, `of`, common auxiliaries / pronouns / connectives) that often have legitimate disambig matches but aren't entities the user is querying jointly.
  - **Probed-token-in-canonical check**: only count a probe as "strong" when the probed token appears in the canonical path tokens OR the pre-redirect-path tokens. Filters fuzzy/stemming hits AND defends against overly-permissive test mocks.

`_promote_topic_via_title_index` Pass 1 / Pass 2 now consult both helpers via an `_accept_with_multi_entity_check` closure. The multi-entity discriminator overrides `accept_possessive_promotion`'s unconditional tail-hijack rejection only when the topic probes as single-entity.

## Decision matrix

| Topic | Tail-hijack? | Multi-entity? | Decision |
|---|---|---|---|
| `Stalin USSR Russia` | yes | yes (2+) | REJECT |
| `Hitler Germany Berlin` | yes | yes | REJECT |
| `Marie Curie polonium discovery` | yes | yes | REJECT |
| `Big Rapids Michigan tourism` | yes | yes | REJECT |
| `O'Brien character 1984` | yes | yes | REJECT |
| `what is the population of detroit` | yes | no (stop-filter, 1 left) | ACCEPT |
| `people who live in michigan` | yes | no | ACCEPT |
| `Berlin Germany` | no (<3 tk) | n/a | ACCEPT |
| `musicians from tokyo` (a18 mock) | yes | no (canonical doesn't contain probed token) | ACCEPT |

## Tests

**16 new tests** in `tests/test_post_b10_beta_fixes.py`. Two b9 tests updated to reflect post-b10 architecture.

```
2503 passed, 54 skipped (full suite, ~28s)
```

mypy / black / flake8 / isort all clean.

## Methodology — "fix unlocks new paths" 18 sweeps strong

Each prior sweep peeled back another layer; this one peels three:
- b10 case-based discriminator broken by upstream Sub-D-2 Rule 1 lowercasing.
- Probe-based replacement fooled by stop words that match disambig pages.
- Probe ALSO fooled by overly-permissive test mocks.

Discriminator now has three layers — shape, stop-word filter, in-canonical check.
