### PR TITLE
fix: scope content tools to main content (chrome leak), restore TOC nesting, dedupe search URL variants

### DIFF
--- a/openzim_mcp/bundle.py
+++ b/openzim_mcp/bundle.py
@@ -84,6 +84,22 @@ def _normalize_heading_text(text: str) -> str:
     return " ".join(text.split())
 
 
+def _loose_escaped_text(text: str) -> str:
+    """Regex source matching ``text`` even when html2text backslash-escaped
+    interior punctuation.
+
+    html2text escapes markdown-significant punctuation by prefixing a
+    backslash — a numbered heading ``1. Topic`` renders as ``1\\. Topic``,
+    so a plain ``re.escape`` pattern never matches and the section is dropped
+    (this is the root cause of the IEP "flattened TOC": every ``## 1.``,
+    ``## 2.`` ... H2 vanished, leaving the H3 subsections misnested under the
+    H1). Allowing an optional backslash before each character matches the
+    escaped and unescaped forms alike. Used only by the relaxed fallback, so
+    the larger pattern is paid only for headings the strict match missed.
+    """
+    return "".join(r"\\?" + re.escape(ch) for ch in text)
+
+
 def _resolve_entry_html(archive: "Archive", entry_path: str) -> tuple[str, str, str]:
     """Fetch the entry's HTML, returning (title, mimetype, html).
 
@@ -179,9 +195,13 @@ def _compute_section_offsets(
             # emits (``*``, ``_``, ``` ` ```, backslashes, whitespace) so
             # the relaxed branch only catches decorated-heading cases, not
             # any heading containing the text anywhere.
+            # Inline markup (``**bold**`` etc.) is tolerated as a prefix/suffix
+            # wrapper; ``_loose_escaped_text`` additionally tolerates html2text's
+            # backslash-escaped interior punctuation (e.g. ``1\.`` for ``1.``).
             _MD_INLINE = r"[ \t\*_`\\]*"
             relaxed = re.compile(
-                rf"^{'#' * level} {_MD_INLINE}{re.escape(text)}{_MD_INLINE}\s*$",
+                rf"^{'#' * level} {_MD_INLINE}{_loose_escaped_text(text)}"
+                rf"{_MD_INLINE}\s*$",
                 re.MULTILINE,
             )
             match = relaxed.search(rendered_markdown, cursor)

--- a/openzim_mcp/bundle.py
+++ b/openzim_mcp/bundle.py
@@ -269,7 +269,7 @@ def extract_entry_bundle(
     """
     from bs4 import BeautifulSoup
 
-    from openzim_mcp.content_processor import _build_headings
+    from openzim_mcp.content_processor import _build_headings, select_main_content
 
     title, mime, html = _resolve_entry_html(archive, entry_path)
 
@@ -293,10 +293,19 @@ def extract_entry_bundle(
         return empty
 
     soup = BeautifulSoup(html, "html.parser")
-    headings = _build_headings(soup)
-    raw_links = content_processor.extract_html_links(html)
+    # Scope every downstream extraction to the page's main-content landmark
+    # so ZIMIT/warc2zim site chrome (banner, header nav, footer, aside) does
+    # not leak into headings (TOC), links (related articles), or the rendered
+    # markdown (summary). No landmark -> the whole document, unchanged.
+    # ``extract_html_links`` is fed the scoped subtree's HTML rather than the
+    # raw entry HTML so nav links are excluded too; capture it BEFORE
+    # ``_extract_infobox`` decomposes the infobox, preserving the prior order
+    # in which links were extracted ahead of infobox removal.
+    content_root = select_main_content(soup)
+    headings = _build_headings(content_root)
+    raw_links = content_processor.extract_html_links(str(content_root))
     link_buckets = _build_link_buckets(raw_links)
-    infobox = _extract_infobox(soup, content_processor)
+    infobox = _extract_infobox(content_root, content_processor)
     # Render with compact=True so that the bundle's rendered_markdown
     # carries the same table-stripping placeholders that direct
     # ``get_zim_entry`` callers see. Without this, get_section returns
@@ -304,7 +313,7 @@ def extract_entry_bundle(
     # tables embedded in Wikipedia articles — a UX regression vs. the
     # surrounding article-fetch path. The infobox is already
     # ``decompose()``d above, so compact rendering won't re-extract it.
-    rendered = content_processor._render_soup_to_text(soup, compact=True)
+    rendered = content_processor._render_soup_to_text(content_root, compact=True)
     sections = _compute_section_offsets(rendered, headings)
 
     bundle: EntryBundle = cast(

--- a/openzim_mcp/content_processor.py
+++ b/openzim_mcp/content_processor.py
@@ -293,6 +293,38 @@ def _collect_meta_tag_metadata(soup: BeautifulSoup) -> Dict[str, str]:
     return metadata
 
 
+# Main-content landmarks, in priority order. ZIMIT / warc2zim entries embed
+# the origin site's full chrome (federal banner, header nav, footer, aside
+# sidebars) around the article body. Scoping content extraction to the
+# main-content landmark drops that chrome at the source, so every bundle
+# consumer (summary, TOC, related-article links) and the search-snippet
+# renderer see the article body only. Wikipedia / mwoffliner pages carry no
+# such landmark, so the helper returns the document unchanged and their
+# behaviour is preserved.
+_MAIN_CONTENT_SELECTORS = ("main", "[role=main]", "article")
+
+
+def select_main_content(soup: BeautifulSoup) -> BeautifulSoup:
+    """Return the page's main-content subtree, or ``soup`` if none is clear.
+
+    Tries ``<main>``, then ``[role=main]``, then ``<article>``. A landmark
+    is used only when EXACTLY ONE matches — multiple matches (e.g. a blog
+    index rendered as many ``<article>`` cards) are ambiguous, so we fall
+    back to the whole document rather than guess and risk dropping content.
+
+    The matched landmark is re-parsed into its OWN document rather than
+    returned as a detached child ``Tag``: downstream rendering calls
+    BeautifulSoup-only APIs (``new_tag`` during oversized-table replacement),
+    which a bare child ``Tag`` does not expose. Re-parsing keeps the return
+    type a full ``BeautifulSoup`` for every caller and code path.
+    """
+    for selector in _MAIN_CONTENT_SELECTORS:
+        nodes = soup.select(selector)
+        if len(nodes) == 1:
+            return BeautifulSoup(str(nodes[0]), HTML_PARSER)
+    return soup
+
+
 def _build_headings(soup: BeautifulSoup) -> List[Dict[str, Any]]:
     """Collect headings (h1-h6) in document order with disambiguated anchors.
 

--- a/openzim_mcp/content_processor.py
+++ b/openzim_mcp/content_processor.py
@@ -301,16 +301,22 @@ def _collect_meta_tag_metadata(soup: BeautifulSoup) -> Dict[str, str]:
 # renderer see the article body only. Wikipedia / mwoffliner pages carry no
 # such landmark, so the helper returns the document unchanged and their
 # behaviour is preserved.
-_MAIN_CONTENT_SELECTORS = ("main", "[role=main]", "article")
+#
+# ``<article>`` is tried FIRST (narrower) so that when a ``<main>`` /
+# ``[role=main]`` wrapper contains both the article and an ``<aside>``
+# sidebar, the single article wins and the sidebar is excluded.
+_MAIN_CONTENT_SELECTORS = ("article", "main", "[role=main]")
 
 
 def select_main_content(soup: BeautifulSoup) -> BeautifulSoup:
     """Return the page's main-content subtree, or ``soup`` if none is clear.
 
-    Tries ``<main>``, then ``[role=main]``, then ``<article>``. A landmark
-    is used only when EXACTLY ONE matches — multiple matches (e.g. a blog
-    index rendered as many ``<article>`` cards) are ambiguous, so we fall
-    back to the whole document rather than guess and risk dropping content.
+    Tries ``<article>``, then ``<main>``, then ``[role=main]``. A landmark
+    is used only when EXACTLY ONE matches AND it carries text — multiple
+    matches (e.g. a blog index rendered as many ``<article>`` cards) are
+    ambiguous, and an empty/whitespace-only landmark would silently drop the
+    real content when it sits in a sibling; in both cases we fall through to
+    the next selector and ultimately to the whole document.
 
     The matched landmark is re-parsed into its OWN document rather than
     returned as a detached child ``Tag``: downstream rendering calls
@@ -320,7 +326,7 @@ def select_main_content(soup: BeautifulSoup) -> BeautifulSoup:
     """
     for selector in _MAIN_CONTENT_SELECTORS:
         nodes = soup.select(selector)
-        if len(nodes) == 1:
+        if len(nodes) == 1 and nodes[0].get_text(strip=True):
             return BeautifulSoup(str(nodes[0]), HTML_PARSER)
     return soup
 
@@ -1203,6 +1209,7 @@ class ContentProcessor:
         *,
         compact: bool = False,
         snippet_mode: bool = False,
+        scope_main_content: bool = False,
     ) -> str:
         """
         Process content based on MIME type.
@@ -1233,6 +1240,16 @@ class ContentProcessor:
                     # Skip structural rewrites; render the soup as-is.
                     soup = BeautifulSoup(raw_content, HTML_PARSER)
                     return self._render_soup_to_text(soup, compact=False)
+                if scope_main_content:
+                    # Entry-content fetch (get_zim_entry / get_entries): scope
+                    # to the page's main-content landmark so the primary read
+                    # path drops ZIMIT/warc2zim site chrome, matching the
+                    # bundle-based tools. No landmark -> whole document, so
+                    # chrome-free (Wikipedia/mwoffliner) pages are unchanged.
+                    soup = BeautifulSoup(raw_content, HTML_PARSER)
+                    return self._render_soup_to_text(
+                        select_main_content(soup), compact=compact
+                    )
                 return self.html_to_plain_text(raw_content, compact=compact)
             elif mime_type.startswith("text/"):
                 return raw_content.strip()

--- a/openzim_mcp/zim/content.py
+++ b/openzim_mcp/zim/content.py
@@ -159,16 +159,38 @@ class _ContentMixin:
         """
         try:
             item = entry.get_item()
-            if item.mimetype.startswith(_TEXT_MIME_PREFIX):
-                content = self.content_processor.process_mime_content(
-                    bytes(item.content), item.mimetype, compact=True
+            mime = item.mimetype or ""
+            if not mime.startswith(_TEXT_MIME_PREFIX):
+                return f"(Unsupported content type: {mime})"
+            if mime.startswith("text/html"):
+                # Scope to the page's main-content landmark so snippets are
+                # drawn from the article body, not the ZIMIT/warc2zim site
+                # chrome (banner / header nav / footer) wrapping it. With no
+                # landmark, select_main_content returns the whole document, so
+                # this matches process_mime_content output for chrome-free
+                # (e.g. Wikipedia/mwoffliner) pages — no regression there.
+                from bs4 import BeautifulSoup
+
+                from openzim_mcp.content_processor import (
+                    HTML_PARSER,
+                    select_main_content,
                 )
-                entry_title = getattr(entry, "title", None) or ""
-                return self.content_processor.create_snippet(
-                    content, query=query, title=entry_title
+
+                soup = BeautifulSoup(
+                    bytes(item.content).decode("utf-8", errors="replace"),
+                    HTML_PARSER,
+                )
+                content = self.content_processor._render_soup_to_text(
+                    select_main_content(soup), compact=True
                 )
             else:
-                return f"(Unsupported content type: {item.mimetype})"
+                content = self.content_processor.process_mime_content(
+                    bytes(item.content), mime, compact=True
+                )
+            entry_title = getattr(entry, "title", None) or ""
+            return self.content_processor.create_snippet(
+                content, query=query, title=entry_title
+            )
         except Exception as e:
             logger.warning(f"Error getting content snippet: {e}")
             return "(Unable to get content preview)"

--- a/openzim_mcp/zim/content.py
+++ b/openzim_mcp/zim/content.py
@@ -550,7 +550,10 @@ class _ContentMixin:
             item = entry.get_item()
             content_type = item.mimetype or ""
             content = self.content_processor.process_mime_content(
-                bytes(item.content), content_type, compact=compact
+                bytes(item.content),
+                content_type,
+                compact=compact,
+                scope_main_content=True,
             )
         except Exception as e:
             logger.warning(f"Error getting entry content: {e}")
@@ -1088,9 +1091,14 @@ class _ContentMixin:
             mime_type = item.mimetype or ""
             content_type = mime_type
 
-            # Process content based on MIME type
+            # Process content based on MIME type. ``scope_main_content`` strips
+            # ZIMIT/warc2zim site chrome from the primary entry-content fetch
+            # so get_zim_entry / get_entries match the cleaned bundle tools.
             content = self.content_processor.process_mime_content(
-                bytes(item.content), mime_type, compact=compact
+                bytes(item.content),
+                mime_type,
+                compact=compact,
+                scope_main_content=True,
             )
 
         except Exception as e:

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -57,6 +57,18 @@ _FILTERED_BATCH_SIZE = 500
 _FILTERED_MAX_SCAN = 10000
 
 
+def canonical_result_path(path: str) -> str:
+    """Strip the query string and fragment from a result path.
+
+    warc2zim stores query-string URL variants as distinct entries, so a
+    full-text search surfaces e.g. ``ency/quiz/001214_3.htm`` and
+    ``ency/quiz/001214_3.htm?quiz=1`` as two hits for the same page.
+    Collapsing on the canonical (query/fragment-free) path lets the
+    filtered-search scanner emit each page once.
+    """
+    return path.split("?", 1)[0].split("#", 1)[0]
+
+
 def _no_fulltext_index_payload(
     query: str,
     *,
@@ -1630,6 +1642,11 @@ class _SearchMixin:
         filtered_count = 0
         scanned = 0
         scan_cap_hit = False
+        # Canonical paths already placed on this page, so warc2zim query-string
+        # variants (foo.htm and foo.htm?x=1) don't each consume a result slot.
+        # Scoped to the emitted page; a duplicate is skipped without filling a
+        # slot, and scanning continues so the page still fills to ``limit``.
+        seen_canonical: set[str] = set()
         has_new_scheme = getattr(archive, "has_new_namespace_scheme", False)
         # When namespace-only filtering is active (no content_type), the
         # entry namespace is derivable from the path string without an
@@ -1690,6 +1707,13 @@ class _SearchMixin:
 
                 filtered_count += 1
                 if filtered_count > offset and len(page) < limit:
+                    canonical = canonical_result_path(materialised[0])
+                    if canonical in seen_canonical:
+                        # A query-string variant of an entry already on this
+                        # page — skip it and keep scanning so the dropped slot
+                        # is backfilled with the next distinct result.
+                        continue
+                    seen_canonical.add(canonical)
                     page.append(materialised)
                     if len(page) >= limit:
                         break

--- a/tests/test_beta_sweep_chrome_fixes.py
+++ b/tests/test_beta_sweep_chrome_fixes.py
@@ -80,6 +80,7 @@ def _make_archive(html: str, *, title: str, entry_path: str) -> MagicMock:
     entry = MagicMock()
     entry.title = title
     entry.path = entry_path
+    entry.is_redirect = False
     entry.get_item.return_value = item
     archive = MagicMock()
     archive.get_entry_by_path.return_value = entry
@@ -311,3 +312,121 @@ def test_filtered_scan_dedupes_query_variants(tmp_path) -> None:
     canon = [canonical_result_path(p) for p in paths]
     assert len(canon) == len(set(canon)), f"duplicate canonical paths: {paths}"
     assert len(page) == 3  # three distinct quiz pages, variants collapsed
+
+
+# --------------------------------------------------------------------------
+# Pass-7: select_main_content robustness (empty landmark, precedence)
+# --------------------------------------------------------------------------
+
+
+def test_select_main_content_skips_empty_landmark() -> None:
+    """An empty/whitespace-only landmark must not be chosen over real content
+    elsewhere; the helper falls back rather than dropping the body."""
+    from bs4 import BeautifulSoup
+
+    from openzim_mcp.content_processor import select_main_content
+
+    # The only landmark (<main>) is empty; real content sits in a body
+    # sibling. Selecting the empty landmark would drop all content.
+    html = "<body><main>   </main><p>The real article body lives here.</p></body>"
+    soup = BeautifulSoup(html, "html.parser")
+    node = select_main_content(soup)
+    assert "The real article body lives here." in node.get_text()
+
+
+def test_select_main_content_prefers_article_over_broad_role_main() -> None:
+    """When [role=main] wraps both <article> and an <aside> sidebar, the
+    single <article> (narrower) should win so the sidebar is excluded."""
+    from bs4 import BeautifulSoup
+
+    from openzim_mcp.content_processor import select_main_content
+
+    html = (
+        "<body><div role='main'>"
+        "<article><p>The real article prose.</p></article>"
+        "<aside><p>Sidebar navigation junk.</p></aside>"
+        "</div></body>"
+    )
+    soup = BeautifulSoup(html, "html.parser")
+    text = select_main_content(soup).get_text()
+    assert "The real article prose." in text
+    assert "Sidebar navigation junk." not in text
+
+
+# --------------------------------------------------------------------------
+# Pass-7 / C: entry-content fetch (get_zim_entry / get_entries) scoping
+# --------------------------------------------------------------------------
+
+
+def test_process_mime_content_scope_main_content(cp: ContentProcessor) -> None:
+    scoped = cp.process_mime_content(
+        ZIMIT_HTML.encode("utf-8"), "text/html", compact=True, scope_main_content=True
+    )
+    full = cp.process_mime_content(
+        ZIMIT_HTML.encode("utf-8"), "text/html", compact=True, scope_main_content=False
+    )
+    assert "Type 2 diabetes is a long-term" in scoped
+    assert "official website" not in scoped
+    assert "Stay Connected" not in scoped
+    # Default (False) is unchanged: full-page chrome still present.
+    assert "official website" in full
+
+
+def test_get_zim_entry_scopes_to_main_content(tmp_path) -> None:
+    """get_zim_entry returns article content, not site chrome, for an entry
+    wrapped in a main-content landmark."""
+    from openzim_mcp.cache import OpenZimMcpCache
+    from openzim_mcp.config import CacheConfig, ContentConfig, OpenZimMcpConfig
+    from openzim_mcp.security import PathValidator
+    from openzim_mcp.zim_operations import ZimOperations
+
+    config = OpenZimMcpConfig(
+        allowed_directories=[str(tmp_path)],
+        cache=CacheConfig(enabled=False, max_size=10, ttl_seconds=60),
+        content=ContentConfig(max_content_length=100000, snippet_length=200),
+    )
+    ops = ZimOperations(
+        config,
+        PathValidator(config.allowed_directories),
+        OpenZimMcpCache(config.cache),
+        ContentProcessor(),
+    )
+    out = ops._get_zim_entry_from_archive(
+        _make_archive(ZIMIT_HTML, title="Type 2 Diabetes", entry_path="C/000313"),
+        tmp_path / "x.zim",
+        "C/000313",
+        100000,
+        0,
+    )
+    assert "Type 2 diabetes is a long-term" in out
+    assert "official website" not in out
+    assert "Stay Connected" not in out
+
+
+# --------------------------------------------------------------------------
+# Pass-7 / E: heading offset matching tolerates html2text escaping (#6 root)
+# --------------------------------------------------------------------------
+
+
+def test_bundle_locates_html2text_escaped_numbered_headings(
+    cp: ContentProcessor,
+) -> None:
+    """IEP-style numbered headings (<h2><strong>1. X</strong></h2>) render via
+    html2text as '## **1\\. X**' (bold + backslash-escaped period). The
+    section-offset matcher must still locate them, otherwise the H2 sections
+    are silently dropped and their H3 children misnest under the H1 (beta #6)."""
+    numbered = (
+        "<body><article>"
+        "<h1>Doc</h1><p>lead paragraph</p>"
+        "<h2><strong>1. First Section</strong></h2><p>alpha body</p>"
+        "<h3>a. A Subsection</h3><p>sub body</p>"
+        "<h2>2. Second Section</h2><p>beta body</p>"
+        "</article></body>"
+    )
+    archive = _make_archive(numbered, title="Doc", entry_path="C/doc")
+    bundle = extract_entry_bundle(archive, "C/doc", content_processor=cp)
+    secs = {s["title"]: s for s in bundle["sections"]}
+    assert "1. First Section" in secs
+    assert "2. Second Section" in secs
+    # The H3 nests under its H2 parent, not the H1 — the #6 fix.
+    assert secs["a. A Subsection"]["parent_id"] == secs["1. First Section"]["id"]

--- a/tests/test_beta_sweep_chrome_fixes.py
+++ b/tests/test_beta_sweep_chrome_fixes.py
@@ -1,0 +1,313 @@
+"""Post-v2.0.5 beta-sweep fixes: site-chrome leakage + search dup variants.
+
+Background: on ZIMIT / warc2zim archives (MedlinePlus, IEP) the original
+site's banner / nav / header / footer / aside chrome is embedded in the
+entry HTML. The content-shape tools that read from the top of the
+rendered document (get_entry_summary), or that enumerate every heading /
+link (get_table_of_contents, get_related_articles), or that build search
+snippets, surfaced that chrome instead of the article body. The shared
+fix scopes extraction to the page's main-content landmark
+(``<main>`` / ``[role=main]`` / ``<article>``) when present, falling back
+to the whole document when absent (so Wikipedia/mwoffliner pages, which
+carry no such landmark, are unaffected).
+
+Separately, warc2zim stores query-string URL variants as distinct
+entries, so filtered search returned ``foo.htm`` and ``foo.htm?quiz=1``
+as two hits; results are now deduped by canonical path.
+
+These mirror the real structures observed on
+``medlineplus.gov_en_all_2025-01.zim`` and
+``internet-encyclopedia-philosophy_en_all_2025-06.zim``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from openzim_mcp.bundle import extract_entry_bundle
+from openzim_mcp.content_processor import ContentProcessor
+
+# A page whose real article lives inside <article>, with the original
+# site's chrome (skip-nav, federal banner, header nav, footer, aside)
+# surrounding it — the shape seen on MedlinePlus / IEP.
+ZIMIT_HTML = """\
+<html><body>
+<a class="usa-skipnav" href="#main">Skip navigation</a>
+<section class="usa-banner"><p>An official website of the United States government</p></section>
+<header>
+  <h1>MedlinePlus Trusted Health Information</h1>
+  <a href="../../healthtopics.html">Health Topics</a>
+  <a href="../../encyclopedia.html">Medical Encyclopedia</a>
+  <a href="../../about/">About MedlinePlus</a>
+</header>
+<article>
+  <h1>Type 2 Diabetes</h1>
+  <p>Type 2 diabetes is a long-term condition in which the body does not
+  use insulin properly, causing blood sugar levels to rise over time.</p>
+  <h2>Causes</h2>
+  <p>Insulin resistance develops in the body's cells, and the pancreas
+  cannot keep blood glucose in the normal range.</p>
+  <a href="ency/article/000305.htm">Blood glucose test</a>
+  <a href="ency/article/000313.htm">Type 1 diabetes</a>
+</article>
+<footer>
+  <h2>Stay Connected</h2>
+  <a href="../../about/">About MedlinePlus</a>
+  <a href="../../index.html">Home</a>
+</footer>
+</body></html>
+"""
+
+# A Wikipedia/mwoffliner-style page with NO main-content landmark — the
+# fallback path must leave these untouched.
+PLAIN_HTML = """\
+<html><body>
+<h1>Berlin</h1>
+<p>Berlin is the capital and largest city of Germany.</p>
+<h2>Geography</h2>
+<p>Berlin's terrain is generally flat.</p>
+<a href="A/Spree_River">Spree</a>
+</body></html>
+"""
+
+
+def _make_archive(html: str, *, title: str, entry_path: str) -> MagicMock:
+    item = MagicMock()
+    item.content = html.encode("utf-8")
+    item.mimetype = "text/html"
+    entry = MagicMock()
+    entry.title = title
+    entry.path = entry_path
+    entry.get_item.return_value = item
+    archive = MagicMock()
+    archive.get_entry_by_path.return_value = entry
+    return archive
+
+
+@pytest.fixture
+def cp() -> ContentProcessor:
+    return ContentProcessor()
+
+
+# --------------------------------------------------------------------------
+# select_main_content helper
+# --------------------------------------------------------------------------
+
+
+def test_select_main_content_prefers_article() -> None:
+    from bs4 import BeautifulSoup
+
+    from openzim_mcp.content_processor import select_main_content
+
+    soup = BeautifulSoup(ZIMIT_HTML, "html.parser")
+    node = select_main_content(soup)
+    text = node.get_text()
+    assert "Type 2 diabetes is a long-term" in text
+    assert "official website" not in text
+    assert "Stay Connected" not in text
+
+
+def test_select_main_content_falls_back_without_landmark() -> None:
+    from bs4 import BeautifulSoup
+
+    from openzim_mcp.content_processor import select_main_content
+
+    soup = BeautifulSoup(PLAIN_HTML, "html.parser")
+    node = select_main_content(soup)
+    # No <main>/<article>/[role=main] -> return the whole document unchanged.
+    assert node is soup
+    assert "Berlin is the capital" in node.get_text()
+
+
+def test_select_main_content_ambiguous_multiple_articles_falls_back() -> None:
+    from bs4 import BeautifulSoup
+
+    from openzim_mcp.content_processor import select_main_content
+
+    html = "<body><article><p>one</p></article><article><p>two</p></article></body>"
+    soup = BeautifulSoup(html, "html.parser")
+    node = select_main_content(soup)
+    assert node is soup  # >1 article is ambiguous -> no scoping
+
+
+# --------------------------------------------------------------------------
+# #3 get_entry_summary / rendered_markdown — no leading chrome
+# --------------------------------------------------------------------------
+
+
+def test_bundle_rendered_markdown_excludes_site_chrome(cp: ContentProcessor) -> None:
+    archive = _make_archive(ZIMIT_HTML, title="Type 2 Diabetes", entry_path="C/000313")
+    bundle = extract_entry_bundle(archive, "C/000313", content_processor=cp)
+    md = bundle["rendered_markdown"]
+    assert "Type 2 diabetes is a long-term" in md
+    assert "official website of the United States" not in md
+    assert "Stay Connected" not in md
+    assert "Health Topics" not in md
+
+
+def test_bundle_first_section_is_article_lead(cp: ContentProcessor) -> None:
+    # The summary slices md[:first_section.char_end]; the first section must
+    # be the article H1, not the header/banner chrome.
+    archive = _make_archive(ZIMIT_HTML, title="Type 2 Diabetes", entry_path="C/000313")
+    bundle = extract_entry_bundle(archive, "C/000313", content_processor=cp)
+    assert bundle["sections"], "expected at least one section"
+    assert bundle["sections"][0]["title"] == "Type 2 Diabetes"
+
+
+# --------------------------------------------------------------------------
+# #7 get_table_of_contents — headings exclude nav/header/footer chrome
+# --------------------------------------------------------------------------
+
+
+def test_bundle_headings_exclude_chrome(cp: ContentProcessor) -> None:
+    archive = _make_archive(ZIMIT_HTML, title="Type 2 Diabetes", entry_path="C/000313")
+    bundle = extract_entry_bundle(archive, "C/000313", content_processor=cp)
+    titles = [s["title"] for s in bundle["sections"]]
+    assert titles == ["Type 2 Diabetes", "Causes"]
+    assert "Stay Connected" not in titles
+    assert "MedlinePlus Trusted Health Information" not in titles
+
+
+# --------------------------------------------------------------------------
+# #5 get_related_articles — links exclude nav/header/footer chrome
+# --------------------------------------------------------------------------
+
+
+def test_bundle_internal_links_exclude_nav(cp: ContentProcessor) -> None:
+    archive = _make_archive(ZIMIT_HTML, title="Type 2 Diabetes", entry_path="C/000313")
+    bundle = extract_entry_bundle(archive, "C/000313", content_processor=cp)
+    urls = [link["url"] for link in bundle["links"]["internal"]]
+    # Real in-article cross-references are kept.
+    assert any("ency/article/000305.htm" in u for u in urls)
+    # Header/footer navigation links are gone.
+    assert not any("healthtopics.html" in u for u in urls)
+    assert not any("about/" in u for u in urls)
+    assert not any(u.endswith("index.html") for u in urls)
+
+
+def test_bundle_links_preserved_without_landmark(cp: ContentProcessor) -> None:
+    # Fallback path: a page with no landmark keeps its links (no regression).
+    archive = _make_archive(PLAIN_HTML, title="Berlin", entry_path="A/Berlin")
+    bundle = extract_entry_bundle(archive, "A/Berlin", content_processor=cp)
+    urls = [link["url"] for link in bundle["links"]["internal"]]
+    assert any("Spree_River" in u for u in urls)
+
+
+# --------------------------------------------------------------------------
+# #4 search snippet — drawn from main content, not chrome
+# --------------------------------------------------------------------------
+
+
+def test_entry_snippet_excludes_chrome(tmp_path) -> None:
+    from openzim_mcp.cache import OpenZimMcpCache
+    from openzim_mcp.config import (
+        CacheConfig,
+        ContentConfig,
+        LoggingConfig,
+        OpenZimMcpConfig,
+    )
+    from openzim_mcp.security import PathValidator
+    from openzim_mcp.zim_operations import ZimOperations
+
+    config = OpenZimMcpConfig(
+        allowed_directories=[str(tmp_path)],
+        cache=CacheConfig(enabled=True, max_size=10, ttl_seconds=60),
+        content=ContentConfig(max_content_length=10000, snippet_length=200),
+        logging=LoggingConfig(level="WARNING"),
+    )
+    ops = ZimOperations(
+        config,
+        PathValidator(config.allowed_directories),
+        OpenZimMcpCache(config.cache),
+        ContentProcessor(),
+    )
+    item = MagicMock()
+    item.content = ZIMIT_HTML.encode("utf-8")
+    item.mimetype = "text/html"
+    entry = MagicMock()
+    entry.title = "Type 2 Diabetes"
+    entry.get_item.return_value = item
+
+    # No query (or a query whose term lives only outside the body) falls back
+    # to the leading paragraphs — which, before the fix, are the federal
+    # banner + header nav rather than the article lead.
+    snippet = ops._get_entry_snippet(entry, query=None)
+    assert "Type 2 diabetes is a long-term" in snippet
+    assert "official website" not in snippet
+    assert "Health Topics" not in snippet
+    assert "Stay Connected" not in snippet
+
+
+# --------------------------------------------------------------------------
+# #8 filtered search — dedupe query-string URL variants by canonical path
+# --------------------------------------------------------------------------
+
+
+def test_canonical_result_path_strips_query_and_fragment() -> None:
+    from openzim_mcp.zim.search import canonical_result_path
+
+    assert canonical_result_path("a/b/quiz.htm?quiz=1") == "a/b/quiz.htm"
+    assert canonical_result_path("a/b/quiz.htm#frag") == "a/b/quiz.htm"
+    assert canonical_result_path("a/b/quiz.htm?x=1#frag") == "a/b/quiz.htm"
+    assert canonical_result_path("a/b/quiz.htm") == "a/b/quiz.htm"
+
+
+def test_filtered_scan_dedupes_query_variants(tmp_path) -> None:
+    from openzim_mcp.cache import OpenZimMcpCache
+    from openzim_mcp.config import CacheConfig, OpenZimMcpConfig
+    from openzim_mcp.security import PathValidator
+    from openzim_mcp.zim_operations import ZimOperations
+
+    config = OpenZimMcpConfig(
+        allowed_directories=[str(tmp_path)],
+        cache=CacheConfig(enabled=False, max_size=10, ttl_seconds=60),
+    )
+    ops = ZimOperations(
+        config,
+        PathValidator(config.allowed_directories),
+        OpenZimMcpCache(config.cache),
+        ContentProcessor(),
+    )
+
+    # warc2zim surfaces each quiz page twice: bare + ?quiz=1.
+    entry_ids = [
+        "C/quiz/001214_3.htm",
+        "C/quiz/001214_3.htm?quiz=1",
+        "C/quiz/000249_49.htm",
+        "C/quiz/000249_49.htm?quiz=1",
+        "C/quiz/007617_46.htm",
+    ]
+
+    def _entry_for(eid):
+        e = MagicMock()
+        e.path = eid
+        e.title = eid.rsplit("/", 1)[-1]
+        e.get_item.return_value = MagicMock(mimetype="text/html")
+        return e
+
+    archive = MagicMock()
+    archive.has_new_namespace_scheme = False
+    archive.get_entry_by_path.side_effect = _entry_for
+
+    search = MagicMock()
+    search.getResults.side_effect = lambda start, count: entry_ids[
+        start : start + count
+    ]
+
+    page, _scan = ops._scan_filtered_search(
+        archive,
+        search,
+        total_results=len(entry_ids),
+        namespace=None,
+        content_type=None,
+        limit=10,
+        offset=0,
+    )
+    paths = [m[0] for m in page]
+    from openzim_mcp.zim.search import canonical_result_path
+
+    canon = [canonical_result_path(p) for p in paths]
+    assert len(canon) == len(set(canon)), f"duplicate canonical paths: {paths}"
+    assert len(page) == 3  # three distinct quiz pages, variants collapsed


### PR DESCRIPTION
## Summary

Post-v2.0.5 beta-sweep content-quality fixes (sweep passes 6 & 7), on top of the native-libzim feature already on `main`.

On ZIMIT / warc2zim archives (MedlinePlus, IEP) the origin site's chrome (federal banner, header nav, footer, aside) is embedded in each entry's HTML. `UNWANTED_HTML_SELECTORS` is Wikipedia-tuned and omits those landmarks, so the chrome leaked into every content-shape tool that reads the top of the document or enumerates all headings/links. `get_section` only looked clean because it slices a mid-document section past the chrome.

### Fixes
- **Main-content scoping** — new `content_processor.select_main_content()` scopes extraction to the page's `<article>` / `<main>` / `[role=main]` landmark (single match, with text), re-parsed into its own document, falling back to the whole document when no landmark exists (so Wikipedia/mwoffliner pages are unchanged). Wired into the bundle (`get_entry_summary`, `get_table_of_contents`, `get_related_articles`, `get_section`), the search-snippet path, and the entry-content fetch (`get_zim_entry` / `get_entries` via a new `process_mime_content(scope_main_content=True)`).
- **TOC "flattening" fixed** — html2text renders `<h2>1. Topic</h2>` as `## **1\. Topic**` (bold + backslash-escaped period), which the section-offset matcher couldn't locate, so every numbered H2 was silently dropped and its H3 subsections misnested under the H1. The relaxed matcher now tolerates html2text's interior backslash escapes, restoring the H1→H2→H3 tree.
- **Search dedup** — warc2zim stores query-string URL variants as distinct entries; filtered search now dedupes by canonical (query/fragment-free) path so `foo.htm` and `foo.htm?quiz=1` collapse to one hit.
- **Robustness** — `select_main_content` skips empty/whitespace-only landmarks (content-loss guard) and prefers a single `<article>` over a broader wrapper that also contains an `<aside>` sidebar.

### Not bugs (verified by direct measurement, no change)
The reported `get_zim_entries` / `get_search_suggestions` "timeouts" were cold-cache disk I/O on the 1.9 GB archive amplified by parallel access — both run sub-second warm and already use open-once batching / native `SuggestionSearcher`.

## Test plan
- [x] 16 new TDD tests (`tests/test_beta_sweep_chrome_fixes.py`)
- [x] Full suite green locally: 2664 passed / 0 failed
- [x] `mypy` + `flake8` + `black` + `isort` clean
- [x] Live-verified on real IEP + MedlinePlus archives: chrome gone from summary/snippet/related/TOC and `get_zim_entry`; IEP TOC nests H1→H2→H3; MedlinePlus "quiz" search dup-groups 9 → 0
