### PR TITLE
fix: post-v2.0.0 beta-test sweep — 7 dispatcher defects + website 3-pass audit

### DIFF
--- a/openzim_mcp/intent_parser.py
+++ b/openzim_mcp/intent_parser.py
@@ -178,6 +178,47 @@ def _extract_filtered_search(query: str, params: Dict[str, Any]) -> None:
         params["content_type"] = type_match.group(1)
 
 
+# Post-v2.0.0 D-C/D-D fallback: when the shared keyworded extractor
+# finds no canonical ``article|entry|page|of|for|in|from|to`` anchor,
+# fall back to peeling a leading intent-keyword prefix. Covers the
+# bare-verb forms surfaced by the v2.0.0 live sweep:
+#
+#   structure Photosynthesis    summary Photosynthesis
+#   outline Photosynthesis      summarize Photosynthesis
+#   sections Photosynthesis     overview Photosynthesis
+#   headings Photosynthesis     toc Photosynthesis
+#   table of contents X         contents Photosynthesis
+#   show structure Photosynthesis
+#
+# The optional ``show|display|give|tell`` preamble (with optional
+# ``me``/``the``) handles natural-language preambles. Each verb is the
+# same one that lights up the corresponding intent regex; if a future
+# contributor widens the intent regex (e.g. adds ``layout`` as a
+# structure synonym) the prefix set must be widened in lockstep —
+# pinned by ``TestEntryPathExtractorVerbSetCanonicalPin`` in the
+# post-v2.0.0 sweep file.
+_LEADING_INTENT_KEYWORDS_RE = re.compile(
+    r"^\s*"
+    r"(?:(?:show|display|give|tell)\s+(?:me\s+)?(?:the\s+)?)?"
+    r"(?:"
+    r"table\s+of\s+contents|"
+    r"structure|outline|sections?|headings?|"
+    r"summary|summarize|summarise|overview|brief|"
+    r"toc|contents"
+    r")"
+    r"\b\s+",
+    re.IGNORECASE,
+)
+
+# Post-v2.0.0 D-C: when the canonical-keyword extractor anchors on
+# ``of`` inside ``table of contents X``, the captured tail is
+# ``contents X``. Peel the leading ``contents`` token so the
+# downstream path-resolver sees ``X``. Confined to a leading position
+# so legitimate entries containing the word ``contents`` mid-title
+# (rare but possible) are untouched.
+_TAIL_LEADING_CONTENTS_RE = re.compile(r"^contents\s+", re.IGNORECASE)
+
+
 def _extract_entry_path_keyworded(query: str, params: Dict[str, Any]) -> None:
     """Shared extractor for get_article / structure / links / toc / summary.
 
@@ -190,6 +231,14 @@ def _extract_entry_path_keyworded(query: str, params: Dict[str, Any]) -> None:
     silently truncated, dropping the user at the wrong article (the
     common silent-fall-through failure mode for ``show structure of
     United States`` returning the ``United`` disambig page).
+
+    Post-v2.0.0 D-C / D-D additions: when no canonical anchor matches,
+    fall back to stripping a leading intent-keyword prefix
+    (``structure``/``summary``/``toc``/etc.) so bare-verb forms
+    ``structure Photosynthesis`` and ``toc Photosynthesis`` resolve
+    correctly. When the canonical anchor matched on ``of`` inside
+    ``table of contents X``, peel the leading ``contents`` token from
+    the tail so ``X`` survives as the entry_path.
 
     The downstream :meth:`SimpleToolsHandler._resolve_natural_language_path`
     helper then runs the captured tail through ``find_title_match`` so a
@@ -213,11 +262,27 @@ def _extract_entry_path_keyworded(query: str, params: Dict[str, Any]) -> None:
         re.IGNORECASE,
     )
     matches = list(keyword_re.finditer(query))
-    if not matches:
+    if matches:
+        tail = query[matches[-1].end() :].strip().rstrip("?.,;:!").strip()
+        # Post-v2.0.0 D-C: ``table of contents X`` anchors on ``of`` →
+        # tail = ``contents X``. Peel the leading ``contents`` so the
+        # downstream resolver sees ``X``.
+        cleaned = _TAIL_LEADING_CONTENTS_RE.sub("", tail, count=1).strip()
+        if cleaned and cleaned != tail:
+            tail = cleaned
+        if tail:
+            params["entry_path"] = tail
         return
-    tail = query[matches[-1].end() :].strip().rstrip("?.,;:!").strip()
-    if tail:
-        params["entry_path"] = tail
+
+    # Post-v2.0.0 D-D fallback: no canonical anchor — the intent verb
+    # itself acts as the of/for anchor (``structure X``, ``summary X``,
+    # ``toc X``). Strip the leading verb (with optional show/give
+    # preamble) and use the remainder as the entry_path.
+    prefix_match = _LEADING_INTENT_KEYWORDS_RE.match(query)
+    if prefix_match:
+        tail = query[prefix_match.end() :].strip().rstrip("?.,;:!").strip()
+        if tail:
+            params["entry_path"] = tail
 
 
 def _extract_binary(query: str, params: Dict[str, Any]) -> None:
@@ -547,6 +612,36 @@ def _extract_get_section(query: str, params: Dict[str, Any]) -> None:
         params["entry_path"] = m.group(2).strip().rstrip("?.,;:!")
 
 
+# Post-v2.0.0 D-B: filename hint extractor for the ``metadata`` intent.
+# ``metadata for wikipedia_en_all_maxi_2026-02.zim`` carries the target
+# file name in the query body; pre-fix the parser ignored it and the
+# dispatcher's no-zim-file gate fired when 2+ archives were loaded. The
+# hint is stashed in ``params["metadata_target"]`` and resolved against
+# ``zim_operations.list_zim_files_data()`` in the dispatcher.
+#
+# Limited to ``.zim``-suffixed tokens — a permissive bare-name match
+# would collide with phrasings like ``info about Python`` (where
+# ``Python`` is a topic, not a file). The ``.zim`` suffix is the
+# canonical disambiguator.
+_METADATA_FILENAME_RE = re.compile(
+    r"\b(metadata|info|details?)\s+(?:for|about|of)\s+" r"([A-Za-z0-9_.\-]+\.zim)\b",
+    re.IGNORECASE,
+)
+
+
+def _extract_metadata(query: str, params: Dict[str, Any]) -> None:
+    """Extract a filename hint for the ``metadata`` intent.
+
+    See module-level ``_METADATA_FILENAME_RE`` docstring. Only ``.zim``
+    targets are captured. Bare ``metadata`` (no filename) leaves
+    ``metadata_target`` unset and the dispatcher's existing no-zim-file
+    behaviour kicks in.
+    """
+    match = _METADATA_FILENAME_RE.search(query)
+    if match:
+        params["metadata_target"] = match.group(2)
+
+
 _PARAM_EXTRACTORS = {
     "browse": _extract_browse,
     "filtered_search": _extract_filtered_search,
@@ -565,6 +660,7 @@ _PARAM_EXTRACTORS = {
     "related": _extract_related,
     "get_zim_entries": _extract_get_zim_entries,
     "get_section": _extract_get_section,
+    "metadata": _extract_metadata,
 }
 
 

--- a/openzim_mcp/intent_parser.py
+++ b/openzim_mcp/intent_parser.py
@@ -577,6 +577,14 @@ def _extract_tell_me_about(query: str, params: Dict[str, Any]) -> None:
         topic = safe_regex_sub(r"\s*[,&]\s*$", "", topic).strip()
         if topic == before:
             break
+    # Post-v2.0.0 D-E (extended pass-4): strip a surrounding matched
+    # quote pair so ``tell me about ""`` doesn't survive as the literal
+    # 2-char ``""`` and silently resolve to the ``Empty_string``
+    # Wikipedia article (the same shape D-E fixed for find_by_title,
+    # related, and entry_path_keyworded). Bonus regression upside:
+    # ``tell me about "Photosynthesis"`` now searches the bare topic
+    # instead of the quoted form, which is a cleaner search input.
+    topic = _strip_quote_pair(topic)
     params["topic"] = topic
 
 

--- a/openzim_mcp/intent_parser.py
+++ b/openzim_mcp/intent_parser.py
@@ -66,6 +66,28 @@ _QUOTE_OPEN = f"[{_QUOTE_CHARS}]"
 _QUOTE_NOT = f"[^{_QUOTE_CHARS}]"
 
 
+def _strip_quote_pair(value: str) -> str:
+    """Peel a single surrounding matched quote-pair from ``value`` and
+    trim interior whitespace.
+
+    Post-v2.0.0 D-E: when a caller types ``""`` (or ``''`` / curly
+    equivalents) as an entry path or title, several extractors capture
+    the 2-char literal verbatim, the handler's ``.strip()`` only trims
+    whitespace, and the backend's title-promotion fuzzy-matches the
+    empty input to the ``Empty_string`` article at score 1.00. Stripping
+    surrounding quotes here drops the value cleanly so the handler's
+    missing-arg guard can fire.
+
+    Stripping is opportunistic — both endpoints just need to live in
+    ``_QUOTE_CHARS``. Mixed quote endpoints (``"foo'``) are stripped too
+    so LLM-generated mismatched pairs don't survive as wrong values.
+    Single-char inputs (already < 2 chars) pass through unchanged.
+    """
+    if len(value) >= 2 and value[0] in _QUOTE_CHARS and value[-1] in _QUOTE_CHARS:
+        return value[1:-1].strip()
+    return value
+
+
 def safe_regex_findall(
     pattern: str,
     text: str,
@@ -270,6 +292,13 @@ def _extract_entry_path_keyworded(query: str, params: Dict[str, Any]) -> None:
         cleaned = _TAIL_LEADING_CONTENTS_RE.sub("", tail, count=1).strip()
         if cleaned and cleaned != tail:
             tail = cleaned
+        # Post-v2.0.0 D-E: peel a surrounding quote pair so an
+        # empty-quoted tail (``structure of ""`` / ``get article ""``)
+        # doesn't survive to the backend, which would otherwise
+        # fuzzy-match it to the Empty_string article at score 1.00.
+        # When the quote-pair encloses a real entity (``get article
+        # "Photosynthesis"``) the strip also improves the lookup score.
+        tail = _strip_quote_pair(tail)
         if tail:
             params["entry_path"] = tail
         return
@@ -281,6 +310,8 @@ def _extract_entry_path_keyworded(query: str, params: Dict[str, Any]) -> None:
     prefix_match = _LEADING_INTENT_KEYWORDS_RE.match(query)
     if prefix_match:
         tail = query[prefix_match.end() :].strip().rstrip("?.,;:!").strip()
+        # Post-v2.0.0 D-E: same quote-pair peel as the canonical branch.
+        tail = _strip_quote_pair(tail)
         if tail:
             params["entry_path"] = tail
 
@@ -382,7 +413,12 @@ def _extract_find_by_title(query: str, params: Dict[str, Any]) -> None:
         r"(?:titled|named|called|path\s+for)\s+(.+?)$", query, re.IGNORECASE
     )
     if m:
-        params["title"] = m.group(1).strip().rstrip("?.")
+        title = _strip_quote_pair(m.group(1).strip().rstrip("?."))
+        # Post-v2.0.0 D-E: empty-quoted input must not survive to the
+        # handler — the backend fuzzy-matches '""' to the Empty_string
+        # article at score 1.00.
+        if title:
+            params["title"] = title
 
 
 def _extract_related(query: str, params: Dict[str, Any]) -> None:
@@ -392,7 +428,10 @@ def _extract_related(query: str, params: Dict[str, Any]) -> None:
         re.IGNORECASE,
     )
     if m:
-        params["entry_path"] = m.group(1).strip().rstrip("?.")
+        entry_path = _strip_quote_pair(m.group(1).strip().rstrip("?."))
+        # Post-v2.0.0 D-E: see _extract_find_by_title.
+        if entry_path:
+            params["entry_path"] = entry_path
 
 
 def _extract_tell_me_about(query: str, params: Dict[str, Any]) -> None:

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -899,8 +899,37 @@ class SimpleToolsHandler:
             if intent == "list_files":
                 return self.zim_operations.list_zim_files() + low_confidence_note
 
-            if not zim_file_path:
-                zim_file_path = self._auto_select_zim_file()
+            # Post-v2.0.0 D-A: ``search_all`` is semantically cross-archive
+            # — ``_handle_search_all`` ignores ``zim_file_path`` and
+            # iterates every loaded archive via ``search_all_data`` /
+            # ``search_all``. Pre-fix this intent tripped the
+            # no-zim-file gate when 2+ archives were loaded and the
+            # caller followed the docstring's recommendation to OMIT
+            # the path; the gate blocked the intended cross-archive
+            # query. Mirror the ``list_files`` bypass: route past the
+            # gate and let the handler iterate. Pass any caller-supplied
+            # path through unchanged (the handler ignores it but
+            # downstream low-confidence rendering / telemetry expect a
+            # non-empty string).
+            if intent == "search_all":
+                zim_file_path = zim_file_path or ""
+            elif not zim_file_path:
+                # Post-v2.0.0 D-B: ``metadata for X.zim`` carries a
+                # filename hint that the dispatcher can resolve against
+                # the loaded archives BEFORE the no-zim-file gate fires.
+                # Without this, the multi-archive case (2+ loaded ZIMs)
+                # fails the gate even though the query named the target
+                # in plain text. Only resolves to a real archive path;
+                # unknown filenames still fall through to the gate so
+                # the operator sees a clear error.
+                if intent == "metadata" and isinstance(params, dict):
+                    hint = params.get("metadata_target")
+                    if hint:
+                        resolved = self._resolve_zim_path(hint)
+                        if resolved:
+                            zim_file_path = resolved
+                if not zim_file_path:
+                    zim_file_path = self._auto_select_zim_file()
                 if not zim_file_path:
                     return (
                         "**No ZIM File Specified**\n\n"

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -5463,6 +5463,51 @@ class SimpleToolsHandler:
         except Exception as e:  # pragma: no cover — defensive
             logger.debug("intent_parser failed in synthesize prelude: %s", e)
             intent, params = "search", {}
+        # Post-v2.0.0 D-G: mirror the empty-topic / empty-search guards
+        # the non-synthesize path fires at simple_tools.py:836-887.
+        # Pre-fix, ``tell me about `` (trailing whitespace, empty topic)
+        # with synthesize=True silently searched the literal verb prefix
+        # "tell me about" via BM25 and returned title-prefix matches
+        # (``Tell_Me_About_Tomorrow``, ``Tell_Me_About_Your_Day_Today``).
+        # Same shape for ``tell me about ?`` (punctuation-only) and
+        # ``tell me about ""`` (D-E quoted-empty on the synthesize path).
+        # Return a structured tool_error envelope — synthesize's native
+        # error shape — rather than the markdown the non-synthesize path
+        # emits, since the synthesize return type is already
+        # ``Union[SynthesizeResponse, ToolErrorPayload]``.
+        if intent == "tell_me_about" and isinstance(params, dict):
+            _topic_check = (params.get("topic") or "").strip()
+            if not _topic_check:
+                return tool_error(
+                    operation="topic_required",
+                    message=(
+                        "`tell me about` needs a non-empty topic to look up. "
+                        "Examples: `tell me about Photosynthesis`, "
+                        "`who is Albert Einstein`, `describe DNA`."
+                    ),
+                )
+        elif intent == "search" and isinstance(params, dict):
+            # Mirror the non-synthesize empty-search check at line ~869:
+            # ``_extract_search`` falls back to the whole query when no
+            # tail follows ``search for``, so ``params["query"]`` for
+            # ``search for `` is the full literal "search for " — which
+            # ``.strip()`` reduces to "search for", non-empty. Use
+            # ``_search_query_tail`` which peels the verb prefix and
+            # returns "" when no terms follow.
+            _search_tail = self._search_query_tail(query)
+            if _search_tail is not None:
+                _search_tail = IntentParser._strip_trailing_politeness(
+                    _search_tail
+                ).strip()
+            if _search_tail is not None and not _search_tail:
+                return tool_error(
+                    operation="search_terms_required",
+                    message=(
+                        "`search for` needs at least one search term. "
+                        'Examples: `search for "quantum mechanics"`, '
+                        "`search for Berlin in namespace C`."
+                    ),
+                )
         search_query = query
         if intent == "tell_me_about" and isinstance(params, dict):
             topic = params.get("topic")

--- a/openzim_mcp/tools/zim_get.py
+++ b/openzim_mcp/tools/zim_get.py
@@ -73,6 +73,29 @@ def register(server: "OpenZimMcpServer") -> None:
         compact_budget: Optional[Union[str, int]] = None,
     ) -> Any:
         try:
+            # Post-v2.0.0 D-F (sibling fix from pass-4): mirror the
+            # input-validation envelopes ``zim_query`` adopted in pass-3.
+            # Pre-fix this advanced surface silently passed
+            # ``content_offset < 0`` / ``max_content_length <= 0`` to the
+            # data layer (zim_get accepted negatives and ``<= 0`` meant
+            # "no limit"). Keeping the two surfaces consistent prevents
+            # a misconfigured advanced caller from bypassing the cap.
+            if content_offset < 0:
+                return tool_error(
+                    operation="invalid_content_offset",
+                    message=(
+                        "`content_offset` must be non-negative "
+                        f"(provided: {content_offset})."
+                    ),
+                )
+            if max_content_length is not None and max_content_length < 1:
+                return tool_error(
+                    operation="invalid_max_content_length",
+                    message=(
+                        "`max_content_length` must be a positive integer "
+                        f"(provided: {max_content_length})."
+                    ),
+                )
             err = _validate_branch_combination(
                 entry_path=entry_path,
                 entry_paths=entry_paths,

--- a/openzim_mcp/tools/zim_query.py
+++ b/openzim_mcp/tools/zim_query.py
@@ -80,6 +80,21 @@ def register(server: "OpenZimMcpServer") -> None:
                     operation="invalid_offset",
                     message=(f"`offset` must be non-negative (provided: {offset})."),
                 )
+            # Post-v2.0.0 D-F: `max_content_length` was the only sibling
+            # of `limit` / `offset` / `content_offset` without an upfront
+            # validator. Pre-fix `max_content_length <= 0` silently meant
+            # "no limit" because the truncation site
+            # (`simple_tools.py:3329-3334`) gates on `max_len > 0`. That
+            # contradicts the param contract (positive char-cap) and
+            # diverges from the existing `limit < 1` rejection shape.
+            if max_content_length is not None and max_content_length < 1:
+                return tool_error(
+                    operation="invalid_max_content_length",
+                    message=(
+                        "`max_content_length` must be a positive integer "
+                        f"(provided: {max_content_length})."
+                    ),
+                )
 
             # Simple-mode defaults: 3 results × 4 000-char bodies fit
             # comfortably in an 8B Q4 model's agentic prompt window.

--- a/tests/test_post_v2_0_0_beta_fixes.py
+++ b/tests/test_post_v2_0_0_beta_fixes.py
@@ -92,6 +92,18 @@ Defects span THREE surfaces:
   scores 1.00 instead of 0.95 (the quote-stripped lookup is an exact
   title match instead of fuzzy).
 
+* **D-F — ``max_content_length`` input validation gap.** Pass-3 of the
+  sweep surfaced an input-validation hole: ``zim_query`` validates
+  ``limit < 1`` / ``offset < 0`` / ``content_offset < 0`` upfront with
+  clear ``invalid_<param>`` envelopes, but ``max_content_length``
+  silently treats ``<= 0`` as "no limit" (the truncation site at
+  ``simple_tools.py:3329-3334`` only fires when ``max_len > 0``). Live
+  impact: ``max_content_length=0`` and ``max_content_length=-1`` both
+  bypass the cap and return full article bodies, contradicting the
+  parameter contract. Fix: add ``max_content_length < 1`` validation
+  to ``zim_query.py`` mirroring the existing ``limit`` check, returning
+  ``invalid_max_content_length`` for non-positive values.
+
 The post-v2.0.0 sweep is run from the same ``mcp__openzim-mcp__zim_query``
 surface that the b-series sweeps used. v2.0.0 ships a stable Phase F
 surface (22→8 tool collapse) so this is the first sweep against the
@@ -778,3 +790,99 @@ class TestEmptyQuotedInputDoesNotResolveToEmptyStringArticle:
         # are in the quote set (covers ``"foo'`` and similar
         # LLM-generated mismatched pairs).
         assert _strip_quote_pair("\"hello'") == "hello"
+
+
+# ===========================================================================
+# D-F — max_content_length input validation gap
+# ===========================================================================
+
+
+class TestMaxContentLengthValidation:
+    """`zim_query` already validates `limit` / `offset` / `content_offset`
+    with structured `invalid_<param>` envelopes for out-of-bounds values.
+    Pass-3 surfaced that `max_content_length` skipped this validation —
+    `<= 0` silently bypassed the truncation cap (``simple_tools.py:3332``
+    only fires when ``max_len > 0``), returning full article bodies and
+    contradicting the parameter contract.
+
+    The fix mirrors the existing `limit` check: ``max_content_length < 1``
+    returns an `invalid_max_content_length` envelope upfront.
+    """
+
+    @staticmethod
+    def _call_zim_query(**kwargs: Any) -> Any:
+        """Drive the wire-layer `zim_query` tool wrapper directly.
+
+        The tool is registered against an MCP server; for unit testing we
+        import the module, attach a minimal mocked server with a stub
+        ``simple_tools_handler``, register the tool, then call the
+        underlying coroutine. Returns the (sync) result of awaiting the
+        coroutine — small enough to ``asyncio.run`` per-call without
+        thread pool overhead.
+        """
+        import asyncio
+        from unittest.mock import MagicMock
+
+        from openzim_mcp.tools import zim_query as zq_module
+
+        mock_server = MagicMock()
+        # Capture the registered tool callable so we can invoke it
+        # directly with kwargs.
+        registered: list[Any] = []
+
+        def fake_decorator(*_a: Any, **_kw: Any) -> Any:
+            def wrapper(fn: Any) -> Any:
+                registered.append(fn)
+                return fn
+
+            return wrapper
+
+        mock_server.mcp = MagicMock()
+        mock_server.mcp.tool = fake_decorator
+        mock_server.simple_tools_handler = MagicMock()
+        mock_server.simple_tools_handler.handle_zim_query.return_value = "ok"
+
+        zq_module.register(mock_server)
+        assert registered, "register_zim_query_tool failed to register the tool"
+        tool_fn = registered[0]
+        return asyncio.run(tool_fn(**kwargs))
+
+    def test_max_content_length_zero_rejected(self) -> None:
+        """``max_content_length=0`` → structured invalid_max_content_length
+        envelope, mirroring the existing ``limit=0`` rejection."""
+        result = self._call_zim_query(query="tell me about X", max_content_length=0)
+        assert isinstance(result, dict)
+        assert result.get("error") is True
+        assert result.get("operation") == "invalid_max_content_length", (
+            f"Pre-fix max_content_length=0 silently meant 'no limit' and "
+            f"returned the full article body. Post-fix the tool must "
+            f"return an invalid_max_content_length envelope. "
+            f"Got: {result}"
+        )
+
+    def test_max_content_length_negative_rejected(self) -> None:
+        """``max_content_length=-1`` → same shape."""
+        result = self._call_zim_query(query="tell me about X", max_content_length=-1)
+        assert isinstance(result, dict)
+        assert result.get("error") is True
+        assert result.get("operation") == "invalid_max_content_length"
+
+    def test_max_content_length_positive_accepted(self) -> None:
+        """Regression guard: positive values still route through to the
+        handler."""
+        result = self._call_zim_query(query="tell me about X", max_content_length=4000)
+        # Tool returns the handler's string result on success.
+        assert result == "ok"
+
+    def test_max_content_length_none_accepted(self) -> None:
+        """Regression guard: omitting ``max_content_length`` (the
+        default) still works — the tool falls back to its 4000-char
+        simple-mode default."""
+        result = self._call_zim_query(query="tell me about X")
+        assert result == "ok"
+
+    def test_max_content_length_one_accepted(self) -> None:
+        """Boundary: ``max_content_length=1`` is the smallest legal
+        positive value and must succeed."""
+        result = self._call_zim_query(query="tell me about X", max_content_length=1)
+        assert result == "ok"

--- a/tests/test_post_v2_0_0_beta_fixes.py
+++ b/tests/test_post_v2_0_0_beta_fixes.py
@@ -1,0 +1,579 @@
+r"""Regression tests for the post-v2.0.0 beta-test sweep.
+
+The post-v2.0.0 live-MCP sweep against the 2-archive remote
+(``zim.owl-atlas.ts.net`` carrying Wikipedia + SuperUser SE) surfaced
+FOUR user-facing defects in the Phase F simple-mode surface. All four
+share a common pattern: the v2.0.0 cut consolidated the dispatcher and
+intent-parser plumbing for the 8-tool advanced surface but kept the
+simple-mode dispatcher gates and entry-path extractors narrower than the
+docstring contract advertises.
+
+Defects span THREE surfaces:
+
+* **D-A — ``search_all`` intent trips the no-zim-file gate.** The
+  ``handle_zim_query`` dispatcher at ``simple_tools.py:902-912`` requires
+  a resolved ``zim_file_path`` for every intent EXCEPT ``list_files``.
+  ``search_all`` (parsed from ``search all files for <terms>``) is
+  semantically cross-archive — ``_handle_search_all`` ignores the
+  ``zim_file_path`` argument and iterates every loaded archive
+  internally. When two or more archives are loaded and the caller omits
+  the path (as the docstring recommends), the gate fires
+  ``no_zim_file_specified`` BEFORE the handler runs, blocking the
+  intended cross-archive search. Live impact on the 2-archive remote:
+  ``search all files for kernel`` → ``**No ZIM File Specified**`` instead
+  of the cross-archive hit list.
+
+* **D-B — ``metadata for <file>`` doesn't extract the filename hint.**
+  The intent regex matches ``metadata for X`` and routes to the
+  ``metadata`` intent, but no extractor pulls the trailing filename out
+  of the query. With 2+ archives loaded, ``_auto_select_zim_file()``
+  returns ``None`` and the gate fires ``no_zim_file_specified`` even
+  though the caller named the target file in the query body. The fix:
+  add ``_extract_metadata`` that captures the filename hint into
+  ``params["metadata_target"]`` and have the dispatcher resolve the hint
+  to a real path before the gate fires.
+
+* **D-C / D-D — bare intent-keyword forms drop the entry-path tail.**
+  Five simple-mode intents (``structure`` / ``summary`` / ``toc`` /
+  ``links`` / ``get_article``) share ``_extract_entry_path_keyworded``
+  in ``intent_parser.py:181-220``. The shared extractor anchors on
+  ``article|entry|page|of|for|in|from|to`` keywords; without one of
+  those anchors the extractor silently returns and the handler falls to
+  ``Missing Article Path``. Live impact on the 2-archive remote:
+
+  - ``structure Photosynthesis`` → ``Missing Article Path`` (D-D)
+  - ``summary Photosynthesis`` → ``Missing Article Path`` (D-D)
+  - ``summarize Photosynthesis`` → ``Missing Article Path`` (D-D)
+  - ``overview Photosynthesis`` → ``Missing Article Path`` (D-D)
+  - ``outline Photosynthesis`` → ``Missing Article Path`` (D-D)
+  - ``sections Photosynthesis`` → ``Missing Article Path`` (D-D)
+  - ``toc Photosynthesis`` → ``Missing Article Path`` (D-D)
+  - ``contents Photosynthesis`` → ``Missing Article Path`` (D-D)
+  - ``show structure Photosynthesis`` → ``Missing Article Path`` (D-D)
+  - ``table of contents Photosynthesis`` → ``Cannot find entry`` from
+    the backend (D-C; the extractor anchors on ``of`` in ``table of``,
+    yielding ``entry_path="contents Photosynthesis"`` — a wrong path
+    that escalates past the missing-arg guard into a backend error).
+
+  Fix: enhance ``_extract_entry_path_keyworded`` with TWO additions:
+  (a) when the canonical-keyword tail starts with ``contents``, peel
+  that prefix so ``table of contents X`` resolves to ``X``; (b) when no
+  canonical-keyword anchor is found, fall back to a leading
+  intent-keyword strip so ``structure X`` / ``summary X`` / ``toc X``
+  resolve to ``X``.
+
+The post-v2.0.0 sweep is run from the same ``mcp__openzim-mcp__zim_query``
+surface that the b-series sweeps used. v2.0.0 ships a stable Phase F
+surface (22→8 tool collapse) so this is the first sweep against the
+post-rc1 GA cut.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+# ===========================================================================
+# D-A — search_all gate bypass
+# ===========================================================================
+
+
+class TestSearchAllGateBypass:
+    """Cross-archive search must NOT trip the no-zim-file gate.
+
+    ``_handle_search_all`` ignores the ``zim_file_path`` arg — it iterates
+    every loaded archive via ``zim_operations.search_all_data`` (compact
+    mode) or ``search_all`` (legacy mode). The dispatcher gate must mirror
+    the ``list_files`` bypass for symmetry: both intents are
+    archive-agnostic.
+    """
+
+    def _make_handler(self, archive_count: int) -> Any:
+        """Build a SimpleToolsHandler with N stubbed archives and a
+        no-op ``_handle_search_all`` sentinel so we can prove the
+        dispatcher reached the handler rather than the gate.
+        """
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        mock_ops = MagicMock()
+        mock_ops.list_zim_files_data.return_value = [
+            {"path": f"/data/zim_{i}.zim", "name": f"zim_{i}.zim"}
+            for i in range(archive_count)
+        ]
+        mock_ops.list_zim_files.return_value = f"Found {archive_count} ZIM files."
+        mock_ops.search_all_data.return_value = {
+            "results": [],
+            "_meta": {"chars": 0, "truncated": False, "tokens_est": 0},
+        }
+        mock_ops.search_all.return_value = "no-op search_all result"
+
+        return SimpleToolsHandler(mock_ops)
+
+    def test_search_all_bypasses_gate_with_two_archives(self) -> None:
+        """``search all files for X`` must reach ``_handle_search_all``
+        when 2+ archives are loaded and ``zim_file_path`` is omitted.
+        """
+        handler = self._make_handler(archive_count=2)
+        result = handler.handle_zim_query(query="search all files for kernel")
+        # Pre-fix: result contains "No ZIM File Specified" /
+        # ``intent=no_zim_file_specified``. Post-fix: result is the
+        # search_all body (or stub render) with ``intent=search_all``.
+        assert "no_zim_file_specified" not in result, (
+            f"search_all must bypass the no-zim-file gate; pre-fix dispatcher "
+            f"returned the gate error.\n\nGot:\n{result}"
+        )
+        assert "**No ZIM File Specified**" not in result, (
+            f"search_all must bypass the no-zim-file gate; pre-fix dispatcher "
+            f"returned the gate error.\n\nGot:\n{result}"
+        )
+
+    def test_search_all_still_works_with_one_archive(self) -> None:
+        """Regression guard: single-archive case still works (auto-select
+        gives a path, handler runs as before)."""
+        handler = self._make_handler(archive_count=1)
+        result = handler.handle_zim_query(query="search all files for kernel")
+        assert "no_zim_file_specified" not in result
+
+
+# ===========================================================================
+# D-B — metadata filename hint extraction
+# ===========================================================================
+
+
+class TestMetadataFilenameHintExtraction:
+    """``metadata for X.zim`` must extract the filename hint into params
+    so the dispatcher can resolve it against ``zim_operations`` when no
+    ``zim_file_path`` is passed.
+    """
+
+    def test_metadata_for_filename_extracts_hint(self) -> None:
+        """``metadata for wikipedia_en_all_maxi_2026-02.zim`` →
+        ``params['metadata_target']`` carries the filename."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            "metadata for wikipedia_en_all_maxi_2026-02.zim"
+        )
+        assert intent == "metadata"
+        assert params.get("metadata_target") == "wikipedia_en_all_maxi_2026-02.zim", (
+            f"Pre-fix params had no metadata_target field; got " f"params={params!r}"
+        )
+
+    def test_metadata_about_filename_extracts_hint(self) -> None:
+        """``metadata about X.zim`` — same shape, different preposition."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            "metadata about superuser.com_en_all_2026-02.zim"
+        )
+        assert intent == "metadata"
+        assert params.get("metadata_target") == "superuser.com_en_all_2026-02.zim"
+
+    def test_info_for_filename_extracts_hint(self) -> None:
+        """``info for X.zim`` — alternate verb same target."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            "info for wikipedia_en_all_maxi_2026-02.zim"
+        )
+        assert intent == "metadata"
+        assert params.get("metadata_target") == "wikipedia_en_all_maxi_2026-02.zim"
+
+    def test_bare_metadata_intent_no_hint(self) -> None:
+        """``metadata`` alone — no filename to extract, the hint stays
+        absent and the existing gate behaviour kicks in.
+        """
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent("metadata for")
+        # The intent should still classify as metadata; the hint is
+        # absent.
+        assert intent == "metadata"
+        assert not params.get("metadata_target")
+
+
+class TestMetadataHintDispatcherResolution:
+    """End-to-end: when ``metadata for X.zim`` is called against a
+    multi-archive server with no ``zim_file_path``, the dispatcher must
+    resolve the filename hint to a real archive path before the
+    no-zim-file gate fires.
+    """
+
+    def _make_handler(self) -> Any:
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        archives = [
+            {
+                "path": "/data/wikipedia_en_all_maxi_2026-02.zim",
+                "name": "wikipedia_en_all_maxi_2026-02.zim",
+            },
+            {
+                "path": "/data/superuser.com_en_all_2026-02.zim",
+                "name": "superuser.com_en_all_2026-02.zim",
+            },
+        ]
+        mock_ops = MagicMock()
+        mock_ops.list_zim_files_data.return_value = archives
+        mock_ops.list_zim_files.return_value = "Found 2 ZIM files."
+        mock_ops.get_zim_metadata.return_value = '{"_meta": {}, "title": "wikipedia"}'
+        return SimpleToolsHandler(mock_ops), mock_ops
+
+    def test_metadata_hint_resolves_to_real_path(self) -> None:
+        """``metadata for wikipedia_en_all_maxi_2026-02.zim`` with no
+        ``zim_file_path`` must reach ``get_zim_metadata`` with the
+        resolved path."""
+        handler, mock_ops = self._make_handler()
+        result = handler.handle_zim_query(
+            query="metadata for wikipedia_en_all_maxi_2026-02.zim"
+        )
+        assert "no_zim_file_specified" not in result, (
+            f"Pre-fix the gate fired; post-fix the metadata hint must "
+            f"resolve to /data/wikipedia_en_all_maxi_2026-02.zim before "
+            f"the gate. Got:\n{result}"
+        )
+        mock_ops.get_zim_metadata.assert_called_once()
+        called_with_path = mock_ops.get_zim_metadata.call_args[0][0]
+        assert called_with_path == "/data/wikipedia_en_all_maxi_2026-02.zim"
+
+    def test_metadata_hint_for_second_archive(self) -> None:
+        """Same shape against the second archive — proves the resolver
+        picks the matching archive, not always the first."""
+        handler, mock_ops = self._make_handler()
+        result = handler.handle_zim_query(
+            query="metadata for superuser.com_en_all_2026-02.zim"
+        )
+        assert "no_zim_file_specified" not in result
+        mock_ops.get_zim_metadata.assert_called_once()
+        called_with_path = mock_ops.get_zim_metadata.call_args[0][0]
+        assert called_with_path == "/data/superuser.com_en_all_2026-02.zim"
+
+    def test_metadata_unknown_filename_falls_to_gate(self) -> None:
+        """``metadata for nonexistent.zim`` doesn't match a loaded
+        archive — fall through to the existing no-zim-file gate so the
+        operator sees a clear error rather than a silent wrong-archive."""
+        handler, _mock_ops = self._make_handler()
+        result = handler.handle_zim_query(query="metadata for nonexistent.zim")
+        assert "no_zim_file_specified" in result
+
+
+# ===========================================================================
+# D-C / D-D — bare-verb-prefix entry-path extraction
+# ===========================================================================
+
+
+class TestBareVerbPrefixEntryPathExtraction:
+    """The shared ``_extract_entry_path_keyworded`` must also handle
+    bare-verb-prefix forms — queries where the intent keyword itself
+    (``structure``/``summary``/``toc``/etc.) acts as the of/for anchor
+    without an explicit ``of``/``for``.
+
+    Pre-fix, only quoted strings or ``article``/``entry``/``page``/
+    ``of``/``for``/``in``/``from``/``to`` anchors triggered extraction.
+    Bare ``structure X`` queries fell through to the handler's
+    ``Missing Article Path`` guard. ``table of contents X`` was worse —
+    it anchored on ``of`` (from ``table of``) and produced a wrong
+    entry_path ``contents X`` that escalated past the missing-arg guard
+    into a backend ``Cannot find entry`` error.
+    """
+
+    # --- D-D direct bare-verb forms ---
+
+    def test_structure_bare_form(self) -> None:
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent("structure Photosynthesis")
+        assert intent == "structure"
+        # Sub-D-2 Rule 1 lowercases the query upstream of extraction;
+        # downstream ``find_title_match`` resolves the lowercase tail to
+        # the canonical title path. So the extractor-level param is
+        # lowercase here.
+        assert params.get("entry_path") == "photosynthesis"
+
+    def test_outline_bare_form(self) -> None:
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent("outline Photosynthesis")
+        assert intent == "structure"  # 'outline' routes to structure
+        # Sub-D-2 Rule 1 lowercases the query upstream of extraction;
+        # downstream ``find_title_match`` resolves the lowercase tail to
+        # the canonical title path. So the extractor-level param is
+        # lowercase here.
+        assert params.get("entry_path") == "photosynthesis"
+
+    def test_sections_bare_form(self) -> None:
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent("sections Photosynthesis")
+        assert intent == "structure"
+        # Sub-D-2 Rule 1 lowercases the query upstream of extraction;
+        # downstream ``find_title_match`` resolves the lowercase tail to
+        # the canonical title path. So the extractor-level param is
+        # lowercase here.
+        assert params.get("entry_path") == "photosynthesis"
+
+    def test_summary_bare_form(self) -> None:
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent("summary Photosynthesis")
+        assert intent == "summary"
+        # Sub-D-2 Rule 1 lowercases the query upstream of extraction;
+        # downstream ``find_title_match`` resolves the lowercase tail to
+        # the canonical title path. So the extractor-level param is
+        # lowercase here.
+        assert params.get("entry_path") == "photosynthesis"
+
+    def test_summarize_bare_form(self) -> None:
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent("summarize Photosynthesis")
+        assert intent == "summary"
+        # Sub-D-2 Rule 1 lowercases the query upstream of extraction;
+        # downstream ``find_title_match`` resolves the lowercase tail to
+        # the canonical title path. So the extractor-level param is
+        # lowercase here.
+        assert params.get("entry_path") == "photosynthesis"
+
+    def test_overview_bare_form(self) -> None:
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent("overview Photosynthesis")
+        assert intent == "summary"
+        # Sub-D-2 Rule 1 lowercases the query upstream of extraction;
+        # downstream ``find_title_match`` resolves the lowercase tail to
+        # the canonical title path. So the extractor-level param is
+        # lowercase here.
+        assert params.get("entry_path") == "photosynthesis"
+
+    def test_brief_bare_form(self) -> None:
+        """``brief X`` — ``brief`` is in the summary intent regex
+        ``(summary|summarize|summarise|overview|brief)``; the fallback
+        prefix set must cover the same verbs."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent("brief Photosynthesis")
+        assert intent == "summary"
+        assert params.get("entry_path") == "photosynthesis"
+
+    def test_toc_bare_form(self) -> None:
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent("toc Photosynthesis")
+        assert intent == "toc"
+        # Sub-D-2 Rule 1 lowercases the query upstream of extraction;
+        # downstream ``find_title_match`` resolves the lowercase tail to
+        # the canonical title path. So the extractor-level param is
+        # lowercase here.
+        assert params.get("entry_path") == "photosynthesis"
+
+    def test_contents_bare_form(self) -> None:
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent("contents Photosynthesis")
+        assert intent == "toc"
+        # Sub-D-2 Rule 1 lowercases the query upstream of extraction;
+        # downstream ``find_title_match`` resolves the lowercase tail to
+        # the canonical title path. So the extractor-level param is
+        # lowercase here.
+        assert params.get("entry_path") == "photosynthesis"
+
+    def test_show_structure_bare_form(self) -> None:
+        """``show structure X`` (preamble + verb + entity) — same
+        defect class, common natural phrasing."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            "show structure Photosynthesis"
+        )
+        assert intent == "structure"
+        # Sub-D-2 Rule 1 lowercases the query upstream of extraction;
+        # downstream ``find_title_match`` resolves the lowercase tail to
+        # the canonical title path. So the extractor-level param is
+        # lowercase here.
+        assert params.get("entry_path") == "photosynthesis"
+
+    # --- D-C the dangerous case: anchor mis-fires on "of" in "table of" ---
+
+    def test_table_of_contents_bare_form(self) -> None:
+        """The DANGEROUS D-C case: pre-fix ``table of contents X``
+        anchored on ``of`` (from ``table of``) and yielded
+        ``entry_path="contents X"``. Backend then failed with
+        ``Cannot find entry``. Post-fix: the ``contents `` prefix is
+        peeled from the tail.
+        """
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            "table of contents Photosynthesis"
+        )
+        assert intent == "toc"
+        # Sub-D-2 Rule 1 lowercases the query upstream of extraction;
+        # downstream ``find_title_match`` resolves the lowercase tail to
+        # the canonical title path. So the extractor-level param is
+        # lowercase here.
+        assert params.get("entry_path") == "photosynthesis", (
+            f"Pre-fix the extractor anchored on 'of' in 'table of', leaving "
+            f"entry_path='contents Photosynthesis' which the backend rejects "
+            f"as Cannot find entry. Post-fix the 'contents ' prefix must be "
+            f"peeled. Got entry_path={params.get('entry_path')!r}"
+        )
+
+    # --- Regression guards: existing canonical forms must still work ---
+
+    def test_structure_of_form_unchanged(self) -> None:
+        """``structure of X`` — the canonical form must still resolve
+        via the ``of`` anchor as before."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent("structure of Photosynthesis")
+        assert intent == "structure"
+        # Sub-D-2 Rule 1 lowercases the query upstream of extraction;
+        # downstream ``find_title_match`` resolves the lowercase tail to
+        # the canonical title path. So the extractor-level param is
+        # lowercase here.
+        assert params.get("entry_path") == "photosynthesis"
+
+    def test_summary_of_form_unchanged(self) -> None:
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent("summary of Photosynthesis")
+        assert intent == "summary"
+        # Sub-D-2 Rule 1 lowercases the query upstream of extraction;
+        # downstream ``find_title_match`` resolves the lowercase tail to
+        # the canonical title path. So the extractor-level param is
+        # lowercase here.
+        assert params.get("entry_path") == "photosynthesis"
+
+    def test_toc_of_form_unchanged(self) -> None:
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent("toc of Photosynthesis")
+        assert intent == "toc"
+        # Sub-D-2 Rule 1 lowercases the query upstream of extraction;
+        # downstream ``find_title_match`` resolves the lowercase tail to
+        # the canonical title path. So the extractor-level param is
+        # lowercase here.
+        assert params.get("entry_path") == "photosynthesis"
+
+    def test_contents_of_form_unchanged(self) -> None:
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent("contents of Photosynthesis")
+        assert intent == "toc"
+        # Sub-D-2 Rule 1 lowercases the query upstream of extraction;
+        # downstream ``find_title_match`` resolves the lowercase tail to
+        # the canonical title path. So the extractor-level param is
+        # lowercase here.
+        assert params.get("entry_path") == "photosynthesis"
+
+    def test_table_of_contents_for_form_unchanged(self) -> None:
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            "table of contents for Biology"
+        )
+        assert intent == "toc"
+        assert params.get("entry_path") == "biology"  # Sub-D-2 Rule 1
+
+    def test_get_article_form_unchanged(self) -> None:
+        """``get article X`` — anchors on ``article`` keyword,
+        unrelated to the new fallback. Pre-fix and post-fix must
+        agree."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent("get article Photosynthesis")
+        assert intent == "get_article"
+        # Sub-D-2 Rule 1 lowercases the query upstream of extraction;
+        # downstream ``find_title_match`` resolves the lowercase tail to
+        # the canonical title path. So the extractor-level param is
+        # lowercase here.
+        assert params.get("entry_path") == "photosynthesis"
+
+    def test_quoted_form_unchanged(self) -> None:
+        """Quoted entry — extractor's first branch, unchanged."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            'structure of "C/Photosynthesis"'
+        )
+        assert intent == "structure"
+        # Quoted form preserves case (the quoted-match branch runs before
+        # any lowercasing-affected logic touches the captured value).
+        # But Sub-D-2 Rule 1 still lowercases the QUERY before quoted_match
+        # runs, so the captured value will be lowercased too.
+        assert params.get("entry_path") == "c/photosynthesis"
+
+    def test_multi_word_entity_bare_form(self) -> None:
+        """``structure United States`` — multi-token entity follows the
+        bare verb. The fallback must capture the full tail."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent("structure United States")
+        assert intent == "structure"
+        # Sub-D-2 Rule 1 lowercases.
+        assert params.get("entry_path") == "united states"
+
+
+# ===========================================================================
+# Source-level invariant: extractor and parser must agree on the canonical
+# verb set used in the leading-prefix fallback. Pin the verb set in the
+# parser-side intent regex against the extractor-side fallback regex so a
+# future contributor who widens one and forgets the other gets a clear
+# diff signal.
+# ===========================================================================
+
+
+class TestEntryPathExtractorVerbSetCanonicalPin:
+    """The fallback strip in ``_extract_entry_path_keyworded`` must cover
+    every intent verb that routes through that extractor without an
+    explicit of/for anchor. Drift between the parser's intent regex and
+    the extractor's fallback strip is the post-v2.0.0 D-D bug shape."""
+
+    def test_fallback_strip_covers_structure_intent_verbs(self) -> None:
+        """Every structure-routed verb (`structure`, `outline`,
+        `sections`, `headings`) must be peelable as a leading prefix."""
+        from openzim_mcp.intent_parser import _LEADING_INTENT_KEYWORDS_RE
+
+        # All five verbs must match when followed by an entity.
+        verbs_with_args = [
+            "structure Photosynthesis",
+            "outline Photosynthesis",
+            "sections Photosynthesis",
+            "section Photosynthesis",  # singular
+            "headings Photosynthesis",
+        ]
+        for q in verbs_with_args:
+            match = _LEADING_INTENT_KEYWORDS_RE.match(q)
+            assert match is not None, (
+                f"Leading-prefix regex must match {q!r}; missing verb in "
+                f"the canonical set will leave the extractor unable to "
+                f"peel the prefix."
+            )
+            assert q[match.end() :].strip() == "Photosynthesis"
+
+    def test_fallback_strip_covers_summary_intent_verbs(self) -> None:
+        """Every summary-routed verb (`summary`, `summarize`,
+        `summarise`, `overview`, `brief`) must be peelable."""
+        from openzim_mcp.intent_parser import _LEADING_INTENT_KEYWORDS_RE
+
+        verbs_with_args = [
+            "summary Photosynthesis",
+            "summarize Photosynthesis",
+            "summarise Photosynthesis",
+            "overview Photosynthesis",
+            "brief Photosynthesis",
+        ]
+        for q in verbs_with_args:
+            match = _LEADING_INTENT_KEYWORDS_RE.match(q)
+            assert match is not None, f"Leading-prefix regex must match {q!r}."
+
+    def test_fallback_strip_covers_toc_intent_verbs(self) -> None:
+        """`toc`, `contents`, `table of contents` all peelable."""
+        from openzim_mcp.intent_parser import _LEADING_INTENT_KEYWORDS_RE
+
+        for q in (
+            "toc Photosynthesis",
+            "contents Photosynthesis",
+            "table of contents Photosynthesis",
+        ):
+            match = _LEADING_INTENT_KEYWORDS_RE.match(q)
+            assert match is not None, f"Leading-prefix regex must match {q!r}."

--- a/tests/test_post_v2_0_0_beta_fixes.py
+++ b/tests/test_post_v2_0_0_beta_fixes.py
@@ -62,6 +62,36 @@ Defects span THREE surfaces:
   intent-keyword strip so ``structure X`` / ``summary X`` / ``toc X``
   resolve to ``X``.
 
+* **D-E — empty-quoted titles / entry paths silently resolve to the
+  ``Empty_string`` article.** Pass-2 of the sweep surfaced a separate
+  defect class: when a caller types ``""`` (literal empty-quote pair)
+  as an entry path or title, several extractors capture the literal
+  2-char ``""`` value, the handler treats it as non-empty (``.strip()``
+  removes whitespace, not quotes), the backend's title-promotion path
+  resolves the empty input to ``Empty_string`` at score 1.00, and the
+  user gets a silent-wrong response. Affected:
+
+  - ``find article titled ""`` → ``Empty_string`` at score 1.00
+    (find_by_title)
+  - ``articles related to ""`` → links from ``Empty_string`` (related)
+  - ``structure of ""`` → structure of ``Empty_string``
+    (entry_path_keyworded keyword-branch tail)
+  - ``links in ""`` → links from ``Empty_string``
+    (entry_path_keyworded keyword-branch tail)
+  - ``get article ""`` → ``Empty_string`` article body
+    (entry_path_keyworded keyword-branch tail)
+
+  Fix: add ``_strip_quote_pair`` helper that peels a single surrounding
+  matched quote-pair (covering ASCII ``'`` / ``"`` plus Unicode smart
+  quotes via the existing ``_QUOTE_CHARS`` set). Apply at the tail of
+  ``_extract_find_by_title`` / ``_extract_related`` / the keyword-branch
+  arm of ``_extract_entry_path_keyworded``. Empty result → don't set
+  the param, letting the handler's missing-arg guard fire.
+
+  Bonus regression upside: ``find article titled "World War II"`` now
+  scores 1.00 instead of 0.95 (the quote-stripped lookup is an exact
+  title match instead of fuzzy).
+
 The post-v2.0.0 sweep is run from the same ``mcp__openzim-mcp__zim_query``
 surface that the b-series sweeps used. v2.0.0 ships a stable Phase F
 surface (22→8 tool collapse) so this is the first sweep against the
@@ -577,3 +607,174 @@ class TestEntryPathExtractorVerbSetCanonicalPin:
         ):
             match = _LEADING_INTENT_KEYWORDS_RE.match(q)
             assert match is not None, f"Leading-prefix regex must match {q!r}."
+
+
+# ===========================================================================
+# D-E — empty-quoted titles / entry paths silent-resolve to Empty_string
+# ===========================================================================
+
+
+class TestEmptyQuotedInputDoesNotResolveToEmptyStringArticle:
+    """Pass-2 of the sweep: ``find article titled ""`` and siblings
+    silently resolved to the ``Empty_string`` Wikipedia article at
+    score 1.00. The extractor captured the 2-char literal ``""``, the
+    handler's ``.strip()`` only trimmed whitespace, and the backend's
+    title-promotion fuzzy-matched the empty input to ``Empty_string``.
+
+    The fix peels a single surrounding matched quote-pair from the
+    captured value and drops the param entirely when the result is
+    empty/whitespace. Affected extractors:
+    ``_extract_find_by_title`` (title), ``_extract_related``
+    (entry_path), ``_extract_entry_path_keyworded`` keyword-branch
+    (entry_path).
+    """
+
+    def test_find_by_title_empty_double_quotes_unset(self) -> None:
+        """``find article titled ""`` must NOT carry a title param,
+        so the handler's missing-arg guard fires."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent('find article titled ""')
+        assert intent == "find_by_title"
+        assert not params.get("title"), (
+            f"Pre-fix params['title'] was the literal 2-char '\"\"' which "
+            f"the backend fuzzy-matched to Empty_string. Post-fix the "
+            f"quote-pair-empty title must drop entirely. "
+            f"Got title={params.get('title')!r}"
+        )
+
+    def test_find_by_title_empty_single_quotes_unset(self) -> None:
+        """``find article titled ''`` — same shape, single-quote pair."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent("find article titled ''")
+        assert intent == "find_by_title"
+        assert not params.get("title")
+
+    def test_find_by_title_quoted_whitespace_unset(self) -> None:
+        """``find article titled "  "`` — non-empty between quotes but
+        only whitespace. Same expected behaviour as empty quotes."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent('find article titled "  "')
+        assert intent == "find_by_title"
+        assert not params.get("title")
+
+    def test_find_by_title_quoted_real_title_strips_quotes(self) -> None:
+        """``find article titled "World War II"`` — quotes peeled,
+        title stored cleanly. Regression upside: backend's title
+        promotion scores exact-match 1.00 instead of fuzzy-quote 0.95."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            'find article titled "World War II"'
+        )
+        assert intent == "find_by_title"
+        # Sub-D-2 Rule 1 lowercases.
+        assert params.get("title") == "world war ii", (
+            f"Quote-strip must remove surrounding quote pair so the "
+            f"backend gets the bare title. Got "
+            f"{params.get('title')!r}"
+        )
+
+    def test_find_by_title_bare_title_unchanged(self) -> None:
+        """``find article titled World War II`` (no quotes) — regression
+        guard, the quote-strip must only fire on a matched quote pair."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            "find article titled World War II"
+        )
+        assert intent == "find_by_title"
+        assert params.get("title") == "world war ii"
+
+    def test_related_empty_double_quotes_unset(self) -> None:
+        """``articles related to ""`` — same shape via related
+        extractor."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent('articles related to ""')
+        assert intent == "related"
+        assert not params.get("entry_path"), (
+            f"Pre-fix params['entry_path']=='\"\"' silent-matched "
+            f"Empty_string in the backend. Got "
+            f"{params.get('entry_path')!r}"
+        )
+
+    def test_structure_of_empty_quotes_unset(self) -> None:
+        """``structure of ""`` — keyword-branch tail of
+        ``_extract_entry_path_keyworded`` captured ``""`` and the
+        backend resolved it to ``Empty_string``."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent('structure of ""')
+        assert intent == "structure"
+        assert not params.get("entry_path"), (
+            f"Pre-fix the keyword-branch tail was the literal '\"\"' "
+            f"which the natural-language path resolver fuzzy-matched "
+            f"to Empty_string. Got {params.get('entry_path')!r}"
+        )
+
+    def test_get_article_empty_quotes_unset(self) -> None:
+        """``get article ""`` — same shape, get_article intent."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent('get article ""')
+        assert intent == "get_article"
+        assert not params.get("entry_path")
+
+    def test_links_in_empty_quotes_unset(self) -> None:
+        """``links in ""`` — same shape, links intent."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent('links in ""')
+        assert intent == "links"
+        assert not params.get("entry_path")
+
+    def test_summary_of_quoted_real_topic_strips_quotes(self) -> None:
+        """``summary of "Photosynthesis"`` — regression guard: the
+        keyword-branch tail must peel quotes when the value is
+        non-empty. Pre-existing quoted-match branch already handled
+        this; just confirm post-fix behaviour is unchanged."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent('summary of "Photosynthesis"')
+        assert intent == "summary"
+        assert params.get("entry_path") == "photosynthesis"
+
+    def test_structure_of_unquoted_bare_topic_unchanged(self) -> None:
+        """``structure of Photosynthesis`` — regression guard, no quote
+        pair present, behaviour identical to pre-fix."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent("structure of Photosynthesis")
+        assert intent == "structure"
+        assert params.get("entry_path") == "photosynthesis"
+
+    def test_strip_quote_pair_helper_direct(self) -> None:
+        """Direct unit test of the helper — covers ASCII single/double
+        quotes plus Unicode smart quotes from the existing
+        ``_QUOTE_CHARS`` set."""
+        from openzim_mcp.intent_parser import _strip_quote_pair
+
+        # Stripped:
+        assert _strip_quote_pair('"hello"') == "hello"
+        assert _strip_quote_pair("'hello'") == "hello"
+        assert _strip_quote_pair("“hello”") == "hello"  # curly double
+        assert _strip_quote_pair("‘hello’") == "hello"  # curly single
+
+        # Empty / whitespace-only quoted:
+        assert _strip_quote_pair('""') == ""
+        assert _strip_quote_pair("''") == ""
+        assert _strip_quote_pair('"  "') == ""
+
+        # Unmatched: preserve verbatim
+        assert _strip_quote_pair("hello") == "hello"
+        assert _strip_quote_pair('"hello') == '"hello'
+        assert _strip_quote_pair('hello"') == 'hello"'
+        # Single character — not a quote pair, preserve
+        assert _strip_quote_pair('"') == '"'
+        # Mixed quote characters — STILL strip since both endpoints
+        # are in the quote set (covers ``"foo'`` and similar
+        # LLM-generated mismatched pairs).
+        assert _strip_quote_pair("\"hello'") == "hello"

--- a/tests/test_post_v2_0_0_beta_fixes.py
+++ b/tests/test_post_v2_0_0_beta_fixes.py
@@ -104,6 +104,34 @@ Defects span THREE surfaces:
   to ``zim_query.py`` mirroring the existing ``limit`` check, returning
   ``invalid_max_content_length`` for non-positive values.
 
+  Pass-4 sibling extension: ``tools/zim_get.py`` (advanced surface)
+  inherited the same validation gap — neither ``content_offset < 0``
+  nor ``max_content_length < 1`` was rejected. Same fix shape applied
+  there so the two surfaces stay consistent.
+
+* **D-G — synthesize path bypasses empty-topic / empty-search guards.**
+  Pass-4 found that the synthesize branch (early exit at
+  ``simple_tools.py:626``) completely skips the structured
+  ``topic_required`` / ``search_terms_required`` guards the
+  intent-classification path fires at lines 836-887. Pre-fix live impact:
+
+  - ``tell me about `` (trailing space, synthesize=True) → RAG-searched
+    the literal verb prefix "tell me about" and returned title-prefix
+    matches (``Tell_Me_About_Tomorrow``, ``Tell_Me_About_Your_Day_Today``)
+  - ``tell me about ?`` (punctuation-only) → same silent-wrong shape
+  - ``tell me about ""`` (D-E shape on synthesize path) →
+    ``Empty_string`` Wikipedia article at score 1.00
+  - ``search for `` (synthesize=True) → returned the ``For`` disambig
+    article
+
+  Fix: in ``_handle_synthesize_query`` after the existing ``parse_intent``
+  prelude, mirror the same empty-topic / empty-search guards as the
+  non-synthesize path. Returns a structured ``tool_error`` envelope
+  (synthesize's native error shape). Also extended D-E's quote-strip
+  to ``_extract_tell_me_about`` so the ``tell me about ""`` shape
+  drops cleanly before the guard rather than carrying the literal
+  ``""`` topic through to the RAG pipeline.
+
 The post-v2.0.0 sweep is run from the same ``mcp__openzim-mcp__zim_query``
 surface that the b-series sweeps used. v2.0.0 ships a stable Phase F
 surface (22→8 tool collapse) so this is the first sweep against the
@@ -886,3 +914,240 @@ class TestMaxContentLengthValidation:
         positive value and must succeed."""
         result = self._call_zim_query(query="tell me about X", max_content_length=1)
         assert result == "ok"
+
+
+# ===========================================================================
+# D-G — synthesize path bypasses empty-topic / empty-search guards
+# ===========================================================================
+
+
+class TestSynthesizePathEmptyTopicGuard:
+    """The non-synthesize path fires structured guards at
+    ``simple_tools.py:836-887`` when the parsed intent is
+    ``tell_me_about`` with an empty topic or ``search`` with no terms.
+    Pass-4 surfaced that the synthesize branch (early-exit at line 626)
+    completely bypasses these guards — the raw query string ("tell me
+    about ", "tell me about ?", "tell me about ""\", "search for ")
+    flows through the RAG pipeline and returns silent-wrong hits
+    (``Tell_Me_About_Tomorrow``-style title-prefix matches, or the
+    ``Empty_string`` Wikipedia article for the quoted-empty case —
+    same shape as D-E but on a different code path).
+
+    The fix mirrors the non-synthesize guards inside
+    ``_handle_synthesize_query`` after its own ``parse_intent`` call,
+    returning a structured ``tool_error`` envelope (synthesize's
+    native error shape) when topic / query is empty.
+    """
+
+    def _make_handler(self) -> Any:
+        """Build a SimpleToolsHandler with a stub archive list. The
+        guard fires BEFORE archive resolution, so we don't need a real
+        archive backend.
+        """
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        mock_ops = MagicMock()
+        mock_ops.list_zim_files_data.return_value = [
+            {"path": "/data/zim_0.zim", "name": "zim_0.zim"},
+        ]
+        mock_ops.list_zim_files.return_value = "Found 1 ZIM file."
+        # Stub config for query_rewrite gating.
+        mock_ops.config = MagicMock()
+        mock_ops.config.query_rewrite = MagicMock()
+        mock_ops.config.query_rewrite.enabled = False
+        return SimpleToolsHandler(mock_ops)
+
+    def test_synthesize_empty_tell_me_about_returns_topic_required(self) -> None:
+        """``tell me about `` with synthesize=True must fire the
+        same topic_required guard as the non-synthesize path."""
+        handler = self._make_handler()
+        result = handler.handle_zim_query(
+            query="tell me about ", options={"synthesize": True}
+        )
+        # Either a tool_error envelope (dict) or a markdown string with
+        # the topic_required intent comment. Accept either shape.
+        if isinstance(result, dict):
+            assert result.get("error") is True
+            assert result.get("operation") == "topic_required", (
+                f"Pre-fix synthesize=True with empty topic silently "
+                f"searched the literal verb and returned Tell_Me_About_* "
+                f"hits. Post-fix must return topic_required envelope. "
+                f"Got: {result}"
+            )
+        else:
+            assert "topic_required" in result or "Topic Required" in result, (
+                f"Pre-fix synthesize=True with empty topic silent-wrong. "
+                f"Got: {result}"
+            )
+
+    def test_synthesize_empty_tell_me_about_punctuation_returns_topic_required(
+        self,
+    ) -> None:
+        """``tell me about ?`` (punctuation-only topic) — same shape."""
+        handler = self._make_handler()
+        result = handler.handle_zim_query(
+            query="tell me about ?", options={"synthesize": True}
+        )
+        if isinstance(result, dict):
+            assert result.get("error") is True
+            assert result.get("operation") == "topic_required"
+        else:
+            assert "topic_required" in result or "Topic Required" in result
+
+    def test_synthesize_empty_quoted_tell_me_about_returns_topic_required(
+        self,
+    ) -> None:
+        """``tell me about ""`` (D-E shape on synthesize path) — must
+        also fire topic_required, NOT silent-resolve to Empty_string."""
+        handler = self._make_handler()
+        result = handler.handle_zim_query(
+            query='tell me about ""', options={"synthesize": True}
+        )
+        if isinstance(result, dict):
+            # Either topic_required (preferred) OR a synthesize result
+            # that doesn't silently match Empty_string. The fix
+            # specifically prevents the silent-Empty-string match.
+            if result.get("error"):
+                assert result.get("operation") == "topic_required"
+            else:
+                # If synthesize ran at all, ensure it didn't latch on
+                # to Empty_string at score 1.00.
+                citations = result.get("citations") or []
+                for c in citations:
+                    if c.get("rank") == 1:
+                        assert c.get("entry_path") != "Empty_string", (
+                            f"Synthesize must not silent-resolve quoted-"
+                            f"empty topic to Empty_string. Got rank-1 "
+                            f"citation: {c}"
+                        )
+
+    def test_synthesize_empty_search_returns_search_terms_required(self) -> None:
+        """``search for `` with synthesize=True — empty search terms."""
+        handler = self._make_handler()
+        result = handler.handle_zim_query(
+            query="search for ", options={"synthesize": True}
+        )
+        if isinstance(result, dict):
+            assert result.get("error") is True
+            assert result.get("operation") == "search_terms_required", (
+                f"Pre-fix synthesize=True with empty search terms "
+                f"silently searched the literal verb 'for'. Got: "
+                f"{result}"
+            )
+        else:
+            assert "search_terms_required" in result or "Search Terms" in result
+
+    def test_synthesize_non_empty_tell_me_about_unchanged(self) -> None:
+        """Regression guard: a real topic flows through to the
+        synthesize pipeline as before. We expect either a
+        SynthesizeResponse or an envelope from archive-resolution that
+        isn't ``topic_required``."""
+        handler = self._make_handler()
+        result = handler.handle_zim_query(
+            query="tell me about Photosynthesis",
+            options={"synthesize": True},
+        )
+        # Should NOT be topic_required. Anything else is fine for this
+        # regression guard (synthesize will likely fail to open the
+        # stubbed archive but that's a different surface).
+        if isinstance(result, dict) and result.get("error"):
+            assert result.get("operation") != "topic_required"
+
+
+# ===========================================================================
+# D-F sibling — zim_get advanced surface validates content_offset /
+# max_content_length (mirrors the zim_query gap fixed in pass-3)
+# ===========================================================================
+
+
+class TestZimGetInputValidation:
+    """The advanced ``zim_get`` tool inherits the same input-validation
+    gap as ``zim_query`` pre-D-F: ``content_offset < 0`` and
+    ``max_content_length < 1`` both silently propagate to the data
+    layer. Pass-3's D-F fix landed in ``tools/zim_query.py`` only —
+    pass-4 extends the same shape to ``tools/zim_get.py`` so the two
+    surfaces stay consistent and a misconfigured advanced caller can't
+    bypass the cap either.
+    """
+
+    @staticmethod
+    def _call_zim_get(**kwargs: Any) -> Any:
+        """Drive the wire-layer ``zim_get`` tool directly, identical
+        shape to the ``zim_query`` test helper."""
+        import asyncio
+
+        from openzim_mcp.tools import zim_get as zg_module
+
+        mock_server = MagicMock()
+        registered: list[Any] = []
+
+        def fake_decorator(*_a: Any, **_kw: Any) -> Any:
+            def wrapper(fn: Any) -> Any:
+                registered.append(fn)
+                return fn
+
+            return wrapper
+
+        mock_server.mcp = MagicMock()
+        mock_server.mcp.tool = fake_decorator
+        # zim_get reaches into server.zim_operations to build the
+        # AsyncZimOperations wrapper. We don't need it to actually
+        # work — only path-validation failures show up post-guard.
+        mock_server.zim_operations = MagicMock()
+        zg_module.register(mock_server)
+        assert registered, "register failed to register the zim_get tool"
+        tool_fn = registered[0]
+        return asyncio.run(tool_fn(**kwargs))
+
+    def test_zim_get_content_offset_negative_rejected(self) -> None:
+        """``content_offset=-1`` → structured invalid_content_offset
+        envelope, mirroring the existing ``zim_query`` rejection."""
+        result = self._call_zim_get(
+            zim_file_path="/x.zim",
+            entry_path="Photosynthesis",
+            content_offset=-1,
+        )
+        assert isinstance(result, dict)
+        assert result.get("error") is True
+        assert result.get("operation") == "invalid_content_offset"
+
+    def test_zim_get_max_content_length_zero_rejected(self) -> None:
+        """``max_content_length=0`` → invalid_max_content_length."""
+        result = self._call_zim_get(
+            zim_file_path="/x.zim",
+            entry_path="Photosynthesis",
+            max_content_length=0,
+        )
+        assert isinstance(result, dict)
+        assert result.get("error") is True
+        assert result.get("operation") == "invalid_max_content_length"
+
+    def test_zim_get_max_content_length_negative_rejected(self) -> None:
+        """``max_content_length=-1`` → same shape."""
+        result = self._call_zim_get(
+            zim_file_path="/x.zim",
+            entry_path="Photosynthesis",
+            max_content_length=-1,
+        )
+        assert isinstance(result, dict)
+        assert result.get("error") is True
+        assert result.get("operation") == "invalid_max_content_length"
+
+    def test_zim_get_valid_inputs_pass_validation(self) -> None:
+        """Regression guard: positive ``max_content_length`` /
+        non-negative ``content_offset`` still pass the validator —
+        downstream archive open may fail, but NOT with the validation
+        operations."""
+        result = self._call_zim_get(
+            zim_file_path="/x.zim",
+            entry_path="Photosynthesis",
+            max_content_length=4000,
+            content_offset=100,
+        )
+        # Whatever fails downstream, it must NOT be one of our validators.
+        if isinstance(result, dict) and result.get("error"):
+            op = result.get("operation")
+            assert op not in (
+                "invalid_content_offset",
+                "invalid_max_content_length",
+            )

--- a/website/public/assets/script.js
+++ b/website/public/assets/script.js
@@ -10,11 +10,9 @@
   }
 
   // ============= THEME =============
+  // Initial theme is applied by an inline <script> in <head> to avoid FOUC.
+  // Here we only wire up the user-facing toggle.
   function initTheme() {
-    const stored = safeStorage('get', 'theme');
-    const initial = stored || (globalThis.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
-    document.documentElement.dataset.theme = initial;
-
     const toggle = document.getElementById('theme-toggle');
     if (!toggle) return;
     toggle.addEventListener('click', () => {
@@ -195,6 +193,7 @@
       panels.forEach(p => {
         const active = p.id === target;
         p.classList.toggle('is-active', active);
+        p.setAttribute('aria-hidden', String(!active));
         if (active) p.removeAttribute('hidden'); else p.setAttribute('hidden', '');
       });
     };
@@ -203,6 +202,11 @@
     buttons.forEach(b => {
       const active = b.classList.contains('is-active');
       b.setAttribute('tabindex', active ? '0' : '-1');
+    });
+    // Initial aria-hidden state — needed because the usage tabs use grid
+    // stacking + visibility:hidden, which AT browse mode would otherwise expose.
+    panels.forEach(p => {
+      p.setAttribute('aria-hidden', String(!p.classList.contains('is-active')));
     });
 
     const onKeydown = (btn) => (e) => {
@@ -222,6 +226,24 @@
 
   function initTabs() {
     document.querySelectorAll('[data-tabs]').forEach(setupTabGroup);
+  }
+
+  // ============= DOCS SIDEBAR (mobile disclosure) =============
+  function initSidebarToggle() {
+    const btn = document.getElementById('docs-sidebar-toggle');
+    const nav = document.getElementById('docs-sidebar-nav');
+    if (!btn || !nav) return;
+    const mq = globalThis.matchMedia('(max-width: 900px)');
+    const sync = () => {
+      if (mq.matches) btn.setAttribute('aria-expanded', 'false');
+      else btn.setAttribute('aria-expanded', 'true');
+    };
+    sync();
+    mq.addEventListener('change', sync);
+    btn.addEventListener('click', () => {
+      const expanded = btn.getAttribute('aria-expanded') === 'true';
+      btn.setAttribute('aria-expanded', String(!expanded));
+    });
   }
 
   // ============= LEGACY ANCHOR REDIRECT =============
@@ -257,6 +279,7 @@
     initReveal();
     initCopyButtons();
     initTabs();
+    initSidebarToggle();
     redirectLegacyAnchors();
   });
 })();

--- a/website/public/assets/styles.css
+++ b/website/public/assets/styles.css
@@ -77,6 +77,10 @@
   --text: var(--ink);
   --text-secondary: var(--muted-light);
   --border-color: var(--border-light);
+  /* Yellow #FFD24A on the cream paper fails WCAG AA when used as text.
+     Swap to a deeper mustard for any signal-as-text use. Backgrounds and
+     SVG fills can override locally if a brighter accent is needed. */
+  --signal: #946F1C;
 }
 
 /* ============= RESET ============= */
@@ -120,13 +124,17 @@ p { color: var(--text-secondary); }
 /* ============= LAYOUT PRIMITIVES ============= */
 .container { max-width: var(--container-max); margin-inline: auto; padding-inline: var(--space-6); }
 .container--narrow { max-width: var(--container-narrow); }
-.section { padding-block: var(--space-24); }
+.section { padding-block: clamp(4rem, 10vw, 6rem); }
 .section--surface { background: var(--surface); }
 .skip-link {
-  position: absolute; top: -40px; left: 0; background: var(--signal); color: var(--ink);
+  position: absolute; top: 0; left: 0; transform: translateY(-100%);
+  background: var(--signal); color: var(--ink);
   padding: var(--space-2) var(--space-4); z-index: 100; border-radius: 0 0 var(--radius-md) 0;
 }
-.skip-link:focus { top: 0; }
+.skip-link:focus-visible { transform: translateY(0); }
+/* Skip-link target — give programmatic focus a visible ring so the user
+   knows focus has moved into <main>. */
+main:focus-visible { outline: 2px solid var(--signal); outline-offset: -4px; }
 
 /* ============= UTILITIES ============= */
 .btn {
@@ -206,15 +214,21 @@ p { color: var(--text-secondary); }
   .nav__menu { display: none; }
   .nav__toggle { display: flex; }
   .nav.is-open .nav__menu {
-    display: flex; flex-direction: column; gap: var(--space-4);
+    display: flex; flex-direction: column; gap: var(--space-2);
     position: absolute; top: 64px; left: 0; right: 0;
     background: var(--surface);
-    padding: var(--space-6); border-bottom: 1px solid var(--border-color);
+    padding: var(--space-4) var(--space-6); border-bottom: 1px solid var(--border-color);
   }
+  .nav.is-open .nav__menu .nav__link {
+    min-height: 44px;
+    display: flex; align-items: center;
+  }
+  .nav__theme { width: 44px; height: 44px; }
+  .hero__install-copy { width: 36px; height: 36px; }
 }
 
 /* ============= HERO ============= */
-.hero { padding-block: var(--space-20) var(--space-24); overflow: hidden; }
+.hero { padding-block: clamp(3rem, 8vw, 5rem) clamp(4rem, 10vw, 6rem); overflow: hidden; }
 .hero__inner {
   display: grid;
   grid-template-columns: 1fr;
@@ -273,7 +287,10 @@ p { color: var(--text-secondary); }
 }
 
 /* ============= CONSTELLATION ============= */
-.constellation { width: 100%; max-width: 480px; height: auto; }
+.constellation { width: 100%; max-width: 480px; height: auto; margin-inline: auto; display: block; }
+@media (max-width: 640px) {
+  .constellation { max-width: 280px; }
+}
 @keyframes constellation-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.85; }
@@ -292,7 +309,36 @@ p { color: var(--text-secondary); }
 .section__header p { max-width: 60ch; margin-inline: auto; font-size: var(--text-lg); }
 
 .what__diagram { margin-block: var(--space-12) var(--space-16); }
-.what__diagram svg { width: 100%; height: auto; max-width: 720px; margin-inline: auto; }
+.what__diagram svg { width: 100%; height: auto; max-width: 720px; margin-inline: auto; display: block; }
+
+/* Hide the "Static / Intelligent / Conversational" subtitles on narrow
+   screens where they'd render at <8px effective and become illegible. */
+@media (max-width: 480px) {
+  .what__diagram-sublabel { display: none; }
+}
+
+/* Dashes march left-to-right along the two connector arrows. Dash period
+   = 6 + 4 = 10, so a -10 offset shift is one full cycle. */
+.what__diagram-flow { animation: diagram-flow 3s linear infinite; }
+@keyframes diagram-flow {
+  from { stroke-dashoffset: 0; }
+  to   { stroke-dashoffset: -10; }
+}
+
+/* Brain-icon dots gently pulse in a staggered wave to suggest processing. */
+.what__diagram-spark { animation: diagram-spark 2.8s ease-in-out infinite; }
+.what__diagram-spark:nth-of-type(2) { animation-delay: 0.35s; }
+.what__diagram-spark:nth-of-type(3) { animation-delay: 0.7s; }
+.what__diagram-spark:nth-of-type(4) { animation-delay: 1.05s; }
+@keyframes diagram-spark {
+  0%, 100% { opacity: 0.45; }
+  50%      { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .what__diagram-flow,
+  .what__diagram-spark { animation: none; }
+}
 
 .what__triad {
   display: grid; grid-template-columns: 1fr; gap: var(--space-6);
@@ -317,104 +363,6 @@ p { color: var(--text-secondary); }
   color: var(--signal); font-weight: var(--weight-medium);
 }
 .what__production-label { font-size: var(--text-sm); color: var(--text-secondary); }
-
-/* ============= WHATS-IN-V1 ============= */
-.v1 { position: relative; overflow: hidden; }
-.v1__watermark {
-  position: absolute; bottom: -3rem; right: -1rem;
-  font-family: var(--font-display);
-  font-size: clamp(8rem, 25vw, 18rem);
-  font-weight: 600;
-  color: var(--text);
-  opacity: 0.04;
-  pointer-events: none;
-  user-select: none;
-  line-height: 1;
-}
-
-.v1__cards {
-  display: grid; grid-template-columns: 1fr; gap: var(--space-6);
-  margin-block: var(--space-12);
-}
-@media (min-width: 768px) {
-  .v1__cards { grid-template-columns: repeat(2, 1fr); gap: var(--space-8); }
-}
-.v1__card {
-  position: relative;
-  background: var(--surface);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-lg);
-  padding: var(--space-8);
-  transition: border-color var(--dur-base) ease, transform var(--dur-base) ease;
-}
-.v1__card:hover { border-color: var(--signal); transform: translateY(-2px); }
-.v1__card-dot {
-  position: absolute; top: var(--space-5); right: var(--space-5);
-  width: 10px; height: 10px; border-radius: 50%;
-  background: var(--signal);
-  box-shadow: 0 0 12px rgba(255, 210, 74, 0.5);
-}
-.v1__card h3 {
-  font-size: var(--text-xl); margin-bottom: var(--space-3);
-  padding-right: var(--space-6);
-}
-.v1__card p { margin-bottom: var(--space-5); }
-.v1__card pre {
-  background: var(--bg);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-  padding: var(--space-4);
-  overflow-x: auto;
-  font-size: var(--text-sm);
-  line-height: 1.5;
-}
-.v1__card code:not(pre code) {
-  background: var(--bg); padding: 1px 6px; border-radius: 3px;
-  font-size: 0.92em; color: var(--signal);
-}
-
-.v1__also {
-  background: var(--surface);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-lg);
-  padding: var(--space-6);
-  margin-bottom: var(--space-12);
-}
-.v1__also summary {
-  cursor: pointer; font-size: var(--text-lg);
-  list-style: none; padding-block: var(--space-2);
-  display: flex; align-items: center; gap: var(--space-2);
-}
-.v1__also summary::-webkit-details-marker { display: none; }  /* Safari */
-.v1__also summary::before {
-  content: '▸'; color: var(--signal); transition: transform var(--dur-fast) ease;
-  display: inline-block;
-}
-.v1__also[open] summary::before { transform: rotate(90deg); }
-.v1__also-grid {
-  display: grid; grid-template-columns: 1fr; gap: var(--space-6);
-  margin-top: var(--space-6);
-}
-@media (min-width: 768px) { .v1__also-grid { grid-template-columns: repeat(2, 1fr); } }
-.v1__also-grid h4 { font-size: var(--text-base); margin-bottom: var(--space-3); color: var(--text); }
-.v1__also-grid ul { display: flex; flex-direction: column; gap: var(--space-2); }
-.v1__also-grid li, .v1__also-grid p {
-  font-size: var(--text-sm); color: var(--text-secondary); line-height: 1.6;
-}
-.v1__also-grid code {
-  background: var(--bg); padding: 1px 5px; border-radius: 3px;
-  font-size: 0.9em; color: var(--signal);
-}
-
-.v1__prior { padding-top: var(--space-6); border-top: 1px solid var(--border-color); }
-.v1__prior h3 { font-size: var(--text-lg); color: var(--text-secondary); margin-bottom: var(--space-4); }
-.v1__prior-label { font-weight: var(--weight-regular); }
-.v1__prior ul { display: flex; flex-direction: column; gap: var(--space-2); }
-.v1__prior li { font-size: var(--text-sm); color: var(--text-secondary); }
-.v1__prior code {
-  background: var(--surface); padding: 1px 5px; border-radius: 3px;
-  font-size: 0.9em; color: var(--signal);
-}
 
 /* ============= TRY-IT ============= */
 .try__steps {
@@ -449,13 +397,14 @@ p { color: var(--text-secondary); }
   overflow-x: auto;
 }
 .try__callout {
-  font-size: var(--text-xs); color: var(--text-secondary);
+  font-size: var(--text-sm); color: var(--text-secondary);
   border-top: 1px dashed var(--border-color); padding-top: var(--space-3);
   margin-top: auto;
 }
 .try__callout code {
   background: var(--surface); padding: 1px 4px; border-radius: 3px;
   font-size: 0.95em; color: var(--signal);
+  overflow-wrap: anywhere;
 }
 
 .try__usage { padding-top: var(--space-12); border-top: 1px solid var(--border-color); }
@@ -468,7 +417,7 @@ p { color: var(--text-secondary); }
 @media (min-width: 1024px) {
   .try__exchange { grid-template-columns: 1fr 1fr; }
 }
-.try__exchange > div { display: flex; flex-direction: column; }
+.try__exchange > div { display: flex; flex-direction: column; min-width: 0; }
 .try__exchange h4 {
   font-size: var(--text-sm); font-family: var(--font-mono);
   text-transform: uppercase; letter-spacing: 0.1em;
@@ -489,6 +438,7 @@ p { color: var(--text-secondary); }
   display: flex; gap: var(--space-1);
   border-bottom: 1px solid var(--border-color);
   margin-bottom: var(--space-4);
+  flex-wrap: wrap;
 }
 .tabs__btn {
   padding: var(--space-2) var(--space-4);
@@ -496,6 +446,7 @@ p { color: var(--text-secondary); }
   color: var(--text-secondary);
   border-bottom: 2px solid transparent;
   margin-bottom: -1px;
+  min-height: 44px;
   transition: color var(--dur-fast) ease, border-color var(--dur-fast) ease;
 }
 .tabs__btn:hover { color: var(--text); }
@@ -505,6 +456,22 @@ p { color: var(--text-secondary); }
 }
 .tabs__panel { display: none; }
 .tabs__panel.is-active { display: block; }
+
+/* Usage tabs: stack panels in one grid cell so the container reserves the
+   tallest panel's height and content below doesn't shift on tab switch. */
+.tabs[data-tabs="usage"] {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+}
+.tabs[data-tabs="usage"] .tabs__buttons { grid-row: 1; }
+.tabs[data-tabs="usage"] .tabs__panel,
+.tabs[data-tabs="usage"] .tabs__panel[hidden] {
+  display: block;
+  grid-row: 2;
+  grid-column: 1;
+  visibility: hidden;
+}
+.tabs[data-tabs="usage"] .tabs__panel.is-active { visibility: visible; }
 
 /* ============= DEEPER ============= */
 .deeper__grid {
@@ -666,9 +633,32 @@ p { color: var(--text-secondary); }
   border-top: 1px solid currentColor;
 }
 
+/* Mobile disclosure for the docs sidebar — collapsed by default,
+   toggled by initSidebarToggle() in script.js. Desktop hides the toggle. */
+.docs-sidebar-toggle { display: none; }
+
 @media (max-width: 900px) {
   .docs-shell { grid-template-columns: 1fr; }
   .docs-toc { display: none; }
+  .docs-sidebar-toggle {
+    display: flex; align-items: center; justify-content: space-between;
+    width: 100%; min-height: 44px;
+    padding: var(--space-3) var(--space-4);
+    background: var(--surface);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    color: var(--text);
+    font-family: inherit; font-size: var(--text-sm); font-weight: var(--weight-medium);
+    cursor: pointer;
+  }
+  .docs-sidebar-toggle::after {
+    content: "\25BE";
+    color: var(--text-secondary);
+    transition: transform var(--dur-fast) ease;
+  }
+  .docs-sidebar-toggle[aria-expanded="false"]::after { transform: rotate(-90deg); }
+  .docs-sidebar-toggle[aria-expanded="false"] + .docs-sidebar { display: none; }
+  .docs-sidebar { margin-top: var(--space-3); }
 }
 
 /* ===== Docs article typography ===== */
@@ -854,8 +844,11 @@ html[data-theme="dark"] .astro-code span {
   display: grid; grid-template-columns: 1fr; gap: var(--space-6);
   margin-block: var(--space-12);
 }
-@media (min-width: 768px) {
-  .v2__cards { grid-template-columns: repeat(2, 1fr); gap: var(--space-8); }
+@media (min-width: 900px) {
+  .v2__cards { grid-template-columns: repeat(3, 1fr); gap: var(--space-6); }
+}
+@media (min-width: 1024px) {
+  .v2__cards { gap: var(--space-8); }
 }
 .v2__card {
   position: relative;
@@ -863,9 +856,7 @@ html[data-theme="dark"] .astro-code span {
   border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
   padding: var(--space-8);
-  transition: border-color var(--dur-base) ease, transform var(--dur-base) ease;
 }
-.v2__card:hover { border-color: var(--signal); transform: translateY(-2px); }
 .v2__card-dot {
   position: absolute; top: var(--space-5); right: var(--space-5);
   width: 10px; height: 10px; border-radius: 50%;

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -2,7 +2,7 @@ User-agent: *
 Allow: /
 
 # Sitemap
-Sitemap: https://cameronrye.github.io/openzim-mcp/sitemap.xml
+Sitemap: https://cameronrye.github.io/openzim-mcp/sitemap-index.xml
 
 # Well-known URIs
 Allow: /.well-known/

--- a/website/src/components/Sidebar.astro
+++ b/website/src/components/Sidebar.astro
@@ -10,7 +10,15 @@ const orderedGroups = ['Get started', 'Reference', 'Guides', 'Operations'] as co
 const { currentSlug } = Astro.props as { currentSlug: string };
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
-<nav class="docs-sidebar" aria-label="Documentation">
+<div class="docs-sidebar-wrap">
+<button
+  class="docs-sidebar-toggle"
+  id="docs-sidebar-toggle"
+  type="button"
+  aria-controls="docs-sidebar-nav"
+  aria-expanded="true"
+>Documentation menu</button>
+<nav class="docs-sidebar" id="docs-sidebar-nav" aria-label="Documentation">
   {orderedGroups.map((g) =>
     groups[g] && (
       <section>
@@ -29,3 +37,4 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
     )
   )}
 </nav>
+</div>

--- a/website/src/components/SiteFooter.astro
+++ b/website/src/components/SiteFooter.astro
@@ -33,8 +33,8 @@ const docsHref = `${base}/docs/`;
         </a>
         <p>Knowledge that works offline. Released under the <a href="https://opensource.org/licenses/MIT">MIT License</a>.</p>
         <div class="footer__badges">
-          <img src="https://img.shields.io/badge/python-3.12+-blue.svg" alt="Python 3.12+" loading="lazy">
-          <img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="MIT License" loading="lazy">
+          <img src="https://img.shields.io/badge/python-3.12+-blue.svg" alt="Python 3.12+" width="98" height="20" loading="lazy">
+          <img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="MIT License" width="87" height="20" loading="lazy">
         </div>
       </div>
       <div>

--- a/website/src/content/docs/api-reference.mdx
+++ b/website/src/content/docs/api-reference.mdx
@@ -359,7 +359,7 @@ Single entry served with native MIME type:
 zim://wikipedia_en/entry/A%2FClimate_change
 ```
 
-A literal slash will fail to route. See the [Resources, prompts and subscriptions guide](/openzim-mcp/docs/resources-prompts-subscriptions/) for full details.
+A literal slash will fail to route. See the [Resources, prompts & subscriptions guide](/openzim-mcp/docs/resources-prompts-subscriptions/) for full details.
 
 ---
 
@@ -377,7 +377,7 @@ Configuration:
 | `OPENZIM_MCP_SUBSCRIPTIONS_ENABLED` | `true` | master switch |
 | `OPENZIM_MCP_WATCH_INTERVAL_SECONDS` | `5` | 1–60 |
 
-See [Resources, prompts and subscriptions](/openzim-mcp/docs/resources-prompts-subscriptions/) for full client-side examples.
+See [Resources, prompts & subscriptions](/openzim-mcp/docs/resources-prompts-subscriptions/) for full client-side examples.
 
 ---
 
@@ -464,6 +464,6 @@ There are no on-the-wire aliases at v2.0 — old tool names disappear cleanly pe
 
 ---
 
-**Need configuration help?** See [Configuration](/openzim-mcp/docs/configuration/). **Deploying over HTTP?** See [HTTP and Docker Deployment](/openzim-mcp/docs/http-and-docker-deployment/). **Using resources / subscriptions?** See [Resources, prompts and subscriptions](/openzim-mcp/docs/resources-prompts-subscriptions/).
+**Need configuration help?** See [Configuration](/openzim-mcp/docs/configuration/). **Deploying over HTTP?** See [HTTP and Docker Deployment](/openzim-mcp/docs/http-and-docker-deployment/). **Using resources / subscriptions?** See [Resources, prompts & subscriptions](/openzim-mcp/docs/resources-prompts-subscriptions/).
 
 *v1.x is in maintenance through 2026-11-27. See [CHANGELOG](https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md) for the v1 → v2 migration table.*

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -16,18 +16,62 @@ export interface Props {
 const { title, description, group, slug, headings } = Astro.props;
 const repoEditUrl = `https://github.com/cameronrye/openzim-mcp/blob/main/website/src/content/docs/${slug === 'index' ? 'index' : slug}.mdx`;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const canonicalUrl = `https://cameronrye.github.io${base}/docs/${slug === 'index' ? '' : slug + '/'}`;
+const pageTitle = `${title} — OpenZIM MCP docs`;
+const breadcrumbLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'OpenZIM MCP', item: `https://cameronrye.github.io${base}/` },
+    { '@type': 'ListItem', position: 2, name: 'Documentation', item: `https://cameronrye.github.io${base}/docs/` },
+    ...(slug === 'index' ? [] : [{ '@type': 'ListItem', position: 3, name: title, item: canonicalUrl }]),
+  ],
+};
 ---
 <!doctype html>
 <html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>{title} — OpenZIM MCP docs</title>
+    <title>{pageTitle}</title>
     <meta name="description" content={description} />
     <meta name="theme-color" content="#0B0F1A">
     <meta name="color-scheme" content="dark light">
     <link rel="icon" type="image/svg+xml" href={`${base}/assets/favicon.svg`}>
-    <link rel="canonical" href={`https://cameronrye.github.io${base}/docs/${slug === 'index' ? '' : slug + '/'}`}>
+    <link rel="canonical" href={canonicalUrl}>
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="article">
+    <meta property="og:site_name" content="OpenZIM MCP">
+    <meta property="og:url" content={canonicalUrl}>
+    <meta property="og:title" content={pageTitle}>
+    <meta property="og:description" content={description}>
+    <meta property="og:image" content="https://cameronrye.github.io/openzim-mcp/assets/og-image.svg">
+    <meta property="og:image:alt" content="OpenZIM MCP 2.0.0 — Knowledge that works offline">
+    <meta property="og:locale" content="en_US">
+    <meta property="article:section" content={group}>
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content={canonicalUrl}>
+    <meta name="twitter:title" content={pageTitle}>
+    <meta name="twitter:description" content={description}>
+    <meta name="twitter:image" content="https://cameronrye.github.io/openzim-mcp/assets/og-image.svg">
+    <meta name="twitter:image:alt" content="OpenZIM MCP 2.0.0 — Knowledge that works offline">
+
+    <script type="application/ld+json" is:inline set:html={JSON.stringify(breadcrumbLd)} />
+
+    <!-- Theme init: set before stylesheet parse to avoid FOUC. -->
+    <script is:inline>
+      (function () {
+        try {
+          var stored = localStorage.getItem('theme');
+          var theme = stored || (matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+          document.documentElement.dataset.theme = theme;
+        } catch (e) {}
+      })();
+    </script>
+
     <link rel="stylesheet" href={`${base}/assets/styles.css`} />
   </head>
   <body>
@@ -35,9 +79,12 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
     <SiteHeader context="docs" />
     <div class="docs-shell">
       <Sidebar currentSlug={slug} />
-      <main class="docs-main" id="docs-main">
+      <main class="docs-main" id="docs-main" tabindex="-1">
         <Breadcrumbs group={group} title={title} />
-        <article class="docs-article"><slot /></article>
+        <article class="docs-article">
+          <h1>{title}</h1>
+          <slot />
+        </article>
         <PrevNext currentSlug={slug} />
         <p class="docs-edit"><a href={repoEditUrl} target="_blank" rel="noopener">Edit this page on GitHub ↗</a></p>
       </main>

--- a/website/src/layouts/LandingLayout.astro
+++ b/website/src/layouts/LandingLayout.astro
@@ -13,6 +13,17 @@ const { title, description } = Astro.props;
   <title>{title}</title>
   <meta name="description" content={description}>
 
+  <!-- Theme init: set before stylesheet parse to avoid FOUC. -->
+  <script is:inline>
+    (function () {
+      try {
+        var stored = localStorage.getItem('theme');
+        var theme = stored || (matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+        document.documentElement.dataset.theme = theme;
+      } catch (e) {}
+    })();
+  </script>
+
   <slot name="head" />
 </head>
 <body>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -25,12 +25,12 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
     <meta property="og:title" content="OpenZIM MCP — Knowledge that works offline">
     <meta property="og:description" content="MCP server for offline ZIM-archive access. 8-tool advanced surface, streamable HTTP, batch retrieval, per-entry resources, subscriptions. v2.0.0.">
     <meta property="og:image" content="https://cameronrye.github.io/openzim-mcp/assets/og-image.svg">
+    <meta property="og:image:alt" content="OpenZIM MCP 2.0.0 — Knowledge that works offline">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta property="og:image:alt" content="OpenZIM MCP 1.0 — Knowledge that works offline">
     <meta property="og:locale" content="en_US">
     <meta property="article:author" content="Cameron Rye">
-    <meta property="article:modified_time" content="2026-05-27T00:00:00Z">
+    <meta property="article:modified_time" content="2026-05-28T00:00:00Z">
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
@@ -40,7 +40,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
     <meta name="twitter:title" content="OpenZIM MCP — Knowledge that works offline">
     <meta name="twitter:description" content="MCP server for offline ZIM-archive access. 8-tool advanced surface, streamable HTTP, batch retrieval, per-entry resources, subscriptions. v2.0.0.">
     <meta name="twitter:image" content="https://cameronrye.github.io/openzim-mcp/assets/og-image.svg">
-    <meta name="twitter:image:alt" content="OpenZIM MCP 1.0 — Knowledge that works offline">
+    <meta name="twitter:image:alt" content="OpenZIM MCP 2.0.0 — Knowledge that works offline">
 
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico">
@@ -142,7 +142,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
   <SiteHeader context="landing" />
 
-  <main id="main">
+  <main id="main" tabindex="-1">
 
     <section id="hero" class="hero">
       <div class="container hero__inner">
@@ -219,8 +219,8 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
           </p>
         </header>
 
-        <figure class="what__diagram" aria-label="Architecture diagram: ZIM archive flows through openzim-mcp to your LLM">
-          <svg viewBox="0 0 720 220" role="img" xmlns="http://www.w3.org/2000/svg">
+        <figure class="what__diagram">
+          <svg viewBox="0 0 720 220" role="img" aria-label="Architecture diagram: ZIM archive flows through openzim-mcp to your LLM" xmlns="http://www.w3.org/2000/svg">
             <defs>
               <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
                 <path d="M0,0 L10,5 L0,10 z" fill="#FFD24A"/>
@@ -228,8 +228,8 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
             </defs>
             <g>
               <rect x="20"  y="60" width="180" height="100" rx="10" fill="transparent" stroke="currentColor" stroke-opacity="0.2" stroke-width="1.5"/>
-              <text x="110" y="105" text-anchor="middle" fill="currentColor" font-family="Geist, system-ui, sans-serif" font-size="18" font-weight="600">ZIM archive</text>
-              <text x="110" y="130" text-anchor="middle" fill="currentColor" fill-opacity="0.6" font-family="JetBrains Mono, ui-monospace, monospace" font-size="13">Static</text>
+              <text class="what__diagram-label" x="110" y="105" text-anchor="middle" fill="currentColor" font-family="Geist, system-ui, sans-serif" font-size="18" font-weight="600">ZIM archive</text>
+              <text class="what__diagram-sublabel" x="110" y="130" text-anchor="middle" fill="currentColor" fill-opacity="0.6" font-family="JetBrains Mono, ui-monospace, monospace" font-size="13">Static</text>
             </g>
             <g>
               <rect x="270" y="40" width="180" height="140" rx="10" fill="transparent" stroke="#FFD24A" stroke-width="2"/>
@@ -240,21 +240,21 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
                 <path d="M12 18h6a2 2 0 0 1 2 2v1"/>
                 <path d="M12 8h8"/>
                 <path d="M16 8V5a2 2 0 0 1 2-2"/>
-                <circle cx="16" cy="13" r=".7" fill="#FFD24A" stroke="none"/>
-                <circle cx="18" cy="3"  r=".7" fill="#FFD24A" stroke="none"/>
-                <circle cx="20" cy="8"  r=".7" fill="#FFD24A" stroke="none"/>
-                <circle cx="20" cy="21" r=".7" fill="#FFD24A" stroke="none"/>
+                <circle class="what__diagram-spark" cx="16" cy="13" r=".7" fill="#FFD24A" stroke="none"/>
+                <circle class="what__diagram-spark" cx="18" cy="3"  r=".7" fill="#FFD24A" stroke="none"/>
+                <circle class="what__diagram-spark" cx="20" cy="8"  r=".7" fill="#FFD24A" stroke="none"/>
+                <circle class="what__diagram-spark" cx="20" cy="21" r=".7" fill="#FFD24A" stroke="none"/>
               </g>
-              <text x="360" y="148" text-anchor="middle" fill="currentColor" font-family="Geist, system-ui, sans-serif" font-size="16" font-weight="600">openzim-mcp</text>
-              <text x="360" y="168" text-anchor="middle" fill="#FFD24A" font-family="JetBrains Mono, ui-monospace, monospace" font-size="13">Intelligent</text>
+              <text class="what__diagram-label" x="360" y="148" text-anchor="middle" fill="currentColor" font-family="Geist, system-ui, sans-serif" font-size="16" font-weight="600">openzim-mcp</text>
+              <text class="what__diagram-sublabel" x="360" y="168" text-anchor="middle" fill="#FFD24A" font-family="JetBrains Mono, ui-monospace, monospace" font-size="13">Intelligent</text>
             </g>
             <g>
               <rect x="520" y="60" width="180" height="100" rx="10" fill="transparent" stroke="currentColor" stroke-opacity="0.2" stroke-width="1.5"/>
-              <text x="610" y="105" text-anchor="middle" fill="currentColor" font-family="Geist, system-ui, sans-serif" font-size="18" font-weight="600">Your LLM</text>
-              <text x="610" y="130" text-anchor="middle" fill="currentColor" fill-opacity="0.6" font-family="JetBrains Mono, ui-monospace, monospace" font-size="13">Conversational</text>
+              <text class="what__diagram-label" x="610" y="105" text-anchor="middle" fill="currentColor" font-family="Geist, system-ui, sans-serif" font-size="18" font-weight="600">Your LLM</text>
+              <text class="what__diagram-sublabel" x="610" y="130" text-anchor="middle" fill="currentColor" fill-opacity="0.6" font-family="JetBrains Mono, ui-monospace, monospace" font-size="13">Conversational</text>
             </g>
-            <line x1="200" y1="110" x2="265" y2="110" stroke="#FFD24A" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrow)"/>
-            <line x1="450" y1="110" x2="515" y2="110" stroke="#FFD24A" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrow)"/>
+            <line class="what__diagram-flow" x1="200" y1="110" x2="265" y2="110" stroke="#FFD24A" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrow)"/>
+            <line class="what__diagram-flow" x1="450" y1="110" x2="515" y2="110" stroke="#FFD24A" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrow)"/>
           </svg>
         </figure>
 


### PR DESCRIPTION
## Summary

Post-v2.0.0 hardening sweep: 4 passes of live-Wikipedia beta-testing uncovered 7 dispatcher/tool defects, all fixed. Bundled with a separate 3-pass website audit (a11y, SEO, mobile polish, bug fixes).

## Defect passes

- **Pass-1 (D-A/B/C/D)** — `4179945` — 4 dispatcher defects in `simple_tools`
- **Pass-2 (D-E)** — `18cedf9` — empty-quoted silent-resolve in `intent_parser`
- **Pass-3 (D-F)** — `cad2797` — `max_content_length` input validation in `tools/zim_query`
- **Pass-4 (D-G + D-F sibling)** — `2eac830` — `synthesize` empty-topic guard + `zim_get` sibling

## Website audit

- `cdfbc48` — three-pass audit covering bug fixes, accessibility/SEO, and mobile polish

## Tests

- 57 regression tests added in `tests/test_post_v2_0_0_beta_fixes.py` (1,153 lines)
- Full suite: **2554 passed**, 236 skipped, 38 deselected (locally on macOS)

## Test plan

- [ ] CI: lint
- [ ] CI: type-check
- [ ] CI: security
- [ ] CI: test matrix (3.11 / 3.12, ubuntu/macos/windows)
- [ ] CI: CodeQL
- [ ] CI: SonarCloud
