### PR TITLE
fix: post-v2.1.0 beta-test sweep — highlighter empty-link protection + related-articles media exclusion

### DIFF
--- a/openzim_mcp/content_processor.py
+++ b/openzim_mcp/content_processor.py
@@ -164,8 +164,13 @@ def _word_in(folded_paragraph: str, term: str) -> bool:
 # italic disambig links, ``[**Photosynthesis**](**Photosynthesis** "…")``
 # where bolding inside the link target breaks the URL).
 #
-# - ``\[[^\]\n]+\]\([^\n)]*\)`` — full ``[text](href "title")`` link,
+# - ``\[[^\]\n]*\]\([^\n)]*\)`` — full ``[text](href "title")`` link,
 #   matched as ONE unit so the URL/tooltip parenthetical only counts
+#   (``*`` not ``+`` on the link text so EMPTY-text links ``[](url)`` —
+#   the shape ZIMIT/warc2zim emits for inline images with no alt text —
+#   are protected too; otherwise a query term inside the image URL,
+#   e.g. ``[](../media/plato.jpg)`` for query "plato", got bolded into
+#   ``[](../media/**plato**.jpg)`` and broke the path).
 #   when it's attached to a link. An earlier shape matched any ``(...)``
 #   parenthetical — that protected ordinary prose parentheticals like
 #   ``(also called assimilation)`` from highlighting too, silently
@@ -180,7 +185,7 @@ def _word_in(folded_paragraph: str, term: str) -> bool:
 #   Wikipedia, but cheap to skip and prevents bold-inside-code from
 #   breaking code-formatted text).
 _HIGHLIGHT_SKIP_RE = re.compile(
-    r"\[[^\]\n]+\]\([^\n)]*\)"
+    r"\[[^\]\n]*\]\([^\n)]*\)"
     r"|\*\*[^*\n]+\*\*"
     r"|(?<!\w)_[^_\n]+_(?!\w)"
     r"|`[^`\n]+`",

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -750,6 +750,56 @@ class _StructureMixin:
             ),
         )
 
+    @staticmethod
+    def _is_non_article_target(path: str) -> bool:
+        """True when ``path`` points at a binary asset, not a navigable article.
+
+        ZIMIT / warc2zim wraps an article's lead image in an
+        ``<a href="…/plato.jpg">`` anchor, so the image leaks into the
+        internal-link graph. Pre-fix, ``articles related to Plato`` on the IEP
+        archive surfaced ``iep.utm.edu/wp-content/media/plato.jpg`` as the
+        rank-1 "related article". Asset targets (images, fonts, styles,
+        scripts, media, archives) are never navigable articles and must be
+        excluded from the related-article set.
+
+        ``.htm`` / ``.html`` are intentionally NOT treated as assets —
+        MedlinePlus article paths legitimately end in ``.html`` / ``.htm``.
+        """
+        extensions = (
+            ".jpg",
+            ".jpeg",
+            ".png",
+            ".gif",
+            ".svg",
+            ".webp",
+            ".bmp",
+            ".ico",
+            ".tif",
+            ".tiff",
+            ".eot",
+            ".otf",
+            ".ttf",
+            ".woff",
+            ".woff2",
+            ".css",
+            ".js",
+            ".mjs",
+            ".json",
+            ".pdf",
+            ".zip",
+            ".gz",
+            ".mp4",
+            ".webm",
+            ".mp3",
+            ".ogg",
+            ".wav",
+            ".avi",
+            ".mov",
+            ".m4a",
+        )
+        base = path.split("?", 1)[0].split("#", 1)[0].lower()
+        return base.endswith(extensions)
+
     def get_related_articles_data(
         self,
         zim_file_path: str,
@@ -848,6 +898,12 @@ class _StructureMixin:
                     link.get("url", ""), resolved_source
                 )
                 if not target or target in (entry_path, resolved_source):
+                    continue
+                if self._is_non_article_target(target):
+                    # ZIMIT/warc2zim wraps the lead image in
+                    # ``<a href="…/plato.jpg">`` so the image leaks into the
+                    # internal-link graph; asset targets are not navigable
+                    # articles and must not rank as "related".
                     continue
                 target_counts[target] += 1
                 if target not in first_text:

--- a/tests/test_post_v2_1_0_beta_fixes.py
+++ b/tests/test_post_v2_1_0_beta_fixes.py
@@ -1,0 +1,115 @@
+"""Regression tests for the post-v2.1.0 live beta-test sweep.
+
+Defects surfaced by an end-to-end real-world sweep against the live remote
+deployment (Wikipedia 2026-02 + superuser.com sotoki) and a local source
+build driven over the IEP + MedlinePlus ZIMIT archives.
+
+D1 — query-term highlighting corrupts EMPTY-text markdown links.
+     ``[](../wp-content/media/plato.jpg)`` rendered as
+     ``[](../wp-content/media/**plato**.jpg)`` because ``_HIGHLIGHT_SKIP_RE``
+     required NON-empty link text (``[^\\]\\n]+``) to recognise a link, so
+     ZIMIT image links with empty alt text (``[](url)``) were not protected
+     and a query term inside the URL got bolded — breaking the image path.
+     Observed live in IEP search snippets and synthesize answers.
+
+D2 — "articles related to <X>" surfaces image / media links as articles.
+     ``articles related to Plato`` (IEP) returned
+     ``iep.utm.edu/wp-content/media/plato.jpg`` (an image, empty link text)
+     as the rank-1 "related article". Media links should be excluded from
+     the related-article result set.
+"""
+
+from __future__ import annotations
+
+import re
+
+from openzim_mcp.content_processor import _highlight_terms
+from openzim_mcp.zim_operations import ZimOperations
+
+
+class TestD1HighlightEmptyLinks:
+    """D1 — highlighting must not bold inside an empty-text link's URL."""
+
+    def test_empty_text_image_link_url_not_highlighted(self) -> None:
+        text = "[](../wp-content/media/plato.jpg)Plato wrote the Meno."
+        out = _highlight_terms(text, "plato", max_hits=10)
+        # The URL inside the link must survive verbatim — no ** injected.
+        assert "](../wp-content/media/plato.jpg)" in out
+        assert "**plato**.jpg" not in out
+        # The prose occurrence outside the link is still highlighted.
+        assert "**Plato**" in out
+
+    def test_empty_text_link_with_term_in_path(self) -> None:
+        text = "[](../plato/) and then Plato again"
+        out = _highlight_terms(text, "plato", max_hits=10)
+        assert "[](../plato/)" in out  # link target intact
+        assert "**Plato**" in out  # prose term highlighted
+
+    def test_nonempty_link_text_still_protected(self) -> None:
+        # Pre-existing protection must not regress.
+        text = "See [Plato bio](../plato/) for more."
+        out = _highlight_terms(text, "plato", max_hits=10)
+        assert out == text  # nothing to highlight outside the protected link
+
+    def test_image_with_alt_text_still_protected(self) -> None:
+        text = "![alt plato](../media/plato.jpg) text"
+        out = _highlight_terms(text, "plato", max_hits=10)
+        assert out == text
+
+    def test_plain_prose_highlight_unaffected(self) -> None:
+        text = "The Theory of relativity by Einstein."
+        out = _highlight_terms(text, "relativity einstein", max_hits=10)
+        assert "**relativity**" in out
+        assert "**Einstein**" in out
+
+    def test_no_bold_inside_any_link_url(self) -> None:
+        """General invariant: no ``**`` may appear between ``](`` and ``)``."""
+        text = (
+            "[](../wp-content/media/slideshow-plato.jpg)"
+            "Plato: Organicism is the position..."
+        )
+        out = _highlight_terms(text, "plato", max_hits=10)
+        # Find every markdown link target and assert no bold markers inside.
+        for m in re.finditer(r"\]\(([^)]*)\)", out):
+            assert "**" not in m.group(1), f"bold leaked into link URL: {m.group(1)}"
+
+
+class TestD2RelatedArticlesExcludeMedia:
+    """D2 — related-articles must exclude binary-asset link targets."""
+
+    def test_image_targets_are_non_article(self) -> None:
+        for path in (
+            "iep.utm.edu/wp-content/media/plato.jpg",
+            "iep.utm.edu/wp-content/media/slideshow-plato.JPG",
+            "I/Foo.png",
+            "static/x.svg",
+            "a/b/c.webp",
+        ):
+            assert ZimOperations._is_non_article_target(path) is True, path
+
+    def test_asset_targets_are_non_article(self) -> None:
+        for path in (
+            "_zim_static/wombat.js",
+            "_zim_static/custom.css",
+            "cdnjs.cloudflare.com/.../MathJax_AMS-Regular.eot",
+            "fonts/X.woff2",
+            "doc/manual.pdf",
+        ):
+            assert ZimOperations._is_non_article_target(path) is True, path
+
+    def test_article_targets_are_articles(self) -> None:
+        # Real navigable articles — including MedlinePlus .html/.htm pages —
+        # must NOT be treated as assets.
+        for path in (
+            "iep.utm.edu/plato/",
+            "iep.utm.edu/socrates/",
+            "Theory_of_relativity",
+            "U.S._Route_66",
+            "medlineplus.gov/appendicitis.html",
+            "medlineplus.gov/ency/article/000256.htm",
+        ):
+            assert ZimOperations._is_non_article_target(path) is False, path
+
+    def test_query_and_fragment_are_ignored(self) -> None:
+        assert ZimOperations._is_non_article_target("x.png?v=2") is True
+        assert ZimOperations._is_non_article_target("foo.html#sec") is False


### PR DESCRIPTION
End-to-end live real-world sweep of v2.1.0 against the remote deployment (Wikipedia 2026-02 + superuser.com sotoki) and a local source build over the IEP + MedlinePlus ZIMIT archives. v2.1.0's chrome/TOC/dedup/libzim fixes and the a-series dispatcher fixes all verified clean live. Two new output-quality defects fixed here:

**D1 — highlighter corrupts empty-text markdown links.** `_HIGHLIGHT_SKIP_RE` required non-empty link text, so ZIMIT image links with empty alt (`[](../media/plato.jpg)`) were unprotected; a query term inside the URL got bolded, breaking the path. Surfaced in search snippets and synthesize answers.

**D2 — related-articles surfaces binary assets.** The IEP lead image (`<a href="../media/plato.jpg">`) leaked into the internal-link graph and ranked #1 for `articles related to Plato`. Exclude image/font/style/script/media/archive targets; `.html`/`.htm` stay articles (MedlinePlus paths).

Tests: +10 in tests/test_post_v2_1_0_beta_fixes.py. Full suite 2674 passed, 236 skipped. black/flake8/mypy clean.

Deferred (documented; complex or optional): cross-archive synthesize relevance leakage (needs the optional semantic reranker), `_zim_static`/cdnjs replay infra in browse/walk (needs pagination rework), MedlinePlus in-article furniture.