### PR TITLE
fix(release): draft release-please shell + publish after asset upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,6 +325,31 @@ jobs:
 
           echo "✅ Assets uploaded to release $TAG_NAME"
 
+      - name: Publish draft release
+        # release-please creates the release shell as a draft
+        # (release-please-config.json#draft=true). On repos with immutable
+        # releases enabled, assets can only be uploaded to a draft — once a
+        # release is published, GitHub locks its asset list. This step flips
+        # the draft to published *after* the upload step above has run, so
+        # the final release ends up with both the changelog body
+        # (release-please) and the dist artifacts (this workflow).
+        if: steps.check-release.outputs.release_exists == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG_NAME="${{ steps.tag.outputs.tag_name }}"
+          # Verify it's actually a draft before flipping — release-please
+          # may have already published it, or someone may have manually
+          # published it. Either way, "edit --draft=false" on an already-
+          # published release is a no-op, so this is safe.
+          if gh release view "$TAG_NAME" --json isDraft --jq .isDraft | grep -qi true; then
+            echo "🚀 Publishing draft release: $TAG_NAME"
+            gh release edit "$TAG_NAME" --draft=false
+            echo "✅ Release $TAG_NAME published"
+          else
+            echo "ℹ️  Release $TAG_NAME is already published — nothing to do"
+          fi
+
       - name: Create new release
         if: steps.check-release.outputs.release_exists != 'true'
         uses: softprops/action-gh-release@v3

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -75,7 +75,7 @@
       ],
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
-      "draft": false,
+      "draft": true,
       "prerelease": false,
       "draft-pull-request": false,
       "include-component-in-tag": false,


### PR DESCRIPTION
The `Release` workflow has been silently broken on every prerelease tag since GitHub turned on the immutable-releases feature for this repo. Symptom: `Cannot upload asset openzim_mcp-<ver>.tar.gz to an immutable release` from the `Create GitHub Release` job, after PyPI publish has already succeeded.

See the failed run for `v2.0.0rc0`: [actions/runs/26420364723](https://github.com/cameronrye/openzim-mcp/actions/runs/26420364723).

## Root cause

`release-please` creates the GitHub release shell when a release commit lands on `main` (the comment in `release-please.yml` documents this intentional ownership split). The config was setting `"draft": false`, so the release published immediately. Then the `Release` workflow, triggered by the tag push that follows, tried to upload the wheel/sdist to that already-published release — which the immutable-releases feature rejects.

This broke for rc0 because release-please's release shell creation won the race. v2.0.0b13 et al. only succeeded because their release shells were created manually after prior workflow failures, which masked the underlying bug.

## Fix

Two coordinated changes, both opt-in to the GitHub-documented "draft prereleases on immutable-release repos" pattern:

1. **`release-please-config.json#draft`** flipped `false → true`. The release-please action now creates the release shell as a draft, which lets downstream workflows upload assets before publish.

2. **`release.yml`** `create-release` job gets a new `Publish draft release` step that runs immediately after `Upload assets to existing release`. It flips the draft to published only after the upload succeeded.

The new publish step is guarded by an `isDraft` check, so it's a no-op if the release is somehow already published (manual creation, race with another workflow, etc).

## Impact on v2.0.0rc0

PyPI publish succeeded — `openzim-mcp==2.0.0rc0` is installable. The only effect of the failure was the GitHub Releases page showing the changelog body but no downloadable wheel/tarball. Easy to miss.

I'll attach the dist artifacts to the existing rc0 release out-of-band (separate task), if the immutable-releases feature allows it on the published release. If not, rc0 stays as PyPI-only and v2.0.0rc1 will be the first release with assets on the Releases page.

## Verification needed

This PR's CI doesn't exercise the release workflow itself (it only runs on tag pushes). The next tag push after merging this — likely `v2.0.0rc1` or `v2.0.0` — will be the real test. If something is still wrong, the symptom will land as another `Create GitHub Release` job failure with assets missing.
