### PR TITLE
fix(v2): post-b12 beta-test sweep — Play-style disambig phrasing variant

### DIFF
--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -2659,7 +2659,17 @@ class SimpleToolsHandler:
     # behaviour via normalized ``endswith`` — no regex engine, no
     # backtracking risk, and easier to extend with new phrasings if
     # ZIM exporters ever produce them.
-    _DISAMBIG_LEAD_PHRASES = ("may refer to", "may also refer to")
+    # Post-b12: ``may refer also to`` added for the Play-style
+    # disambig template variant (word order: may-refer-also-to vs the
+    # may-also-refer-to of Mercury-style). Live repro at v2.0.0b12:
+    # ``Shakespeare England plays`` routed to the ``Play`` disambig at
+    # cert=0.85 because the trailing-tail ``endswith`` check missed
+    # this phrasing variant.
+    _DISAMBIG_LEAD_PHRASES = (
+        "may refer to",
+        "may also refer to",
+        "may refer also to",
+    )
 
     # ``_lead_density`` strips the ZIM-renderer preamble + duplicated H1
     # to measure substantive lead prose. Both patterns are anchored at

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -1038,7 +1038,7 @@ def _promote_title_match(
             full_probe, query
         ):
 
-            def _z4_probe(tok: str, _vp: "Path" = vp) -> Optional[dict]:
+            def _z4_probe(tok: str, _vp: Path = vp) -> Optional[dict]:
                 return find_title_match(search_handler, str(_vp), tok)
 
             if not (
@@ -1441,7 +1441,7 @@ def _maybe_rerank_synthesize_passages(
     *,
     query: str,
     top_hits: list[tuple[str, dict[str, Any]]],
-    reranker_config: "Optional[RerankerConfig]",
+    reranker_config: Optional[RerankerConfig],
 ) -> tuple[list[SynthesizePassage], list[tuple[str, str]]]:
     """Apply cross-encoder rerank to synthesize passage candidates.
 
@@ -1535,7 +1535,7 @@ def synthesize_query(
     cache: OpenZimMcpCache,
     content_processor: ContentProcessor,
     config: SynthesizeConfig,
-    reranker_config: "Optional[RerankerConfig]" = None,
+    reranker_config: Optional[RerankerConfig] = None,
     original_query: Optional[str] = None,
     strip_links: bool = False,
     omit_passage_text: bool = False,

--- a/tests/_promote_fixtures.py
+++ b/tests/_promote_fixtures.py
@@ -77,3 +77,41 @@ def run_promote_simple(
             "test.zim",
             topic,
         )
+
+
+def make_disambig_handler(
+    *,
+    article_body: str,
+    search_results: list,
+    title_index: Optional[Dict[str, Any]] = None,
+    zim_file_path: str = "/x.zim",
+    bm25_fallback_text: str = "## BM25 fallback rendered\n\n...",
+) -> tuple[Any, Any]:
+    """Build a ``(SimpleToolsHandler, mock)`` pair for tell_me_about
+    integration tests that exercise the disambig-render-time rejection
+    path (post-b11 Sub-pattern C + post-b12 phrasing variants).
+
+    The mock supplies the standard tell_me_about dependencies:
+    BM25 search results, title-index lookup, article body fetch, the
+    fall-to-search rendering hook, and a stubbed article structure.
+    Returns the (handler, mock) tuple so callers can assert on mock
+    invocations like ``mock.search_zim_file.assert_called()``.
+
+    Extracted to share between b11 + b12 sweep test files (Sonar
+    new-code duplication threshold).
+    """
+    from unittest.mock import MagicMock
+
+    from openzim_mcp.simple_tools import SimpleToolsHandler
+
+    mock = MagicMock()
+    mock.list_zim_files_data.return_value = [{"path": zim_file_path}]
+    mock.search_zim_file_data.return_value = {"results": search_results}
+    mock.search_zim_file.return_value = bm25_fallback_text
+    mock.get_zim_entry.return_value = article_body
+    mock.config.meta.footer_enabled = False
+    mock.find_entry_by_title_data.return_value = (
+        {"results": [title_index]} if title_index else {"results": []}
+    )
+    mock.get_article_structure_data.return_value = {"sections": []}
+    return SimpleToolsHandler(mock), mock

--- a/tests/test_post_b11_beta_fixes.py
+++ b/tests/test_post_b11_beta_fixes.py
@@ -103,6 +103,7 @@ from typing import Any, Dict, Optional
 from unittest.mock import patch
 
 from tests._promote_fixtures import fake_find_title_match as _fake_find_title_match
+from tests._promote_fixtures import make_disambig_handler as _make_disambig_handler
 from tests._promote_fixtures import make_simple_handler as _make_simple_handler
 
 
@@ -1277,28 +1278,7 @@ class TestSubPatternCDisambigRejection:
     back to BM25 search so the LLM sees the ranked specific articles
     instead of the disambig list."""
 
-    @staticmethod
-    def _make_handler(
-        *,
-        article_body: str,
-        search_results: list,
-        title_index: Optional[Dict[str, Any]] = None,
-    ) -> Any:
-        from unittest.mock import MagicMock
-
-        from openzim_mcp.simple_tools import SimpleToolsHandler
-
-        mock = MagicMock()
-        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
-        mock.search_zim_file_data.return_value = {"results": search_results}
-        mock.search_zim_file.return_value = "## BM25 fallback rendered\n\n..."
-        mock.get_zim_entry.return_value = article_body
-        mock.config.meta.footer_enabled = False
-        mock.find_entry_by_title_data.return_value = (
-            {"results": [title_index]} if title_index else {"results": []}
-        )
-        mock.get_article_structure_data.return_value = {"sections": []}
-        return SimpleToolsHandler(mock), mock
+    _make_handler = staticmethod(_make_disambig_handler)
 
     def test_lincoln_multi_token_falls_to_search(self) -> None:
         """Multi-content-token topic + disambig body → fall back."""

--- a/tests/test_post_b12_beta_fixes.py
+++ b/tests/test_post_b12_beta_fixes.py
@@ -44,8 +44,7 @@ extend with new phrasings if ZIM exporters ever produce them".
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
-from unittest.mock import MagicMock
+from tests._promote_fixtures import make_disambig_handler as _make_disambig_handler
 
 # ---------------------------------------------------------------------------
 # Direct unit tests on the extended _DISAMBIG_LEAD_PHRASES set.
@@ -130,26 +129,7 @@ class TestPlayDisambigRejection:
     ``may refer also to`` phrasing. With the fix, the body is
     classified as disambig and the Sub-pattern C rejection fires."""
 
-    @staticmethod
-    def _make_handler(
-        *,
-        article_body: str,
-        search_results: list,
-        title_index: Optional[Dict[str, Any]] = None,
-    ) -> Any:
-        from openzim_mcp.simple_tools import SimpleToolsHandler
-
-        mock = MagicMock()
-        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
-        mock.search_zim_file_data.return_value = {"results": search_results}
-        mock.search_zim_file.return_value = "## BM25 fallback rendered\n\n..."
-        mock.get_zim_entry.return_value = article_body
-        mock.config.meta.footer_enabled = False
-        mock.find_entry_by_title_data.return_value = (
-            {"results": [title_index]} if title_index else {"results": []}
-        )
-        mock.get_article_structure_data.return_value = {"sections": []}
-        return SimpleToolsHandler(mock), mock
+    _make_handler = staticmethod(_make_disambig_handler)
 
     def test_play_style_disambig_multi_token_falls_to_search(self) -> None:
         """Topic with 3 content tokens + Play-style disambig body →

--- a/tests/test_post_b12_beta_fixes.py
+++ b/tests/test_post_b12_beta_fixes.py
@@ -1,0 +1,199 @@
+r"""Regression tests for the post-b12 beta-test sweep.
+
+Post-b12 live-MCP verification surfaced one new defect not caught by
+the b11 ``_DISAMBIG_LEAD_PHRASES`` set — the Wikipedia ``Play``-style
+disambig page uses the phrase ``may refer also to`` (word order:
+may-refer-**also**-to) instead of ``may also refer to`` (word order:
+may-**also**-refer-to).
+
+## Live repro at v2.0.0b12
+
+``tell me about Shakespeare England plays`` at v2.0.0b12 ships
+``Play`` (disambig) at cert=0.85 — a Sub-pattern C leak that should
+have been caught by the b12 disambig-render-time rejection. Path
+through the gate:
+
+  1. Z4 layer correctly rejects ``Shakespeare's_Kings`` at Pass 0.
+  2. Pass 1 tail-iter probes ``"plays"`` → libzim returns ``Play``
+     (the disambig page, direct match).
+  3. Z4 check on ``Play``: canonical is single-token → not tangential
+     → ``_passes_z4`` returns True.
+  4. ``_handle_tell_me_about`` fetches the ``Play`` body.
+  5. ``_is_disambig_lead(pre_h2_in_body)`` runs the trailing-tail
+     ``endswith`` check against ``_DISAMBIG_LEAD_PHRASES``. The
+     normalized pre-H2 tail is ``may refer also to`` — NOT in the
+     phrase set ``("may refer to", "may also refer to")`` — so the
+     check returns False and the b12 Sub-pattern C rejection does
+     NOT fire.
+  6. The Play disambig page is served as the tell_me_about answer.
+
+The fix is a one-line tuple extension: add ``"may refer also to"`` to
+``_DISAMBIG_LEAD_PHRASES``. The existing comment at
+``simple_tools.py:2660`` explicitly anticipates this: "easier to
+extend with new phrasings if ZIM exporters ever produce them".
+
+## Counter-cases the fix preserves
+
+- ``may refer to`` — original phrase (Martin-style) — still matches.
+- ``may also refer to`` — b11 added (Lincoln-style) — still matches.
+- ``may refer also to`` — b12 fix adds (Play-style) — NOW matches.
+- Random body containing ``refer`` earlier but ending differently —
+  still doesn't false-positive (trailing-tail endswith check is
+  position-anchored).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock
+
+# ---------------------------------------------------------------------------
+# Direct unit tests on the extended _DISAMBIG_LEAD_PHRASES set.
+# ---------------------------------------------------------------------------
+
+
+class TestIsDisambigLeadPhrasingVariants:
+    """The b12 disambig-render-time rejection depends on
+    ``_is_disambig_lead`` detecting the Wikipedia disambig template's
+    pre-H2 trailing phrase. The post-b12 sweep extends the phrase set
+    to cover the ``may refer also to`` variant used by the ``Play``-
+    style disambig pages."""
+
+    def test_may_refer_to_detected(self) -> None:
+        """Original Martin-style phrasing — preserved."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        assert SimpleToolsHandler._is_disambig_lead("**Martin** may refer to:")
+
+    def test_may_also_refer_to_detected(self) -> None:
+        """b11 Mercury-style phrasing (may-also-refer-to) — preserved."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        assert SimpleToolsHandler._is_disambig_lead("**Mercury** may also refer to:")
+
+    def test_may_refer_also_to_detected(self) -> None:
+        """b12 fix: Play-style phrasing (may-refer-also-to) — NEW."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        assert SimpleToolsHandler._is_disambig_lead("**Play** may refer also to:")
+
+    def test_play_style_full_pre_h2_detected(self) -> None:
+        """End-to-end: full Play-style pre-H2 body (Wiktionary look-up
+        + most-commonly-refers preamble + may-refer-also-to tail) is
+        correctly classified as disambig."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        play_pre_h2 = (
+            "Look up _**play**_ or _**plays**_ in Wiktionary, the free "
+            "dictionary.\n\n"
+            "**Play** most commonly refers to: \n\n"
+            "  * Play (activity), an activity done for enjoyment\n"
+            "  * Play (theatre), a work of drama\n\n"
+            "**Play** may refer also to:"
+        )
+        assert SimpleToolsHandler._is_disambig_lead(play_pre_h2)
+
+    def test_non_disambig_with_refer_earlier_not_false_positive(self) -> None:
+        """Defense: a body that mentions ``refer also to`` earlier but
+        ends differently shouldn't trigger. The trailing-tail
+        ``endswith`` check is position-anchored."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        body = (
+            "Some article body that includes the phrase may refer also to "
+            "somewhere in the middle of a sentence. " * 10
+            + "But it ends with descriptive prose about its subject."
+        )
+        assert not SimpleToolsHandler._is_disambig_lead(body)
+
+
+# ---------------------------------------------------------------------------
+# Integration test: Shakespeare England plays → Play disambig leak.
+# Mirrors the b11 TestSubPatternCDisambigRejection test pattern but
+# uses the Play-style ``may refer also to`` phrasing.
+# ---------------------------------------------------------------------------
+
+
+_PLAY_DISAMBIG_PRE_H2 = (
+    "Look up _**play**_ or _**plays**_ in Wiktionary, the free dictionary.\n\n"
+    "**Play** most commonly refers to: \n\n"
+    "  * Play (activity), an activity done for enjoyment\n"
+    "  * Play (theatre), a work of drama\n\n"
+    "**Play** may refer also to:"
+)
+
+
+class TestPlayDisambigRejection:
+    """Integration test for the Play-style disambig rejection path.
+    Without the b12 fix, ``Shakespeare England plays`` → ``Play``
+    disambig leaks through because ``_is_disambig_lead`` misses the
+    ``may refer also to`` phrasing. With the fix, the body is
+    classified as disambig and the Sub-pattern C rejection fires."""
+
+    @staticmethod
+    def _make_handler(
+        *,
+        article_body: str,
+        search_results: list,
+        title_index: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.search_zim_file_data.return_value = {"results": search_results}
+        mock.search_zim_file.return_value = "## BM25 fallback rendered\n\n..."
+        mock.get_zim_entry.return_value = article_body
+        mock.config.meta.footer_enabled = False
+        mock.find_entry_by_title_data.return_value = (
+            {"results": [title_index]} if title_index else {"results": []}
+        )
+        mock.get_article_structure_data.return_value = {"sections": []}
+        return SimpleToolsHandler(mock), mock
+
+    def test_play_style_disambig_multi_token_falls_to_search(self) -> None:
+        """Topic with 3 content tokens + Play-style disambig body →
+        b12 Sub-pattern C rejection must fire → BM25 fallback."""
+        disambig_body = (
+            f"# Play\n\n{_PLAY_DISAMBIG_PRE_H2}\n\n"
+            "## Computers and technology\n  * Play (something)\n"
+        )
+        handler, mock = self._make_handler(
+            article_body=disambig_body,
+            search_results=[
+                {"path": "Play", "title": "Play", "score": 100},
+            ],
+            title_index={"path": "Play", "title": "Play", "score": 1.0},
+        )
+        out = handler.handle_zim_query(
+            "tell me about Shakespeare England plays",
+            zim_file_path="/x.zim",
+            options={"compact": False},
+        )
+        # b12 Sub-pattern C must reject the disambig auto-fetch.
+        assert "## BM25 fallback rendered" in out
+        mock.search_zim_file.assert_called()
+
+    def test_play_style_disambig_bare_head_preserved(self) -> None:
+        """``tell me about Play`` (1 content token) legitimately wants
+        the disambig — don't override."""
+        disambig_body = (
+            f"# Play\n\n{_PLAY_DISAMBIG_PRE_H2}\n\n"
+            "## Computers and technology\n  * Play (something)\n"
+        )
+        handler, mock = self._make_handler(
+            article_body=disambig_body,
+            search_results=[
+                {"path": "Play", "title": "Play", "score": 100},
+            ],
+            title_index={"path": "Play", "title": "Play", "score": 1.0},
+        )
+        out = handler.handle_zim_query(
+            "tell me about Play",
+            zim_file_path="/x.zim",
+            options={"compact": False},
+        )
+        # Bare-head 1-content-token topic: serve the disambig as
+        # the answer.
+        assert "_Source: `Play`_" in out
+        mock.search_zim_file.assert_not_called()


### PR DESCRIPTION
Post-b12 live-MCP verification confirmed the Z4 multi-token canonical fix lands cleanly (7/8 historical defects now route correctly) and the Sub-pattern C disambig rejection works for Lincoln/O'Brien. But `Shakespeare England plays` at v2.0.0b12 still ships `Play` (disambig page) at cert=0.85.

## Root cause — phrasing variant not in `_DISAMBIG_LEAD_PHRASES`

`_is_disambig_lead` runs a trailing-tail `endswith` check against the phrase set `("may refer to", "may also refer to")`. The Wikipedia `Play` disambig template ends its pre-H2 with `**Play** may refer also to:` — word order **may-refer-also-to** (NOT **may-also-refer-to**). The two-phrase set misses this variant, so `_is_disambig_lead` returns False, the b12 Sub-pattern C rejection doesn't fire, and the Play disambig page is served as the tell_me_about answer.

The b11 implementation comment at [simple_tools.py:2660](openzim_mcp/simple_tools.py#L2660) explicitly anticipated this: "easier to extend with new phrasings if ZIM exporters ever produce them".

## Fix — extend `_DISAMBIG_LEAD_PHRASES` with the third variant

```python
_DISAMBIG_LEAD_PHRASES = (
    "may refer to",
    "may also refer to",
    "may refer also to",  # b12 fix: Play-style word order
)
```

No regex, no backtracking risk, no architectural change. The trailing-tail `endswith` check still position-anchors against false-positives where the phrase appears earlier in the body but not at the tail.

## Verification of b12 sweep (broader context)

The b12 live-MCP verification probed all documented preserved cases plus the 8 Z4 defect repros. Summary:

| Topic | b11 (defect) | b12 (live) | Status |
|---|---|---|---|
| `Tesla electricity` | `Tesla's_Wireless_Electricity` | `Electricity` | ✅ FIXED |
| `Mozart Vienna` | `Mozarthaus_Vienna` | `Vienna` | ✅ FIXED |
| `Beethoven symphony` | `Symphony_No._1_(Beethoven)` | `Symphony` | ✅ FIXED |
| `Lenin Russia` | `Leninist_Komsomol_...` | `Russia` | ✅ FIXED |
| `Marie Curie radioactivity` | `Radioactive_(Redniss_book)` | `Marie_Curie` | ✅✅ IDEAL |
| `Mao China revolution` | `History_of_PRC_...` | `Mao_Zedong` | ✅✅ IDEAL |
| `Darwin evolution Galapagos` | `Galápagos_Islands` | BM25 search | ✅ FIXED |
| `Shakespeare England plays` | `Shakespeare's_Kings` | `Play` (disambig) | ⚠️ **THIS PR** |
| `Lincoln slavery emancipation` | `Lincoln` (disambig) | BM25 (Emancipation rank 1) | ✅ FIXED |
| `O'Brien character 1984` | `O'Brien` (disambig) | BM25 (`O'Brien_(Nineteen_Eighty-Four)` rank 1) | ✅✅ IDEAL |

13/13 preserved cases hold; no regressions.

## Tests

7 new in `tests/test_post_b12_beta_fixes.py`:

- 5 direct unit tests on `_is_disambig_lead` covering the three phrase variants + Play-style full pre-H2 + false-positive defense.
- 2 integration tests: `Shakespeare England plays` (multi-token → BM25 fallback) and `tell me about Play` (bare-head → preserve disambig).

**Verification**: 2562 passed full suite (~28s), mypy clean 52 files, black + flake8 + pip-audit clean.

## Methodology — "fix unlocks new paths" 20 sweeps strong

Smallest sweep since b6 — one-line phrase extension. The b11 Sub-pattern C rejection architecture was solid; only the underlying detection primitive needed a phrase variant added. This is the "easy to extend" promise of the b11 design paying off.