### PR TITLE
fix(release): create-then-publish on manual-tag path (immutable releases)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,15 +325,40 @@ jobs:
 
           echo "✅ Assets uploaded to release $TAG_NAME"
 
+      - name: Create new release (draft)
+        # Manual `git tag` push path: no release-please draft shell exists,
+        # so this step creates one. On repos with immutable releases enabled,
+        # assets can only be uploaded WHILE the release is a draft — publishing
+        # locks the asset list. softprops/action-gh-release uploads the dist
+        # artifacts as part of the draft creation in this branch; the
+        # "Publish draft release" step below then flips draft -> published.
+        # rc0 and rc1 both shipped with empty Releases pages because this
+        # step used to set draft: false (single-shot create+publish), which
+        # failed on the asset-upload step under immutable releases.
+        if: steps.check-release.outputs.release_exists != 'true'
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.tag.outputs.tag_name }}
+          name: Release v${{ steps.extract-notes.outputs.version }}
+          body_path: release_notes.md
+          files: |
+            dist/*
+          draft: true
+          # Use the resolved tag name (works for workflow_dispatch where
+          # github.ref is the source branch, not the release tag).
+          prerelease: ${{ contains(steps.tag.outputs.tag_name, 'alpha') || contains(steps.tag.outputs.tag_name, 'beta') || contains(steps.tag.outputs.tag_name, 'rc') }}
+
       - name: Publish draft release
-        # release-please creates the release shell as a draft
-        # (release-please-config.json#draft=true). On repos with immutable
-        # releases enabled, assets can only be uploaded to a draft — once a
-        # release is published, GitHub locks its asset list. This step flips
-        # the draft to published *after* the upload step above has run, so
-        # the final release ends up with both the changelog body
-        # (release-please) and the dist artifacts (this workflow).
-        if: steps.check-release.outputs.release_exists == 'true'
+        # Both paths converge here:
+        #   - release-please path: "Upload assets to existing release" above
+        #     populated a release-please-created draft with assets.
+        #   - manual-tag-push path: "Create new release (draft)" above created
+        #     a fresh draft with assets.
+        # In both cases the release is a draft at this point; flip it to
+        # published. On repos with immutable releases enabled, this step is
+        # what makes assets visible on the Releases page — once published,
+        # GitHub locks the asset list, so the order
+        # (create-draft → upload-assets → publish) is load-bearing.
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -349,17 +374,3 @@ jobs:
           else
             echo "ℹ️  Release $TAG_NAME is already published — nothing to do"
           fi
-
-      - name: Create new release
-        if: steps.check-release.outputs.release_exists != 'true'
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ steps.tag.outputs.tag_name }}
-          name: Release v${{ steps.extract-notes.outputs.version }}
-          body_path: release_notes.md
-          files: |
-            dist/*
-          draft: false
-          # Use the resolved tag name (works for workflow_dispatch where
-          # github.ref is the source branch, not the release tag).
-          prerelease: ${{ contains(steps.tag.outputs.tag_name, 'alpha') || contains(steps.tag.outputs.tag_name, 'beta') || contains(steps.tag.outputs.tag_name, 'rc') }}


### PR DESCRIPTION
## Summary

Closes the workflow-level half of the **"GitHub Release page has no asset attachments"** issue that hit both v2.0.0rc0 and v2.0.0rc1. Pre-flight fix before v2.0.0 final tag.

## Background

This repo has GitHub's [immutable releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#immutable-releases) setting enabled. With it on, a release's asset list is locked once the release is published — you can only upload assets while the release is still a draft.

`release.yml` has two paths:

| Path | When | Status |
| --- | --- | --- |
| **release-please** | `release_exists=true` (release-please created a draft shell when its release PR merged) | ✅ Works — PR #193 wired the create-draft → upload-assets → publish sequence |
| **manual `git tag` push** | `release_exists=false` (no release-please involvement) | ❌ Broken — the workflow used `softprops/action-gh-release@v3` with `draft: false`, asset upload sub-step hits `Cannot upload asset ... to an immutable release`, the release ends up empty |

Both v2.0.0rc0 and v2.0.0rc1 hit Path B because the operator pushed the tag manually. PyPI uploads succeeded on both releases, but [the rc1 Releases page](https://github.com/cameronrye/openzim-mcp/releases/tag/v2.0.0rc1) carries the changelog body with **no `.whl`/`.tar.gz` attached**.

v2.0.0 final tag will hit the same path unless this is fixed.

## What this changes

Path B (`release_exists=false`) now uses the same create-draft → upload-assets → publish sequence as Path A:

1. **`Create new release (draft)`** — `softprops/action-gh-release@v3` with `draft: true` creates the draft AND uploads the dist artifacts in the same call.
2. **`Publish draft release`** — the existing step's `release_exists == 'true'` guard is dropped so it fires on both paths. Order also reshuffled so it comes AFTER both upload paths (was wedged between them).

Net diff: +33/-22 lines, all in `.github/workflows/release.yml`. No new dependencies; uses the same actions and `gh` CLI commands that already worked on Path A.

## Why the diff is bigger than expected

The bulk of the line-count is **comment expansion**, not logic change. Both steps now carry explicit comments about the immutable-releases ordering constraint so the next maintainer who edits this section understands what's load-bearing.

## Testing

**Cannot test directly** — this code only fires on tag push, and the first opportunity is v2.0.0 final tag itself. Two mitigations:

- The logic is structurally identical to the proven-working Path A. `softprops/action-gh-release@v3` accepts `draft: true` (well-documented), and `gh release edit --draft=false` was already working for Path A.
- I could test it by pushing a throwaway tag (e.g., `v2.0.0rc1.post1`) but that creates Releases-page noise and the same rule that blocks asset uploads also blocks deleting the resulting release page. So the safer test is just to land this and watch v2.0.0 carefully.

If v2.0.0 hits an issue, fallback is straightforward: revert this PR, run `gh release create v2.0.0 --notes-file ... --draft` manually, upload assets via `gh release upload`, then `gh release edit v2.0.0 --draft=false`. The same sequence the workflow now automates.

## Closes

The rc1 follow-up I flagged in [PR #194's session summary](https://github.com/cameronrye/openzim-mcp/pull/194#issuecomment-...) — "flip the repo's 'immutable releases' setting OFF, or route v2.0.0 through release-please's draft flow". This PR picks option 2's spirit (use the draft flow) but applies it to the manual-tag path so we don't have to switch release mechanisms for the final tag.
