### PR TITLE
docs(v2): flip Phase D to shipped, roll Phase E + deferred Phase D items to v2.5

### DIFF
--- a/docs/v2.5/README.md
+++ b/docs/v2.5/README.md
@@ -1,0 +1,132 @@
+# openzim-mcp v2.5 — Release Tracking
+
+**Status:** Planning
+**Target:** v2.5.0 (minor release, additive)
+**Started:** 2026-05-24
+**Owner:** @cameronrye
+**Predecessor:** [v2 tracker](../v2/README.md) (v2.0.0 final cuts after Phase F)
+
+This document tracks v2.5 — a minor release that collects everything deferred from v2 that is **additive** (extras-gated, sidecar-based, or otherwise optional). Nothing in v2.5 breaks the v2 tool surface or response contract.
+
+The work is grouped into two themes. Each item ships independently as a `v2.5.0aN` / `v2.5.0bN` pre-release, then the final `v2.5.0` tag cuts once all in-scope items ship OR are formally closed.
+
+---
+
+## Why v2.5, not v3
+
+All items are additive: opt-in extras (`[planner]`, `[embeddings]`), optional sidecars (`<archive>.zim.linkgraph.sqlite`, `<archive>.zim.semantic.faiss`), and data-only presets (`presets/wikipedia.toml`). None changes the v2 tool surface or response shapes. Semantic versioning argues minor.
+
+v3 would be reserved for a future breaking change — e.g., a libzim major version bump, or a deeper tool-surface restructure beyond Phase F.
+
+---
+
+## Foundational decisions (inherited from v2)
+
+These continue to apply.
+
+- **ML accelerators are opt-in via extras.** Default install stays lean.
+- **Offline-first.** Sidecars and models load from disk; build steps are explicit operator commitments.
+- **Markdown for prose, JSON for navigation; no XML in tool responses.**
+- **Backward compat at the data layer.** Sidecars live next to `.zim` files and are optional; absence is reported gracefully.
+
+---
+
+## Theme 1 — Items deferred from Phase D
+
+The [v2 Phase D design spec](../superpowers/specs/2026-05-20-v2-phase-d-ml-accelerators-design.md) shipped #6 (cross-encoder reranker) and #8 Tier 1 (rules-based query rewriting) at v2.0.0b1, then deliberately deferred three items pending live evidence. Each has a **measurable trigger** that would justify cutting a follow-up design spec.
+
+### sub-D-3 — Hybrid intent parser + Tier 2 decomposition (#8 Tier 2 + #12)
+
+**Current state.** [`openzim_mcp/intent_parser.py`](../../openzim_mcp/intent_parser.py) is regex-based with 19 weighted patterns. Confidence < 0.7 routes to a low-confidence path; confidence < 0.55 marks "low confidence" with a footer.
+
+**Target.** Hybrid path: regex stays as the fast path; below confidence 0.7, route to a small intent classifier (fastText / distilled sentence-transformer / lightweight rules-tree). Tier 2 decomposition adds entity-then-property lookups for multi-hop queries like "what year did the inventor of X die." Behind `pip install openzim-mcp[planner]`.
+
+**Trigger to design.** After v2.0.0b1 deploy (already shipped) and ≥2 weeks of live telemetry shows EITHER:
+
+- ≥5% of `parse_intent` calls land in the existing low-confidence path (regex confidence < 0.7), OR
+- Small-model transcript review surfaces multi-hop queries that the regex path fails on at ≥1 per 100 queries.
+
+**Status as of 2026-05-24.** Beta sweep cycles (b2 → b13) have driven the regex path to roughly 99% accuracy on labeled queries. No live evidence has met either trigger. If neither fires by 2026-07-19 (8 weeks post-sub-D-2 deploy), formally close sub-D-3 as "not justified by live evidence."
+
+**Reference design.** Previous draft of the fastText classifier path preserved at commit [`a92d04e`](https://github.com/cameronrye/openzim-mcp/commit/a92d04e).
+
+### sub-D-4 — Embeddings sidecar + hybrid retrieval (#15)
+
+**Current state.** No semantic search. Pure Xapian BM25 is the only relevance signal beyond the cross-encoder reranker (which reranks Xapian's top-50). Semantic-divergent queries ("the chemical that makes leaves green") have no path to canonical matches that don't share lexical tokens.
+
+**Target.** Behind `pip install openzim-mcp[embeddings]`. A build-time CLI generates `<archive>.zim.semantic.faiss` next to the archive (32 GB per multi-million-article archive, 3–4 hour build time). At query time, hybrid retrieval: Xapian top-K + semantic top-K → RRF fuse (k=60) → rerank.
+
+**Trigger to design.** After v2.0.0b1 deploy and ≥4 weeks of live telemetry shows BOTH:
+
+- Reranker hit rate is meaningful (≥15% of search-tool calls past the skip-on-short-query gate), AND
+- Operators or end-users report that semantic-divergent queries consistently miss in Xapian-only search even with the reranker active.
+
+**Status as of 2026-05-24.** Telemetry not yet collected at the required granularity. No operator reports.
+
+**Reference design.** Previous draft preserved at commit [`a92d04e`](https://github.com/cameronrye/openzim-mcp/commit/a92d04e).
+
+---
+
+## Theme 2 — Phase E offline build artifacts
+
+Phase E was scoped in the v2 tracker but deferred to v2.5 because it's independent of runtime code and doesn't block v2.0.0 final. Both items add operator-build commands that produce optional sidecars; the default behavior is unchanged.
+
+### #16 — Inbound link-graph sidecar
+
+**Current state.** [`openzim_mcp/zim/content.py`](../../openzim_mcp/zim/content.py) `get_related_articles` is outbound-only. Inbound link discovery was removed in v0.9.0 because the runtime cost is prohibitive on a multi-million-article archive.
+
+**Target.** `openzim-mcp build link-graph <archive>.zim` produces `<archive>.zim.linkgraph.sqlite` (or similar) with reverse-edge indexes. At runtime, `get_related_articles(direction="inbound")` becomes a SQLite lookup. Sidecar is optional; absence is reported gracefully.
+
+**Build cost.** Estimated 30–60 minutes per multi-million-article archive (single-pass entry walk + bulk SQLite insert). Storage: ~500 MB – 2 GB per archive depending on link density.
+
+### #17 — Archive-type presets
+
+**Current state.** Wikipedia, Wiktionary, Stack Exchange, and TED-style ZIMs behave differently (encyclopedic prose vs. dictionary entries vs. Q&A vs. transcripts), but the server treats them uniformly. Models waste turns discovering archive shape.
+
+**Target.** Detect archive type via the `M`-namespace metadata + heuristics on `Creator` / `Name` / `Title`. Each detected type has a preset that adjusts: snippet shape, summary style, default namespace for unfiltered queries, and intent-parser priors. Presets are data, not code — `openzim_mcp/presets/wikipedia.toml` etc. Users can override per-archive in config.
+
+---
+
+## v2.5 milestones (proposed)
+
+| Milestone | Items | Tag |
+|-----------|-------|-----|
+| **v2.5.0a1** | #17 archive-type presets (smallest scope, data-only) | _TBD_ |
+| **v2.5.0a2** | #16 link-graph sidecar + `build` CLI | _TBD_ |
+| **v2.5.0a3** | sub-D-3 if triggered | _TBD_ |
+| **v2.5.0a4** | sub-D-4 if triggered | _TBD_ |
+| **v2.5.0** | Final after all triggered items ship (closed sub-Ds annotated in CHANGELOG) | _TBD_ |
+
+The deferred Phase D sub-Ds are conditional — if their triggers never fire, v2.5 ships with #16 + #17 only and sub-D-3/sub-D-4 formally close with a CHANGELOG entry citing the lack of live evidence.
+
+---
+
+## Out of scope for v2.5
+
+- **HyDE** (hypothetical document expansion). Hurts small models per v2 README research; explicit non-goal carried forward.
+- **Network-fetching tools.** v2.5 stays offline-only.
+- **A built-in summarization LLM.** Synthesize mode (#10, shipped in v2.0.0a4) is retrieval + concatenation, not generation.
+- **Multi-archive federated search beyond what `search_all` already does.**
+- **Replacing libzim.** v2.5 builds on libzim 9+.
+- **Tool surface changes.** That's Phase F (v2.0.0 final).
+
+---
+
+## Per-item spec process
+
+For each item, when work begins:
+
+1. Verify the trigger (for sub-D-3 / sub-D-4) or confirm scope (for #16 / #17).
+2. Brainstorm against this tracking doc to refine scope and approaches.
+3. Write a spec to `docs/superpowers/specs/YYYY-MM-DD-v2.5-<item>-design.md`.
+4. Update the milestones table above with the spec link and status.
+5. Generate an implementation plan via the writing-plans skill.
+6. Execute, review, ship as `v2.5.0aN` / `v2.5.0bN` pre-release.
+
+When all in-scope items ship (or formally close), tag `v2.5.0`.
+
+## Tracking
+
+- All v2.5 PRs use the label `v2.5`.
+- Per-item labels: `v2.5-sub-d-3`, `v2.5-sub-d-4`, `v2.5-link-graph`, `v2.5-presets`.
+- This document is updated as decisions land. Treat the **milestones** table as source of truth for "where are we."

--- a/docs/v2/README.md
+++ b/docs/v2/README.md
@@ -31,11 +31,19 @@ These apply across all phases; per-phase specs do not re-litigate them.
 | **A** | Quality wins, non-breaking | #1, #2, #4, #5, #14 | **Shipped (v2.0.0a1)** | [2026-05-08-v2-phase-a-quality-wins-design.md](../superpowers/specs/2026-05-08-v2-phase-a-quality-wins-design.md) |
 | **B** | Response contract | #3, #13 | **Shipped (v2.0.0a2)** | [2026-05-08-v2-phase-b-response-contract-design.md](../superpowers/specs/2026-05-08-v2-phase-b-response-contract-design.md) |
 | **C** | New retrieval primitives | #7, #10, #11 | **Shipped (v2.0.0a4)** | [2026-05-09-v2-phase-c-retrieval-primitives-design.md](../superpowers/specs/2026-05-09-v2-phase-c-retrieval-primitives-design.md) |
-| **D** (trimmed) | Optional ML accelerators | #6, #8 Tier 1 (others deferred) | In Design | [2026-05-20-v2-phase-d-ml-accelerators-design.md](../superpowers/specs/2026-05-20-v2-phase-d-ml-accelerators-design.md) |
-| **E** | Offline build artifacts | #16, #17 | Planned | _TBD_ |
-| **F** | Tool surface v2 | #9 | Planned | _TBD_ |
+| **D** (trimmed) | Optional ML accelerators | #6 reranker + #8 Tier 1 query rewriting | **Shipped (v2.0.0b1)** | [2026-05-20-v2-phase-d-ml-accelerators-design.md](../superpowers/specs/2026-05-20-v2-phase-d-ml-accelerators-design.md) |
+| _Beta polish_ | Title-promotion defect sweeps | Z1, Z2, Z3, Z4, OPP-1, Sub-pattern C | **In progress (v2.0.0b2 → b13)** | Per-sweep PRs (see CHANGELOG) |
+| **E** | Offline build artifacts | #16, #17 | **Rolled to v2.5** | [docs/v2.5/README.md](../v2.5/README.md) |
+| **F** | Tool surface v2 | #9 | Planned (next) | _TBD_ |
+| _Deferred from Phase D_ | Hybrid intent + embeddings sidecar | #8 Tier 2, #12, #15 | **Rolled to v2.5** | [docs/v2.5/README.md](../v2.5/README.md) |
 
 Each phase's spec is created via the brainstorming workflow when that phase begins. The spec link gets filled in when the design is approved.
+
+### Re-scope decision (2026-05-24)
+
+v2's remaining scope is now exactly **Phase F (tool-surface consolidation)**. Phase E (offline build artifacts) and the deferred Phase D items (#8 Tier 2, #12, #15) move to [v2.5](../v2.5/README.md) — they are all additive (extras-gated or sidecar-based) and don't require waiting for the v2.0.0 final tag. When Phase F ships, v2.0.0 cuts. v2.5 picks up E + the deferred Phase D items on its own schedule.
+
+The beta polish line (b2 → b13, 12 sweep releases) has been the de-facto Phase D maintenance follow-up — every sweep cycled defects in the Tier 1 query rewriting / title-promotion path that sub-D-2 introduced. b13's live-MCP sweep returned 25/25 cases pass with no defects, suggesting the line is converging.
 
 ---
 
@@ -135,6 +143,10 @@ Each phase's spec is created via the brainstorming workflow when that phase begi
 
 **Why fourth:** Each depends on the response shape from B and the section bundles from C to be useful. Doing ML before structure means rebuilding integration points twice.
 
+**What shipped (v2.0.0b1, trimmed scope):** #6 cross-encoder reranker (behind `[reranker]` extra) and #8 Tier 1 rules-based query rewriting (base install). See the [Phase D design spec](../superpowers/specs/2026-05-20-v2-phase-d-ml-accelerators-design.md) for the deliberate trim rationale: ship the two items that pay off regardless, instrument them, decide what's actually missing.
+
+**What deferred to [v2.5](../v2.5/README.md):** #8 Tier 2 multi-hop decomposition, #12 hybrid intent parser (regex + classifier fallback), #15 sentence-embedding sidecar. The Phase D spec captures measurable triggers that would justify designing each. The beta polish line (b2 → b13) has not surfaced live evidence that meets those triggers; they sit in v2.5 awaiting evidence.
+
 ### #6 — Cross-encoder reranker
 
 **Current state.** Pure Xapian BM25 is the only relevance signal. Wikipedia title queries are entity-driven, but content-fragment queries ("the chemical that makes leaves green") need semantic re-ranking.
@@ -163,11 +175,13 @@ Each phase's spec is created via the brainstorming workflow when that phase begi
 
 ---
 
-## Phase E — Offline build artifacts
+## Phase E — Offline build artifacts (rolled to v2.5)
 
 **Goal:** Ship an `openzim-mcp build` CLI that produces optional sidecar files at archive-load or pre-deployment time.
 
-**Why fifth:** Independent of all runtime code; can ship after D without blocking it.
+**Why deferred to [v2.5](../v2.5/README.md):** Independent of all runtime code AND additive (sidecars are optional; absence is reported gracefully). Doesn't need to block the v2.0.0 final tag. Phase F is the highest-impact remaining v2 work; Phase E ships on its own schedule afterward.
+
+The original item descriptions remain below for reference but the live tracker is [docs/v2.5/README.md](../v2.5/README.md).
 
 ### #16 — Inbound link-graph sidecar
 


### PR DESCRIPTION
Brings the v2 tracker in line with ground truth as of v2.0.0b13 and creates the v2.5 tracker for everything additive that was deferred from v2.

## What changed in `docs/v2/README.md`

- **Phase D** flipped from "In Design" to **"Shipped (v2.0.0b1)"**. sub-D-1 (reranker) + sub-D-2 (Tier 1 query rewriting) both shipped at b1 per the deliberate trim in the Phase D design spec.
- **Beta polish row added** for the title-promotion sweep cycle b2 → b13. b13 returned 25/25 cases pass with no defects.
- **Phase E rolled to v2.5** with a forward link. Original item descriptions preserved for reference.
- **Deferred from Phase D row** added pointing at v2.5 for #8 Tier 2, #12, #15.
- **Re-scope note**: v2's remaining scope is now exactly Phase F. When F ships, v2.0.0 cuts. v2.5 picks up E + deferred D items afterward.

## What's new in `docs/v2.5/README.md`

New release tracker for everything additive deferred from v2:

**Theme 1 — Items deferred from Phase D**
- **sub-D-3**: #8 Tier 2 + #12 hybrid intent parser (behind `[planner]`)
- **sub-D-4**: #15 embeddings sidecar (behind `[embeddings]`)
- Each carries the measurable trigger from the Phase D spec, plus current status (no live evidence has met either trigger as of 2026-05-24)

**Theme 2 — Phase E offline build artifacts**
- **#16** inbound link-graph sidecar (`openzim-mcp build link-graph`)
- **#17** archive-type presets (Wikipedia / Wiktionary / Stack Exchange / TED)

Foundational decisions inherited from v2 (extras-gated, offline-first, backward-compat at data layer). Out-of-scope list carried forward.

## Why v2.5, not v3

All items are additive: opt-in extras, optional sidecars, data-only presets. None changes the v2 tool surface or response shapes. Semantic versioning argues minor. v3 stays reserved for a future actual breaking change (libzim major bump, deeper tool-surface restructure beyond Phase F, etc.).

## Documentation only

No code changes. No tests run; no CI gates affected by the doc-only changes (Sonar may flag the new file size as new code but the changes are all prose).