### PR TITLE
docs: restore ❤️ in 'Made with' attribution (README + landing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,4 +144,4 @@ MIT. See [LICENSE](LICENSE).
 
 ---
 
-Made with care by [Cameron Rye](https://rye.dev)
+Made with ❤️ by [Cameron Rye](https://rye.dev)

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -637,7 +637,7 @@ artificial intelligence...</code></pre>
             <path d="M12 8h8"/>
           </g>
         </svg>
-        <span>Made with care by <a href="https://rye.dev" target="_blank" rel="noopener">Cameron Rye</a>.</span>
+        <span>Made with ❤️ by <a href="https://rye.dev" target="_blank" rel="noopener">Cameron Rye</a>.</span>
       </div>
     </div>
   </footer>


### PR DESCRIPTION
PR #205 + #207 dropped the heart from the landing-page footer and README acknowledgments during the v1→v2 refresh and README slim. llms.txt kept it. Restoring so all three attribution lines agree.