### PR TITLE
fix: post-v2.0.4 beta-test sweep — 4 defects across 4 passes

### DIFF
--- a/openzim_mcp/intent_parser.py
+++ b/openzim_mcp/intent_parser.py
@@ -271,7 +271,16 @@ def _extract_entry_path_keyworded(query: str, params: Dict[str, Any]) -> None:
         rf"{_QUOTE_OPEN}({_QUOTE_NOT}+){_QUOTE_OPEN}", query
     )
     if quoted_match:
-        params["entry_path"] = quoted_match.group(1)
+        # Post-v2.0.4 D-E sibling: ``get article "  "`` /
+        # ``structure of "  "`` (whitespace-only between matched
+        # quotes) bypassed the canonical-branch's empty-drop guard
+        # because the ``+`` quantifier matches whitespace chars. Trim
+        # the captured value and drop the param entirely when empty
+        # so the handler's missing-arg guard fires instead of
+        # propagating ``"  "`` to the backend's title-promotion.
+        captured = quoted_match.group(1).strip()
+        if captured:
+            params["entry_path"] = captured
         return
 
     # Find every keyword position; take the LAST so that

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -5431,6 +5431,31 @@ class SimpleToolsHandler:
         """
         from openzim_mcp.synthesize import synthesize_query
 
+        # Post-v2.0.4 D-I: mirror the meta-only / chained-intent guards
+        # the non-synthesize path fires at handle_zim_query lines 693
+        # and 710. Pre-fix the synthesize early-exit at line 626 skipped
+        # both: ``try again`` BM25-searched and returned Aaliyah's "Try
+        # Again" song; ``tell me about Berlin then list namespaces``
+        # silently RAG-searched the literal verb chain and returned
+        # Namespace + War articles instead of rejecting the chain.
+        # Same shape as the post-v2.0.0 D-G fix — return a structured
+        # tool_error envelope (synthesize's native error shape) with
+        # the full markdown guidance from the simple-mode helpers so
+        # callers get the same actionable recovery info.
+        if self._is_meta_only_query(query):
+            self._track("meta_only_guidance")
+            return tool_error(
+                operation="meta_only_guidance",
+                message=self._meta_query_guidance(),
+            )
+        chained_warning = self._chained_intent_guidance(query)
+        if chained_warning is not None:
+            self._track("chained_intent_rejected")
+            return tool_error(
+                operation="chained_intent_rejected",
+                message=chained_warning,
+            )
+
         # D5: distill the user's natural-language query down to the
         # topic (or actual search terms) BEFORE handing it to BM25.
         # The intent parser already knows how to pull "Berlin" out of
@@ -5525,6 +5550,40 @@ class SimpleToolsHandler:
                         'Examples: `search for "quantum mechanics"`, '
                         "`search for Berlin in namespace C`."
                     ),
+                )
+        # Post-v2.0.4 D-I: mirror the multi-entity chain rejection the
+        # non-synthesize path fires at handle_zim_query line 960.
+        # Pre-fix, ``tell me about Berlin and Munich and Cologne`` with
+        # synthesize=True silently RAG-searched the literal three-entity
+        # chain and returned Cologne plus unrelated articles — Berlin
+        # and Munich data dropped on the floor. ``_multi_entity_chain_
+        # guidance`` requires a real archive path to probe the title
+        # index (so canonical multi-entity titles like ``Earth, Wind &
+        # Fire`` aren't false-rejected). Resolve best-effort: use the
+        # explicit zim_file_path if given, else pick the first
+        # available archive. When no archive is available skip the
+        # probe — the synthesize pipeline will surface a
+        # no_archives_available error below anyway.
+        multi_probe_path: Optional[str] = zim_file_path
+        if not multi_probe_path:
+            try:
+                _file_entries = self.zim_operations.list_zim_files_data()
+                for _entry in _file_entries:
+                    _ep = _entry.get("path")
+                    if _ep:
+                        multi_probe_path = str(_ep)
+                        break
+            except Exception:
+                multi_probe_path = None
+        if multi_probe_path:
+            multi_entity_warning = self._multi_entity_chain_guidance(
+                intent, params, multi_probe_path
+            )
+            if multi_entity_warning is not None:
+                self._track("multi_entity_chain_rejected")
+                return tool_error(
+                    operation="multi_entity_chain_rejected",
+                    message=multi_entity_warning,
                 )
         search_query = query
         if intent == "tell_me_about" and isinstance(params, dict):

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -3518,14 +3518,22 @@ class SimpleToolsHandler:
         if params.get("namespace") is None and re.search(
             r"\bin\s+namespace\b", query, re.IGNORECASE
         ):
+            # Post-v2.0.4 sweep pass-2: the embedded
+            # ``<!-- intent=filtered_search cert=0.80 -->`` here
+            # duplicated the dispatcher's auto-appended intent footer
+            # at line 1017 (every string result gets ``intent={intent}
+            # cert={confidence:.2f}`` from the parser's classification).
+            # Sibling ``_handle_browse`` / ``_handle_walk_namespace``
+            # missing-namespace envelopes never embedded it and rely on
+            # the auto-append. Drop the embedded comment so the
+            # response carries exactly one intent footer.
             return (
                 "**Missing or Invalid Namespace**\n\n"
                 "**Issue**: `search ... in namespace` needs a single "
                 "namespace letter (A, C, M, W, etc.; case-insensitive).\n"
                 "**Examples**:\n"
                 "- `search Berlin in namespace C` — main content\n"
-                "- `search Counter in namespace M` — archive metadata\n"
-                "<!-- intent=filtered_search cert=0.80 -->"
+                "- `search Counter in namespace M` — archive metadata"
             )
         # Post-a19 P1-D2: reject cursors issued by a different
         # cursor-emitting tool. Pre-fix, a ``walk_namespace`` cursor

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -3950,6 +3950,36 @@ class SimpleToolsHandler:
             topic=topic,
         )
 
+    @staticmethod
+    def _swap_tell_me_about_recovery_hint(text: str, topic: str) -> str:
+        """Post-v2.0.4 D-J: when ``_handle_tell_me_about`` falls back
+        to the search backend's rendered no-results output, the shared
+        ``_format_search_text`` recovery hints (zim/search.py:774-782)
+        suggest ``tell me about {topic}`` — which is exactly what the
+        caller just tried. Swap that bullet for a ``find article
+        titled {topic}`` hint (title-index fuzzy lookup) that's
+        genuinely a different recovery path.
+
+        Implemented as a narrow string-replace at the handler edge
+        rather than parameterizing the shared formatter so the
+        search-backend recovery wording stays canonical for direct
+        ``search for X`` callers (where the ``tell me about`` cross-
+        intent nudge is still useful). The replace is canonical-source
+        pinned by ``TestTellMeAboutNoResultsRecoveryNotCircular`` —
+        future search.py wording changes need to update the swap in
+        tandem.
+        """
+        truncated = topic[:30]
+        circular = (
+            f"- `tell me about {truncated}` — structured topic "
+            f"lookup with auto article fetch"
+        )
+        replacement = (
+            f"- `find article titled {truncated}` — title-index "
+            f"lookup with fuzzy fallback"
+        )
+        return text.replace(circular, replacement)
+
     def _handle_tell_me_about(
         self,
         query: str,
@@ -4132,8 +4162,11 @@ class SimpleToolsHandler:
 
         results = payload.get("results", []) if isinstance(payload, dict) else []
         if not results:
-            return self.zim_operations.search_zim_file(
-                zim_file_path, topic, search_limit, 0
+            return self._swap_tell_me_about_recovery_hint(
+                self.zim_operations.search_zim_file(
+                    zim_file_path, topic, search_limit, 0
+                ),
+                topic,
             )
 
         top = results[0]
@@ -4142,8 +4175,11 @@ class SimpleToolsHandler:
         if not is_strong_title_match(topic, top_path, top_title):
             promoted = self._promote_topic_via_title_index(zim_file_path, topic)
             if promoted is None:
-                return self.zim_operations.search_zim_file(
-                    zim_file_path, topic, search_limit, 0
+                return self._swap_tell_me_about_recovery_hint(
+                    self.zim_operations.search_zim_file(
+                        zim_file_path, topic, search_limit, 0
+                    ),
+                    topic,
                 )
             top_path = promoted["path"]
             top_title = promoted["title"]

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -21,7 +21,7 @@ import openzim_mcp.zim_operations as _zim_ops_mod
 
 from . import compact_renderers
 from .exceptions import RegexTimeoutError
-from .intent_parser import IntentParser, safe_regex_sub
+from .intent_parser import IntentParser, _strip_quote_pair, safe_regex_sub
 from .meta import build_meta, format_footer
 from .responses import ToolErrorPayload, tool_error
 from .security import sanitize_context_for_error
@@ -3633,6 +3633,16 @@ class SimpleToolsHandler:
                 ).strip()
             except RegexTimeoutError:
                 cleaned_query = query.strip()
+            # Post-v2.0.4 D-E sibling: peel a surrounding quote-pair so
+            # ``get article ""`` / ``get article ''`` drop to the missing-
+            # arg guard. Pre-fix the word-strip left the literal 2-char
+            # quote pair, which the backend fuzzy-matched to the
+            # ``Empty_string`` article at cert=0.75 (same silent-wrong-
+            # answer shape as the post-v2.0.0 D-E sweep — that fix landed
+            # on the extractor and the keyword-branch tail, but the
+            # ``_handle_get_article`` word-strip recovery branch
+            # regenerates the literal from ``query`` and bypasses it).
+            cleaned_query = _strip_quote_pair(cleaned_query)
             if not cleaned_query:
                 return (
                     "**Missing Article Path**\n\n"

--- a/tests/test_post_v2_0_4_beta_fixes.py
+++ b/tests/test_post_v2_0_4_beta_fixes.py
@@ -1,0 +1,202 @@
+"""Regression tests for the post-v2.0.4 beta-test sweep.
+
+Single defect surfaced by a live two-archive sweep
+(zim.owl-atlas.ts.net, wikipedia_en_all_maxi_2026-02 + superuser.com_en_all
+_2026-02):
+
+D-E sibling on ``_handle_get_article`` word-strip recovery branch.
+The post-v2.0.0 sweep's D-E fix landed on three extractors
+(``_extract_find_by_title``, ``_extract_related``,
+``_extract_entry_path_keyworded``) and dropped the empty-quote 2-char
+literal cleanly at parse time. ``IntentParser.parse_intent('get article
+"")`` correctly returns ``{}`` (no ``entry_path``) — the parser is
+fine.
+
+But ``_handle_get_article`` has a word-strip recovery branch for the
+case when the parser returned no ``entry_path``: it does
+``safe_regex_sub(r"\\b(get|show|read|display|fetch|article|entry|page)\\b",
+"", query, flags=IGNORECASE).strip()`` and assigns the result as the
+``entry_path``. For ``get article ""``, that word-strip leaves the
+literal 2-char ``""`` (whitespace ``.strip()`` is no-op on quote
+chars), the truthy 2-char string passes the ``if not cleaned_query:``
+guard, and the backend's title-promotion fuzzy-matches the literal
+``""`` to the ``Empty_string`` Wikipedia article at cert=0.75.
+
+Fix mirrors the post-v2.0.0 D-E shape: apply ``_strip_quote_pair`` to
+``cleaned_query`` after the word-strip and re-check the empty guard.
+Empty quote-pair drops to the ``Missing Article Path`` envelope;
+quote-stripped real content (``get article "Photosynthesis"``) flows
+through normally; bare paths (``get article Biology``) are unaffected.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from openzim_mcp.simple_tools import SimpleToolsHandler
+
+# ===========================================================================
+# D-E sibling — ``_handle_get_article`` word-strip recovery branch
+# ===========================================================================
+
+
+class TestGetArticleEmptyQuotedDropsToMissingArgGuard:
+    """Pre-fix, ``get article ""`` reached the backend with
+    ``entry_path='""'`` (the literal 2-char ASCII quote pair) which
+    title-promotion fuzzy-matched to the ``Empty_string`` Wikipedia
+    article at cert=0.75. Same silent-wrong-answer shape as the
+    post-v2.0.0 D-E sweep, on the one handler the original fix
+    couldn't cover (the parser drops ``entry_path`` correctly; this
+    handler regenerates the literal from ``query`` via word-strip
+    fallback).
+    """
+
+    @pytest.fixture
+    def mock_zim_operations(self) -> Mock:
+        mock = Mock()
+        mock.list_zim_files.return_value = (
+            '[{"path": "/test/file.zim", "name": "file.zim"}]'
+        )
+        mock.get_zim_entry.return_value = "Article content"
+        return mock
+
+    @pytest.fixture
+    def handler(self, mock_zim_operations: Mock) -> SimpleToolsHandler:
+        return SimpleToolsHandler(mock_zim_operations)
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            # Canonical ``get article`` trigger; ASCII single + double:
+            'get article ""',
+            "get article ''",
+            # Sibling phrasings that still route to ``get_article`` intent
+            # (``show article`` routes to ``browse`` — out of scope here):
+            'read article ""',
+            'fetch article ""',
+            'get entry ""',
+            'get page ""',
+            # Curly quote pairs from LLM/copy-paste:
+            "get article “”",  # “”
+            "get article ‘’",  # ‘’
+            # Whitespace-only between quotes — same expected behaviour:
+            'get article "  "',
+            "get article '  '",
+        ],
+    )
+    def test_empty_quoted_input_drops_to_missing_arg_guard(
+        self,
+        handler: SimpleToolsHandler,
+        mock_zim_operations: Mock,
+        query: str,
+    ) -> None:
+        """Each empty/whitespace-only quote pair must surface the
+        structured ``Missing Article Path`` envelope WITHOUT calling
+        ``get_zim_entry``. Pre-fix the literal 2-char quote pair
+        propagated to ``get_zim_entry`` which fuzzy-matched to the
+        ``Empty_string`` Wikipedia article at cert=0.75.
+        """
+        result = handler.handle_zim_query(query, "/test/file.zim")
+        assert "Missing Article Path" in result, (
+            f"Empty-quoted input {query!r} must fire the missing-arg "
+            f"guard. Got: {result!r}"
+        )
+        mock_zim_operations.get_zim_entry.assert_not_called()
+
+    def test_quote_stripped_real_topic_still_resolves(
+        self,
+        handler: SimpleToolsHandler,
+        mock_zim_operations: Mock,
+    ) -> None:
+        """Regression: ``get article "Photosynthesis"`` (quote-pair with
+        real content) must continue to reach ``get_zim_entry`` with the
+        quote-stripped value, not fire the missing-arg guard.
+        """
+        result = handler.handle_zim_query(
+            'get article "Photosynthesis"', "/test/file.zim"
+        )
+        assert "Missing Article Path" not in result
+        mock_zim_operations.get_zim_entry.assert_called_once()
+        # entry_path is the second positional arg
+        called_entry_path = mock_zim_operations.get_zim_entry.call_args.args[1]
+        assert '"' not in called_entry_path and "'" not in called_entry_path, (
+            f"Quote-strip must remove surrounding quote pair before the "
+            f"backend lookup. Got entry_path={called_entry_path!r}"
+        )
+
+    def test_bare_topic_unaffected(
+        self,
+        handler: SimpleToolsHandler,
+        mock_zim_operations: Mock,
+    ) -> None:
+        """Regression guard: ``get article Biology`` (no quotes) must
+        keep flowing through the word-strip fallback unchanged."""
+        result = handler.handle_zim_query("get article Biology", "/test/file.zim")
+        assert "Missing Article Path" not in result
+        mock_zim_operations.get_zim_entry.assert_called_once()
+
+
+# ===========================================================================
+# Parser-level: ``_extract_entry_path_keyworded`` quoted_match branch
+# whitespace-only widening — benefits get_article / structure / toc /
+# summary / links via the shared extractor.
+# ===========================================================================
+
+
+class TestEntryPathExtractorWhitespaceQuotedDrops:
+    """``get article "  "`` and siblings reached the handler with
+    ``entry_path="  "`` (2 whitespace chars) because the quoted_match
+    branch's ``+`` quantifier matched whitespace-only content. Truthy
+    2-char string then bypassed every downstream ``if not entry_path:``
+    guard. Fix strips the captured value and drops the param entirely
+    when empty after strip.
+    """
+
+    @pytest.mark.parametrize(
+        "query,expected_intent",
+        [
+            ('get article "  "', "get_article"),
+            ("get article '  '", "get_article"),
+            ('structure of "  "', "structure"),
+            ('links in "  "', "links"),
+            ('summary of "  "', "summary"),
+            ('toc of "  "', "toc"),
+        ],
+    )
+    def test_whitespace_only_quoted_drops_entry_path(
+        self, query: str, expected_intent: str
+    ) -> None:
+        """Each entry-path-keyworded intent must drop the param when
+        the quoted value is whitespace-only, so the handler's
+        missing-arg guard fires instead of the backend silent-matching
+        the literal whitespace to a disambig page."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(query)
+        assert intent == expected_intent
+        assert not params.get("entry_path"), (
+            f"{query!r} captured entry_path={params.get('entry_path')!r}; "
+            f"expected drop after whitespace-strip so the handler's "
+            f"missing-arg guard fires."
+        )
+
+    def test_quoted_real_topic_still_resolves(self) -> None:
+        """Regression: ``get article "Photosynthesis"`` must still
+        capture the topic (no spurious strip on non-empty content)."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent(
+            'get article "Photosynthesis"'
+        )
+        assert intent == "get_article"
+        assert params.get("entry_path") == "photosynthesis"
+
+    def test_quoted_topic_with_inner_whitespace_preserved(self) -> None:
+        """Regression: interior whitespace in a real topic
+        (``get article "World War II"``) must survive — only
+        surrounding whitespace is stripped."""
+        from openzim_mcp.intent_parser import IntentParser
+
+        intent, params, _conf = IntentParser.parse_intent('get article "World War II"')
+        assert intent == "get_article"
+        assert params.get("entry_path") == "world war ii"

--- a/tests/test_post_v2_0_4_beta_fixes.py
+++ b/tests/test_post_v2_0_4_beta_fixes.py
@@ -271,3 +271,147 @@ class TestFilteredSearchMissingNamespaceSingleIntentFooter:
         )
         assert "Missing or Invalid Namespace" in out
         assert out.count("<!-- intent=browse cert=") == 1
+
+
+# ===========================================================================
+# Pass-3 D-I — synthesize path bypasses meta-only / chained-intent /
+# multi-entity-chain guards. Same shape as the post-v2.0.0 D-G fix:
+# the synthesize early-exit at simple_tools.py:626 skipped three
+# additional guards the non-synthesize path fires at handle_zim_query
+# lines 693, 710, 960.
+# ===========================================================================
+
+
+class TestSynthesizePathBypassesGuards:
+    """Pre-fix, ``synthesize=True`` with a meta-only / chained / multi-
+    entity query bypassed the guards and silently RAG-searched the
+    literal verb chain:
+      * ``try again`` → Aaliyah's "Try Again" song body
+      * ``tell me about Berlin then list namespaces`` → Namespace + War
+      * ``tell me about Berlin and Munich and Cologne`` → Cologne only
+
+    Fix mirrors the simple-mode guards inside ``_handle_synthesize_query``
+    and returns structured ``tool_error`` envelopes (synthesize's
+    native error shape, same as D-G).
+    """
+
+    def _make_handler(self) -> SimpleToolsHandler:
+        from unittest.mock import MagicMock
+
+        mock_ops = MagicMock()
+        mock_ops.list_zim_files_data.return_value = [
+            {"path": "/data/zim_0.zim", "name": "zim_0.zim"},
+        ]
+        mock_ops.list_zim_files.return_value = "Found 1 ZIM file."
+        # ``_multi_entity_chain_guidance`` probes the title index. For
+        # bare chain rejections we want the probe to MISS so the
+        # guidance fires; return an empty results envelope.
+        mock_ops.find_entry_by_title_data.return_value = {"results": []}
+        mock_ops.config = MagicMock()
+        mock_ops.config.query_rewrite = MagicMock()
+        mock_ops.config.query_rewrite.enabled = False
+        return SimpleToolsHandler(mock_ops)
+
+    def test_synthesize_meta_only_returns_meta_only_guidance(self) -> None:
+        """``try again`` with synthesize=True must fire the same meta-
+        only guidance the simple path fires at handle_zim_query line
+        693, NOT silently BM25-search the literal phrase and return
+        the Aaliyah "Try Again" song body."""
+        handler = self._make_handler()
+        result = handler.handle_zim_query(
+            query="try again", options={"synthesize": True}
+        )
+        assert isinstance(result, dict), (
+            f"Expected tool_error envelope (dict). Got {type(result).__name__}: "
+            f"{result!r}"
+        )
+        assert result.get("error") is True
+        assert result.get("operation") == "meta_only_guidance", (
+            f"Pre-fix `try again` with synthesize silently returned the "
+            f"Aaliyah `Try Again` song. Post-fix must return "
+            f"meta_only_guidance. Got operation="
+            f"{result.get('operation')!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "tell me about Berlin then list namespaces",
+            "get article Photosynthesis then search for Berlin",
+            "search for biology then show structure of Evolution",
+        ],
+    )
+    def test_synthesize_chained_intent_returns_chained_rejection(
+        self, query: str
+    ) -> None:
+        """Each chained-operation query with synthesize=True must fire
+        the same chained_intent_rejected envelope as the simple path
+        (handle_zim_query line 710), NOT silently RAG-search the
+        literal chain."""
+        handler = self._make_handler()
+        result = handler.handle_zim_query(query, options={"synthesize": True})
+        assert isinstance(result, dict)
+        assert result.get("error") is True
+        assert result.get("operation") == "chained_intent_rejected", (
+            f"Pre-fix {query!r} with synthesize silently returned RAG hits "
+            f"on the literal chain. Post-fix must return "
+            f"chained_intent_rejected. Got operation="
+            f"{result.get('operation')!r}"
+        )
+        # Recovery info preserved: simple-mode markdown body should be
+        # passed through as the tool_error message.
+        assert "Chained Operations Detected" in (result.get("message") or "")
+
+    def test_synthesize_multi_entity_returns_multi_entity_rejection(self) -> None:
+        """``tell me about Berlin and Munich and Cologne`` with
+        synthesize=True must fire multi_entity_chain_rejected as the
+        simple path does (handle_zim_query line 960). Pre-fix returned
+        Cologne plus unrelated articles — Berlin and Munich silently
+        dropped."""
+        handler = self._make_handler()
+        result = handler.handle_zim_query(
+            "tell me about Berlin and Munich and Cologne",
+            options={"synthesize": True},
+        )
+        assert isinstance(result, dict)
+        assert result.get("error") is True
+        assert result.get("operation") == "multi_entity_chain_rejected"
+        assert "Multi-Entity Chain Detected" in (result.get("message") or "")
+
+    def test_synthesize_canonical_multi_entity_title_not_rejected(self) -> None:
+        """Regression: ``Earth, Wind & Fire`` is a canonical multi-entity
+        article title. The simple-mode path suppresses chain rejection
+        when the whole-topic title-index probe returns a high-score
+        hit. Synthesize must follow the same suppression — pin by
+        mocking the title-index probe to return score=1.0 for the
+        full topic."""
+        from unittest.mock import MagicMock
+
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        mock_ops = MagicMock()
+        mock_ops.list_zim_files_data.return_value = [
+            {"path": "/data/zim_0.zim", "name": "zim_0.zim"},
+        ]
+        mock_ops.list_zim_files.return_value = "Found 1 ZIM file."
+        mock_ops.find_entry_by_title_data.return_value = {
+            "results": [
+                {"path": "Earth,_Wind_&_Fire", "score": 1.0},
+            ]
+        }
+        mock_ops.config = MagicMock()
+        mock_ops.config.query_rewrite = MagicMock()
+        mock_ops.config.query_rewrite.enabled = False
+        # Backend synthesize path must be reached — pin by having it
+        # raise an obviously-not-a-chain-rejection error.
+        handler = SimpleToolsHandler(mock_ops)
+        result = handler.handle_zim_query(
+            "tell me about Earth, Wind & Fire",
+            options={"synthesize": True},
+        )
+        if isinstance(result, dict):
+            assert result.get("operation") != "multi_entity_chain_rejected", (
+                f"Canonical multi-entity title was incorrectly rejected. "
+                f"The title-index probe (score=1.0) should suppress the "
+                f"chain rejection. Got: {result}"
+            )

--- a/tests/test_post_v2_0_4_beta_fixes.py
+++ b/tests/test_post_v2_0_4_beta_fixes.py
@@ -415,3 +415,108 @@ class TestSynthesizePathBypassesGuards:
                 f"The title-index probe (score=1.0) should suppress the "
                 f"chain rejection. Got: {result}"
             )
+
+
+# ===========================================================================
+# Pass-4 D-J — circular ``tell me about <X>`` no-results recovery hint
+# ===========================================================================
+
+
+class TestTellMeAboutNoResultsRecoveryNotCircular:
+    """When ``_handle_tell_me_about`` falls back to the search backend
+    on no-results, the shared ``_format_search_text`` recovery hints
+    (zim/search.py:774-782) include a ``tell me about {topic}`` bullet
+    — which is exactly what the caller just tried. Live repro:
+    ``tell me about photosynthsis`` (misspelling not in the post-a11
+    map) → "No search results found for photosynthsis" with a recovery
+    bullet `tell me about photosynthsis` (circular).
+
+    Fix swaps the bullet for ``find article titled {topic}`` (title-
+    index fuzzy lookup) — a genuinely different recovery path. Pinned
+    via the canonical search-backend wording so future drift in
+    ``_format_search_text`` surfaces here.
+    """
+
+    def test_swap_replaces_circular_tell_me_about_bullet(self) -> None:
+        """Direct unit test on the helper. Given the canonical no-
+        results recovery body, the swap must drop the ``tell me about
+        X`` bullet and emit ``find article titled X`` instead."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        topic = "photosynthsis"
+        # Mirror exactly what zim/search.py:_format_search_text
+        # produces for a no-results echo. If the canonical wording
+        # drifts, the swap silently no-ops — this test pins it.
+        input_text = (
+            f'No search results found for "{topic}".\n\n'
+            f"**Try one of these:**\n"
+            f"- `suggestions for {topic[:30]}` — autocomplete to "
+            f"catch typos or partial names\n"
+            f"- `tell me about {topic[:30]}` — structured topic "
+            f"lookup with auto article fetch\n"
+            f"- A shorter or differently-cased query"
+        )
+        out = SimpleToolsHandler._swap_tell_me_about_recovery_hint(input_text, topic)
+        assert f"tell me about {topic[:30]}" not in out, (
+            f"Circular `tell me about {topic[:30]}` bullet must be removed. "
+            f"Got:\n{out}"
+        )
+        assert f"find article titled {topic[:30]}" in out, (
+            f"Replacement `find article titled {topic[:30]}` bullet missing. "
+            f"Got:\n{out}"
+        )
+
+    def test_swap_idempotent_when_no_circular_bullet(self) -> None:
+        """Regression: when the input doesn't contain the circular
+        bullet (e.g. it's already been swapped, or it's an entirely
+        different envelope), the swap leaves the text unchanged."""
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+
+        unchanged = "**Some envelope** that doesn't carry the bullet."
+        assert (
+            SimpleToolsHandler._swap_tell_me_about_recovery_hint(unchanged, "Berlin")
+            == unchanged
+        )
+
+    def test_swap_canonical_source_pin_against_format_search_text(self) -> None:
+        """Canonical-source pin: the swap relies on an EXACT-string
+        match against ``_format_search_text``'s wording. Reach into
+        the formatter directly with a zero-results payload and
+        confirm the swap consumes the bullet end-to-end. If
+        ``_format_search_text`` ever changes the wording, this test
+        fails and the swap string in ``_swap_tell_me_about_recovery_hint``
+        must be updated in tandem."""
+        from unittest.mock import MagicMock
+
+        from openzim_mcp.simple_tools import SimpleToolsHandler
+        from openzim_mcp.zim.search import _SearchMixin
+
+        topic = "photosynthsis"
+        # Build a minimal payload the formatter accepts as
+        # ``total == 0`` with no filter context.
+        payload = {
+            "query": topic,
+            "total": 0,
+            "page_info": {"offset": 0, "limit": 3},
+            "results": [],
+            "done": True,
+            "next_cursor": None,
+        }
+        # Call as an unbound method — _format_search_text is on a
+        # mixin and is self-bound, but its no-results path doesn't
+        # touch any instance state.
+        rendered = _SearchMixin._format_search_text(MagicMock(), payload)
+        # Sanity-check the formatter still emits the circular bullet
+        # the swap targets. If this assertion fires, the canonical
+        # source wording has drifted and the swap is no-opping.
+        assert (
+            f"- `tell me about {topic[:30]}` — structured topic "
+            f"lookup with auto article fetch"
+        ) in rendered, (
+            "_format_search_text no longer emits the canonical "
+            "circular bullet — update the swap string in "
+            "_swap_tell_me_about_recovery_hint to match."
+        )
+        swapped = SimpleToolsHandler._swap_tell_me_about_recovery_hint(rendered, topic)
+        assert f"tell me about {topic[:30]}" not in swapped
+        assert f"find article titled {topic[:30]}" in swapped

--- a/tests/test_post_v2_0_4_beta_fixes.py
+++ b/tests/test_post_v2_0_4_beta_fixes.py
@@ -200,3 +200,74 @@ class TestEntryPathExtractorWhitespaceQuotedDrops:
         intent, params, _conf = IntentParser.parse_intent('get article "World War II"')
         assert intent == "get_article"
         assert params.get("entry_path") == "world war ii"
+
+
+# ===========================================================================
+# Pass-2 D-H — duplicate ``<!-- intent=filtered_search cert=0.80 -->``
+# telemetry comment on missing-namespace envelope.
+# ===========================================================================
+
+
+class TestFilteredSearchMissingNamespaceSingleIntentFooter:
+    """``_handle_filtered_search`` missing-namespace envelope embedded an
+    ``<!-- intent=filtered_search cert=0.80 -->`` comment in the body
+    that duplicated the dispatcher's auto-appended footer (every string
+    result gets an intent footer at handle_zim_query, line ~1017). The
+    sibling ``_handle_browse`` / ``_handle_walk_namespace`` envelopes
+    relied on the auto-append and emitted exactly one footer. Pinning
+    parity here.
+    """
+
+    @pytest.fixture
+    def handler(self) -> SimpleToolsHandler:
+        from unittest.mock import MagicMock
+
+        mock = MagicMock()
+        mock.list_zim_files_data.return_value = [{"path": "/x.zim"}]
+        mock.config.meta.footer_enabled = False
+        # Backend must NOT be reached for invalid namespace inputs.
+        mock.search_with_filters_with_canonical_splice.side_effect = AssertionError(
+            "backend should not be called for invalid namespace"
+        )
+        return SimpleToolsHandler(mock)
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            'search Berlin in namespace ""',
+            "search photosynthesis in namespace abc",
+            "search Berlin in namespace XYZ",
+            "search foo in namespace 1",
+        ],
+    )
+    def test_exactly_one_filtered_search_intent_footer(
+        self, handler: SimpleToolsHandler, query: str
+    ) -> None:
+        """Each invalid-namespace envelope must carry exactly one
+        ``<!-- intent=filtered_search cert=...`` footer — not two. The
+        sibling browse / walk_namespace envelopes (line 2974, line 5111)
+        already emit one; this pins parity for filtered_search."""
+        out = handler.handle_zim_query(
+            query, zim_file_path="/x.zim", options={"compact": False}
+        )
+        assert "Missing or Invalid Namespace" in out
+        footer_count = out.count("<!-- intent=filtered_search cert=")
+        assert footer_count == 1, (
+            f"Expected exactly one filtered_search intent footer; got "
+            f"{footer_count}. Full output:\n{out}"
+        )
+
+    def test_browse_missing_namespace_unchanged(
+        self, handler: SimpleToolsHandler
+    ) -> None:
+        """Regression guard: the sibling ``_handle_browse`` envelope
+        already emitted exactly one ``<!-- intent=browse cert=`` footer
+        via the dispatcher auto-append; this pin confirms the fix
+        didn't accidentally touch that surface."""
+        out = handler.handle_zim_query(
+            "browse namespace XYZ",
+            zim_file_path="/x.zim",
+            options={"compact": False},
+        )
+        assert "Missing or Invalid Namespace" in out
+        assert out.count("<!-- intent=browse cert=") == 1

--- a/uv.lock
+++ b/uv.lock
@@ -1170,7 +1170,7 @@ wheels = [
 
 [[package]]
 name = "openzim-mcp"
-version = "2.0.1"
+version = "2.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

First sweep against the v2.0.4 cut. 4 passes of live two-archive beta-testing (`zim.owl-atlas.ts.net`, wikipedia_en_all_maxi_2026-02 + superuser.com_en_all_2026-02) surfaced 4 defects. Three widen post-v2.0.0 fixes that landed narrower than the defect class needed; pass-4 D-J is a separate cosmetic UX cleanup on the simple-mode no-results recovery path.

## Defects

### Pass-1 — D-E sibling (`84bb134`)

`_handle_get_article` word-strip recovery + `_extract_entry_path_keyworded` quoted_match whitespace. The post-v2.0.0 D-E quote-strip fix landed on three extractors (`_extract_find_by_title`, `_extract_related`, the canonical-keyword branch of `_extract_entry_path_keyworded`). Two paths still let empty-quoted input silent-resolve to `Empty_string` at cert=0.75:

1. `_extract_entry_path_keyworded` quoted_match branch — `+` quantifier matched whitespace, set `entry_path="  "` and returned. Truthy 2-char string bypassed every downstream `if not entry_path:` guard. Affects ALL handlers using the shared extractor (get_article / structure / toc / summary / links).
2. `_handle_get_article` word-strip recovery branch — when the parser correctly drops `entry_path` for `get article ""`, handler regenerates the literal from `query` via `re.sub(r"\b(get|...|article|entry|page)\b", "", query)`. Word-strip leaves the literal 2-char quote pair (`.strip()` no-op on quote chars), truthy 2-char string passes the guard, propagates to backend.

Fix: parser quoted_match strips the captured value and drops if empty; handler applies `_strip_quote_pair` to `cleaned_query` after the word-strip.

### Pass-2 — D-H (`1fa0b20`)

Duplicate `<!-- intent=filtered_search cert=0.80 -->` telemetry footer. `_handle_filtered_search`'s missing-namespace envelope embedded the comment in the body. Outer dispatcher unconditionally appends `<!-- intent={intent} cert={confidence:.2f} -->` at line 1017 — so the response carried two identical footers. Sibling `_handle_browse` (line 2974) and `_handle_walk_namespace` (line 5111) relied on the auto-append; filtered_search was drift.

Cursor-mismatch envelopes (lines 2469, 2499) intentionally embed `cursor_decode cert=1.00` (different intent than parser's classification — dual-marker convention documented at line 4720-4726). Same for `namespace_path_redirect` (line 4069) and `subject_attribute_section` (lines 4681, 4727). Kept — they encode a distinct signal vs. the auto-append. Only filtered_search's embedded marker exactly duplicated the parser's classification → only one to remove.

Fix: drop the embedded comment.

### Pass-3 — D-I (`9f5adfd`)

Synthesize early-exit bypasses meta-only / chained-intent / multi-entity-chain guards. Same family as the post-v2.0.0 D-G fix (which patched `topic_required` and `search_terms_required` inside `_handle_synthesize_query`), but **broader**: the simple path also fires three more guards in `handle_zim_query` (meta_only at line 693, chained_intent at line 710, multi_entity_chain at line 960) — D-G missed all three. Three repros (silent-wrong-answer class):

- `try again` (meta-only) → Aaliyah's "Try Again" song body at rank 1
- `tell me about Berlin then list namespaces` (chained) → Namespace + War articles (Berlin not even ranked)
- `tell me about Berlin and Munich and Cologne` (3-entity) → Cologne only; Berlin and Munich silently dropped

Fix: mirror all three guards inside `_handle_synthesize_query`, returning `tool_error` envelopes (D-G's shape). `meta_only` + `chained_intent` run before the intent_parser prelude (query-only); `multi_entity_chain` runs after the D-G topic/search guards with best-effort archive path resolution for the title-index probe (preserves `Earth, Wind & Fire`-shape canonical-title suppression).

### Pass-4 — D-J (`73a2185`)

Circular `tell me about <X>` no-results recovery hint. `_handle_tell_me_about` falls back to the search backend on no-results (`simple_tools.py:4135 + 4145`). The shared `_format_search_text` recovery body (`zim/search.py:774-782`) emits a `tell me about {topic}` bullet that's a useful cross-intent nudge for `search for X` callers but is exactly what the `tell_me_about` caller just tried. Live repro: `tell me about photosynthsis` (missing 'e', not in the post-a11 misspelling map) → "No search results found for photosynthsis" with recovery bullet `tell me about photosynthsis` (the same query).

Fix: narrow string-replace at the handler edge (`_swap_tell_me_about_recovery_hint`) swaps the circular bullet for `find article titled {topic}` (title-index fuzzy lookup — genuinely a different recovery path). Implemented at the handler edge rather than parameterising the shared formatter so the `search for X` recovery wording stays canonical for direct search callers.

## Methodology continuity

- "Fix unlocks new paths" (15 sweeps strong): pass-1 D-E fix unlocked the empty-quote attack surface for the canonical extractor; pass-2 D-H surfaced via re-probing the now-clean filtered_search input; pass-3 D-I surfaced via probing synthesize-mode edges the D-G fix only partially covered; pass-4 D-J surfaced via probing the tell_me_about no-results fallback.
- "Narrow-scope sibling" pattern: D-E (post-v2.0.0) was narrower than its defect class (3 extractors covered, 2 paths missed); D-G was narrower than its defect class (2 guards covered, 3 guards missed); D-H was a drift from sibling pattern. Every prior sweep's narrow guard gets widened by the next.
- New pattern observation: "guard-bypass branches that share an early-exit" — `_handle_synthesize_query` at simple_tools.py:626 early-exits past all guards `handle_zim_query` runs in its main flow. Any future guard added to `handle_zim_query` must be considered for mirroring inside the synthesize handler.

## Tests

34 regression tests in `tests/test_post_v2_0_4_beta_fixes.py`:

- D-E sibling: 20 tests (10 handler-level for `_handle_get_article` empty-quote shapes; 10 parser-level for whitespace-quoted drops across get_article / structure / toc / summary / links + non-empty regression).
- D-H: 5 tests (4 invalid-namespace envelopes pinned to single footer; 1 browse sibling regression guard).
- D-I: 6 tests (meta-only rejection, 3 chained-intent variants, multi-entity rejection, canonical `Earth, Wind & Fire` suppression regression guard via mocked title-index probe at score 1.0).
- D-J: 3 tests (helper swap; idempotency on non-matching input; canonical-source pin against `_format_search_text` output for drift detection).

Full suite: **2588 passed**, 236 skipped, 38 deselected (locally on macOS). black / isort / flake8 / mypy clean.

## Test plan

- [ ] CI: lint
- [ ] CI: type-check
- [ ] CI: security
- [ ] CI: test matrix (3.11 / 3.12, ubuntu/macos/windows)
- [ ] CI: CodeQL
- [ ] CI: SonarCloud
