### PR TITLE
docs: drop v2.5 references from README + website/llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 
 > 🆕 **NEW in v2.0.0: 8-tool advanced surface.** Phase F collapses the 22 advanced-mode tools into 8 consolidated ones — `zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`. The advanced-mode wire footprint drops from ~36KB to ~23.5KB, clearing the [MCP Tax](https://www.mmntm.net/articles/mcp-context-tax) pain band (25–50KB schema) for small-model dispatch. Migration is mechanical and 1-to-1; see the [v1 → v2 migration table](#migration) and the [Stage E F2 verdict](CHANGELOG.md#200--2026-05-27--phase-f-stage-d-ships) in the v2.0.0 changelog. [Learn more →](#whats-new-in-v200)
 >
-> Still on a v1.x release? Highlights for [v1.2.0](#whats-new-in-v120), [v1.1.0](#whats-new-in-v110), and [v1.0.0](#whats-new-in-v100) remain documented below. v1.x is in maintenance mode (security + data-corruption + pre-v2.0.0 crash fixes accepted; no new features) until the FIRST of `{v2.5.0 ships, 2026-11-27}`.
+> Still on a v1.x release? Highlights for [v1.2.0](#whats-new-in-v120), [v1.1.0](#whats-new-in-v110), and [v1.0.0](#whats-new-in-v100) remain documented below. v1.x is in maintenance mode (security + data-corruption + pre-v2.0.0 crash fixes accepted; no new features) through 2026-11-27.
 
 > **Dual Mode Support:** Choose between Simple mode (1 intelligent natural language tool, default) or Advanced mode (8 specialized tools, plus 3 MCP prompts and 3 MCP resources) to match your LLM's capabilities.
 

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -95,7 +95,7 @@ v2.0.0 collapses the prior 22-tool advanced surface into 8 consolidated tools (s
 - `zim_get_section`: Section-level fetch by section ID (renamed from `get_section`)
 - `zim_browse`: Namespace browse / walk dispatch (replaces `browse_namespace`, `walk_namespace`). Modes: `mode="page" | "walk"` (default `"page"` — sampled namespace overview; `"walk"` returns cursor-paginated deterministic iteration)
 - `zim_metadata`: Combined archive metadata + namespaces (replaces `get_zim_metadata`, `list_namespaces`)
-- `zim_links`: Outbound / related link dispatch (replaces `extract_article_links`, `get_related_articles`). Directions: `direction="outbound" | "related"` (inbound arrives in v2.5)
+- `zim_links`: Outbound / related link dispatch (replaces `extract_article_links`, `get_related_articles`). Directions: `direction="outbound" | "related"`
 - `zim_health`: Combined server health, configuration, and loaded archives (replaces `get_server_health`, `get_server_configuration`, `list_zim_files`)
 
 ### MCP Prompts


### PR DESCRIPTION
## Summary

Removes forward-looking `v2.5` product mentions from the two user-facing surfaces.

## Changes

- **`README.md` (1 line)** — v1.x maintenance window: `until the FIRST of `{v2.5.0 ships, 2026-11-27}`` → `through 2026-11-27`. The calendar EOL date is preserved; the v2.5.0-ships co-trigger drops out.
- **`website/llms.txt` (1 line)** — `zim_links` description: removed the `(inbound arrives in v2.5)` parenthetical. The `direction` enum still lists the v2.0.0 ship values (`"outbound" | "related"`).

## Intentionally preserved

- **`README.md` line 143** — `Qwen-2.5-7B-Instruct` is the model name used for the Phase F dispatch eval, not a reference to openzim-mcp v2.5.
- **`openzim_mcp/tools/zim_links_description.md`, `zim_get_description.md`, `zim_get_section_description.md`** — these are code (tool descriptions shipped via package data) and document v2.0 surface behaviors that explicitly defer to v2.5 (zim_links inbound, zim_get compact default, zim_get_section raw-text path). Out of scope for a README/website-only request.
- **CHANGELOG `[2.0.0]` section** — historical record; the v2.5-bound rollover notes in there are part of the release log.

## Test plan

- Repo-wide grep for `v2.5` in README.md + website/ (excluding SVG path / CSS coordinate noise + Qwen-2.5 model name): **0 hits** ✓
