### PR TITLE
fix(release-please): pass pr output via env to avoid JS-string injection

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -49,24 +49,40 @@ jobs:
       pull-requests: write
     steps:
       - name: Comment on PR
+        # release-please's ``pr`` output is a JSON object (not a URL string
+        # as an earlier iteration of this workflow assumed). Pass it via an
+        # env var and JSON.parse to avoid embedding the body content into
+        # the github-script source, which previously broke when commit
+        # subjects contained single-quoted tokens like ``plumb 'rc1'``.
         uses: actions/github-script@v9
+        env:
+          RELEASE_PR_JSON: ${{ needs.release-please.outputs.pr }}
         with:
           script: |
-            // Extract PR number from the PR output (format: "https://github.com/owner/repo/pull/123")
-            const prUrl = '${{ needs.release-please.outputs.pr }}';
-            if (!prUrl) {
-              console.log('No PR URL found');
+            const raw = process.env.RELEASE_PR_JSON;
+            if (!raw) {
+              console.log('No PR data found');
               return;
             }
-
-            const prNumber = prUrl.split('/').pop();
+            let prData;
+            try {
+              prData = JSON.parse(raw);
+            } catch (e) {
+              console.log('Failed to JSON.parse release-please pr output:', e.message);
+              return;
+            }
+            const prNumber = prData && prData.number;
+            if (!prNumber) {
+              console.log('release-please pr output had no .number field');
+              return;
+            }
             console.log(`Found PR number: ${prNumber}`);
 
             try {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: parseInt(prNumber),
+                issue_number: prNumber,
                 body: `🤖 **Automated Release PR Created**
 
                 This PR was automatically created by release-please based on conventional commits.


### PR DESCRIPTION
## Summary

Closes the `Release Please` workflow failure introduced when [PR #196](https://github.com/cameronrye/openzim-mcp/pull/196) merged.

## Root cause

`notify-release-pr` interpolated release-please's `pr` output into a single-quoted JS string:

```yaml
script: |
  const prUrl = '${{ needs.release-please.outputs.pr }}';
```

That output is a JSON object (the inline comment claiming "format: URL" was stale — release-please's `pr` output type was changed earlier in its lifecycle). When the JSON body contains literal single-quoted tokens — like `plumb 'rc1' variant in runner` from #196's commit subject — the inner quotes terminate the outer JS string at the wrong point, and Node raises `SyntaxError: Unexpected identifier 'rc1'` at parse time.

The failed run: [actions/runs/26483022824](https://github.com/cameronrye/openzim-mcp/actions/runs/26483022824) (post-#197 merge). The same error fired on the post-#196 merge run too.

## What this changes

- Pass `needs.release-please.outputs.pr` via an env var `RELEASE_PR_JSON` so the github-script body never embeds user-controlled content.
- `JSON.parse` the env var inside the script and read `.number` directly. No more URL-splitting heuristic.
- Defensive error handling: empty input, JSON-parse failure, missing `.number` field — each logs a message and exits cleanly rather than throwing.

## Blast radius

**None** — `notify-release-pr` is a non-load-bearing comment job. It posts a help comment on release-please's release PR; its failure has never blocked an actual release. The fix just stops the spurious red-mark spam on every release-please trigger.

## Tests

Can't trigger release-please from a feature branch, so this is verified by inspection: the github-script body is now content-agnostic (no `${{ }}` interpolation inside the script), and `JSON.parse` of a valid release-please output yields a properly-typed object with `.number`.
