### PR TITLE
feat(dispatch-eval): plumb 'rc1' variant in runner

### DIFF
--- a/tests/dispatch_eval/runner.py
+++ b/tests/dispatch_eval/runner.py
@@ -7,7 +7,7 @@ records per-probe outcomes to a JSONL file.
 USAGE (Cameron runs this — the present module builds the harness only):
 
     python tests/dispatch_eval/runner.py \\
-      --variant {b13,phase-f,phase-f-fallback} \\
+      --variant {b13,rc1,phase-f,phase-f-fallback} \\
       --mode {simple,advanced} \\
       --model {qwen2.5-7b-instruct,haiku-4.5,llama-3.1-8b-instruct, \\
                phi-3.5-mini-instruct,qwen-2.5-3b-instruct} \\
@@ -19,12 +19,20 @@ Variant semantics:
   - ``b13``    — runs against whichever surface is active in the current
                  working tree (no env overrides). Operator invokes this from
                  a worktree at the ``v2.0.0b13`` tag.
+  - ``rc1``    — runs against whichever surface is active in the current
+                 working tree (no env overrides). Operator invokes this from
+                 a worktree at the ``v2.0.0rc1`` tag (or ``main`` after rc1
+                 merged). Structurally identical to b13's empty-overlay path;
+                 the variant label distinguishes the cell for Stage E A/B
+                 comparison.
   - ``phase-f`` — sets ``OZM_PHASE_F_PROTOTYPE=1`` and ``OZM_TOOL_MODE=<mode>``
-                 in the spawned MCP server's env. Drives the prototype
-                 skeleton.
+                 in the spawned MCP server's env. Drives the throwaway
+                 prototype skeleton — Gate 0b only.
   - ``phase-f-fallback`` — like ``phase-f`` but ALSO sets
-                 ``OZM_CRITERION_C_PATH=fallback`` so ``zim_search`` swaps to
-                 the legibility-fallback description.
+                 ``OZM_CRITERION_C_PATH=fallback`` so the prototype's
+                 ``zim_search`` swaps to the legibility-fallback description.
+                 rc1's ``_CRITERION_C_PATH`` is a baked Python constant; a
+                 Stage E fallback re-run would require a code amend.
 
 Per-model adapter table:
 
@@ -106,7 +114,7 @@ DEFAULT_TEMPERATURE = float(os.environ.get("OZM_DISPATCH_TEMPERATURE", "0.2"))
 PER_REP_TIMEOUT_S = float(os.environ.get("OZM_DISPATCH_TIMEOUT_S", "30"))
 MAX_RETRIES = 3
 
-VALID_VARIANTS = {"b13", "phase-f", "phase-f-fallback"}
+VALID_VARIANTS = {"b13", "phase-f", "phase-f-fallback", "rc1"}
 VALID_MODES = {"simple", "advanced"}
 
 SYSTEM_PROMPT_PATH = Path(__file__).resolve().parent / "system_prompt.md"
@@ -412,8 +420,17 @@ def _build_server_env(variant: str, mode: str) -> Dict[str, str]:
     """Return the env-var overlay for an MCP server subprocess.
 
     - b13: empty overlay; the working tree's surface is whatever's at HEAD.
-    - phase-f: OZM_PHASE_F_PROTOTYPE=1, OZM_TOOL_MODE=<mode>.
-    - phase-f-fallback: + OZM_CRITERION_C_PATH=fallback.
+      Operator invokes from a worktree at the ``v2.0.0b13`` tag.
+    - rc1: empty overlay; the working tree's surface is whatever's at HEAD.
+      Operator invokes from a worktree at the ``v2.0.0rc1`` tag (or main
+      after rc1 merged). Structurally identical to b13's empty-overlay path
+      — the variant label only affects output filenames + scoring cell
+      identification, so a Stage E sweep can compare b13 vs rc1 runs.
+    - phase-f: OZM_PHASE_F_PROTOTYPE=1, OZM_TOOL_MODE=<mode> (drives the
+      throwaway prototype branch — used only for Gate 0b).
+    - phase-f-fallback: + OZM_CRITERION_C_PATH=fallback (prototype's
+      fallback cell; rc1 does NOT read this env var because the constant
+      is baked in — fallback re-runs at Stage E require a code amend).
     """
     env = os.environ.copy()
     if variant == "phase-f":
@@ -423,9 +440,9 @@ def _build_server_env(variant: str, mode: str) -> Dict[str, str]:
         env["OZM_PHASE_F_PROTOTYPE"] = "1"
         env["OZM_TOOL_MODE"] = mode
         env["OZM_CRITERION_C_PATH"] = "fallback"
-    # b13: no overlay — operator must invoke from a v2.0.0b13 worktree, the
-    # surface there is the default. We still pass the requested mode so the
-    # b13 server boots in the right tool set.
+    # b13 / rc1: no overlay — the surface there is the working tree's
+    # default. We still pass the requested mode so the spawned server
+    # boots in the right tool set.
     env["OPENZIM_MCP_TOOL_MODE"] = mode
     return env
 


### PR DESCRIPTION
## Summary

Adds `rc1` to the dispatch-eval runner's `--variant` choices so Stage E (Task E1 / E3) can re-run the eval against the released v2.0.0rc1 surface.

## Why

The dispatch-eval runner at `tests/dispatch_eval/runner.py` is the harness for the Gate 0b probe-set sweep that validated Phase F's surface change. Stage E ([2026-05-24-v2-phase-f-tool-surface plan §E1+E3](docs/superpowers/plans/2026-05-24-v2-phase-f-tool-surface.md)) re-runs the same eval against the released rc1 surface — primarily to enforce F2 (per-class deltas) on the same 300-probe set Gate 0b measured, and confirm the rc1 implementation didn't drift from the prototype's behavior.

The runner already accepts:
- `b13` — empty env overlay; operator invokes from a v2.0.0b13 worktree
- `phase-f` — sets `OZM_PHASE_F_PROTOTYPE=1 OZM_TOOL_MODE=<mode>`; drives the throwaway prototype skeleton
- `phase-f-fallback` — like `phase-f` plus `OZM_CRITERION_C_PATH=fallback`

Missing: `rc1`. Per the plan's E1 step 1 command:

```bash
python tests/dispatch_eval/runner.py --variant rc1 --mode advanced --model qwen3-8b-q4 --reps 5 --probes tests/dispatch_eval/probes.jsonl --output /tmp/rc1_sweep.jsonl
```

— `rc1` was never plumbed in (the plan was authored before the rc1 implementation landed). Without this PR, the operator hits `argparse: error: argument --variant: invalid choice: 'rc1'`.

## What this changes

- `VALID_VARIANTS` set on `tests/dispatch_eval/runner.py:109` adds `"rc1"`.
- `_build_server_env` documents `rc1` as structurally identical to `b13`'s empty-overlay path (the variant label only affects scoring cell identification + output filename, enabling Stage E A/B comparison cleanly).
- Module + CLI docstring note that `phase-f-fallback` is prototype-only — rc1's `_CRITERION_C_PATH` is a baked Python constant (`"wired"` per `gate_0b_decision.json`), so a Stage E fallback re-run would require a code amend, not an env-var toggle.

## Tests

`make lint` ✓. No new behavior to test directly — the variant is a dispatch label; the `_build_server_env` empty-overlay path is exercised by the existing `b13` codepath the runner shares. Operator-driven dispatch-eval runs are the actual test.

## Operator usage (Stage E1, condensed)

```bash
# Endpoint already overridden via OZM_VLLM_BASE_URL / OZM_OWL_ATLAS_API_KEY (in shell).
python tests/dispatch_eval/runner.py \
  --variant rc1 \
  --mode advanced \
  --model qwen3-8b-q4 \
  --reps 5 \
  --probes tests/dispatch_eval/probes.jsonl \
  --output tests/dispatch_eval/runs/rc1__advanced__qwen3-8b-q4__$(date -u +%Y-%m-%dT%H-%M-%SZ).jsonl
```

**Note on the probe set:** the plan §E1 step 1 references `tests/dispatch_eval/data/b1_b13_probes.jsonl` but that file is in the b-series-sweep schema (topic→entry_path), not the dispatch-eval schema (query+expected_tool). The 300-probe `tests/dispatch_eval/probes.jsonl` file is the right input — it already includes ~130 b-series-derived probes translated into the dispatch-eval schema (the same set Gate 0b measured against).

A follow-up task could translate `b1_b13_probes.jsonl` into the dispatch-eval schema for the full ~150-probe E1 expansion, but it's not blocking E1's pass criteria.
