### PR TITLE
docs: comprehensive v2.0.0 surface update across README, website, deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@
 
 ---
 
-> 🆕 **NEW in v1.1.0: Structured tool output!** All 17 JSON-returning tools now emit MCP `structuredContent` alongside the legacy text envelope — no more double-stringified JSON, no more escape soup. Plus a major namespace-handling fix for new-scheme archives (`list_namespaces` / `browse_namespace` / `walk_namespace` were silently broken on Wikipedia-style ZIMs), pagination for `extract_article_links`, case-insensitive `find_entry_by_title` with proper scoring, and CORS support for browser MCP clients. [Learn more →](#whats-new-in-v110)
+> 🆕 **NEW in v2.0.0: 8-tool advanced surface.** Phase F collapses the 22 advanced-mode tools into 8 consolidated ones — `zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`. The advanced-mode wire footprint drops from ~36KB to ~23.5KB, clearing the [MCP Tax](https://www.mmntm.net/articles/mcp-context-tax) pain band (25–50KB schema) for small-model dispatch. Migration is mechanical and 1-to-1; see the [v1 → v2 migration table](#migration) and the [Stage E F2 verdict](CHANGELOG.md#200--2026-05-27--phase-f-stage-d-ships) in the v2.0.0 changelog. [Learn more →](#whats-new-in-v200)
 >
-> Still on the v1.0.0 highlights? Streamable HTTP transport, batch entry retrieval, and per-entry resources are documented in the [v1.0.0 section](#whats-new-in-v100).
+> Still on a v1.x release? Highlights for [v1.2.0](#whats-new-in-v120), [v1.1.0](#whats-new-in-v110), and [v1.0.0](#whats-new-in-v100) remain documented below. v1.x is in maintenance mode (security + data-corruption + pre-v2.0.0 crash fixes accepted; no new features) until the FIRST of `{v2.5.0 ships, 2026-11-27}`.
 
-> **Dual Mode Support:** Choose between Simple mode (1 intelligent natural language tool, default) or Advanced mode (21 specialized tools, plus 3 MCP prompts and 3 MCP resources) to match your LLM's capabilities.
+> **Dual Mode Support:** Choose between Simple mode (1 intelligent natural language tool, default) or Advanced mode (8 specialized tools, plus 3 MCP prompts and 3 MCP resources) to match your LLM's capabilities.
 
 ## Built for LLM Intelligence
 
@@ -64,7 +64,7 @@ Whether you're building a research assistant, knowledge chatbot, or content anal
 
 ## Features
 
-- **Dual Mode Support**: Choose between Simple mode (1 intelligent natural language tool, default) or Advanced mode (21 specialized tools)
+- **Dual Mode Support**: Choose between Simple mode (1 intelligent natural language tool, default) or Advanced mode (8 specialized tools)
 - **Streamable HTTP Transport**: 🆕 Run as a long-running service over HTTP — bearer-token auth, CORS, health endpoints, multi-arch Docker image, and resource subscriptions
 - **Batch Entry Retrieval**: 🆕 Fetch up to 50 entries per call with `get_zim_entries` — pairs naturally with HTTP, where round-trip cost matters
 - **Per-Entry MCP Resources**: 🆕 Stream individual entries via `zim://{name}/entry/{path}` with native MIME types — browse HTML, PDFs, and images directly
@@ -476,7 +476,7 @@ mkdir ~/zim-files
 openzim-mcp /path/to/zim/files
 python -m openzim_mcp /path/to/zim/files
 
-# Advanced mode - all 21 specialized tools
+# Advanced mode - all 8 specialized tools
 openzim-mcp --mode advanced /path/to/zim/files
 python -m openzim_mcp --mode advanced /path/to/zim/files
 
@@ -493,7 +493,7 @@ make run ZIM_DIR=/path/to/zim/files
 OpenZIM MCP supports two modes:
 
 - **Simple Mode** (default): Provides 1 intelligent tool (`zim_query`) that accepts natural language queries
-- **Advanced Mode**: Exposes all 21 specialized MCP tools for maximum control
+- **Advanced Mode**: Exposes all 8 specialized MCP tools (`zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`) for maximum control
 
 ### MCP Configuration
 
@@ -1615,7 +1615,7 @@ export OPENZIM_MCP_SERVER_NAME=my_openzim_mcp_server
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `OPENZIM_MCP_TOOL_MODE` | `simple` | Tool surface: `simple` (one `zim_query` tool) or `advanced` (21 specialized tools). Controlled by `--tool-mode` on the CLI as well. |
+| `OPENZIM_MCP_TOOL_MODE` | `simple` | Tool surface: `simple` (one `zim_query` tool) or `advanced` (8 specialized tools). Controlled by `--tool-mode` on the CLI as well. |
 | `OPENZIM_MCP_TRANSPORT` | `stdio` | Transport protocol: `stdio`, `http`, or `sse`. |
 | `OPENZIM_MCP_HOST` | `127.0.0.1` | HTTP/SSE bind host. Non-loopback hosts require `OPENZIM_MCP_AUTH_TOKEN`. |
 | `OPENZIM_MCP_PORT` | `8000` | HTTP/SSE bind port. |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -107,7 +107,7 @@ This recipe puts OpenZIM MCP on a single host, reachable from the rest of your L
 ```yaml
 services:
   openzim-mcp:
-    image: ghcr.io/cameronrye/openzim-mcp:1.2.0
+    image: ghcr.io/cameronrye/openzim-mcp:2.0.0
     restart: unless-stopped
     ports:
       - "127.0.0.1:8000:8000"
@@ -117,9 +117,11 @@ services:
       OPENZIM_MCP_AUTH_TOKEN: "${OPENZIM_MCP_AUTH_TOKEN}"
 ```
 
+> Still running v1.x? The `ghcr.io/cameronrye/openzim-mcp:1.2.0` image stays available; v1.x is in maintenance mode (security + data-corruption + pre-v2.0.0 crash fixes accepted; no new features) until the FIRST of `{v2.5.0 ships, 2026-11-27}`. The v2.0.0 advanced tool surface is a breaking rename per [CHANGELOG.md](../CHANGELOG.md#200--2026-05-27--phase-f-stage-d-ships) — migrate when convenient.
+
 What's intentional here:
 
-- **Pinned tag** (`:1.2.0`, not `:latest`). Upgrades are deliberate — `docker compose pull` is a thing you do, not a thing that happens to you.
+- **Pinned tag** (`:2.0.0`, not `:latest`). Upgrades are deliberate — `docker compose pull` is a thing you do, not a thing that happens to you.
 - **Host port bound to `127.0.0.1`**. The container listens on all interfaces (the image's default `OPENZIM_MCP_HOST=0.0.0.0`), but Docker's port publish restricts external exposure to loopback. The Tailscale variant below lifts this restriction by binding to a specific interface.
 - **Read-only ZIM mount** (`:ro`). The server only reads ZIM files; mounting read-only ensures a server compromise can't damage them.
 - **Token via env, not hard-coded.** Put it in a `.env` file next to the compose file (and add `.env` to `.gitignore`). The image's defaults already set `TRANSPORT=http`, `HOST=0.0.0.0`, `PORT=8000`, so they're not repeated here.
@@ -227,7 +229,7 @@ This is the LAN compose file with two changes: a `caddy` service is added, and t
 ```yaml
 services:
   openzim-mcp:
-    image: ghcr.io/cameronrye/openzim-mcp:1.2.0
+    image: ghcr.io/cameronrye/openzim-mcp:2.0.0
     restart: unless-stopped
     expose:
       - "8000"
@@ -313,7 +315,7 @@ docker compose pull
 docker compose up -d
 ```
 
-The image tag in `docker-compose.yml` is pinned (`:1.2.0`) — change it to the new version before pulling. Pinning is deliberate: `:latest` makes upgrades a surprise, and the v1 release notes (or future v1.x release notes) tell you when an upgrade involves a breaking change.
+The image tag in `docker-compose.yml` is pinned (`:2.0.0`) — change it to the new version before pulling. Pinning is deliberate: `:latest` makes upgrades a surprise, and the release notes for each tag tell you when an upgrade involves a breaking change. The v1.x → v2.0.0 jump is a breaking rename of the advanced-mode tool surface (22 tools → 8); see the [v1 → v2 migration table](../CHANGELOG.md#migrating-from-v1x--v2-beta) before bumping.
 
 ### Watching logs
 

--- a/openzim_mcp/main.py
+++ b/openzim_mcp/main.py
@@ -25,7 +25,7 @@ Examples:
   python -m openzim_mcp /path/to/zim/files
   python -m openzim_mcp --mode simple /path/to/zim/files
 
-  # Advanced mode (all 21 tools)
+  # Advanced mode (all 8 tools)
   python -m openzim_mcp --mode advanced /path/to/zim/files
 
 Environment Variables:
@@ -42,7 +42,7 @@ Environment Variables:
         choices=list(VALID_TOOL_MODES),
         default=None,
         help=(
-            f"Tool mode: 'advanced' for all 21 tools, 'simple' for 1 "
+            f"Tool mode: 'advanced' for all 8 tools, 'simple' for 1 "
             f"intelligent NL tool "
             f"(default: {TOOL_MODE_SIMPLE}, or from OPENZIM_MCP_TOOL_MODE env var)"
         ),
@@ -134,7 +134,7 @@ def main() -> None:
         mode_desc = (
             "SIMPLE mode (1 intelligent tool)"
             if config.tool_mode == TOOL_MODE_SIMPLE
-            else "ADVANCED mode (21 specialized tools)"
+            else "ADVANCED mode (8 specialized tools)"
         )
         # Route the startup banner through the logger so log-level configuration
         # (env: ``OPENZIM_MCP_LOGGING__LEVEL``) actually suppresses it. The

--- a/website/humans.txt
+++ b/website/humans.txt
@@ -60,8 +60,8 @@
 
 # SITE
 
-    Last update: 2026-05-03
+    Last update: 2026-05-27
     Language: English
     Doctype: HTML5
     IDE: Various (VS Code, Vim, etc.)
-    Version: 1.2.0
+    Version: 2.0.0

--- a/website/index.html
+++ b/website/index.html
@@ -20,14 +20,14 @@
   <meta property="og:site_name" content="OpenZIM MCP">
   <meta property="og:url" content="https://cameronrye.github.io/openzim-mcp/">
   <meta property="og:title" content="OpenZIM MCP — Knowledge that works offline">
-  <meta property="og:description" content="MCP server for offline ZIM-archive access. Streamable HTTP, batch retrieval, per-entry resources, subscriptions. v1.2.0.">
+  <meta property="og:description" content="MCP server for offline ZIM-archive access. 8-tool advanced surface, streamable HTTP, batch retrieval, per-entry resources, subscriptions. v2.0.0.">
   <meta property="og:image" content="https://cameronrye.github.io/openzim-mcp/assets/og-image.svg">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:alt" content="OpenZIM MCP 1.0 — Knowledge that works offline">
   <meta property="og:locale" content="en_US">
   <meta property="article:author" content="Cameron Rye">
-  <meta property="article:modified_time" content="2026-05-05T00:00:00Z">
+  <meta property="article:modified_time" content="2026-05-27T00:00:00Z">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
@@ -35,7 +35,7 @@
   <meta name="twitter:creator" content="@cameronrye">
   <meta name="twitter:url" content="https://cameronrye.github.io/openzim-mcp/">
   <meta name="twitter:title" content="OpenZIM MCP — Knowledge that works offline">
-  <meta name="twitter:description" content="MCP server for offline ZIM-archive access. Streamable HTTP, batch retrieval, per-entry resources, subscriptions. v1.2.0.">
+  <meta name="twitter:description" content="MCP server for offline ZIM-archive access. 8-tool advanced surface, streamable HTTP, batch retrieval, per-entry resources, subscriptions. v2.0.0.">
   <meta name="twitter:image" content="https://cameronrye.github.io/openzim-mcp/assets/og-image.svg">
   <meta name="twitter:image:alt" content="OpenZIM MCP 1.0 — Knowledge that works offline">
 
@@ -72,7 +72,7 @@
     "alternateName": "OpenZIM MCP Server",
     "description": "A modern, secure MCP server that enables AI models to access and search ZIM format knowledge bases offline with intelligent, structured access patterns",
     "url": "https://cameronrye.github.io/openzim-mcp/",
-    "softwareVersion": "1.2.0",
+    "softwareVersion": "2.0.0",
     "releaseNotes": "https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md",
     "applicationCategory": "DeveloperApplication",
     "applicationSubCategory": "AI Tools",
@@ -121,7 +121,7 @@
     "description": "MCP server for offline ZIM-archive access. Streamable HTTP transport, batch retrieval, per-entry resources, resource subscriptions.",
     "author": { "@type": "Person", "name": "Cameron Rye", "url": "https://rye.dev" },
     "datePublished": "2024-01-01T00:00:00Z",
-    "dateModified": "2026-05-03T00:00:00Z",
+    "dateModified": "2026-05-27T00:00:00Z",
     "publisher": {
       "@type": "Organization",
       "name": "OpenZIM MCP",
@@ -182,7 +182,7 @@
     <section id="hero" class="hero">
       <div class="container hero__inner">
         <div class="hero__content">
-          <span class="eyebrow">MCP&nbsp;SERVER · v1.2.0</span>
+          <span class="eyebrow">MCP&nbsp;SERVER · v2.0.0</span>
           <h1 class="hero__title">Knowledge that works offline.</h1>
           <p class="hero__lead">
             OpenZIM MCP gives any AI model structured, secure access to ZIM archives —
@@ -204,8 +204,8 @@
             </button>
           </div>
           <ul class="hero__stats">
-            <li><span class="hero__stat-num">v1.2.0</span><span class="hero__stat-label">Latest release</span></li>
-            <li><span class="hero__stat-num">1 + 21</span><span class="hero__stat-label">Simple / advanced tools</span></li>
+            <li><span class="hero__stat-num">v2.0.0</span><span class="hero__stat-label">Latest release</span></li>
+            <li><span class="hero__stat-num">1 + 8</span><span class="hero__stat-label">Simple / advanced tools</span></li>
             <li><span class="hero__stat-num">80%+</span><span class="hero__stat-label">Test coverage</span></li>
             <li><span class="hero__stat-num">MIT</span><span class="hero__stat-label">License</span></li>
           </ul>
@@ -304,7 +304,7 @@
           </li>
           <li>
             <h3>Structured</h3>
-            <p>Search, browse, summarize, traverse — one intelligent NL tool by default, or 21 specialized tools in advanced mode, designed for how LLMs actually consume knowledge.</p>
+            <p>Search, browse, summarize, traverse — one intelligent NL tool by default, or 8 specialized tools in advanced mode, designed for how LLMs actually consume knowledge.</p>
           </li>
         </ul>
 
@@ -333,7 +333,7 @@
             <pre><code>docker run -p 8000:8000 \
   -e OPENZIM_MCP_AUTH_TOKEN="$TOKEN" \
   -v /path/to/zim:/data:ro \
-  ghcr.io/cameronrye/openzim-mcp:1.2.0 \
+  ghcr.io/cameronrye/openzim-mcp:2.0.0 \
   --transport http --host 0.0.0.0 /data</code></pre>
           </li>
 
@@ -447,7 +447,7 @@ zim://gutenberg/entry/I%2Fbook_cover.jpg
                 <pre><code>uv tool install openzim-mcp</code></pre>
               </div>
               <div class="tabs__panel" id="install-docker" role="tabpanel" aria-labelledby="tab-install-docker" hidden>
-                <pre><code>docker pull ghcr.io/cameronrye/openzim-mcp:1.2.0</code></pre>
+                <pre><code>docker pull ghcr.io/cameronrye/openzim-mcp:2.0.0</code></pre>
               </div>
               <div class="tabs__panel" id="install-source" role="tabpanel" aria-labelledby="tab-install-source" hidden>
                 <pre><code>git clone https://github.com/cameronrye/openzim-mcp.git

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -6,7 +6,7 @@
 
 OpenZIM MCP is a Model Context Protocol (MCP) server that enables AI models to access and search ZIM format knowledge bases offline. It provides intelligent, structured access patterns that LLMs need to effectively navigate vast knowledge repositories like Wikipedia, Wiktionary, and other offline content archives.
 
-**Version**: 2.0.0rc1 <!-- x-release-please-version -->
+**Version**: 2.0.0 <!-- x-release-please-version -->
 **License**: MIT
 **Python**: 3.12+
 **Repository**: https://github.com/cameronrye/openzim-mcp
@@ -14,7 +14,7 @@ OpenZIM MCP is a Model Context Protocol (MCP) server that enables AI models to a
 
 ## Key Features
 
-- **Dual Mode Support**: Simple mode (1 intelligent natural language tool) or Advanced mode (21 specialized tools, plus 3 MCP prompts and 3 MCP resources)
+- **Dual Mode Support**: Simple mode (1 intelligent natural language tool) or Advanced mode (8 specialized tools, plus 3 MCP prompts and 3 MCP resources)
 - **Smart Navigation**: Browse by namespace (articles, metadata, media) with intelligent path resolution
 - **Context-Aware Discovery**: Get article structure, link graph, and metadata
 - **Intelligent Search**: Advanced filtering, auto-complete suggestions, relevance-ranked results
@@ -39,7 +39,7 @@ pip install openzim-mcp
 # Simple mode (default) - 1 intelligent natural language tool
 openzim-mcp /path/to/zim/files
 
-# Advanced mode - 21 specialized tools
+# Advanced mode - 8 specialized tools
 openzim-mcp --mode advanced /path/to/zim/files
 
 # Streamable HTTP transport
@@ -87,38 +87,16 @@ Automatic fallback from direct access to search-based retrieval:
 
 ### Advanced Mode
 
-**File & metadata**
-- `list_zim_files`: List available ZIM archives
-- `get_zim_metadata`: Get archive metadata
-- `get_main_page`: Get archive main page
-- `list_namespaces`: Enumerate namespaces with entry counts
+v2.0.0 collapses the prior 22-tool advanced surface into 8 consolidated tools (see CHANGELOG.md for the full v1→v2 migration table).
 
-**Search**
-- `search_zim_file`: Full-text search within a ZIM file
-- `search_with_filters`: Search with namespace/content-type filters
-- `search_all`: Cross-archive full-text search
-- `get_search_suggestions`: Title-based auto-complete
-
-**Content retrieval**
-- `get_zim_entry`: Retrieve a single entry by path
-- `get_zim_entries`: Batch entry retrieval
-- `get_binary_entry`: Retrieve binary content (PDFs, images, media)
-
-**Navigation**
-- `browse_namespace`: Sample entries in a namespace
-- `walk_namespace`: Cursor-paginated deterministic namespace iteration
-- `find_entry_by_title`: Resolve a title to entry path(s)
-
-**Structure & relationships**
-- `get_article_structure`: Headings tree
-- `get_table_of_contents`: Hierarchical TOC
-- `get_entry_summary`: Opening-paragraph summary
-- `extract_article_links`: Internal and external links
-- `get_related_articles`: Outbound link-graph neighbours
-
-**Server diagnostics**
-- `get_server_health`: Cache, directory, and ZIM-file health checks
-- `get_server_configuration`: Active configuration and validation
+- `zim_query`: Natural-language entry point (same tool as simple mode; available in advanced too)
+- `zim_search`: Full-text / title / suggest search dispatch (replaces `search_zim_file`, `search_all`, `search_with_filters`, `find_entry_by_title`, `get_search_suggestions`). Modes: `mode="fulltext" | "title" | "suggest"`; optional `cross_file=True` for multi-archive search
+- `zim_get`: Single / batch / binary / main-page entry fetch (replaces `get_zim_entry`, `get_zim_entries`, `get_main_page`, `get_binary_entry`, `get_entry_summary`, `get_table_of_contents`, `get_article_structure`). Branches: `entry_path` (single), `entry_paths` (batch), `main_page=True`, `binary=True`, `view="summary" | "toc" | "structure"`
+- `zim_get_section`: Section-level fetch by section ID (renamed from `get_section`)
+- `zim_browse`: Namespace browse / walk dispatch (replaces `browse_namespace`, `walk_namespace`). Modes: `mode="browse" | "walk"`
+- `zim_metadata`: Combined archive metadata + namespaces (replaces `get_zim_metadata`, `list_namespaces`)
+- `zim_links`: Outbound / related link dispatch (replaces `extract_article_links`, `get_related_articles`). Directions: `direction="outbound" | "related"` (inbound arrives in v2.5)
+- `zim_health`: Combined server health, configuration, and loaded archives (replaces `get_server_health`, `get_server_configuration`, `list_zim_files`)
 
 ### MCP Prompts
 - `/research <topic>`: Search across all archives, then drill into top hits
@@ -135,31 +113,31 @@ Automatic fallback from direct access to search-based retrieval:
 ### Research Assistant
 ```python
 # Search for articles on a topic
-search_zim_file(zim_file_path="wikipedia_en.zim", query="quantum physics", limit=10)
+zim_search(query="quantum physics", zim_file_path="wikipedia_en.zim", limit=10)
 
 # Get article content
-get_zim_entry(zim_file_path="wikipedia_en.zim", entry_path="C/Quantum_mechanics")
+zim_get(zim_file_path="wikipedia_en.zim", entry_path="C/Quantum_mechanics")
 
 # Discover related articles
-get_related_articles(zim_file_path="wikipedia_en.zim", entry_path="C/Quantum_mechanics")
+zim_links(zim_file_path="wikipedia_en.zim", entry_path="C/Quantum_mechanics", direction="related")
 ```
 
 ### Knowledge Chatbot
 ```python
 # Get main page for context
-get_main_page(zim_file_path="wikipedia_en.zim")
+zim_get(zim_file_path="wikipedia_en.zim", main_page=True)
 
 # Auto-complete on partial titles
-get_search_suggestions(zim_file_path="wikipedia_en.zim", query="artif")
+zim_search(query="artif", zim_file_path="wikipedia_en.zim", mode="suggest")
 ```
 
 ### Content Analysis
 ```python
-# List namespaces with counts
-list_namespaces(zim_file_path="wikipedia_en.zim")
+# Combined archive metadata + namespaces with counts
+zim_metadata(zim_file_path="wikipedia_en.zim")
 
 # Walk a namespace deterministically
-walk_namespace(zim_file_path="wikipedia_en.zim", namespace="C", limit=200)
+zim_browse(zim_file_path="wikipedia_en.zim", namespace="C", mode="walk", limit=200)
 ```
 
 ## Important Notes


### PR DESCRIPTION
## Summary

Comprehensive documentation update aligning user-facing surfaces with the v2.0.0 ship (22→8 tool collapse, v1.2.0 / 2.0.0rc1 version strings → 2.0.0).

## Surfaces updated

| File | Changes |
| --- | --- |
| `README.md` | New v2.0.0 announcement banner replaces v1.1.0 banner; 5 sites bumped from "21 specialized tools" → 8; v1.x maintenance-mode pointer added |
| `openzim_mcp/main.py` | CLI argparse help text + startup log banner from "21 tools" → "8 tools" (3 sites). Ships in `openzim-mcp --help` |
| `website/index.html` | OG/Twitter/JSON-LD/article-modified meta tags v1.2.0 → v2.0.0; hero eyebrow + stats; feature card; 2 docker pull examples |
| `website/llms.txt` | Version 2.0.0rc1 → 2.0.0; Available Tools section rewritten to 8-tool surface with mode/branch hints; Common Use Cases examples rewritten |
| `website/humans.txt` | Site Version 1.2.0 → 2.0.0; Last update 2026-05-27 |
| `docs/deployment.md` | docker-compose example tags :1.2.0 → :2.0.0 (4 sites); v1.x-maintenance-mode note added so v1.x users know the v1.2.0 image stays available |

## What was intentionally preserved

- `## What's new in v1.2.0`, `v1.1.0`, `v1.0.0`, `v2.0.0a1/a2` sections in README.md (historical record)
- Code comments referencing v1.2.0 byte-identical behavior (`openzim_mcp/content_processor.py`, `openzim_mcp/zim/search.py`) — semantic-versioning compatibility statements
- `tests/test_phase_f_migration.py` reference to "## [2.0.0rc1]" in CHANGELOG (the rc1 section is still in CHANGELOG.md)
- `tests/dispatch_eval/runner.py` docstring references to `v2.0.0rc1` — runner's variant=rc1 mode references the rc1 worktree pattern
- `docs/v2/`, `docs/v2.5/`, `docs/superpowers/specs/` — historical design / spec record
- CHANGELOG.md `[2.0.0rc1]` / `[2.0.0rc0]` / `[2.0.0b*]` sections — chronological release log
- `website/index.html`'s "v1.0.0 ships streamable HTTP..." section — that retrospective describes what v1.0.0 introduced, intentionally past-tense; its code examples were updated to current image tag

## Out of scope (known follow-up)

**GitHub Wiki** is a separate repo (`openzim-mcp.wiki.git`, 4,691 lines across 14 pages). 14 of 15 pages have stale references — API-Reference (18KB) and Architecture-Overview (19KB) are the heaviest. I audited but did not modify. Treatment pending operator decision: surgical edits vs full rewrite vs phased per-page approach.

## Verification

- `uv run black --check`: 204 files unchanged ✓
- Targeted tests pass: `test_phase_f_migration` (28), `test_phase_f_packaging` (1), `test_phase_f_schema_budget` (7) ✓
- CLI smoke test: `openzim-mcp --help` shows "all 8 tools" ✓
- Repo-wide grep for "21 specialized" / "21 tools" / "21-tool" / "1 + 21" in user-facing files: 0 hits ✓
- Repo-wide grep for "2.0.0rc1" in user-facing files: 0 hits ✓ (only intentional rc1 refs remain in tests + plan docs)
