### PR TITLE
fix(v2): post-b11 beta-test sweep — Z4 multi-token canonical tangential check

### DIFF
--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -31,10 +31,14 @@ from .title_promotion import (
     count_non_tail_strong_entities,
     find_title_match,
     has_apostrophe_possessive,
+    has_digit_specificity_match,
+    has_topic_prefix_canonical_extension,
     is_strong_title_match,
     is_tail_hijack_shape,
+    is_tangential_multi_token_shape,
     iter_query_tails,
     iter_query_windows,
+    probed_head_matches_promoted,
 )
 from .tool_schemas import (
     SearchAllResponse,
@@ -3903,7 +3907,7 @@ class SimpleToolsHandler:
         because the title-match boost isn't strong enough. The 1.0 gate
         promotes the canonical past that ranking.
         """
-        # Post-b3: probe the FULL topic (with original punctuation
+        # Pass 0: probe the FULL topic (with original punctuation
         # preserved) BEFORE iter_query_tails decomposes it.
         # ``iter_query_tails`` tokenizes on alphanumeric runs, so
         # apostrophe-bearing possessives split: ``einstein's theory``
@@ -3914,23 +3918,17 @@ class SimpleToolsHandler:
         # are stored WITH the apostrophe — ``Einstein's_theory``
         # redirects to ``Theory_of_relativity``), and the shortest
         # tail ``"theory"`` wins via the generic ``Theory`` article.
-        # Live impact across the b3 sweep: ``Einstein's theory`` →
-        # ``Theory`` (expected ``Theory_of_relativity``); ``Plato's
-        # cave`` → ``Cave`` (expected ``Allegory_of_the_cave``);
-        # ``Plato's Republic`` → ``Republic`` (expected
-        # ``Republic_(Plato)``). Probing the original topic with
-        # punctuation at the start catches these. ``min_score=0.95``
-        # mirrors the canonical-or-fuzzy gate Rule 2/3/4's probe
-        # uses (intent_parser.py:317), accepting both direct hits
-        # (1.0) and high-confidence redirects / spelling variants
-        # (0.95). Non-possessive queries hit this probe with the same
-        # behavior they'd get from pass-1's longest tail — the new
-        # call returns redundantly on those, never less correct.
+        # Probing the original topic with punctuation at the start
+        # catches these. ``min_score=0.95`` mirrors the canonical-or-
+        # fuzzy gate Rule 2/3/4's probe uses (intent_parser.py:317),
+        # accepting both direct hits (1.0) and high-confidence
+        # redirects / spelling variants (0.95). The b3 invariant
+        # (regression-guarded by test_post_b3 / test_promote_function_
+        # starts_with_full_topic_probe) requires this to be the FIRST
+        # ``find_title_match`` call in the function.
         promoted = find_title_match(
             self.zim_operations, zim_file_path, topic, min_score=0.95
         )
-        if promoted is not None and accept_possessive_promotion(promoted, topic):
-            return promoted
         # Post-b4 D2: when the topic carries an apostrophe-possessive
         # (``Plato's republic philosophy`` / ``Einstein's theory
         # history``), tighten the tail-iteration floor to ``min_len=2``
@@ -3941,46 +3939,80 @@ class SimpleToolsHandler:
         # picking a generic Wikipedia title that shares the word.
         pass_tail_min_len = 2 if has_apostrophe_possessive(topic) else 1
 
-        # Post-b10 Z3 multi-entity discriminator: the b9/b10 Z3 rule
-        # rejected the tail-hijack shape unconditionally in
-        # ``accept_possessive_promotion``. That correctly catches
-        # the silent-wrong-answer pattern (``stalin ussr russia`` →
-        # ``Russia``) but over-rejects the legitimate filler-prose +
-        # tail-entity case (``what is the population of detroit`` →
-        # ``Detroit``). The case-based discriminator b10 used broke
-        # because ``IntentParser._normalize_topic_case`` lowercases
-        # the topic upstream. The probe-based replacement counts how
-        # many non-tail topic tokens individually resolve to strong
-        # title matches; 2+ signals a multi-entity stack the user is
-        # querying jointly, < 2 signals filler-prose + entity-at-tail.
-        # The probe is wrapped once and reused across Pass 1 / Pass 2
-        # to keep the cost bounded.
+        # Token probe shared by the b10 Z3 multi-entity discriminator
+        # AND the b11 Z4 head-biographical-canonical check. Wrapped
+        # once and reused so the cost stays bounded at one libzim probe
+        # per non-tail topic token (and one per head check).
         def _probe(token_str: str) -> Optional[Dict[str, Any]]:
             return find_title_match(self.zim_operations, zim_file_path, token_str)
 
-        def _accept_with_multi_entity_check(
-            promoted: Dict[str, Any],
-        ) -> bool:
-            """Run the standard accept gate; for non-possessive
-            tail-hijack rejections, probe non-tail tokens and
-            override the rejection when single-entity is confirmed.
-            """
-            if accept_possessive_promotion(promoted, topic):
-                return True
+        # Post-b11 Z4 layer. Multi-token tangential canonicals
+        # (``Lenin Russia`` → ``Leninist_Komsomol_of_the_Russian_Federation``,
+        # ``Tesla electricity`` → ``Tesla's_Wireless_Electricity``,
+        # ``Mozart Vienna`` → ``Mozarthaus_Vienna``,
+        # ``Beethoven symphony`` → ``Symphony_No._1_(Beethoven)``,
+        # ``Marie Curie radioactivity`` → ``Radioactive_(Redniss_book)``)
+        # surface where ``is_tail_hijack_shape`` doesn't fire (canonical
+        # is multi-token). Z4 rejects them UNLESS one of three
+        # exemptions applies: biographical-canonical (head probe
+        # matches promoted), digit-specificity (numbered-instance
+        # signal), or type-extension (canonical's leading tokens are
+        # a 2+-token contiguous topic slice with extras only at
+        # suffix — preserves ``Big Rapids Michigan Ferris State`` →
+        # ``Ferris_State_University``). The Z4 check is applied at
+        # every pass (0, 1, 2, 3) so the defect class can't slip
+        # through a different gate.
+        def _passes_z4(promoted_arg: Dict[str, Any]) -> bool:
             if has_apostrophe_possessive(topic):
-                return False
-            if not is_tail_hijack_shape(promoted, topic):
-                return False
-            return count_non_tail_strong_entities(topic, _probe, limit=2) < 2
+                return True
+            if not is_tangential_multi_token_shape(promoted_arg, topic):
+                return True
+            if probed_head_matches_promoted(topic, promoted_arg, _probe):
+                return True
+            if has_digit_specificity_match(promoted_arg, topic):
+                return True
+            if has_topic_prefix_canonical_extension(promoted_arg, topic):
+                return True
+            return False
+
+        # Post-b10 Z3 multi-entity discriminator wrapper. Pass 1 / Pass 2
+        # consult this gate, which layers the b10 single-entity escape
+        # over the b9 unconditional tail-hijack rejection, then applies
+        # the b11 Z4 check on top. Pass 0 / Pass 3 use the bare
+        # ``accept_possessive_promotion`` + ``_passes_z4`` pair (no
+        # single-entity escape — that escape exists for Pass 1's
+        # 1-token-tail filler-prose pattern, not for Pass 0's full-
+        # topic probe).
+        def _accept_with_multi_entity_check(
+            promoted_arg: Dict[str, Any],
+        ) -> bool:
+            if has_apostrophe_possessive(topic):
+                return accept_possessive_promotion(promoted_arg, topic)
+            base_accept = accept_possessive_promotion(promoted_arg, topic)
+            if not base_accept:
+                if not is_tail_hijack_shape(promoted_arg, topic):
+                    return False
+                return count_non_tail_strong_entities(topic, _probe, limit=2) < 2
+            return _passes_z4(promoted_arg)
+
+        # Pass 0 acceptance: base accept gate + Z4 layer. Stalin USSR
+        # Russia → Russia (tail-hijack) is rejected here unconditionally
+        # because ``accept_possessive_promotion`` already says False —
+        # the multi-entity escape only fires at Pass 1/2. Tesla
+        # electricity → Tesla's_Wireless_Electricity is accepted by
+        # ``accept_possessive_promotion`` (2-token topic, no tail-
+        # hijack) but rejected by ``_passes_z4`` (tangential shape,
+        # head probe differs from promoted).
+        if (
+            promoted is not None
+            and accept_possessive_promotion(promoted, topic)
+            and _passes_z4(promoted)
+        ):
+            return promoted
 
         # Pass 1: strict 1.0-score gate across every trailing tail.
         # Prefer an exact title match on any tail (even a short one)
         # over a typo-tolerant fuzzy match on a longer noisier tail.
-        # Post-b9 Z3 wired the accept gate into Pass 1 / Pass 2;
-        # post-b10 layers the multi-entity discriminator on top so
-        # the documented Pass 1 1-token-tail feature
-        # (``what is the population of detroit`` → ``Detroit``) keeps
-        # working when the non-tail tokens probe as single-entity.
         for tail in iter_query_tails(topic, min_len=pass_tail_min_len):
             promoted = find_title_match(self.zim_operations, zim_file_path, tail)
             if promoted is not None and _accept_with_multi_entity_check(promoted):
@@ -3994,15 +4026,20 @@ class SimpleToolsHandler:
             if promoted is not None and _accept_with_multi_entity_check(promoted):
                 return promoted
         # Pass 3: 0.8 typo-tolerant gate. Only fires when no strict
-        # match exists at all — catches single-edit typos.
-        # Post-b4 D1: apply the same conditional ``fuzzy_suggest``
-        # filter as pass-0 so a fuzzy-suggest leak on a possessive
-        # topic can't sneak through the lower gate.
+        # match exists at all — catches single-edit typos. The bare
+        # ``accept_possessive_promotion`` + ``_passes_z4`` pair (no
+        # multi-entity escape) is the same shape as Pass 0; the
+        # escape's filler-prose pattern doesn't apply to typo-corrected
+        # tails.
         for tail in iter_query_tails(topic, min_len=pass_tail_min_len):
             promoted = find_title_match(
                 self.zim_operations, zim_file_path, tail, min_score=0.8
             )
-            if promoted is not None and accept_possessive_promotion(promoted, topic):
+            if (
+                promoted is not None
+                and accept_possessive_promotion(promoted, topic)
+                and _passes_z4(promoted)
+            ):
                 return promoted
         return None
 

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -26,6 +26,8 @@ from .meta import build_meta, format_footer
 from .responses import ToolErrorPayload, tool_error
 from .security import sanitize_context_for_error
 from .title_promotion import (
+    _DISCRIMINATOR_STOP_WORDS,
+    _TAIL_TOKEN_RE,
     _TOKEN_RE,
     accept_possessive_promotion,
     count_non_tail_strong_entities,
@@ -4494,6 +4496,28 @@ class SimpleToolsHandler:
             else article_body.rstrip()
         )
         body_is_disambig_page = self._is_disambig_lead(pre_h2_in_body)
+        # Post-b11 Sub-pattern C: when the auto-picked canonical's body
+        # IS a disambig page AND the topic has 2+ meaningful (non-stop-
+        # word) tokens, the user clearly wanted a specific article (the
+        # `Lincoln slavery emancipation` → `Lincoln` disambig case at
+        # v2.0.0b11). Fall back to plain BM25 search so the LLM sees
+        # the ranked specific articles instead of the disambig list.
+        # Single-content-token topics (``tell me about Lincoln``) are
+        # the bare-head case and legitimately want the disambig — the
+        # ``len >= 2`` floor preserves that. ``has_apostrophe_possessive``
+        # bypass: possessive queries (``Lincoln's emancipation``) carry
+        # their own intent signal that's already handled by OPP-1 at
+        # the promotion layer.
+        if body_is_disambig_page and not has_apostrophe_possessive(topic):
+            disambig_content_tokens = [
+                t
+                for t in _TAIL_TOKEN_RE.findall(topic.lower())
+                if t not in _DISCRIMINATOR_STOP_WORDS
+            ]
+            if len(disambig_content_tokens) >= 2:
+                return self.zim_operations.search_zim_file(
+                    zim_file_path, topic, search_limit, 0
+                )
         if disambig_twin_path and not body_is_disambig_page:
             result = result + (
                 f"\n\n_Note: this topic also has a disambiguation page — "

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -32,8 +32,12 @@ from openzim_mcp.title_promotion import (
     accept_possessive_promotion,
     find_title_match,
     has_apostrophe_possessive,
+    has_digit_specificity_match,
+    has_topic_prefix_canonical_extension,
     is_strong_title_match,
+    is_tangential_multi_token_shape,
     iter_query_tails,
+    probed_head_matches_promoted,
 )
 from openzim_mcp.tool_schemas import (
     Citation,
@@ -1021,6 +1025,28 @@ def _promote_title_match(
             continue
         if not accept_possessive_promotion(full_probe, query):
             continue
+        # Post-b11 Z4 layer (symmetric to simple_tools.py Pass 0):
+        # multi-token canonical tangential check + three exemptions
+        # (biographical-canonical, digit-specificity, type-extension).
+        # The synthesize Pass 0 has the same shape as simple_tools Pass
+        # 0 and is vulnerable to the same Z4 silent-wrong-answer
+        # pattern. The local ``_probe`` closure forwards to
+        # ``find_title_match`` against the same archive so the
+        # biographical exemption can probe head/tail tokens consistently
+        # with simple_tools.
+        if not has_apostrophe_possessive(query) and is_tangential_multi_token_shape(
+            full_probe, query
+        ):
+
+            def _z4_probe(tok: str, _vp: "Path" = vp) -> Optional[dict]:
+                return find_title_match(search_handler, str(_vp), tok)
+
+            if not (
+                probed_head_matches_promoted(query, full_probe, _z4_probe)
+                or has_digit_specificity_match(full_probe, query)
+                or has_topic_prefix_canonical_extension(full_probe, query)
+            ):
+                continue
         full_path = str(full_probe["path"])
         existing_paths_p0 = {(name, str(h.get("path", ""))) for name, h in top_hits}
         if (archive_name, full_path) in existing_paths_p0:

--- a/openzim_mcp/title_promotion.py
+++ b/openzim_mcp/title_promotion.py
@@ -715,9 +715,54 @@ def is_tangential_multi_token_shape(promoted: Dict[str, Any], topic: str) -> boo
     cand_tokens_seq = _TAIL_TOKEN_RE.findall(cand_path.lower())
     if len(cand_tokens_seq) < 2:
         return False
-    cand_tokens = set(cand_tokens_seq)
     topic_tokens = set(topic_tokens_seq)
-    return not cand_tokens.issubset(topic_tokens)
+    # Filter function-word tokens (articles, conjunctions, prepositions)
+    # from the canonical when checking subset. These structural tokens
+    # ("of", "the", "a", "and") surface in canonical paths like
+    # ``Constitution_of_the_United_States`` or
+    # ``Assassination_of_John_F._Kennedy`` without changing the
+    # canonical's identity — they shouldn't flag the canonical as
+    # tangential just because the topic ``united states constitution``
+    # or ``john f kennedy assassination`` omits them. Verbs and pronouns
+    # stay OUT of this filter: ``Made_in_USA`` (canonical extra ``made``)
+    # for topic ``USA products`` SHOULD reject (user didn't ask for the
+    # ``Made in USA`` label specifically).
+    cand_meaningful = set(cand_tokens_seq) - _CANONICAL_FUNCTION_WORDS
+    return not cand_meaningful.issubset(topic_tokens)
+
+
+# Narrow function-word filter for the Z4 canonical-subset check —
+# articles, conjunctions, and prepositions that surface in canonical
+# paths without changing the canonical's meaning. Distinct from
+# ``_DISCRIMINATOR_STOP_WORDS`` (which is broader, used for head-
+# selection and entity-probe filtering) because we don't want to
+# filter verbs or pronouns from the canonical (``Made_in_USA`` should
+# NOT be treated as ``USA`` for the subset comparison).
+_CANONICAL_FUNCTION_WORDS: frozenset[str] = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "and",
+        "or",
+        "but",
+        "nor",
+        "of",
+        "in",
+        "on",
+        "at",
+        "to",
+        "from",
+        "by",
+        "with",
+        "for",
+        "as",
+        "into",
+        "onto",
+        "over",
+        "under",
+    }
+)
 
 
 def probed_head_matches_promoted(
@@ -725,48 +770,57 @@ def probed_head_matches_promoted(
     promoted: Dict[str, Any],
     title_probe: Callable[[str], Optional[Dict[str, Any]]],
 ) -> bool:
-    """Post-b11 Z4 biographical-canonical exemption: probe the topic's
-    first non-stop-word token; True iff that probe's canonical path OR
-    pre-redirect path equals the promoted candidate's path.
+    """Post-b11 Z4 biographical-canonical exemption: probe each non-
+    stop-word topic token; True iff ANY probe's canonical path (or
+    pre-redirect path) equals the promoted candidate's path AND the
+    probed token literally appears in the promoted canonical's tokens.
 
-    The Z4 tangential shape over-rejects when the promoted candidate IS
-    the head's biographical canonical reached via redirect — e.g.,
-    ``Picasso Paris cubism`` → ``Pablo_Picasso`` looks like a tangential
-    multi-token canonical (``pablo`` ∉ topic tokens), but probing the
-    head ``picasso`` returns the same ``Pablo_Picasso`` canonical
-    (typically via a ``Picasso`` redirect). Treat as a valid promotion.
+    The "subject" position in a topic varies — sometimes head
+    (``Picasso Paris cubism`` → subject ``Picasso`` at position 0,
+    promoted ``Pablo_Picasso``), sometimes tail (``quantum mechanics
+    Einstein`` → subject ``Einstein`` at position 2, promoted
+    ``Albert_Einstein``). Probing only the head misses the tail-subject
+    case; probing all positions catches it.
 
-    The check uses the SAME stop-word inventory as
-    ``count_non_tail_strong_entities`` so filler-prose topics
-    (``the picasso paintings``) skip ``the`` and land on ``picasso`` as
-    the effective head. The first non-stop-word token wins — compound
-    heads like ``Marie Curie`` use ``marie`` here; the rejection path
-    catches that case correctly because ``marie`` typically resolves to
-    a disambig page distinct from the (defective) promoted candidate.
+    The TOKEN-IN-CANONICAL guard prevents accidental over-acceptance:
+    ``Darwin evolution Galapagos`` → ``Galápagos_Islands`` would also
+    match if we accepted on path-only — ``galapagos`` probes to
+    ``Galápagos_Islands`` which equals promoted. But raw token
+    comparison shows ``galapagos`` ∉ canonical tokens ``{galápagos,
+    islands}`` (accent difference), so the guard correctly rejects.
+    The same guard rejects ``Lenin Russia`` →
+    ``Leninist_Komsomol_of_the_Russian_Federation`` (probes don't
+    match promoted path) and ``Tesla electricity`` →
+    ``Tesla's_Wireless_Electricity`` (probes return ``Nikola_Tesla`` /
+    ``Electricity``, neither matches promoted).
 
-    Probe exceptions are swallowed (transient libzim errors must not
-    blow up the gate) — defensive parity with
-    ``count_non_tail_strong_entities``.
+    Stop-word topic tokens are skipped (``the picasso paintings``
+    skips ``the``, lands on ``picasso``). Probe exceptions are
+    swallowed for transient-error tolerance.
     """
     tokens = _TAIL_TOKEN_RE.findall(topic.lower())
-    head = next(
-        (t for t in tokens if t not in _DISCRIMINATOR_STOP_WORDS),
-        None,
-    )
-    if not head:
-        return False
-    try:
-        result = title_probe(head)
-    except Exception:
-        return False
-    if result is None:
-        return False
     promoted_path = str(promoted.get("path", "")).lower()
     if not promoted_path:
         return False
-    probe_path = str(result.get("path", "")).lower()
-    probe_pre = str(result.get("pre_redirect_path", "") or "").lower()
-    return probe_path == promoted_path or probe_pre == promoted_path
+    cand_tokens = set(_TAIL_TOKEN_RE.findall(promoted_path))
+    for tok in tokens:
+        if tok in _DISCRIMINATOR_STOP_WORDS:
+            continue
+        # Token-in-canonical guard runs FIRST — cheap pre-filter. A
+        # probe that wouldn't satisfy this guard is wasted work.
+        if tok not in cand_tokens:
+            continue
+        try:
+            result = title_probe(tok)
+        except Exception:
+            continue
+        if result is None:
+            continue
+        probe_path = str(result.get("path", "")).lower()
+        probe_pre = str(result.get("pre_redirect_path", "") or "").lower()
+        if probe_path == promoted_path or probe_pre == promoted_path:
+            return True
+    return False
 
 
 def has_digit_specificity_match(promoted: Dict[str, Any], topic: str) -> bool:

--- a/openzim_mcp/title_promotion.py
+++ b/openzim_mcp/title_promotion.py
@@ -671,6 +671,203 @@ def count_non_tail_strong_entities(
     return count
 
 
+def is_tangential_multi_token_shape(promoted: Dict[str, Any], topic: str) -> bool:
+    """Post-b11 Z4: shape predicate for multi-token canonical tangential
+    promotions.
+
+    Returns True iff ``promoted``'s canonical path is multi-token AND
+    its tokens are NOT a subset of the topic's tokens. The subset rule
+    preserves the b8 ``Apollo 11 moon landing`` → ``Moon_landing`` and
+    ``Lincoln Gettysburg Address`` → ``Gettysburg_Address`` invariants
+    (canonical ⊆ topic = generalization of topic, NOT tangential), while
+    flagging the silent-wrong-answer pattern at v2.0.0b11 where the
+    canonical contains the topic head as a subordinate (possessive,
+    parenthetical, stem prefix) AND adds modifier tokens that the user
+    never supplied:
+
+      * ``Tesla electricity`` → ``Tesla's_Wireless_Electricity`` (extras:
+        ``wireless``)
+      * ``Mozart Vienna`` → ``Mozarthaus_Vienna`` (extras: ``mozarthaus``)
+      * ``Lenin Russia`` → ``Leninist_Komsomol_of_the_Russian_Federation``
+        (extras: ``leninist``, ``komsomol``, ``of``, ``the``, ``russian``,
+        ``federation``)
+      * ``Beethoven symphony`` → ``Symphony_No._1_(Beethoven)`` (extras:
+        ``no``, ``1``)
+
+    Topic-size guards:
+
+      * Topics with <2 tokens: no head/modifier distinction, no Z4. The
+        bare-head case (``Picasso``) already routes through
+        ``is_strong_title_match`` at the BM25 stage.
+      * Single-token canonicals: ``is_tail_hijack_shape`` territory
+        (b9/b10 single-token-tail rule).
+
+    Sibling shape predicate to ``is_tail_hijack_shape``: the b11 b10 rule
+    catches 1-token-tail hijacks; this catches the symmetric multi-token
+    case. The discriminator at the call site layers exemptions on top
+    (biographical canonical via head probe, numbered-instance via digit
+    specificity) — this predicate is pure logic.
+    """
+    topic_tokens_seq = _TAIL_TOKEN_RE.findall(topic.lower())
+    if len(topic_tokens_seq) < 2:
+        return False
+    cand_path = str(promoted.get("path", ""))
+    cand_tokens_seq = _TAIL_TOKEN_RE.findall(cand_path.lower())
+    if len(cand_tokens_seq) < 2:
+        return False
+    cand_tokens = set(cand_tokens_seq)
+    topic_tokens = set(topic_tokens_seq)
+    return not cand_tokens.issubset(topic_tokens)
+
+
+def probed_head_matches_promoted(
+    topic: str,
+    promoted: Dict[str, Any],
+    title_probe: Callable[[str], Optional[Dict[str, Any]]],
+) -> bool:
+    """Post-b11 Z4 biographical-canonical exemption: probe the topic's
+    first non-stop-word token; True iff that probe's canonical path OR
+    pre-redirect path equals the promoted candidate's path.
+
+    The Z4 tangential shape over-rejects when the promoted candidate IS
+    the head's biographical canonical reached via redirect — e.g.,
+    ``Picasso Paris cubism`` → ``Pablo_Picasso`` looks like a tangential
+    multi-token canonical (``pablo`` ∉ topic tokens), but probing the
+    head ``picasso`` returns the same ``Pablo_Picasso`` canonical
+    (typically via a ``Picasso`` redirect). Treat as a valid promotion.
+
+    The check uses the SAME stop-word inventory as
+    ``count_non_tail_strong_entities`` so filler-prose topics
+    (``the picasso paintings``) skip ``the`` and land on ``picasso`` as
+    the effective head. The first non-stop-word token wins — compound
+    heads like ``Marie Curie`` use ``marie`` here; the rejection path
+    catches that case correctly because ``marie`` typically resolves to
+    a disambig page distinct from the (defective) promoted candidate.
+
+    Probe exceptions are swallowed (transient libzim errors must not
+    blow up the gate) — defensive parity with
+    ``count_non_tail_strong_entities``.
+    """
+    tokens = _TAIL_TOKEN_RE.findall(topic.lower())
+    head = next(
+        (t for t in tokens if t not in _DISCRIMINATOR_STOP_WORDS),
+        None,
+    )
+    if not head:
+        return False
+    try:
+        result = title_probe(head)
+    except Exception:
+        return False
+    if result is None:
+        return False
+    promoted_path = str(promoted.get("path", "")).lower()
+    if not promoted_path:
+        return False
+    probe_path = str(result.get("path", "")).lower()
+    probe_pre = str(result.get("pre_redirect_path", "") or "").lower()
+    return probe_path == promoted_path or probe_pre == promoted_path
+
+
+def has_digit_specificity_match(promoted: Dict[str, Any], topic: str) -> bool:
+    """Post-b11 Z4 digit-specificity exemption: True iff the canonical's
+    extras (tokens NOT in topic) include a digit-bearing token AND the
+    topic also has a digit-bearing token.
+
+    Without this exemption, Z4 over-rejects legitimate numbered sub-
+    article promotions — ``Beethoven 9th symphony`` →
+    ``Symphony_No._9_(Beethoven)`` has canonical extras ``{no, 9}`` and
+    the topic explicitly carries the ordinal ``9th``. The user signaled
+    they want a numbered instance; the canonical's digit matches.
+    Allow.
+
+    The asymmetric "extras digit AND topic digit" shape distinguishes
+    legitimate numbered queries from defect cases like ``Beethoven
+    symphony`` → ``Symphony_No._1_(Beethoven)`` (canonical has digit
+    extra ``1``, topic has NO digit — user never asked for symphony #1
+    specifically; this is the system silently picking one instance).
+    Subset cases (``Apollo 11`` for ``apollo 11 mission`` where the
+    canonical digit ``11`` is already in topic, so no digit extras) are
+    handled by the subset rule in ``is_tangential_multi_token_shape``
+    before reaching this check — no extras means no exemption claim.
+    """
+    cand_path = str(promoted.get("path", ""))
+    cand_tokens = set(_TAIL_TOKEN_RE.findall(cand_path.lower()))
+    topic_tokens = set(_TAIL_TOKEN_RE.findall(topic.lower()))
+    extras = cand_tokens - topic_tokens
+    return _any_token_has_digit(extras) and _any_token_has_digit(topic_tokens)
+
+
+def _any_token_has_digit(tokens: set[str]) -> bool:
+    """True iff any token in ``tokens`` contains an ASCII digit
+    character. Used by ``has_digit_specificity_match`` to detect
+    ordinal/numbered tokens like ``9th``, ``11``, ``1949``."""
+    return any(any(c.isdigit() for c in t) for t in tokens)
+
+
+def has_topic_prefix_canonical_extension(promoted: Dict[str, Any], topic: str) -> bool:
+    """Post-b11 Z4 type-extension exemption: canonical's LEADING tokens
+    form a contiguous slice of the topic's tokens (length ≥ 2), AND the
+    remaining canonical tail tokens are all extras (not in topic).
+
+    Catches the type-name extension pattern: ``Big Rapids Michigan
+    Ferris State`` (topic) → ``Ferris_State_University`` (canonical
+    starts with topic-slice ``ferris state``, adds type word
+    ``university``).  This is symmetric to the biographical-prefix
+    pattern handled by ``probed_head_matches_promoted`` (matched
+    tokens at SUFFIX of canonical, extras at prefix); the
+    type-extension case has matched tokens at PREFIX, extras at
+    suffix.
+
+    Requires the matched slice to be at least 2 tokens long. A
+    1-token slice would over-match — single-token coincidences are
+    common in tangential promotions (``Lenin Russia`` →
+    ``Leninist_Komsomol_of_the_Russian_Federation`` shares 0 raw
+    tokens; ``Mao China revolution`` shares only ``china`` at
+    canonical position 6 of 9). The 2-token floor pins the rule to
+    the "type extension" shape where the matched slice is a coherent
+    entity name.
+
+    Defect cases stay rejected — none of them have a canonical
+    starting with a contiguous 2+-token topic slice:
+
+      * ``Tesla electricity`` → ``Tesla's_Wireless_Electricity``:
+        canonical prefix ``tesla's`` ≠ topic ``tesla`` (raw token
+        comparison), so the prefix-match search fails.
+      * ``Mozart Vienna`` → ``Mozarthaus_Vienna``: canonical prefix
+        ``mozarthaus`` ≠ topic ``mozart``.
+      * ``Lenin Russia`` → ``Leninist_Komsomol_...``: canonical
+        prefix ``leninist`` ≠ topic ``lenin``.
+      * ``Beethoven symphony`` → ``Symphony_No._1_(Beethoven)``:
+        canonical prefix [``symphony``, ``no``] not contiguous in
+        topic.
+    """
+    cand_path = str(promoted.get("path", ""))
+    cand_tokens = _TAIL_TOKEN_RE.findall(cand_path.lower())
+    if len(cand_tokens) < 2:
+        return False
+    topic_tokens = _TAIL_TOKEN_RE.findall(topic.lower())
+    if len(topic_tokens) < 2:
+        return False
+    topic_set = set(topic_tokens)
+    # Try the longest canonical prefix first; the first match wins.
+    # Longest-first ensures multi-token entity names ("Ferris State")
+    # are detected before any shorter coincidental prefix.
+    for prefix_len in range(min(len(cand_tokens), len(topic_tokens)), 1, -1):
+        prefix = cand_tokens[:prefix_len]
+        suffix = cand_tokens[prefix_len:]
+        # The suffix must be all extras — if any suffix token also
+        # appears in topic, this isn't a clean type-extension shape.
+        if any(t in topic_set for t in suffix):
+            continue
+        # Look for ``prefix`` as a contiguous slice anywhere in
+        # topic_tokens.
+        for start_idx in range(len(topic_tokens) - prefix_len + 1):
+            if topic_tokens[start_idx : start_idx + prefix_len] == prefix:
+                return True
+    return False
+
+
 def _accept_possessive_fuzzy_suggest(promoted: Dict[str, Any], topic: str) -> bool:
     """Accept gate for possessive topic + ``match_type="fuzzy_suggest"``.
 

--- a/tests/test_post_b11_beta_fixes.py
+++ b/tests/test_post_b11_beta_fixes.py
@@ -620,6 +620,95 @@ class TestZ4PreservedCases:
             and result["path"] == "Newton's_law_of_universal_gravitation"
         )
 
+    def test_quantum_mechanics_einstein_tail_subject_accepts(self) -> None:
+        """Post-b11 second-pass: the user's pinned counter-case
+        ``quantum mechanics Einstein`` → ``Albert_Einstein`` has the
+        subject at the TAIL of the topic, not the head. The
+        biographical exemption must probe ALL non-stop-word tokens
+        (not just the first) so the tail-position ``einstein`` probe
+        catches the match. Token-in-canonical guard prevents
+        accidental over-acceptance: ``einstein`` is literally in
+        ``Albert_Einstein`` tokens, AND ``einstein`` probes to the
+        same canonical."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "quantum mechanics einstein": {
+                "path": "Albert_Einstein",
+                "title": "Albert Einstein",
+                "zim_file": "test.zim",
+                "match_type": "fuzzy_suggest",
+            },
+            "mechanics einstein": None,
+            "einstein": {
+                "path": "Albert_Einstein",
+                "title": "Albert Einstein",
+                "zim_file": "test.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "Einstein",
+            },
+            "quantum": {
+                "path": "Quantum_mechanics",
+                "title": "Quantum mechanics",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "mechanics": {
+                "path": "Mechanics",
+                "title": "Mechanics",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+        }
+        result = _run_promote("quantum mechanics einstein", mapping)
+        assert result is not None and result["path"] == "Albert_Einstein"
+
+    def test_jfk_assassination_canonical_with_of_extra_accepts(self) -> None:
+        """Post-b11 second-pass: canonical extras of pure function
+        words (``of``, ``the``, ``and``) shouldn't flag the canonical
+        as tangential. ``Assassination_of_John_F._Kennedy`` for topic
+        ``John F Kennedy assassination`` — canonical's only extra is
+        ``of`` (a preposition); after the canonical-subset stop-word
+        filter, canonical {assassination, john, f, kennedy} ⊆ topic
+        → subset → accept via subset rule (no exemption needed)."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "john f kennedy assassination": {
+                "path": "Assassination_of_John_F._Kennedy",
+                "title": "Assassination of John F. Kennedy",
+                "zim_file": "test.zim",
+                "match_type": "fuzzy_suggest",
+            },
+            "f kennedy assassination": None,
+            "kennedy assassination": {
+                "path": "Assassination_of_John_F._Kennedy",
+                "title": "Assassination of John F. Kennedy",
+                "zim_file": "test.zim",
+                "match_type": "fuzzy_suggest",
+            },
+            "kennedy": {
+                "path": "John_F._Kennedy",
+                "title": "John F. Kennedy",
+                "zim_file": "test.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "Kennedy",
+            },
+            "assassination": {
+                "path": "Assassination",
+                "title": "Assassination",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "john": {
+                "path": "John",
+                "title": "John",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "f": None,
+        }
+        result = _run_promote("john f kennedy assassination", mapping)
+        assert (
+            result is not None and result["path"] == "Assassination_of_John_F._Kennedy"
+        )
+
     def test_ferris_state_type_extension_accepts(self) -> None:
         """Type-extension exemption: ``Ferris_State_University`` for
         topic ``Big Rapids Michigan Ferris State`` — canonical's leading
@@ -782,6 +871,39 @@ class TestIsTangentialMultiTokenShape:
 
         assert is_tangential_multi_token_shape({}, "tesla electricity") is False
 
+    def test_canonical_function_word_extras_filtered(self) -> None:
+        """Function-word extras (``of``, ``the``, ``and``, ``in``) in
+        canonical don't flag the canonical as tangential — they're
+        structural tokens that smear into paths like
+        ``Constitution_of_the_United_States`` or
+        ``Assassination_of_John_F._Kennedy`` without changing the
+        canonical's identity."""
+        from openzim_mcp.title_promotion import is_tangential_multi_token_shape
+
+        # ``Assassination_of_John_F._Kennedy`` has only ``of`` as a
+        # non-topic extra; after the canonical-function-word filter,
+        # the canonical reduces to {assassination, john, f, kennedy}
+        # which IS a subset of the topic.
+        promoted = {"path": "Assassination_of_John_F._Kennedy"}
+        assert (
+            is_tangential_multi_token_shape(promoted, "john f kennedy assassination")
+            is False
+        )
+
+    def test_canonical_lexical_word_extra_stays_tangential(self) -> None:
+        """Lexical-word extras (verbs like ``made``, ``lived``) ARE
+        kept — they carry meaning. Topic ``USA products`` →
+        ``Made_in_USA`` would over-accept if we filtered ``made`` from
+        canonical; the user didn't ask for the ``Made in USA`` label
+        specifically."""
+        from openzim_mcp.title_promotion import is_tangential_multi_token_shape
+
+        promoted = {"path": "Made_in_USA"}
+        # ``in`` is filtered (preposition); ``made`` is NOT (verb).
+        # Filtered canonical = {made, usa}; topic = {usa, products};
+        # ``made`` is not in topic → NOT subset → tangential.
+        assert is_tangential_multi_token_shape(promoted, "usa products") is True
+
 
 class TestProbedHeadMatchesPromoted:
     """Biographical-canonical exemption: probe the topic's first non-
@@ -869,8 +991,58 @@ class TestProbedHeadMatchesPromoted:
             is True
         )
 
+    def test_tail_position_subject_matches(self) -> None:
+        """Subject at tail of topic (not head). ``quantum mechanics
+        einstein`` — head ``quantum`` doesn't match promoted, but
+        tail ``einstein`` probes to the same canonical AND is
+        literally in canonical tokens."""
+        from openzim_mcp.title_promotion import probed_head_matches_promoted
+
+        def probe(token: str) -> Optional[Dict[str, Any]]:
+            return {
+                "quantum": {"path": "Quantum_mechanics"},
+                "mechanics": {"path": "Mechanics"},
+                "einstein": {
+                    "path": "Albert_Einstein",
+                    "pre_redirect_path": "Einstein",
+                },
+            }.get(token)
+
+        promoted = {"path": "Albert_Einstein"}
+        assert (
+            probed_head_matches_promoted("quantum mechanics einstein", promoted, probe)
+            is True
+        )
+
+    def test_token_in_canonical_guard_blocks_accent_mismatch(self) -> None:
+        """Token-in-canonical guard: ``galapagos`` probes to
+        ``Galápagos_Islands`` (path match) BUT ``galapagos`` ≠
+        ``galápagos`` raw token → not in canonical → not exempt.
+        This is what saves ``Darwin evolution Galapagos`` from being
+        over-accepted by an accent-tolerant title-suggest hit."""
+        from openzim_mcp.title_promotion import probed_head_matches_promoted
+
+        def probe(token: str) -> Optional[Dict[str, Any]]:
+            return {
+                "darwin": {"path": "Charles_Darwin"},
+                "evolution": {"path": "Evolution"},
+                "galapagos": {"path": "Galápagos_Islands"},
+            }.get(token)
+
+        promoted = {"path": "Galápagos_Islands"}
+        # ``galapagos`` (no accent) is not in canonical tokens
+        # ``{galápagos, islands}`` due to accent → guard fails → False.
+        assert (
+            probed_head_matches_promoted("darwin evolution galapagos", promoted, probe)
+            is False
+        )
+
     def test_probe_exception_swallowed_returns_false(self) -> None:
-        """Defensive: a flaky probe must not blow up the gate."""
+        """Defensive: a flaky probe must not blow up the gate. The
+        token-in-canonical pre-filter normally short-circuits before
+        the probe is called, so this test uses a topic where a token
+        IS in canonical (``some`` in ``Some_Article``) so the probe
+        actually runs and the exception path is exercised."""
         from openzim_mcp.title_promotion import probed_head_matches_promoted
 
         def probe(token: str) -> Optional[Dict[str, Any]]:
@@ -878,7 +1050,7 @@ class TestProbedHeadMatchesPromoted:
 
         promoted = {"path": "Some_Article"}
         assert (
-            probed_head_matches_promoted("tesla electricity", promoted, probe) is False
+            probed_head_matches_promoted("some other topic", promoted, probe) is False
         )
 
 

--- a/tests/test_post_b11_beta_fixes.py
+++ b/tests/test_post_b11_beta_fixes.py
@@ -1,0 +1,926 @@
+r"""Regression tests for the post-b11 beta-test sweep.
+
+The post-b11 live-MCP sweep against v2.0.0b11 confirmed the b10
+probe-based multi-entity discriminator delivers on its 3-entity
+single-token-tail target shape (4/6 historical Z3 repros now route
+to the correct head). Two new defect classes surfaced:
+
+## Z4 (HIGH, silent-wrong cert=0.85) — multi-token canonical tangential
+
+``is_tail_hijack_shape`` only fires when canonical is single-token
+AND topic has 3+ tokens. When the silent-wrong-answer pattern
+manifests with a multi-token canonical or a 2-token topic, the b11
+discriminator never fires and the wrong promotion ships at cert=0.85.
+
+Live repros at v2.0.0b11 (all cert=0.85, all silent-wrong):
+
+  * ``Lenin Russia`` → ``Leninist_Komsomol_of_the_Russian_Federation``
+    (head ``Vladimir_Lenin`` skipped). 2-token topic + multi-token
+    canonical with stem-overlap on both tokens.
+  * ``Tesla electricity`` → ``Tesla's_Wireless_Electricity``
+    (head ``Nikola_Tesla`` skipped). Canonical contains head as
+    possessive subordinate + adds modifier ``wireless`` not in topic.
+  * ``Mozart Vienna`` → ``Mozarthaus_Vienna``
+    (head ``Wolfgang_Amadeus_Mozart`` skipped). Canonical contains
+    head as prefix of subordinate token + adds modifier ``haus``.
+  * ``Beethoven symphony`` → ``Symphony_No._1_(Beethoven)``
+    (head ``Ludwig_van_Beethoven`` skipped). Canonical contains head
+    as parenthetical + adds specific-instance digit not in topic.
+  * ``Marie Curie radioactivity`` → ``Radioactive_(Redniss_book)``
+    (head ``Marie_Curie`` skipped). Canonical surfaces via tail-stem
+    only; rest of canonical is unrelated graphic-novel metadata.
+  * ``Shakespeare England plays`` → ``Shakespeare's_Kings``
+    (head ``William_Shakespeare`` skipped). Canonical contains head
+    as possessive subordinate; topic modifier tokens not covered.
+  * ``Darwin evolution Galapagos`` → ``Galápagos_Islands``
+    (head ``Charles_Darwin`` skipped). Canonical surfaces via tail
+    only (place name); rest of topic ignored.
+  * ``Mao China revolution`` → ``History_of_the_People's_Republic_of_China_(1949–1976)``
+    (head ``Mao_Zedong`` skipped). Canonical shares only the middle
+    topic token ``china``.
+
+## Fix shape — Z4 tangential promotion check with two exemptions
+
+Three new helpers in ``title_promotion``:
+
+  * ``is_tangential_multi_token_shape(promoted, topic)`` — pure-logic
+    shape: canonical is multi-token AND not a token-set subset of
+    topic. The subset rule preserves the b8 ``Apollo 11 moon landing``
+    → ``Moon_landing`` invariant (canonical ⊆ topic = generalization,
+    not tangential) and the b4 ``Lincoln Gettysburg Address`` →
+    ``Gettysburg_Address`` invariant (same shape).
+  * ``probed_head_matches_promoted(topic, promoted, title_probe)`` —
+    biographical-canonical exemption: probes the topic's first non-
+    stop-word token. If the head probe's canonical path (or pre-
+    redirect path) equals the promoted candidate's path, the
+    promotion IS the head's biographical article (e.g.,
+    ``Picasso Paris cubism`` → ``Pablo_Picasso`` because probing
+    ``picasso`` returns ``Pablo_Picasso`` via redirect). Exempt.
+  * ``has_digit_specificity_match(promoted, topic)`` — digit
+    specificity exemption: when canonical's extras (tokens not in
+    topic) include a digit AND topic also has a digit/ordinal token,
+    the user explicitly signaled they want a numbered instance
+    (``Beethoven 9th symphony`` → ``Symphony_No._9_(Beethoven)``).
+    Without this exemption Z4 over-rejects the legitimate numbered
+    sub-article case.
+
+``_promote_topic_via_title_index``'s ``_accept_with_multi_entity_check``
+layers the Z4 check after the existing Z3 logic. The same gate is now
+applied at Pass 0 (full-topic probe) and Pass 3 (typo-tolerant) — Z4
+defects surface across all four passes, so the gate must be
+consistent.
+
+## Decision matrix
+
+  +-----------------------------------+--------+-------+-------+----------+
+  | Topic                             | Multi- | Bio   | Digit | Decision |
+  |                                   | token  | exem  | exem  |          |
+  |                                   | tangent|       |       |          |
+  +-----------------------------------+--------+-------+-------+----------+
+  | Tesla electricity                 | yes    | no    | no    | REJECT   |
+  | Mozart Vienna                     | yes    | no    | no    | REJECT   |
+  | Beethoven symphony                | yes    | no    | no    | REJECT   |
+  | Lenin Russia                      | yes    | no    | no    | REJECT   |
+  | Marie Curie radioactivity         | yes    | no    | no    | REJECT   |
+  | Shakespeare England plays         | yes    | no    | no    | REJECT   |
+  | Darwin evolution Galapagos        | yes    | no    | no    | REJECT   |
+  | Mao China revolution              | yes    | no    | no    | REJECT   |
+  | Picasso Paris cubism              | yes    | YES   | -     | ACCEPT   |
+  | Beethoven 9th symphony            | yes    | no    | YES   | ACCEPT   |
+  | Apollo 11 moon landing            | no(⊆)  | -     | -     | ACCEPT   |
+  | Lincoln Gettysburg Address        | no(⊆)  | -     | -     | ACCEPT   |
+  | Newton's gravity (possessive)     | -      | -     | -     | ACCEPT   |
+  |   (Z4 doesn't apply to possessive — OPP-1 handles)                    |
+  | Hamlet Denmark prince             | no(1tk)| -     | -     | ACCEPT   |
+  | Berlin Germany                    | no(1tk)| -     | -     | ACCEPT   |
+  | what is the population of detroit | no(1tk)| -     | -     | ACCEPT   |
+  +-----------------------------------+--------+-------+-------+----------+
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from unittest.mock import patch
+
+from tests._promote_fixtures import fake_find_title_match as _fake_find_title_match
+from tests._promote_fixtures import make_simple_handler as _make_simple_handler
+
+
+def _run_promote(
+    topic: str, mapping: Dict[str, Optional[Dict[str, Any]]]
+) -> Optional[Dict[str, Any]]:
+    """Drive ``_promote_topic_via_title_index`` with the mapping
+    serving as the find_title_match stand-in for every probe."""
+    from openzim_mcp.simple_tools import SimpleToolsHandler
+
+    fake = _fake_find_title_match(mapping)
+    with patch("openzim_mcp.simple_tools.find_title_match", side_effect=fake):
+        return SimpleToolsHandler._promote_topic_via_title_index(
+            _make_simple_handler(),
+            "test.zim",
+            topic,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Live Z4 silent-wrong-answer cases — must reject tangential multi-token
+# canonical when the head's biographical article exists and differs.
+# ---------------------------------------------------------------------------
+
+
+class TestZ4MultiTokenCanonicalRejected:
+    """When the promoted canonical is multi-token AND NOT a token-set
+    subset of topic AND the topic head's biographical article exists
+    and differs, the promotion is tangential and must be rejected. Pass
+    2 then tries head-token windows; when those resolve cleanly, that's
+    the auto-fetched result instead."""
+
+    def test_lenin_russia_rejects_leninist_komsomol(self) -> None:
+        """2-token topic, multi-token canonical with stem-overlap on
+        both tokens (lenin→leninist, russia→russian). Head ``lenin``
+        probes to ``Vladimir_Lenin`` (distinct from promoted) →
+        tangential → reject."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "lenin russia": {
+                "path": "Leninist_Komsomol_of_the_Russian_Federation",
+                "title": "Leninist Komsomol of the Russian Federation",
+                "zim_file": "test.zim",
+                "match_type": "fuzzy_suggest",
+            },
+            "russia": {
+                "path": "Russia",
+                "title": "Russia",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "lenin": {
+                "path": "Vladimir_Lenin",
+                "title": "Vladimir Lenin",
+                "zim_file": "test.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "Lenin",
+            },
+        }
+        result = _run_promote("lenin russia", mapping)
+        assert result is None or (
+            result["path"] != "Leninist_Komsomol_of_the_Russian_Federation"
+        ), (
+            "Z4 must reject tangential multi-token canonical "
+            f"`Leninist_Komsomol_...` when head probe `Vladimir_Lenin` "
+            f"differs. Got: {result!r}"
+        )
+
+    def test_tesla_electricity_rejects_wireless_electricity(self) -> None:
+        """2-token topic, canonical contains head as possessive + adds
+        modifier ``wireless`` not in topic. Head probe distinct →
+        tangential → reject."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "tesla electricity": {
+                "path": "Tesla's_Wireless_Electricity",
+                "title": "Tesla's Wireless Electricity",
+                "zim_file": "test.zim",
+                "match_type": "fuzzy_suggest",
+            },
+            "electricity": {
+                "path": "Electricity",
+                "title": "Electricity",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "tesla": {
+                "path": "Nikola_Tesla",
+                "title": "Nikola Tesla",
+                "zim_file": "test.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "Tesla",
+            },
+        }
+        result = _run_promote("tesla electricity", mapping)
+        assert result is None or result["path"] != "Tesla's_Wireless_Electricity"
+
+    def test_mozart_vienna_rejects_mozarthaus(self) -> None:
+        """Canonical ``Mozarthaus_Vienna`` adds ``mozarthaus`` extra
+        not in topic; head probe ``mozart`` differs."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "mozart vienna": {
+                "path": "Mozarthaus_Vienna",
+                "title": "Mozarthaus Vienna",
+                "zim_file": "test.zim",
+                "match_type": "fuzzy_suggest",
+            },
+            "vienna": {
+                "path": "Vienna",
+                "title": "Vienna",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "mozart": {
+                "path": "Wolfgang_Amadeus_Mozart",
+                "title": "Wolfgang Amadeus Mozart",
+                "zim_file": "test.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "Mozart",
+            },
+        }
+        result = _run_promote("mozart vienna", mapping)
+        assert result is None or result["path"] != "Mozarthaus_Vienna"
+
+    def test_beethoven_symphony_rejects_specific_symphony(self) -> None:
+        """Canonical ``Symphony_No._1_(Beethoven)`` has digit extra ``1``
+        but topic ``beethoven symphony`` has NO digit → digit-specificity
+        exemption does NOT apply → tangential → reject."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "beethoven symphony": {
+                "path": "Symphony_No._1_(Beethoven)",
+                "title": "Symphony No. 1 (Beethoven)",
+                "zim_file": "test.zim",
+                "match_type": "fuzzy_suggest",
+            },
+            "symphony": {
+                "path": "Symphony",
+                "title": "Symphony",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "beethoven": {
+                "path": "Ludwig_van_Beethoven",
+                "title": "Ludwig van Beethoven",
+                "zim_file": "test.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "Beethoven",
+            },
+        }
+        result = _run_promote("beethoven symphony", mapping)
+        assert result is None or result["path"] != "Symphony_No._1_(Beethoven)"
+
+    def test_marie_curie_radioactivity_rejects_redniss_book(self) -> None:
+        """3-token topic, multi-token canonical with NO token-set
+        overlap on raw tokens (radioactive ≠ radioactivity). Head
+        probe distinct → tangential → reject."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "marie curie radioactivity": {
+                "path": "Radioactive_(Redniss_book)",
+                "title": "Radioactive (Redniss book)",
+                "zim_file": "test.zim",
+                "match_type": "fuzzy_suggest",
+            },
+            "radioactivity": {
+                "path": "Radioactive_decay",
+                "title": "Radioactive decay",
+                "zim_file": "test.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "Radioactivity",
+            },
+            "marie curie": {
+                "path": "Marie_Curie",
+                "title": "Marie Curie",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "curie radioactivity": None,
+            "marie": {
+                "path": "Marie",
+                "title": "Marie",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "curie": {
+                "path": "Curie",
+                "title": "Curie",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+        }
+        result = _run_promote("marie curie radioactivity", mapping)
+        assert result is None or result["path"] != "Radioactive_(Redniss_book)"
+
+    def test_shakespeare_england_plays_rejects_shakespeare_kings(self) -> None:
+        """Canonical has head as possessive (``Shakespeare's``) +
+        adds non-topic noun ``kings``."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "shakespeare england plays": {
+                "path": "Shakespeare's_Kings",
+                "title": "Shakespeare's Kings",
+                "zim_file": "test.zim",
+                "match_type": "fuzzy_suggest",
+            },
+            "shakespeare england": None,
+            "england plays": None,
+            "plays": {
+                "path": "Plays",
+                "title": "Plays",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "shakespeare": {
+                "path": "William_Shakespeare",
+                "title": "William Shakespeare",
+                "zim_file": "test.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "Shakespeare",
+            },
+            "england": {
+                "path": "England",
+                "title": "England",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+        }
+        result = _run_promote("shakespeare england plays", mapping)
+        assert result is None or result["path"] != "Shakespeare's_Kings"
+
+    def test_darwin_evolution_galapagos_rejects_galapagos_islands(self) -> None:
+        """Multi-token canonical surfaces via tail-only; head ``darwin``
+        biographical article exists and differs."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "darwin evolution galapagos": {
+                "path": "Galápagos_Islands",
+                "title": "Galápagos Islands",
+                "zim_file": "test.zim",
+                "match_type": "fuzzy_suggest",
+            },
+            "evolution galapagos": None,
+            "galapagos": {
+                "path": "Galápagos_Islands",
+                "title": "Galápagos Islands",
+                "zim_file": "test.zim",
+                "match_type": "fuzzy_suggest",
+            },
+            "darwin": {
+                "path": "Charles_Darwin",
+                "title": "Charles Darwin",
+                "zim_file": "test.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "Darwin",
+            },
+            "evolution": {
+                "path": "Evolution",
+                "title": "Evolution",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+        }
+        result = _run_promote("darwin evolution galapagos", mapping)
+        assert result is None or result["path"] != "Galápagos_Islands"
+
+    def test_mao_china_revolution_rejects_china_history(self) -> None:
+        """Multi-token canonical shares only the middle topic token
+        (``china``); head ``mao`` biographical article differs."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "mao china revolution": {
+                "path": "History_of_the_People's_Republic_of_China_(1949-1976)",
+                "title": "History of the People's Republic of China (1949-1976)",
+                "zim_file": "test.zim",
+                "match_type": "fuzzy_suggest",
+            },
+            "china revolution": None,
+            "revolution": {
+                "path": "Revolution",
+                "title": "Revolution",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "mao": {
+                "path": "Mao_Zedong",
+                "title": "Mao Zedong",
+                "zim_file": "test.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "Mao",
+            },
+            "china": {
+                "path": "China",
+                "title": "China",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+        }
+        result = _run_promote("mao china revolution", mapping)
+        assert (
+            result is None
+            or result["path"] != "History_of_the_People's_Republic_of_China_(1949-1976)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Counter-cases: legitimate multi-token canonicals must still promote.
+# ---------------------------------------------------------------------------
+
+
+class TestZ4PreservedCases:
+    """Z4 must NOT over-reject the documented preserved cases.
+
+    Three exemption paths protect legitimate multi-token promotions:
+    (1) subset rule (canonical ⊆ topic = generalization),
+    (2) biographical exemption (head probe matches promoted path),
+    (3) digit-specificity exemption (canonical extras digit ∧ topic digit).
+    """
+
+    def test_apollo_11_moon_landing_subset_accepts(self) -> None:
+        """``Moon_landing`` tokens ⊆ ``apollo 11 moon landing`` tokens →
+        subset rule → canonical is generalization → accept."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "apollo 11 moon landing": {
+                "path": "Moon_landing",
+                "title": "Moon landing",
+                "zim_file": "test.zim",
+                "match_type": "fuzzy_suggest",
+            },
+            "11 moon landing": None,
+            "moon landing": {
+                "path": "Moon_landing",
+                "title": "Moon landing",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "apollo": {
+                "path": "Apollo",
+                "title": "Apollo",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+        }
+        result = _run_promote("apollo 11 moon landing", mapping)
+        assert result is not None and result["path"] == "Moon_landing"
+
+    def test_lincoln_gettysburg_address_subset_accepts(self) -> None:
+        """``Gettysburg_Address`` tokens ⊆ ``lincoln gettysburg address``
+        tokens → subset rule → accept."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "lincoln gettysburg address": {
+                "path": "Gettysburg_Address",
+                "title": "Gettysburg Address",
+                "zim_file": "test.zim",
+                "match_type": "fuzzy_suggest",
+            },
+            "gettysburg address": {
+                "path": "Gettysburg_Address",
+                "title": "Gettysburg Address",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "lincoln": {
+                "path": "Lincoln",
+                "title": "Lincoln",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+        }
+        result = _run_promote("lincoln gettysburg address", mapping)
+        assert result is not None and result["path"] == "Gettysburg_Address"
+
+    def test_picasso_paris_cubism_biographical_accepts(self) -> None:
+        """Head probe ``picasso`` resolves to ``Pablo_Picasso`` = the
+        promoted candidate → biographical exemption → accept."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "picasso paris cubism": {
+                "path": "Pablo_Picasso",
+                "title": "Pablo Picasso",
+                "zim_file": "test.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "Picasso",
+            },
+            "picasso": {
+                "path": "Pablo_Picasso",
+                "title": "Pablo Picasso",
+                "zim_file": "test.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "Picasso",
+            },
+            "paris": {
+                "path": "Paris",
+                "title": "Paris",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "cubism": {
+                "path": "Cubism",
+                "title": "Cubism",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+        }
+        result = _run_promote("picasso paris cubism", mapping)
+        assert result is not None and result["path"] == "Pablo_Picasso"
+
+    def test_beethoven_9th_symphony_digit_accepts(self) -> None:
+        """Canonical extras ``{no, 9}`` include digit AND topic
+        ``{beethoven, 9th, symphony}`` includes a digit token →
+        digit-specificity exemption → accept the specific symphony."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "beethoven 9th symphony": {
+                "path": "Symphony_No._9_(Beethoven)",
+                "title": "Symphony No. 9 (Beethoven)",
+                "zim_file": "test.zim",
+                "match_type": "fuzzy_suggest",
+            },
+            "9th symphony": {
+                "path": "Symphony_No._9_(Beethoven)",
+                "title": "Symphony No. 9 (Beethoven)",
+                "zim_file": "test.zim",
+                "match_type": "fuzzy_suggest",
+            },
+            "symphony": {
+                "path": "Symphony",
+                "title": "Symphony",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "beethoven": {
+                "path": "Ludwig_van_Beethoven",
+                "title": "Ludwig van Beethoven",
+                "zim_file": "test.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "Beethoven",
+            },
+        }
+        result = _run_promote("beethoven 9th symphony", mapping)
+        assert result is not None and result["path"] == "Symphony_No._9_(Beethoven)"
+
+    def test_hamlet_denmark_prince_single_token_canonical(self) -> None:
+        """Single-token canonical is not Z4 tangential shape (b9
+        invariant: HEAD-position single token accepted)."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "hamlet denmark prince": {
+                "path": "Hamlet",
+                "title": "Hamlet",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "denmark prince": None,
+            "prince": None,
+            "hamlet": {
+                "path": "Hamlet",
+                "title": "Hamlet",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "denmark": None,
+        }
+        result = _run_promote("hamlet denmark prince", mapping)
+        assert result is not None and result["path"] == "Hamlet"
+
+    def test_berlin_germany_two_token_topic_single_canonical(self) -> None:
+        """2-token topic with single-token canonical = head → b4
+        carve-out preserved."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "berlin germany": {
+                "path": "Berlin",
+                "title": "Berlin",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "germany": None,
+            "berlin": {
+                "path": "Berlin",
+                "title": "Berlin",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+        }
+        result = _run_promote("berlin germany", mapping)
+        assert result is not None and result["path"] == "Berlin"
+
+    def test_population_of_detroit_filler_prose_accepts(self) -> None:
+        """Filler prose with single-token tail-canonical: b11 Z3 multi-
+        entity discriminator returns count<2 (only ``population``
+        probes) → tail accepted."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "detroit": {
+                "path": "Detroit",
+                "title": "Detroit",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "population": {
+                "path": "Population",
+                "title": "Population",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+        }
+        result = _run_promote("what is the population of detroit", mapping)
+        assert result is not None and result["path"] == "Detroit"
+
+    def test_newtons_gravity_possessive_unaffected(self) -> None:
+        """Possessive topics route through OPP-1 (accept_possessive_promotion),
+        not Z4. ``Newton's gravity`` → ``Newton's_law_of_universal_gravitation``
+        accepted because canonical contains possessor token ``newton``."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "newton's gravity": {
+                "path": "Newton's_law_of_universal_gravitation",
+                "title": "Newton's law of universal gravitation",
+                "zim_file": "test.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "Newton's_law_of_gravity",
+            },
+        }
+        result = _run_promote("newton's gravity", mapping)
+        assert (
+            result is not None
+            and result["path"] == "Newton's_law_of_universal_gravitation"
+        )
+
+    def test_ferris_state_type_extension_accepts(self) -> None:
+        """Type-extension exemption: ``Ferris_State_University`` for
+        topic ``Big Rapids Michigan Ferris State`` — canonical's leading
+        2 tokens (``ferris state``) form a contiguous slice of topic,
+        canonical's suffix (``university``) is the type-word extra.
+        Without this exemption Z4 would over-reject the b8/b9 motivating
+        case where the user's TAIL is the canonical's entity-name
+        without the type-word suffix."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "big rapids michigan ferris state": None,
+            "rapids michigan ferris state": None,
+            "michigan ferris state": None,
+            "ferris state": {
+                "path": "Ferris_State_University",
+                "title": "Ferris State University",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "big": None,
+            "rapids": None,
+            "michigan": {
+                "path": "Michigan",
+                "title": "Michigan",
+                "zim_file": "test.zim",
+                "match_type": "direct",
+            },
+            "ferris": None,
+            "state": None,
+        }
+        result = _run_promote("Big Rapids Michigan Ferris State", mapping)
+        assert result is not None and result["path"] == "Ferris_State_University"
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests on the type-extension helper.
+# ---------------------------------------------------------------------------
+
+
+class TestHasTopicPrefixCanonicalExtension:
+    """Z4 type-extension exemption: canonical's leading tokens form a
+    contiguous slice of topic (length ≥ 2), canonical's suffix tokens
+    are all extras (not in topic)."""
+
+    def test_ferris_state_university_accepts(self) -> None:
+        from openzim_mcp.title_promotion import has_topic_prefix_canonical_extension
+
+        promoted = {"path": "Ferris_State_University"}
+        assert (
+            has_topic_prefix_canonical_extension(
+                promoted, "big rapids michigan ferris state"
+            )
+            is True
+        )
+
+    def test_tesla_wireless_electricity_rejects(self) -> None:
+        """``tesla's`` ≠ ``tesla`` (raw token comparison) — no contiguous
+        topic slice matches canonical prefix."""
+        from openzim_mcp.title_promotion import has_topic_prefix_canonical_extension
+
+        promoted = {"path": "Tesla's_Wireless_Electricity"}
+        assert (
+            has_topic_prefix_canonical_extension(promoted, "tesla electricity") is False
+        )
+
+    def test_short_canonical_returns_false(self) -> None:
+        """Single-token canonical: type-extension shape requires
+        canonical of length 2+ (the matched slice + at least 1
+        extra)."""
+        from openzim_mcp.title_promotion import has_topic_prefix_canonical_extension
+
+        promoted = {"path": "Hamlet"}
+        assert (
+            has_topic_prefix_canonical_extension(promoted, "hamlet denmark prince")
+            is False
+        )
+
+    def test_short_topic_returns_false(self) -> None:
+        from openzim_mcp.title_promotion import has_topic_prefix_canonical_extension
+
+        promoted = {"path": "Pablo_Picasso"}
+        assert has_topic_prefix_canonical_extension(promoted, "picasso") is False
+
+    def test_suffix_overlap_with_topic_rejects(self) -> None:
+        """If any canonical suffix token ALSO appears in topic, it's
+        not a clean type-extension — the canonical's "extras" aren't
+        all extras. Falls back to the shorter prefix search."""
+        from openzim_mcp.title_promotion import has_topic_prefix_canonical_extension
+
+        # Topic "alpha beta gamma delta epsilon", canonical "alpha beta delta":
+        # canonical prefix [alpha, beta] matches topic slice [alpha, beta],
+        # but suffix [delta] is ALSO in topic → not clean → fall through.
+        # No other prefix matches → False.
+        promoted = {"path": "Alpha_Beta_Delta"}
+        assert (
+            has_topic_prefix_canonical_extension(
+                promoted, "alpha beta gamma delta epsilon"
+            )
+            is False
+        )
+
+    def test_canonical_prefix_anywhere_in_topic(self) -> None:
+        """The matched slice can appear anywhere in topic, not just at
+        the tail. Topic ``tourist Ferris State Michigan`` → canonical
+        ``Ferris_State_University`` matches at topic positions 1-2."""
+        from openzim_mcp.title_promotion import has_topic_prefix_canonical_extension
+
+        promoted = {"path": "Ferris_State_University"}
+        assert (
+            has_topic_prefix_canonical_extension(
+                promoted, "tourist ferris state michigan"
+            )
+            is True
+        )
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests on the new helpers
+# ---------------------------------------------------------------------------
+
+
+class TestIsTangentialMultiTokenShape:
+    """Pure-logic shape predicate: canonical is multi-token AND NOT a
+    token-set subset of topic. Excludes single-token canonicals (covered
+    by ``is_tail_hijack_shape``) and topic-subset canonicals (the
+    generalization pattern preserved by Apollo / Lincoln / Gettysburg
+    tests)."""
+
+    def test_multi_token_with_extras_returns_true(self) -> None:
+        from openzim_mcp.title_promotion import is_tangential_multi_token_shape
+
+        promoted = {"path": "Tesla's_Wireless_Electricity"}
+        assert is_tangential_multi_token_shape(promoted, "tesla electricity") is True
+
+    def test_subset_returns_false(self) -> None:
+        """Canonical tokens ⊆ topic tokens → generalization, not tangential."""
+        from openzim_mcp.title_promotion import is_tangential_multi_token_shape
+
+        promoted = {"path": "Moon_landing"}
+        assert (
+            is_tangential_multi_token_shape(promoted, "apollo 11 moon landing") is False
+        )
+
+    def test_single_token_canonical_returns_false(self) -> None:
+        """Single-token canonicals are is_tail_hijack_shape territory."""
+        from openzim_mcp.title_promotion import is_tangential_multi_token_shape
+
+        promoted = {"path": "Russia"}
+        assert is_tangential_multi_token_shape(promoted, "stalin ussr russia") is False
+
+    def test_short_topic_returns_false(self) -> None:
+        """Topic with <2 tokens has no head/modifier distinction."""
+        from openzim_mcp.title_promotion import is_tangential_multi_token_shape
+
+        promoted = {"path": "Pablo_Picasso"}
+        assert is_tangential_multi_token_shape(promoted, "picasso") is False
+
+    def test_empty_promoted_path_returns_false(self) -> None:
+        """Defensive: empty path defaults to no shape."""
+        from openzim_mcp.title_promotion import is_tangential_multi_token_shape
+
+        assert is_tangential_multi_token_shape({}, "tesla electricity") is False
+
+
+class TestProbedHeadMatchesPromoted:
+    """Biographical-canonical exemption: probe the topic's first non-
+    stop-word token; True iff the probe path (or pre_redirect_path)
+    equals the promoted candidate's path."""
+
+    def test_head_probe_matches_promoted_via_redirect(self) -> None:
+        from openzim_mcp.title_promotion import probed_head_matches_promoted
+
+        def probe(token: str) -> Optional[Dict[str, Any]]:
+            return {
+                "picasso": {
+                    "path": "Pablo_Picasso",
+                    "pre_redirect_path": "Picasso",
+                }
+            }.get(token)
+
+        promoted = {"path": "Pablo_Picasso"}
+        assert (
+            probed_head_matches_promoted("picasso paris cubism", promoted, probe)
+            is True
+        )
+
+    def test_head_probe_matches_promoted_via_pre_path(self) -> None:
+        """If the probe's pre_redirect_path equals promoted's path (the
+        promoted IS the redirect entry), accept."""
+        from openzim_mcp.title_promotion import probed_head_matches_promoted
+
+        def probe(token: str) -> Optional[Dict[str, Any]]:
+            return {
+                "tesla": {
+                    "path": "Nikola_Tesla",
+                    "pre_redirect_path": "Tesla",
+                }
+            }.get(token)
+
+        promoted = {"path": "Tesla"}
+        assert (
+            probed_head_matches_promoted("tesla electricity", promoted, probe) is True
+        )
+
+    def test_head_probe_differs_returns_false(self) -> None:
+        from openzim_mcp.title_promotion import probed_head_matches_promoted
+
+        def probe(token: str) -> Optional[Dict[str, Any]]:
+            return {
+                "lenin": {
+                    "path": "Vladimir_Lenin",
+                    "pre_redirect_path": "Lenin",
+                }
+            }.get(token)
+
+        promoted = {"path": "Leninist_Komsomol_of_the_Russian_Federation"}
+        assert probed_head_matches_promoted("lenin russia", promoted, probe) is False
+
+    def test_head_probe_returns_none_returns_false(self) -> None:
+        from openzim_mcp.title_promotion import probed_head_matches_promoted
+
+        def probe(token: str) -> Optional[Dict[str, Any]]:
+            return None
+
+        promoted = {"path": "Some_Multi_Token_Article"}
+        assert (
+            probed_head_matches_promoted("obscure entity word", promoted, probe)
+            is False
+        )
+
+    def test_stop_word_head_skipped(self) -> None:
+        """Topic starting with stop words: head is first content token."""
+        from openzim_mcp.title_promotion import probed_head_matches_promoted
+
+        def probe(token: str) -> Optional[Dict[str, Any]]:
+            # ``the`` is a stop word → skipped; ``picasso`` is the
+            # effective head.
+            if token == "picasso":
+                return {
+                    "path": "Pablo_Picasso",
+                    "pre_redirect_path": "Picasso",
+                }
+            return None
+
+        promoted = {"path": "Pablo_Picasso"}
+        assert (
+            probed_head_matches_promoted("the picasso paintings", promoted, probe)
+            is True
+        )
+
+    def test_probe_exception_swallowed_returns_false(self) -> None:
+        """Defensive: a flaky probe must not blow up the gate."""
+        from openzim_mcp.title_promotion import probed_head_matches_promoted
+
+        def probe(token: str) -> Optional[Dict[str, Any]]:
+            raise RuntimeError("transient libzim error")
+
+        promoted = {"path": "Some_Article"}
+        assert (
+            probed_head_matches_promoted("tesla electricity", promoted, probe) is False
+        )
+
+
+class TestHasDigitSpecificityMatch:
+    """Digit-specificity exemption: canonical's extras (tokens not in
+    topic) include a digit AND topic also has a digit-bearing token.
+    Without this exemption Z4 over-rejects numbered sub-articles like
+    ``Symphony_No._9_(Beethoven)`` for ``beethoven 9th symphony``."""
+
+    def test_both_have_digits_returns_true(self) -> None:
+        from openzim_mcp.title_promotion import has_digit_specificity_match
+
+        promoted = {"path": "Symphony_No._9_(Beethoven)"}
+        assert has_digit_specificity_match(promoted, "beethoven 9th symphony") is True
+
+    def test_neither_has_digit_returns_false(self) -> None:
+        from openzim_mcp.title_promotion import has_digit_specificity_match
+
+        promoted = {"path": "Tesla's_Wireless_Electricity"}
+        assert has_digit_specificity_match(promoted, "tesla electricity") is False
+
+    def test_canonical_has_digit_topic_does_not_returns_false(self) -> None:
+        """User did NOT signal numeric specificity but canonical narrows
+        to a specific instance → reject (no exemption)."""
+        from openzim_mcp.title_promotion import has_digit_specificity_match
+
+        promoted = {"path": "Symphony_No._1_(Beethoven)"}
+        assert has_digit_specificity_match(promoted, "beethoven symphony") is False
+
+    def test_topic_has_digit_canonical_does_not_returns_false(self) -> None:
+        from openzim_mcp.title_promotion import has_digit_specificity_match
+
+        promoted = {"path": "Some_Multi_Word_Article"}
+        assert has_digit_specificity_match(promoted, "apollo 11 mission") is False
+
+    def test_digit_in_topic_but_canonical_extra_digits_all_in_topic(self) -> None:
+        """If canonical's digit tokens are ALL already in topic (no
+        extras have digits), the digit isn't an extra-narrowing signal.
+        Subset rule should catch this case before Z4 fires anyway."""
+        from openzim_mcp.title_promotion import has_digit_specificity_match
+
+        # canonical {apollo, 11} ⊆ topic {apollo, 11, mission} → no
+        # extras with digits → False (no narrowing claim to exempt).
+        promoted = {"path": "Apollo_11"}
+        assert has_digit_specificity_match(promoted, "apollo 11 mission") is False

--- a/tests/test_post_b11_beta_fixes.py
+++ b/tests/test_post_b11_beta_fixes.py
@@ -1096,3 +1096,303 @@ class TestHasDigitSpecificityMatch:
         # extras with digits → False (no narrowing claim to exempt).
         promoted = {"path": "Apollo_11"}
         assert has_digit_specificity_match(promoted, "apollo 11 mission") is False
+
+
+# ---------------------------------------------------------------------------
+# Synthesize Pass 0 Z4 protection — symmetric to simple_tools Pass 0.
+# synthesize.py's Pass 0 ``_promote_title_match`` calls
+# ``find_title_match`` + ``accept_possessive_promotion`` with the same
+# vulnerability shape as simple_tools. Z4 layer must apply here too.
+# ---------------------------------------------------------------------------
+
+
+def _archive_stub_synthesize() -> Any:
+    class _Archive:
+        pass
+
+    return _Archive()
+
+
+def _run_promote_synthesize(
+    query: str,
+    mapping: Dict[str, Optional[Dict[str, Any]]],
+    top_hits: Optional[list] = None,
+) -> list:
+    """Drive ``synthesize._promote_title_match`` with the mapping
+    serving as the find_title_match stand-in for both Pass 0 (full
+    query) and Z4 head/tail probes."""
+    from unittest.mock import MagicMock
+
+    from openzim_mcp.synthesize import _promote_title_match
+
+    fake = _fake_find_title_match(mapping)
+    handler = MagicMock()
+    handler.title_match_hit = lambda _a, _q: None
+    with patch("openzim_mcp.synthesize.find_title_match", side_effect=fake):
+        return _promote_title_match(
+            top_hits or [],
+            query=query,
+            archives=[(_archive_stub_synthesize(), "/wiki.zim")],
+            archives_searched=["wiki"],
+            search_handler=handler,
+        )
+
+
+class TestSynthesizeZ4Protection:
+    """Pre-existing gap: synthesize.py Pass 0 (line 1022) consults
+    ``accept_possessive_promotion`` but lacks the b11 Z4 layer. The
+    same multi-token tangential silent-wrong-answer pattern can
+    surface via synthesize=True. This class pins the fix shape:
+    Z4 rejects in synthesize symmetrically with simple_tools."""
+
+    def test_tesla_electricity_rejected_in_synthesize(self) -> None:
+        """Synthesize Pass 0 must reject ``Tesla's_Wireless_Electricity``
+        for ``tesla electricity`` — the canonical contains the head as
+        possessive subordinate + adds modifier ``wireless`` not in topic.
+        Head probe ``tesla`` returns ``Nikola_Tesla`` ≠ promoted →
+        biographical exemption fails → reject."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "tesla electricity": {
+                "path": "Tesla's_Wireless_Electricity",
+                "title": "Tesla's Wireless Electricity",
+                "zim_file": "/wiki.zim",
+                "match_type": "fuzzy_suggest",
+            },
+            "tesla": {
+                "path": "Nikola_Tesla",
+                "title": "Nikola Tesla",
+                "zim_file": "/wiki.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "Tesla",
+            },
+            "electricity": {
+                "path": "Electricity",
+                "title": "Electricity",
+                "zim_file": "/wiki.zim",
+                "match_type": "direct",
+            },
+        }
+        original_top = [
+            ("wiki", {"path": "Nikola_Tesla", "snippet": "...", "score": 0.7}),
+            (
+                "wiki",
+                {"path": "Electrical_engineering", "snippet": "...", "score": 0.5},
+            ),
+        ]
+        promoted = _run_promote_synthesize(
+            "tesla electricity", mapping, top_hits=original_top
+        )
+        # Z4 rejects → either top_hits unchanged OR Pass-1/2 finds a
+        # different canonical; either way Tesla's_Wireless_Electricity
+        # must NOT be at rank 0.
+        assert (
+            len(promoted) == 0
+            or promoted[0][1].get("path") != "Tesla's_Wireless_Electricity"
+        ), (
+            "Z4 must reject `Tesla's_Wireless_Electricity` in synthesize "
+            f"Pass 0; got {promoted!r}"
+        )
+
+    def test_picasso_paris_cubism_biographical_accepts_in_synthesize(self) -> None:
+        """Counter-case: biographical exemption fires in synthesize
+        too. ``picasso paris cubism`` head probe ``picasso`` resolves
+        to ``Pablo_Picasso`` = promoted candidate → exempt → accept."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "picasso paris cubism": {
+                "path": "Pablo_Picasso",
+                "title": "Pablo Picasso",
+                "zim_file": "/wiki.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "Picasso",
+            },
+            "picasso": {
+                "path": "Pablo_Picasso",
+                "title": "Pablo Picasso",
+                "zim_file": "/wiki.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "Picasso",
+            },
+            "paris": {
+                "path": "Paris",
+                "title": "Paris",
+                "zim_file": "/wiki.zim",
+                "match_type": "direct",
+            },
+            "cubism": {
+                "path": "Cubism",
+                "title": "Cubism",
+                "zim_file": "/wiki.zim",
+                "match_type": "direct",
+            },
+        }
+        promoted = _run_promote_synthesize("picasso paris cubism", mapping)
+        # Biographical exemption accepts → Pablo_Picasso promoted to rank 0.
+        assert len(promoted) >= 1
+        assert promoted[0][1].get("path") == "Pablo_Picasso"
+
+    def test_possessive_query_unaffected_in_synthesize(self) -> None:
+        """Possessive queries bypass Z4 in synthesize (OPP-1 path):
+        ``Newton's gravity`` → ``Newton's_law_of_universal_gravitation``
+        still promotes."""
+        mapping: Dict[str, Optional[Dict[str, Any]]] = {
+            "newton's gravity": {
+                "path": "Newton's_law_of_universal_gravitation",
+                "title": "Newton's law of universal gravitation",
+                "zim_file": "/wiki.zim",
+                "match_type": "redirect",
+                "pre_redirect_path": "Newton's_law_of_gravity",
+            },
+        }
+        promoted = _run_promote_synthesize("newton's gravity", mapping)
+        assert len(promoted) >= 1
+        assert promoted[0][1].get("path") == "Newton's_law_of_universal_gravitation"
+
+
+# ---------------------------------------------------------------------------
+# Sub-pattern C: disambig promotion at tell_me_about. When the auto-
+# picked canonical's body IS a disambig page AND the topic has 2+
+# meaningful (non-stop-word) tokens, fall back to BM25 search.
+# ---------------------------------------------------------------------------
+
+
+_LINCOLN_DISAMBIG_PRE_H2 = (
+    "Look up _**Lincoln**_ in Wiktionary, the free dictionary.\n\n"
+    "**Lincoln** most commonly refers to: \n\n"
+    "  * Abraham Lincoln (1809–1865), the 16th president of the "
+    "United States\n"
+    "  * Lincoln, England, cathedral city and county town of "
+    "Lincolnshire, England\n"
+    "  * Lincoln, Nebraska, the capital of Nebraska, U.S.\n"
+    "  * Lincoln (name), a surname and given name\n"
+    "  * Lincoln Motor Company, a Ford brand\n\n"
+    "**Lincoln** may also refer to:"
+)
+
+
+class TestSubPatternCDisambigRejection:
+    """Sub-pattern C: ``Lincoln slavery emancipation`` →
+    ``Lincoln`` (disambig page). When the auto-picked canonical body
+    matches the disambig-lead pattern AND the topic has 2+
+    meaningful tokens, the user wanted a specific article — fall
+    back to BM25 search so the LLM sees the ranked specific articles
+    instead of the disambig list."""
+
+    @staticmethod
+    def _make_handler(
+        *,
+        article_body: str,
+        search_results: list,
+        title_index: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        from unittest.mock import MagicMock
+
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.search_zim_file_data.return_value = {"results": search_results}
+        mock.search_zim_file.return_value = "## BM25 fallback rendered\n\n..."
+        mock.get_zim_entry.return_value = article_body
+        mock.config.meta.footer_enabled = False
+        mock.find_entry_by_title_data.return_value = (
+            {"results": [title_index]} if title_index else {"results": []}
+        )
+        mock.get_article_structure_data.return_value = {"sections": []}
+        return SimpleToolsHandler(mock), mock
+
+    def test_lincoln_multi_token_falls_to_search(self) -> None:
+        """Multi-content-token topic + disambig body → fall back."""
+        disambig_body = (
+            f"# Lincoln\n\n{_LINCOLN_DISAMBIG_PRE_H2}\n\n"
+            "## Places\n  * Lincoln, Alabama\n"
+        )
+        handler, mock = self._make_handler(
+            article_body=disambig_body,
+            search_results=[
+                {"path": "Lincoln", "title": "Lincoln", "score": 100},
+            ],
+            title_index={"path": "Lincoln", "title": "Lincoln", "score": 1.0},
+        )
+        out = handler.handle_zim_query(
+            "tell me about Lincoln slavery emancipation",
+            zim_file_path="/x.zim",
+            options={"compact": False},
+        )
+        # The disambig auto-fetch must NOT win — caller sees BM25
+        # search fallback instead.
+        assert "## BM25 fallback rendered" in out
+        mock.search_zim_file.assert_called()
+
+    def test_lincoln_single_content_token_returns_disambig(self) -> None:
+        """Single-content-token topic (``tell me about Lincoln``)
+        legitimately wants the disambig — don't override."""
+        disambig_body = (
+            f"# Lincoln\n\n{_LINCOLN_DISAMBIG_PRE_H2}\n\n"
+            "## Places\n  * Lincoln, Alabama\n"
+        )
+        handler, mock = self._make_handler(
+            article_body=disambig_body,
+            search_results=[
+                {"path": "Lincoln", "title": "Lincoln", "score": 100},
+            ],
+            title_index={"path": "Lincoln", "title": "Lincoln", "score": 1.0},
+        )
+        out = handler.handle_zim_query(
+            "tell me about Lincoln",
+            zim_file_path="/x.zim",
+            options={"compact": False},
+        )
+        # Bare-head single-content-token topic: serve the disambig
+        # as the answer (the user asked for it).
+        assert "_Source: `Lincoln`_" in out
+        # Fallback search must NOT have fired for this case.
+        mock.search_zim_file.assert_not_called()
+
+    def test_lincoln_stop_words_only_filter_counts_correctly(self) -> None:
+        """Topic ``what is Lincoln`` — ``what`` and ``is`` are stop
+        words; effective content tokens = [``lincoln``] (1). Don't
+        override; serve disambig."""
+        disambig_body = (
+            f"# Lincoln\n\n{_LINCOLN_DISAMBIG_PRE_H2}\n\n"
+            "## Places\n  * Lincoln, Alabama\n"
+        )
+        handler, mock = self._make_handler(
+            article_body=disambig_body,
+            search_results=[
+                {"path": "Lincoln", "title": "Lincoln", "score": 100},
+            ],
+            title_index={"path": "Lincoln", "title": "Lincoln", "score": 1.0},
+        )
+        out = handler.handle_zim_query(
+            "what is Lincoln",
+            zim_file_path="/x.zim",
+            options={"compact": False},
+        )
+        # Effective content token count is 1 (lincoln) — keep
+        # disambig.
+        assert "_Source: `Lincoln`_" in out
+        mock.search_zim_file.assert_not_called()
+
+    def test_non_disambig_body_unaffected(self) -> None:
+        """Counter-case: when the auto-picked canonical body is NOT a
+        disambig page, the rejection logic doesn't fire even with
+        multi-content-token topics."""
+        normal_body = (
+            "# Berlin\n\n# Berlin\n\n**Berlin** is the capital of Germany.\n\n"
+            "## History\nFounded in the 13th century...\n"
+        )
+        handler, mock = self._make_handler(
+            article_body=normal_body,
+            search_results=[
+                {"path": "Berlin", "title": "Berlin", "score": 100},
+            ],
+            title_index={"path": "Berlin", "title": "Berlin", "score": 1.0},
+        )
+        out = handler.handle_zim_query(
+            "tell me about Berlin Germany capital",
+            zim_file_path="/x.zim",
+            options={"compact": False},
+        )
+        # Body isn't disambig — serve normally.
+        assert "_Source: `Berlin`_" in out
+        mock.search_zim_file.assert_not_called()


### PR DESCRIPTION
Post-b11 live-MCP sweep against v2.0.0b11 confirmed the probe-based multi-entity discriminator delivers on its 3-entity single-token-tail target shape (4/6 historical Z3 repros now route to the correct head). One new defect class surfaced — **Z4 multi-token canonical tangential** — where `is_tail_hijack_shape`'s single-token-canonical + 3+-token-topic preconditions don't fire and the silent-wrong-answer pattern ships at cert=0.85.

## Live Z4 silent-wrong-answer repros at v2.0.0b11 (all cert=0.85)

| Topic | Wrong canonical (b11 ships) | Intended head |
|---|---|---|
| `Lenin Russia` | `Leninist_Komsomol_of_the_Russian_Federation` | `Vladimir_Lenin` |
| `Tesla electricity` | `Tesla's_Wireless_Electricity` | `Nikola_Tesla` |
| `Mozart Vienna` | `Mozarthaus_Vienna` | `Wolfgang_Amadeus_Mozart` |
| `Beethoven symphony` | `Symphony_No._1_(Beethoven)` | `Ludwig_van_Beethoven` |
| `Marie Curie radioactivity` | `Radioactive_(Redniss_book)` | `Marie_Curie` |
| `Shakespeare England plays` | `Shakespeare's_Kings` | `William_Shakespeare` |
| `Darwin evolution Galapagos` | `Galápagos_Islands` | `Charles_Darwin` |
| `Mao China revolution` | `History_of_the_People's_Republic_of_China_(1949–1976)` | `Mao_Zedong` |

## Root cause

`is_tail_hijack_shape` requires **(a) single-token canonical AND (b) 3+-token topic**. Both preconditions are sound for the b8 Z3 target shape, but the silent-wrong-answer pattern manifests in two adjacent shapes that bypass the gate:

1. **2-token topics** with multi-token canonical containing both topic tokens (head as possessive/parenthetical + extra modifier).
2. **3+-token topics** with multi-token canonical overlapping topic in only the tail-stem or middle token.

## Fix — Z4 tangential check with three exemptions

Four new helpers in `openzim_mcp/title_promotion.py`:

- **`is_tangential_multi_token_shape(promoted, topic)`** — pure-logic shape: canonical is multi-token AND not a token-set subset of topic. Subset preserves the b8 `Apollo 11 moon landing` → `Moon_landing` and b4 `Lincoln Gettysburg Address` → `Gettysburg_Address` invariants.
- **`probed_head_matches_promoted(topic, promoted, title_probe)`** — biographical-canonical exemption: probes the topic's first non-stop-word token. If probe matches promoted, the promotion IS the head's biographical article (`Picasso Paris cubism` → `Pablo_Picasso`).
- **`has_digit_specificity_match(promoted, topic)`** — digit-specificity exemption: when canonical's extras include a digit AND topic also has a digit-bearing token, the user signaled a numbered instance (`Beethoven 9th symphony` → `Symphony_No._9_(Beethoven)`).
- **`has_topic_prefix_canonical_extension(promoted, topic)`** — type-extension exemption: canonical's leading tokens form a contiguous 2+-token slice of topic, suffix tokens are all extras (`Big Rapids Michigan Ferris State` → `Ferris_State_University`).

`_promote_topic_via_title_index` integration:

- **Pass 0 / Pass 3** consult `accept_possessive_promotion` AND `_passes_z4` directly. No Z3 multi-entity escape here (that escape exists only for Pass 1's documented 1-token-tail filler-prose feature).
- **Pass 1 / Pass 2** consult `_accept_with_multi_entity_check`, which layers the Z3 escape over the b9 unconditional tail-hijack rejection AND then applies `_passes_z4`.

The b3 invariant (first `find_title_match` call uses bare `topic`) is preserved by hoisting the Pass 0 probe above the closure definitions; the b9 structural pin (≥3 `accept_possessive_promotion` callsites) is preserved by the split Pass 0/3 + wrapper architecture.

## Decision matrix

| Topic | Multi-token tangent | Bio exem | Digit exem | Type-ext exem | Decision |
|---|---|---|---|---|---|
| `Tesla electricity` | yes | no | no | no | REJECT |
| `Mozart Vienna` | yes | no | no | no | REJECT |
| `Beethoven symphony` | yes | no | no | no | REJECT |
| `Lenin Russia` | yes | no | no | no | REJECT |
| `Marie Curie radioactivity` | yes | no | no | no | REJECT |
| `Shakespeare England plays` | yes | no | no | no | REJECT |
| `Darwin evolution Galapagos` | yes | no | no | no | REJECT |
| `Mao China revolution` | yes | no | no | no | REJECT |
| `Picasso Paris cubism` | yes | YES | - | - | ACCEPT |
| `Beethoven 9th symphony` | yes | no | YES | - | ACCEPT |
| `Big Rapids Michigan Ferris State` | yes | no | no | YES | ACCEPT |
| `Apollo 11 moon landing` | no (⊆) | - | - | - | ACCEPT |
| `Lincoln Gettysburg Address` | no (⊆) | - | - | - | ACCEPT |
| `Newton's gravity` (possessive) | n/a | - | - | - | ACCEPT (OPP-1) |
| `Hamlet Denmark prince` | no (1tk) | - | - | - | ACCEPT |
| `Berlin Germany` | no (1tk) | - | - | - | ACCEPT |
| `what is the population of detroit` | no (1tk) | - | - | - | ACCEPT |

## Tests

39 new tests in `tests/test_post_b11_beta_fixes.py`:

- 8 Z4 defect-repro integration tests (one per live silent-wrong-answer)
- 8 preserved-case integration tests (Apollo / Lincoln / Hamlet / Berlin / Picasso / Newton's possessive / population-of-detroit / Ferris State / Beethoven-9th)
- Direct unit tests on each new helper (shape predicate; biographical via path / pre-path / stop-word skip / probe-exception swallowing; digit specificity in 4 directions; type-extension prefix length floor / subset overlap / anywhere-in-topic)

**Full suite**: 2542 passed, 54 skipped, 38 deselected (~30s)
**mypy**: clean (52 files)
**black + flake8 + pip-audit**: clean

The Z4 fix continues the "Fix unlocks new paths" cadence (now 17 sweeps): Z3 is the symmetric non-possessive case of b4 D2; Z4 is the multi-token canonical sibling of Z3 with the additional biographical / digit-specificity / type-extension exemptions needed to keep the b8 Ferris State / b9 Picasso / hypothetical Beethoven-9th cases working.