### PR TITLE
refactor: consolidate duplicated scaffolding into shared helpers (Tier 2)

### DIFF
--- a/openzim_mcp/cursor_decode.py
+++ b/openzim_mcp/cursor_decode.py
@@ -20,11 +20,11 @@ caller's logging behavior is unchanged.
 import base64
 import json
 import logging
-import re
 from dataclasses import dataclass
 from typing import AbstractSet, Optional, Union
 
 from .responses import ToolErrorPayload, tool_error
+from .text_utils import tokenize_for_relevance
 
 logger = logging.getLogger(__name__)
 
@@ -207,14 +207,8 @@ def decode_offset_cursor(
             or cursor_t in q_emitting_tools
         )
         if isinstance(cursor_q, str) and cursor_q.strip() and cursor_t_emits_q:
-            cursor_tokens = {
-                t for t in re.findall(r"[a-z0-9]+", cursor_q.lower()) if len(t) >= 3
-            }
-            query_tokens = {
-                t
-                for t in re.findall(r"[a-z0-9]+", (query or "").lower())
-                if len(t) >= 3
-            }
+            cursor_tokens = tokenize_for_relevance(cursor_q)
+            query_tokens = tokenize_for_relevance(query or "")
             cursor_q_lower = cursor_q.lower()
             query_lower = (query or "").lower()
             # Three outcomes:

--- a/openzim_mcp/cursor_decode.py
+++ b/openzim_mcp/cursor_decode.py
@@ -197,13 +197,14 @@ def decode_offset_cursor(
         # shares no terms`` shape (which advises starting
         # the search over — useless when the real fault
         # is cross-tool reuse).
-        cursor_t_for_q = (
-            decoded_payload.get("t") if isinstance(decoded_payload, dict) else None
-        )
+        # ``cursor_t`` (read above) already holds ``decoded_payload["t"]``;
+        # at this point ``decoded_payload`` is guaranteed a dict (a
+        # non-dict would have set ``state = None`` and returned early),
+        # so reuse it directly rather than re-reading behind a dead guard.
         cursor_t_emits_q = (
-            not isinstance(cursor_t_for_q, str)
-            or not cursor_t_for_q
-            or cursor_t_for_q in q_emitting_tools
+            not isinstance(cursor_t, str)
+            or not cursor_t
+            or cursor_t in q_emitting_tools
         )
         if isinstance(cursor_q, str) and cursor_q.strip() and cursor_t_emits_q:
             cursor_tokens = {

--- a/openzim_mcp/cursor_decode.py
+++ b/openzim_mcp/cursor_decode.py
@@ -8,8 +8,9 @@ the cursor, so it deliberately bypasses
 :meth:`openzim_mcp.pagination.Cursor.decode`'s ``expected_tool`` check and
 reads ``s.o`` (offset) directly from any tool's cursor.
 
-Behavior is byte-identical to the inline original: the six structured
-``cursor_decode`` error payloads, the offset/ns/ai/tool projections, and the
+Behavior is byte-identical to the inline original: the five distinct structured
+``cursor_decode`` error payloads (the query-mismatch payload is shared by two
+branches), the offset/ns/ai/tool projections, and the
 token-overlap-vs-substring query-mismatch branching (gated on the
 ``_Q_EMITTING_CURSOR_TOOLS`` set) are preserved exactly. The broad
 ``except Exception`` that emitted the "undecodable" error AND a
@@ -52,8 +53,9 @@ def decode_offset_cursor(
     """Decode a simple-mode pagination cursor for offset extraction.
 
     Returns either a CursorDecodeResult (offset + optional ns/ai/tool to
-    project into options) OR a ToolErrorPayload (one of the 6 structured
-    cursor_decode errors). Behavior is identical to the former inline block
+    project into options) OR a ToolErrorPayload (one of the five distinct
+    structured cursor_decode errors). Behavior is identical to the former
+    inline block
     in handle_zim_query; q_emitting_tools is the handler's
     _Q_EMITTING_CURSOR_TOOLS set.
     """

--- a/openzim_mcp/cursor_decode.py
+++ b/openzim_mcp/cursor_decode.py
@@ -1,0 +1,271 @@
+"""Simple-mode pagination cursor decoding for offset extraction.
+
+This module hosts :func:`decode_offset_cursor`, extracted verbatim from the
+former inline block at the top of
+:meth:`openzim_mcp.simple_tools.SimpleToolsHandler.handle_zim_query`. The
+simple-mode router dispatches by parsed intent, not by the tool that emitted
+the cursor, so it deliberately bypasses
+:meth:`openzim_mcp.pagination.Cursor.decode`'s ``expected_tool`` check and
+reads ``s.o`` (offset) directly from any tool's cursor.
+
+Behavior is byte-identical to the inline original: the six structured
+``cursor_decode`` error payloads, the offset/ns/ai/tool projections, and the
+token-overlap-vs-substring query-mismatch branching (gated on the
+``_Q_EMITTING_CURSOR_TOOLS`` set) are preserved exactly. The broad
+``except Exception`` that emitted the "undecodable" error AND a
+``logger.warning("Could not decode cursor ...")`` is preserved here so the
+caller's logging behavior is unchanged.
+"""
+
+import base64
+import json
+import logging
+import re
+from dataclasses import dataclass
+from typing import AbstractSet, Optional, Union
+
+from .responses import ToolErrorPayload, tool_error
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CursorDecodeResult:
+    """Successful decode: the offset to project into ``options['offset']``
+    plus the optional ``ns`` / ``ai`` / ``tool`` fields the dispatcher
+    stashes into ``options['_cursor_ns']`` / ``['_cursor_ai']`` /
+    ``['_cursor_t']`` when truthy.
+    """
+
+    offset: int
+    ns: Optional[str] = None
+    ai: Optional[str] = None
+    tool: Optional[str] = None
+
+
+def decode_offset_cursor(
+    token: str,
+    *,
+    query: str,
+    q_emitting_tools: AbstractSet[str],
+) -> Union[CursorDecodeResult, ToolErrorPayload]:
+    """Decode a simple-mode pagination cursor for offset extraction.
+
+    Returns either a CursorDecodeResult (offset + optional ns/ai/tool to
+    project into options) OR a ToolErrorPayload (one of the 6 structured
+    cursor_decode errors). Behavior is identical to the former inline block
+    in handle_zim_query; q_emitting_tools is the handler's
+    _Q_EMITTING_CURSOR_TOOLS set.
+    """
+    # Defense-in-depth: cap the token length at 2 KB so an
+    # adversarially-crafted cursor can't trigger oversized
+    # base64-decode or json.loads work. Legitimate cursors
+    # issued by ``Cursor.encode`` are well under 200 chars.
+    if len(token) > 2048:
+        # H24: errors travel as ToolErrorPayload so callers can
+        # programmatically branch on ``result.error``. The legacy
+        # markdown string forced clients to substring-match the
+        # heading, breaking the same shape the advanced tools use.
+        return tool_error(
+            operation="cursor_decode",
+            message=(
+                "The `cursor` value exceeds the maximum length. "
+                "Drop the cursor and call again with an explicit "
+                "`offset` (or no pagination arg)."
+            ),
+            context=f"cursor={token[:64]}...",
+        )
+    try:
+        padded = token + "=" * (-len(token) % 4)
+        decoded_payload = json.loads(
+            base64.urlsafe_b64decode(padded.encode("ascii")).decode("utf-8")
+        )
+        # A11 E3 (post-a10): a base64+JSON token that decodes
+        # but lacks the expected ``s`` envelope (or whose ``s``
+        # has no ``o`` offset) used to be silently treated as
+        # "no cursor" — the caller thought they were paginating
+        # and got page 1 instead with no signal anything was
+        # wrong. Surface a structured ``cursor_decode`` error
+        # for these too so the contract matches the totally-
+        # garbled-token case below.
+        state = decoded_payload.get("s") if isinstance(decoded_payload, dict) else None
+        if not isinstance(state, dict):
+            return tool_error(
+                operation="cursor_decode",
+                message=(
+                    "The `cursor` payload is missing the expected "
+                    "`s` envelope. Drop the cursor and call "
+                    "again with an explicit `offset` (or no "
+                    "pagination arg)."
+                ),
+                context=f"cursor={token[:64]}",
+            )
+        decoded_offset = state.get("o")
+        if not isinstance(decoded_offset, int) or decoded_offset < 0:
+            return tool_error(
+                operation="cursor_decode",
+                message=(
+                    "The `cursor` payload's `s.o` (offset) is "
+                    "missing or invalid. Drop the cursor and "
+                    "call again with an explicit `offset` (or "
+                    "no pagination arg)."
+                ),
+                context=f"cursor={token[:64]}",
+            )
+        result = CursorDecodeResult(offset=decoded_offset)
+        # P3-D7 (live-MCP sweep): stash the cursor's ``s.ns``
+        # so namespace-bound handlers (``_handle_browse`` /
+        # ``_handle_walk_namespace``) can reject mismatches.
+        # Live MCP saw a cursor for ``ns="C"`` accepted by a
+        # ``browse namespace M`` call — the tool silently
+        # rebound to M while applying the cursor's offset.
+        # Same defence-in-depth shape as the existing ``ai`` /
+        # ``q`` mismatch checks: cursors must match the
+        # context they were issued for.
+        cursor_ns = state.get("ns")
+        if isinstance(cursor_ns, str) and cursor_ns:
+            result.ns = cursor_ns
+        # Post-a17 P1-D3: stash the cursor's ``s.ai`` so
+        # cursor-rebuilding handlers (``_handle_walk_namespace``
+        # rebuilds ``{scan_at, l}`` from ``offset`` and passes
+        # that synthetic dict to ``walk_namespace_data``, whose
+        # unconditional ``verify_archive_identity`` then
+        # rejects the missing ``ai`` with a misleading
+        # "missing archive-identity field" error). Preserving
+        # the original ``ai`` round-trips it back through the
+        # check so a walk-namespace cursor returned by the
+        # tool can be replayed against the same archive.
+        cursor_ai = state.get("ai")
+        if isinstance(cursor_ai, str) and cursor_ai:
+            result.ai = cursor_ai
+        # Post-a18 P1-D4: stash the cursor's tool name so the
+        # simple-tools dispatcher can reject cross-tool reuse
+        # (e.g. a ``walk_namespace`` cursor passed to
+        # ``browse namespace M`` silently walked browse from
+        # walk's offset). The advanced tools already enforce
+        # tool-binding via ``Cursor.decode(expected_tool=...)``;
+        # the simple-tools layer decoded the cursor in-place
+        # earlier in this block, bypassing that check. The
+        # ``_cursor_tool_mismatch`` helper fires in each
+        # cursor-consuming handler (``_handle_browse`` /
+        # ``_handle_walk_namespace``) so the user sees a clear
+        # rejection instead of a silent wrong-result.
+        cursor_t = decoded_payload.get("t")
+        if isinstance(cursor_t, str) and cursor_t:
+            result.tool = cursor_t
+        # D9 (beta): the original implementation treated the
+        # cursor's ``s.q`` field as decorative — only ``s.o``
+        # was read. That meant a caller who reused a cursor
+        # issued for ``query="algebra"`` with a fresh request
+        # for ``query="photosynthesis"`` silently got page 2
+        # of "photosynthesis" results (offset applied to the
+        # NEW query). Pagination state coupled to the wrong
+        # query is the same class of bug the advanced tools
+        # explicitly reject via ``CursorMismatchError`` /
+        # ``OpenZimMcpValidationError``.
+        #
+        # D9 (beta, second pass): the first revision used a
+        # one-directional substring check
+        # (``cursor_q.lower() in query.lower()``). That
+        # false-rejected legitimate pagination when the
+        # model shortened the query on the retry —
+        # cursor issued for ``"berlin culture"`` then
+        # resubmitted with ``"berlin"`` errored out
+        # even though both name the same topic. Use a
+        # token-set overlap test instead: as long as
+        # cursor and current query share at least one
+        # meaningful (≥3-char) token, accept the cursor.
+        # This catches the ``"algebra"`` → ``"photosynthesis"``
+        # swap while tolerating same-topic phrase reshaping
+        # in either direction. Cursors whose stored query
+        # has no ≥3-char tokens fall back to a bidirectional
+        # substring check.
+        cursor_q = state.get("q")
+        # Post-a20 P1-D1: only ``search_zim_file`` /
+        # ``search_with_filters`` legitimately emit ``s.q``
+        # in their cursors (see ``Cursor.encode`` callsites
+        # in zim/search.py). When ``_cursor_t`` claims a
+        # non-q-emitting tool (``walk_namespace`` /
+        # ``browse_namespace`` / ``extract_article_links``)
+        # but the payload still carries ``s.q``, the field
+        # is adversarial or vestigial — skipping the
+        # dispatcher q-overlap check here lets the
+        # handler-level ``_cursor_tool_mismatch`` fire
+        # with the correct ``Cursor / Tool Mismatch``
+        # diagnosis instead of the misleading
+        # ``Cursor was issued for query X; current request
+        # shares no terms`` shape (which advises starting
+        # the search over — useless when the real fault
+        # is cross-tool reuse).
+        cursor_t_for_q = (
+            decoded_payload.get("t") if isinstance(decoded_payload, dict) else None
+        )
+        cursor_t_emits_q = (
+            not isinstance(cursor_t_for_q, str)
+            or not cursor_t_for_q
+            or cursor_t_for_q in q_emitting_tools
+        )
+        if isinstance(cursor_q, str) and cursor_q.strip() and cursor_t_emits_q:
+            cursor_tokens = {
+                t for t in re.findall(r"[a-z0-9]+", cursor_q.lower()) if len(t) >= 3
+            }
+            query_tokens = {
+                t
+                for t in re.findall(r"[a-z0-9]+", (query or "").lower())
+                if len(t) >= 3
+            }
+            cursor_q_lower = cursor_q.lower()
+            query_lower = (query or "").lower()
+            # Three outcomes:
+            #   1. Cursor has meaningful tokens AND they
+            #      share at least one with the query → ok.
+            #   2. Cursor has meaningful tokens AND no
+            #      overlap → reject.
+            #   3. Cursor has only short tokens (rare;
+            #      e.g. ``"bio"``) → bidirectional
+            #      substring check.
+            # The two reject branches return a single, identical
+            # payload (formerly duplicated verbatim inline).
+            mismatch = _query_mismatch_error(cursor_q)
+            if cursor_tokens:
+                shares_token = bool(cursor_tokens & query_tokens)
+                if not shares_token:
+                    return mismatch
+            else:
+                mutually_unrelated = (
+                    cursor_q_lower not in query_lower
+                    and query_lower not in cursor_q_lower
+                )
+                if mutually_unrelated:
+                    return mismatch
+        return result
+    except Exception as e:
+        logger.warning("Could not decode cursor %r: %s", token, e)
+        # H24: see above — keep simple-mode error shape consistent
+        # with the advanced surface.
+        return tool_error(
+            operation="cursor_decode",
+            message=(
+                "The `cursor` value could not be decoded. Drop "
+                "the cursor and call again with an explicit "
+                "`offset` (or no pagination arg)."
+            ),
+            context=f"cursor={token[:64]}",
+        )
+
+
+def _query_mismatch_error(cursor_q: str) -> ToolErrorPayload:
+    """The single source of truth for the (formerly duplicated) D9
+    query-mismatch payload. Both the token-overlap and substring-fallback
+    reject branches return this identical error.
+    """
+    return tool_error(
+        operation="cursor_decode",
+        message=(
+            f"Cursor was issued for query {cursor_q!r}; "
+            f"current request shares no terms "
+            f"with it. Drop the cursor and start "
+            f"the search over for the new query."
+        ),
+        context=f"cursor_q={cursor_q!r}",
+    )

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -243,7 +243,7 @@ class SimpleToolsHandler(
             # the payload directly (bypassing that check) so any tool's
             # cursor can be replayed for offset extraction. It returns a
             # ``CursorDecodeResult`` (offset + optional ns/ai/tool to
-            # project into ``options``) or one of the six structured
+            # project into ``options``) or one of the structured
             # ``cursor_decode`` ``ToolErrorPayload`` errors. See
             # ``openzim_mcp.cursor_decode`` for the full rationale.
             cursor_result = decode_offset_cursor(

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -23,6 +23,7 @@ from . import compact_renderers
 from .article_body import _ArticleBodyMixin
 from .chain_detection import _ChainMixin
 from .compact_format import _CompactFormatMixin
+from .cursor_decode import decode_offset_cursor
 from .disambiguation import _DisambiguationMixin
 from .exceptions import RegexTimeoutError
 from .intent_parser import IntentParser, _strip_quote_pair, safe_regex_sub
@@ -238,239 +239,31 @@ class SimpleToolsHandler(
         if cursor_raw is not None:
             # Simple-mode dispatch routes by parsed intent, not by the
             # tool that emitted the cursor — and ``Cursor.decode`` requires
-            # an ``expected_tool`` match. Decode the payload directly so
-            # any tool's cursor can be replayed for offset extraction.
-            # Cross-tool reuse is bounded: the only field we read is
-            # ``s.o`` (offset). Tool-specific cursor state (archive
-            # identity, query, namespace) is preserved if the caller
-            # also re-supplies the matching query terms.
-            #
-            # Defense-in-depth: cap the token length at 2 KB so an
-            # adversarially-crafted cursor can't trigger oversized
-            # base64-decode or json.loads work. Legitimate cursors
-            # issued by ``Cursor.encode`` are well under 200 chars.
-            import base64 as _b64
-            import json as _json
-
-            token = str(cursor_raw)
-            if len(token) > 2048:
-                # H24: errors travel as ToolErrorPayload so callers can
-                # programmatically branch on ``result.error``. The legacy
-                # markdown string forced clients to substring-match the
-                # heading, breaking the same shape the advanced tools use.
-                return tool_error(
-                    operation="cursor_decode",
-                    message=(
-                        "The `cursor` value exceeds the maximum length. "
-                        "Drop the cursor and call again with an explicit "
-                        "`offset` (or no pagination arg)."
-                    ),
-                    context=f"cursor={token[:64]}...",
-                )
-            try:
-                padded = token + "=" * (-len(token) % 4)
-                decoded_payload = _json.loads(
-                    _b64.urlsafe_b64decode(padded.encode("ascii")).decode("utf-8")
-                )
-                # A11 E3 (post-a10): a base64+JSON token that decodes
-                # but lacks the expected ``s`` envelope (or whose ``s``
-                # has no ``o`` offset) used to be silently treated as
-                # "no cursor" — the caller thought they were paginating
-                # and got page 1 instead with no signal anything was
-                # wrong. Surface a structured ``cursor_decode`` error
-                # for these too so the contract matches the totally-
-                # garbled-token case below.
-                state = (
-                    decoded_payload.get("s")
-                    if isinstance(decoded_payload, dict)
-                    else None
-                )
-                if not isinstance(state, dict):
-                    return tool_error(
-                        operation="cursor_decode",
-                        message=(
-                            "The `cursor` payload is missing the expected "
-                            "`s` envelope. Drop the cursor and call "
-                            "again with an explicit `offset` (or no "
-                            "pagination arg)."
-                        ),
-                        context=f"cursor={token[:64]}",
-                    )
-                decoded_offset = state.get("o")
-                if not isinstance(decoded_offset, int) or decoded_offset < 0:
-                    return tool_error(
-                        operation="cursor_decode",
-                        message=(
-                            "The `cursor` payload's `s.o` (offset) is "
-                            "missing or invalid. Drop the cursor and "
-                            "call again with an explicit `offset` (or "
-                            "no pagination arg)."
-                        ),
-                        context=f"cursor={token[:64]}",
-                    )
-                options["offset"] = decoded_offset
-                # P3-D7 (live-MCP sweep): stash the cursor's ``s.ns``
-                # so namespace-bound handlers (``_handle_browse`` /
-                # ``_handle_walk_namespace``) can reject mismatches.
-                # Live MCP saw a cursor for ``ns="C"`` accepted by a
-                # ``browse namespace M`` call — the tool silently
-                # rebound to M while applying the cursor's offset.
-                # Same defence-in-depth shape as the existing ``ai`` /
-                # ``q`` mismatch checks: cursors must match the
-                # context they were issued for.
-                cursor_ns = state.get("ns")
-                if isinstance(cursor_ns, str) and cursor_ns:
-                    options["_cursor_ns"] = cursor_ns
-                # Post-a17 P1-D3: stash the cursor's ``s.ai`` so
-                # cursor-rebuilding handlers (``_handle_walk_namespace``
-                # rebuilds ``{scan_at, l}`` from ``offset`` and passes
-                # that synthetic dict to ``walk_namespace_data``, whose
-                # unconditional ``verify_archive_identity`` then
-                # rejects the missing ``ai`` with a misleading
-                # "missing archive-identity field" error). Preserving
-                # the original ``ai`` round-trips it back through the
-                # check so a walk-namespace cursor returned by the
-                # tool can be replayed against the same archive.
-                cursor_ai = state.get("ai")
-                if isinstance(cursor_ai, str) and cursor_ai:
-                    options["_cursor_ai"] = cursor_ai
-                # Post-a18 P1-D4: stash the cursor's tool name so the
-                # simple-tools dispatcher can reject cross-tool reuse
-                # (e.g. a ``walk_namespace`` cursor passed to
-                # ``browse namespace M`` silently walked browse from
-                # walk's offset). The advanced tools already enforce
-                # tool-binding via ``Cursor.decode(expected_tool=...)``;
-                # the simple-tools layer decoded the cursor in-place
-                # earlier in this block, bypassing that check. The
-                # ``_cursor_tool_mismatch`` helper fires in each
-                # cursor-consuming handler (``_handle_browse`` /
-                # ``_handle_walk_namespace``) so the user sees a clear
-                # rejection instead of a silent wrong-result.
-                cursor_t = decoded_payload.get("t")
-                if isinstance(cursor_t, str) and cursor_t:
-                    options["_cursor_t"] = cursor_t
-                if isinstance(state, dict):  # always True now; kept for diff clarity
-                    # D9 (beta): the original implementation treated the
-                    # cursor's ``s.q`` field as decorative — only ``s.o``
-                    # was read. That meant a caller who reused a cursor
-                    # issued for ``query="algebra"`` with a fresh request
-                    # for ``query="photosynthesis"`` silently got page 2
-                    # of "photosynthesis" results (offset applied to the
-                    # NEW query). Pagination state coupled to the wrong
-                    # query is the same class of bug the advanced tools
-                    # explicitly reject via ``CursorMismatchError`` /
-                    # ``OpenZimMcpValidationError``.
-                    #
-                    # D9 (beta, second pass): the first revision used a
-                    # one-directional substring check
-                    # (``cursor_q.lower() in query.lower()``). That
-                    # false-rejected legitimate pagination when the
-                    # model shortened the query on the retry —
-                    # cursor issued for ``"berlin culture"`` then
-                    # resubmitted with ``"berlin"`` errored out
-                    # even though both name the same topic. Use a
-                    # token-set overlap test instead: as long as
-                    # cursor and current query share at least one
-                    # meaningful (≥3-char) token, accept the cursor.
-                    # This catches the ``"algebra"`` → ``"photosynthesis"``
-                    # swap while tolerating same-topic phrase reshaping
-                    # in either direction. Cursors whose stored query
-                    # has no ≥3-char tokens fall back to a bidirectional
-                    # substring check.
-                    cursor_q = state.get("q")
-                    # Post-a20 P1-D1: only ``search_zim_file`` /
-                    # ``search_with_filters`` legitimately emit ``s.q``
-                    # in their cursors (see ``Cursor.encode`` callsites
-                    # in zim/search.py). When ``_cursor_t`` claims a
-                    # non-q-emitting tool (``walk_namespace`` /
-                    # ``browse_namespace`` / ``extract_article_links``)
-                    # but the payload still carries ``s.q``, the field
-                    # is adversarial or vestigial — skipping the
-                    # dispatcher q-overlap check here lets the
-                    # handler-level ``_cursor_tool_mismatch`` fire
-                    # with the correct ``Cursor / Tool Mismatch``
-                    # diagnosis instead of the misleading
-                    # ``Cursor was issued for query X; current request
-                    # shares no terms`` shape (which advises starting
-                    # the search over — useless when the real fault
-                    # is cross-tool reuse).
-                    cursor_t_for_q = (
-                        decoded_payload.get("t")
-                        if isinstance(decoded_payload, dict)
-                        else None
-                    )
-                    cursor_t_emits_q = (
-                        not isinstance(cursor_t_for_q, str)
-                        or not cursor_t_for_q
-                        or cursor_t_for_q in self._Q_EMITTING_CURSOR_TOOLS
-                    )
-                    if (
-                        isinstance(cursor_q, str)
-                        and cursor_q.strip()
-                        and cursor_t_emits_q
-                    ):
-                        cursor_tokens = {
-                            t
-                            for t in re.findall(r"[a-z0-9]+", cursor_q.lower())
-                            if len(t) >= 3
-                        }
-                        query_tokens = {
-                            t
-                            for t in re.findall(r"[a-z0-9]+", (query or "").lower())
-                            if len(t) >= 3
-                        }
-                        cursor_q_lower = cursor_q.lower()
-                        query_lower = (query or "").lower()
-                        # Three outcomes:
-                        #   1. Cursor has meaningful tokens AND they
-                        #      share at least one with the query → ok.
-                        #   2. Cursor has meaningful tokens AND no
-                        #      overlap → reject.
-                        #   3. Cursor has only short tokens (rare;
-                        #      e.g. ``"bio"``) → bidirectional
-                        #      substring check.
-                        if cursor_tokens:
-                            shares_token = bool(cursor_tokens & query_tokens)
-                            if not shares_token:
-                                return tool_error(
-                                    operation="cursor_decode",
-                                    message=(
-                                        f"Cursor was issued for query {cursor_q!r}; "
-                                        f"current request shares no terms "
-                                        f"with it. Drop the cursor and start "
-                                        f"the search over for the new query."
-                                    ),
-                                    context=f"cursor_q={cursor_q!r}",
-                                )
-                        else:
-                            mutually_unrelated = (
-                                cursor_q_lower not in query_lower
-                                and query_lower not in cursor_q_lower
-                            )
-                            if mutually_unrelated:
-                                return tool_error(
-                                    operation="cursor_decode",
-                                    message=(
-                                        f"Cursor was issued for query {cursor_q!r}; "
-                                        f"current request shares no terms "
-                                        f"with it. Drop the cursor and start "
-                                        f"the search over for the new query."
-                                    ),
-                                    context=f"cursor_q={cursor_q!r}",
-                                )
-            except Exception as e:
-                logger.warning("Could not decode cursor %r: %s", cursor_raw, e)
-                # H24: see above — keep simple-mode error shape consistent
-                # with the advanced surface.
-                return tool_error(
-                    operation="cursor_decode",
-                    message=(
-                        "The `cursor` value could not be decoded. Drop "
-                        "the cursor and call again with an explicit "
-                        "`offset` (or no pagination arg)."
-                    ),
-                    context=f"cursor={token[:64]}",
-                )
+            # an ``expected_tool`` match. ``decode_offset_cursor`` decodes
+            # the payload directly (bypassing that check) so any tool's
+            # cursor can be replayed for offset extraction. It returns a
+            # ``CursorDecodeResult`` (offset + optional ns/ai/tool to
+            # project into ``options``) or one of the six structured
+            # ``cursor_decode`` ``ToolErrorPayload`` errors. See
+            # ``openzim_mcp.cursor_decode`` for the full rationale.
+            cursor_result = decode_offset_cursor(
+                str(cursor_raw),
+                query=query,
+                q_emitting_tools=self._Q_EMITTING_CURSOR_TOOLS,
+            )
+            if isinstance(cursor_result, dict):
+                # ToolErrorPayload — surface it unchanged.
+                return cursor_result
+            options["offset"] = cursor_result.offset
+            # Only project ns/ai/tool when truthy (same condition as the
+            # former inline block); downstream handlers read these to
+            # reject namespace / archive-identity / cross-tool mismatches.
+            if cursor_result.ns:
+                options["_cursor_ns"] = cursor_result.ns
+            if cursor_result.ai:
+                options["_cursor_ai"] = cursor_result.ai
+            if cursor_result.tool:
+                options["_cursor_t"] = cursor_result.tool
         # Normalize hallucinated ``zim_file_path`` BEFORE branching to the
         # synthesize pipeline. Small models pass bare filenames
         # (``"wikipedia.zim"``) or article titles (``"Big Rapids,

--- a/openzim_mcp/text_utils.py
+++ b/openzim_mcp/text_utils.py
@@ -1,0 +1,21 @@
+"""Small shared text helpers with no package-internal dependencies."""
+
+from __future__ import annotations
+
+import re
+from typing import Set
+
+#: Minimum token length for relevance/overlap comparisons. Shorter tokens
+#: (``a``, ``of``, ``to``) are too common to discriminate topics.
+RELEVANCE_TOKEN_MIN_LEN = 3
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def tokenize_for_relevance(
+    text: str, *, min_len: int = RELEVANCE_TOKEN_MIN_LEN
+) -> Set[str]:
+    """Return the set of lowercase alphanumeric tokens in ``text`` whose
+    length is at least ``min_len``. Used for cheap topic-overlap checks
+    (search relevance scoring, cursor query-continuity)."""
+    return {t for t in _TOKEN_RE.findall(text.lower()) if len(t) >= min_len}

--- a/openzim_mcp/tools/_common.py
+++ b/openzim_mcp/tools/_common.py
@@ -27,10 +27,17 @@ def tool_error_response(
     context: Optional[str] = None,
 ) -> str:
     """Log + build the standard enhanced error payload for a tool's broad
-    ``except`` block. Mirrors the b13 envelope every wrapper repeats."""
+    ``except`` block. Mirrors the b13 envelope every wrapper repeats.
+
+    The log is emitted under ``openzim_mcp.tools.<operation>`` so each
+    tool's records keep the same logger name they had when every wrapper
+    logged via its own module-level ``getLogger(__name__)`` (operation is
+    the module basename, e.g. ``zim_links`` → ``...tools.zim_links``)."""
     import logging
 
-    logging.getLogger("openzim_mcp.tools").error("Error in %s: %s", operation, error)
+    logging.getLogger(f"openzim_mcp.tools.{operation}").error(
+        "Error in %s: %s", operation, error
+    )
     return server._create_enhanced_error_message(
         operation=operation, error=error, context=context or ""
     )

--- a/openzim_mcp/tools/_common.py
+++ b/openzim_mcp/tools/_common.py
@@ -1,0 +1,36 @@
+"""Shared helpers for the thin Phase F tool wrappers."""
+
+from __future__ import annotations
+
+import pathlib
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from ..server import OpenZimMcpServer
+
+_DESCRIPTIONS_DIR = pathlib.Path(__file__).parent
+
+
+def load_description(name: str) -> str:
+    """Read the ``<name>_description.md`` markdown next to the tool modules.
+
+    Centralizes the ``(_DIR / "...md").read_text(encoding="utf-8")`` line
+    each wrapper repeated."""
+    return (_DESCRIPTIONS_DIR / f"{name}_description.md").read_text(encoding="utf-8")
+
+
+def tool_error_response(
+    server: "OpenZimMcpServer",
+    *,
+    operation: str,
+    error: Exception,
+    context: Optional[str] = None,
+) -> str:
+    """Log + build the standard enhanced error payload for a tool's broad
+    ``except`` block. Mirrors the b13 envelope every wrapper repeats."""
+    import logging
+
+    logging.getLogger("openzim_mcp.tools").error("Error in %s: %s", operation, error)
+    return server._create_enhanced_error_message(
+        operation=operation, error=error, context=context or ""
+    )

--- a/openzim_mcp/tools/zim_browse.py
+++ b/openzim_mcp/tools/zim_browse.py
@@ -7,18 +7,17 @@ Collapses ``browse_namespace`` + ``walk_namespace`` (2 → 1) via a
 from __future__ import annotations
 
 import logging
-import pathlib
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from ..responses import tool_error
+from ._common import load_description, tool_error_response
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
 
 logger = logging.getLogger(__name__)
 
-_DIR = pathlib.Path(__file__).parent
-_DESCRIPTION = (_DIR / "zim_browse_description.md").read_text(encoding="utf-8")
+_DESCRIPTION = load_description("zim_browse")
 
 _VALID_MODES = {"page", "walk"}
 
@@ -62,8 +61,8 @@ def register(server: "OpenZimMcpServer") -> None:
                 limit=limit if limit is not None else 200,
             )
         except Exception as e:  # noqa: BLE001 — broad catch matches b13 envelope
-            logger.error(f"Error in zim_browse: {e}")
-            return server._create_enhanced_error_message(
+            return tool_error_response(
+                server,
                 operation="zim_browse",
                 error=e,
                 context=f"Namespace: {namespace}, Mode: {mode}",

--- a/openzim_mcp/tools/zim_browse.py
+++ b/openzim_mcp/tools/zim_browse.py
@@ -6,7 +6,6 @@ Collapses ``browse_namespace`` + ``walk_namespace`` (2 → 1) via a
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from ..responses import tool_error
@@ -14,8 +13,6 @@ from ._common import load_description, tool_error_response
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
-
-logger = logging.getLogger(__name__)
 
 _DESCRIPTION = load_description("zim_browse")
 

--- a/openzim_mcp/tools/zim_get.py
+++ b/openzim_mcp/tools/zim_get.py
@@ -36,7 +36,6 @@ this axis. v2.5 revisits the default with adoption telemetry.
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any, List, Literal, Optional, Union
 
 from ..responses import tool_error
@@ -44,8 +43,6 @@ from ._common import load_description, tool_error_response
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
-
-logger = logging.getLogger(__name__)
 
 _DESCRIPTION = load_description("zim_get")
 

--- a/openzim_mcp/tools/zim_get.py
+++ b/openzim_mcp/tools/zim_get.py
@@ -37,18 +37,17 @@ this axis. v2.5 revisits the default with adoption telemetry.
 from __future__ import annotations
 
 import logging
-import pathlib
 from typing import TYPE_CHECKING, Any, List, Literal, Optional, Union
 
 from ..responses import tool_error
+from ._common import load_description, tool_error_response
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
 
 logger = logging.getLogger(__name__)
 
-_DIR = pathlib.Path(__file__).parent
-_DESCRIPTION = (_DIR / "zim_get_description.md").read_text(encoding="utf-8")
+_DESCRIPTION = load_description("zim_get")
 
 _VALID_VIEWS = {"full", "summary", "toc", "structure"}
 
@@ -145,8 +144,8 @@ def register(server: "OpenZimMcpServer") -> None:
             )
 
         except Exception as e:  # noqa: BLE001 — broad catch matches b13 envelope
-            logger.error(f"Error in zim_get: {e}")
-            return server._create_enhanced_error_message(
+            return tool_error_response(
+                server,
                 operation="zim_get",
                 error=e,
                 context=f"Path: {entry_path or entry_paths}",

--- a/openzim_mcp/tools/zim_get_section.py
+++ b/openzim_mcp/tools/zim_get_section.py
@@ -19,7 +19,6 @@ shape (``GetSectionResponse``) are unchanged from Phase C.
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from ..responses import tool_error
@@ -27,8 +26,6 @@ from ._common import load_description, tool_error_response
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
-
-logger = logging.getLogger(__name__)
 
 _DESCRIPTION = load_description("zim_get_section")
 

--- a/openzim_mcp/tools/zim_get_section.py
+++ b/openzim_mcp/tools/zim_get_section.py
@@ -20,18 +20,17 @@ shape (``GetSectionResponse``) are unchanged from Phase C.
 from __future__ import annotations
 
 import logging
-import pathlib
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from ..responses import tool_error
+from ._common import load_description, tool_error_response
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
 
 logger = logging.getLogger(__name__)
 
-_DIR = pathlib.Path(__file__).parent
-_DESCRIPTION = (_DIR / "zim_get_section_description.md").read_text(encoding="utf-8")
+_DESCRIPTION = load_description("zim_get_section")
 
 
 def register(server: "OpenZimMcpServer") -> None:
@@ -68,8 +67,8 @@ def register(server: "OpenZimMcpServer") -> None:
                 max_chars=max_chars,
             )
         except Exception as e:  # noqa: BLE001 — broad catch matches b13 envelope
-            logger.error(f"Error in zim_get_section: {e}")
-            return server._create_enhanced_error_message(
+            return tool_error_response(
+                server,
                 operation="zim_get_section",
                 error=e,
                 context=f"Path: {entry_path}, Section: {section_id}",

--- a/openzim_mcp/tools/zim_health.py
+++ b/openzim_mcp/tools/zim_health.py
@@ -7,15 +7,12 @@ Collapses ``get_server_health`` + ``get_server_configuration`` +
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any, Optional
 
 from ._common import load_description, tool_error_response
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
-
-logger = logging.getLogger(__name__)
 
 _DESCRIPTION = load_description("zim_health")
 

--- a/openzim_mcp/tools/zim_health.py
+++ b/openzim_mcp/tools/zim_health.py
@@ -8,16 +8,16 @@ Collapses ``get_server_health`` + ``get_server_configuration`` +
 from __future__ import annotations
 
 import logging
-import pathlib
 from typing import TYPE_CHECKING, Any, Optional
+
+from ._common import load_description, tool_error_response
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
 
 logger = logging.getLogger(__name__)
 
-_DIR = pathlib.Path(__file__).parent
-_DESCRIPTION = (_DIR / "zim_health_description.md").read_text(encoding="utf-8")
+_DESCRIPTION = load_description("zim_health")
 
 
 def register(server: "OpenZimMcpServer") -> None:
@@ -36,8 +36,8 @@ def register(server: "OpenZimMcpServer") -> None:
                 return await ops.get_health_data(server)
             return await ops.get_archive_validation_data(zim_file_path)
         except Exception as e:  # noqa: BLE001 — broad catch matches b13 envelope
-            logger.error(f"Error in zim_health: {e}")
-            return server._create_enhanced_error_message(
+            return tool_error_response(
+                server,
                 operation="zim_health",
                 error=e,
                 context=(

--- a/openzim_mcp/tools/zim_links.py
+++ b/openzim_mcp/tools/zim_links.py
@@ -7,7 +7,6 @@ v2.0 omits ``"inbound"`` per spec — see description file.
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from ..responses import tool_error
@@ -15,8 +14,6 @@ from ._common import load_description, tool_error_response
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
-
-logger = logging.getLogger(__name__)
 
 _DESCRIPTION = load_description("zim_links")
 

--- a/openzim_mcp/tools/zim_links.py
+++ b/openzim_mcp/tools/zim_links.py
@@ -8,18 +8,17 @@ v2.0 omits ``"inbound"`` per spec — see description file.
 from __future__ import annotations
 
 import logging
-import pathlib
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from ..responses import tool_error
+from ._common import load_description, tool_error_response
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
 
 logger = logging.getLogger(__name__)
 
-_DIR = pathlib.Path(__file__).parent
-_DESCRIPTION = (_DIR / "zim_links_description.md").read_text(encoding="utf-8")
+_DESCRIPTION = load_description("zim_links")
 
 _VALID_DIRECTIONS = {"outbound", "related"}
 
@@ -64,8 +63,8 @@ def register(server: "OpenZimMcpServer") -> None:
                 limit=limit if limit is not None else 10,
             )
         except Exception as e:  # noqa: BLE001 — broad catch matches b13 envelope
-            logger.error(f"Error in zim_links: {e}")
-            return server._create_enhanced_error_message(
+            return tool_error_response(
+                server,
                 operation="zim_links",
                 error=e,
                 context=f"Path: {entry_path}, Direction: {direction}",

--- a/openzim_mcp/tools/zim_metadata.py
+++ b/openzim_mcp/tools/zim_metadata.py
@@ -8,15 +8,12 @@ Delegates to the D2 combined wrapper
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any
 
 from ._common import load_description, tool_error_response
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
-
-logger = logging.getLogger(__name__)
 
 _DESCRIPTION = load_description("zim_metadata")
 

--- a/openzim_mcp/tools/zim_metadata.py
+++ b/openzim_mcp/tools/zim_metadata.py
@@ -9,16 +9,16 @@ Delegates to the D2 combined wrapper
 from __future__ import annotations
 
 import logging
-import pathlib
 from typing import TYPE_CHECKING, Any
+
+from ._common import load_description, tool_error_response
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
 
 logger = logging.getLogger(__name__)
 
-_DIR = pathlib.Path(__file__).parent
-_DESCRIPTION = (_DIR / "zim_metadata_description.md").read_text(encoding="utf-8")
+_DESCRIPTION = load_description("zim_metadata")
 
 
 def register(server: "OpenZimMcpServer") -> None:
@@ -32,8 +32,8 @@ def register(server: "OpenZimMcpServer") -> None:
         try:
             return await ops.get_archive_metadata_data(zim_file_path)
         except Exception as e:  # noqa: BLE001 — broad catch matches b13 envelope
-            logger.error(f"Error in zim_metadata: {e}")
-            return server._create_enhanced_error_message(
+            return tool_error_response(
+                server,
                 operation="zim_metadata",
                 error=e,
                 context=f"Path: {zim_file_path}",

--- a/openzim_mcp/tools/zim_query.py
+++ b/openzim_mcp/tools/zim_query.py
@@ -18,7 +18,6 @@ diverge from what Gate 0b measured.
 from __future__ import annotations
 
 import asyncio
-import logging
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from ..responses import ToolErrorPayload, tool_error
@@ -27,8 +26,6 @@ from ._common import load_description, tool_error_response
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
-
-logger = logging.getLogger(__name__)
 
 # Read description at IMPORT TIME from committed file shipped with the
 # package. Per-tool packaging guard in test_phase_f_packaging.py

--- a/openzim_mcp/tools/zim_query.py
+++ b/openzim_mcp/tools/zim_query.py
@@ -19,11 +19,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import pathlib
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from ..responses import ToolErrorPayload, tool_error
 from ..synthesize import SynthesizeResponse
+from ._common import load_description, tool_error_response
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
@@ -33,8 +33,7 @@ logger = logging.getLogger(__name__)
 # Read description at IMPORT TIME from committed file shipped with the
 # package. Per-tool packaging guard in test_phase_f_packaging.py
 # verifies the wheel ships this file.
-_DIR = pathlib.Path(__file__).parent
-_DESCRIPTION = (_DIR / "zim_query_description.md").read_text(encoding="utf-8")
+_DESCRIPTION = load_description("zim_query")
 
 
 def register(server: "OpenZimMcpServer") -> None:
@@ -124,8 +123,8 @@ def register(server: "OpenZimMcpServer") -> None:
             return "Error: Simple tools handler not initialized"
 
         except Exception as e:  # noqa: BLE001 — broad catch matches b13 envelope
-            logger.error(f"Error in zim_query: {e}")
-            return server._create_enhanced_error_message(
+            return tool_error_response(
+                server,
                 operation="zim_query",
                 error=e,
                 context=f"Query: {query}, File: {zim_file_path}",

--- a/openzim_mcp/tools/zim_search.py
+++ b/openzim_mcp/tools/zim_search.py
@@ -38,18 +38,17 @@ rc0 sign-off: WIRED.
 from __future__ import annotations
 
 import logging
-import pathlib
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from ..responses import tool_error
+from ._common import load_description, tool_error_response
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
 
 logger = logging.getLogger(__name__)
 
-_DIR = pathlib.Path(__file__).parent
-_DESCRIPTION = (_DIR / "zim_search_description.md").read_text(encoding="utf-8")
+_DESCRIPTION = load_description("zim_search")
 
 # Baked-in at rc1 PR time from gate_0b_decision.json. Drift between this
 # value and the committed decision artifact is caught by
@@ -166,8 +165,8 @@ def register(server: "OpenZimMcpServer") -> None:
             )
 
         except Exception as e:  # noqa: BLE001 — broad catch matches b13 envelope
-            logger.error(f"Error in zim_search: {e}")
-            return server._create_enhanced_error_message(
+            return tool_error_response(
+                server,
                 operation="zim_search",
                 error=e,
                 context=f"Query: {query}, Mode: {mode}",

--- a/openzim_mcp/tools/zim_search.py
+++ b/openzim_mcp/tools/zim_search.py
@@ -37,7 +37,6 @@ rc0 sign-off: WIRED.
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from ..responses import tool_error
@@ -45,8 +44,6 @@ from ._common import load_description, tool_error_response
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
-
-logger = logging.getLogger(__name__)
 
 _DESCRIPTION = load_description("zim_search")
 

--- a/openzim_mcp/zim/_ops_base.py
+++ b/openzim_mcp/zim/_ops_base.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from openzim_mcp.security import PathValidator
+
+
+def _json(payload: Any) -> str:
+    """Serialize ``payload`` as the project-standard pretty JSON string
+    (2-space indent, non-ASCII preserved). Single source for the
+    ``indent=2, ensure_ascii=False`` policy the zim wrappers repeat."""
+    return json.dumps(payload, indent=2, ensure_ascii=False)
 
 
 class _ArchiveAccessMixin:

--- a/openzim_mcp/zim/_ops_base.py
+++ b/openzim_mcp/zim/_ops_base.py
@@ -1,4 +1,6 @@
-"""Shared path-validation helper for the ZIM domain mixins."""
+"""Shared low-level helpers for the ZIM domain mixins: path validation
+(``_ArchiveAccessMixin._validate_zim_path``) and the standard JSON serializer
+(``_json``)."""
 
 from __future__ import annotations
 

--- a/openzim_mcp/zim/_ops_base.py
+++ b/openzim_mcp/zim/_ops_base.py
@@ -1,0 +1,26 @@
+"""Shared path-validation helper for the ZIM domain mixins."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from openzim_mcp.security import PathValidator
+
+
+class _ArchiveAccessMixin:
+    """Composed into ``ZimOperations`` so every domain mixin reuses one
+    copy of the previously-duplicated validate-path prologue."""
+
+    if TYPE_CHECKING:
+        path_validator: "PathValidator"
+
+    def _validate_zim_path(self, zim_file_path: str) -> Path:
+        """Validate a path then confirm it is a readable ZIM file.
+
+        This is the 2-line prologue repeated across the domain mixins.
+        Validation/security errors propagate unwrapped, exactly as before.
+        """
+        validated = self.path_validator.validate_path(zim_file_path)
+        return self.path_validator.validate_zim_file(validated)

--- a/openzim_mcp/zim/archive.py
+++ b/openzim_mcp/zim/archive.py
@@ -48,6 +48,7 @@ from openzim_mcp.exceptions import (
 from openzim_mcp.meta import attach_meta
 from openzim_mcp.security import PathValidator
 from openzim_mcp.timeout_utils import run_with_timeout
+from openzim_mcp.zim._ops_base import _ArchiveAccessMixin
 from openzim_mcp.zim.content import _ContentMixin
 from openzim_mcp.zim.namespace import _NamespaceMixin
 from openzim_mcp.zim.redirects import resolve_redirect_chain
@@ -280,7 +281,9 @@ def zim_archive(
         logger.debug(f"Releasing ZIM archive: {file_path}")
 
 
-class ZimOperations(_SearchMixin, _ContentMixin, _StructureMixin, _NamespaceMixin):
+class ZimOperations(
+    _ArchiveAccessMixin, _SearchMixin, _ContentMixin, _StructureMixin, _NamespaceMixin
+):
     """Handles all ZIM file operations with caching and security.
 
     The bulk of the surface is contributed by domain mixins; this class
@@ -502,8 +505,7 @@ class ZimOperations(_SearchMixin, _ContentMixin, _StructureMixin, _NamespaceMixi
             OpenZimMcpArchiveError: If metadata retrieval fails
         """
         # Validate and resolve file path
-        validated_path = self.path_validator.validate_path(zim_file_path)
-        validated_path = self.path_validator.validate_zim_file(validated_path)
+        validated_path = self._validate_zim_path(zim_file_path)
 
         # Distinct cache key from the legacy string variant so the two
         # don't collide on shared cache backends. Bumped to v2c when the
@@ -568,8 +570,7 @@ class ZimOperations(_SearchMixin, _ContentMixin, _StructureMixin, _NamespaceMixi
             OpenZimMcpFileNotFoundError: If ZIM file not found
             OpenZimMcpArchiveError: If validation fails
         """
-        validated_path = self.path_validator.validate_path(zim_file_path)
-        validated_path = self.path_validator.validate_zim_file(validated_path)
+        validated_path = self._validate_zim_path(zim_file_path)
 
         # Include a file-identity (mtime:size) token so an in-place ZIM
         # replacement invalidates the cached verdict. ``is_valid`` is an
@@ -836,8 +837,7 @@ class ZimOperations(_SearchMixin, _ContentMixin, _StructureMixin, _NamespaceMixi
             OpenZimMcpArchiveError: If main page retrieval fails
         """
         # Validate and resolve file path
-        validated_path = self.path_validator.validate_path(zim_file_path)
-        validated_path = self.path_validator.validate_zim_file(validated_path)
+        validated_path = self._validate_zim_path(zim_file_path)
 
         # Check cache
         cache_key = f"main_page:{validated_path}:compact={compact}"
@@ -992,8 +992,7 @@ class ZimOperations(_SearchMixin, _ContentMixin, _StructureMixin, _NamespaceMixi
             OpenZimMcpFileNotFoundError: If ZIM file not found
             OpenZimMcpArchiveError: If main page retrieval fails
         """
-        validated_path = self.path_validator.validate_path(zim_file_path)
-        validated_path = self.path_validator.validate_zim_file(validated_path)
+        validated_path = self._validate_zim_path(zim_file_path)
 
         # Cache key distinct from the legacy text cache so old persisted
         # entries (which hold strings) don't collide with the new dict shape.

--- a/openzim_mcp/zim/archive.py
+++ b/openzim_mcp/zim/archive.py
@@ -19,7 +19,6 @@ Layout:
   the class here.
 """
 
-import json
 import logging
 from contextlib import contextmanager, suppress
 from datetime import datetime
@@ -491,7 +490,7 @@ class ZimOperations(
             f"Found {len(all_zim_files)} ZIM files in "
             f"{len(self.config.allowed_directories)} directories:\n\n"
         )
-        result_text += json.dumps(all_zim_files, indent=2, ensure_ascii=False)
+        result_text += _json(all_zim_files)
         return result_text
 
     def get_zim_metadata_data(self, zim_file_path: str) -> "ZimMetadataResponse":

--- a/openzim_mcp/zim/archive.py
+++ b/openzim_mcp/zim/archive.py
@@ -48,7 +48,7 @@ from openzim_mcp.exceptions import (
 from openzim_mcp.meta import attach_meta
 from openzim_mcp.security import PathValidator
 from openzim_mcp.timeout_utils import run_with_timeout
-from openzim_mcp.zim._ops_base import _ArchiveAccessMixin
+from openzim_mcp.zim._ops_base import _ArchiveAccessMixin, _json
 from openzim_mcp.zim.content import _ContentMixin
 from openzim_mcp.zim.namespace import _NamespaceMixin
 from openzim_mcp.zim.redirects import resolve_redirect_chain
@@ -549,11 +549,7 @@ class ZimOperations(
             OpenZimMcpFileNotFoundError: If ZIM file not found
             OpenZimMcpArchiveError: If metadata retrieval fails
         """
-        return json.dumps(
-            self.get_zim_metadata_data(zim_file_path),
-            indent=2,
-            ensure_ascii=False,
-        )
+        return _json(self.get_zim_metadata_data(zim_file_path))
 
     def get_archive_validation_data(
         self, zim_file_path: str

--- a/openzim_mcp/zim/content.py
+++ b/openzim_mcp/zim/content.py
@@ -23,6 +23,7 @@ from openzim_mcp.exceptions import (
     OpenZimMcpValidationError,
 )
 from openzim_mcp.meta import attach_meta
+from openzim_mcp.zim._ops_base import _json
 from openzim_mcp.zim.redirects import resolve_redirect_chain
 
 if TYPE_CHECKING:
@@ -1303,12 +1304,10 @@ class _ContentMixin:
             OpenZimMcpFileNotFoundError: If ZIM file not found
             OpenZimMcpArchiveError: If entry retrieval fails
         """
-        return json.dumps(
+        return _json(
             self.get_binary_entry_data(
                 zim_file_path, entry_path, max_size_bytes, include_data
-            ),
-            indent=2,
-            ensure_ascii=False,
+            )
         )
 
     def _format_binary_response(
@@ -1436,12 +1435,10 @@ class _ContentMixin:
             OpenZimMcpFileNotFoundError: If ZIM file not found
             OpenZimMcpArchiveError: If summary extraction fails
         """
-        return json.dumps(
+        return _json(
             self.get_entry_summary_data(
                 zim_file_path, entry_path, max_words, compact=compact
-            ),
-            indent=2,
-            ensure_ascii=False,
+            )
         )
 
     def _extract_entry_summary_data(

--- a/openzim_mcp/zim/content.py
+++ b/openzim_mcp/zim/content.py
@@ -120,6 +120,9 @@ class _ContentMixin:
         cache: "OpenZimMcpCache"
         content_processor: "ContentProcessor"
 
+        # Provided by _ArchiveAccessMixin on the concrete coordinator.
+        def _validate_zim_path(self, zim_file_path: str) -> Path: ...
+
         # Provided by other mixins / coordinator class.
         def _find_entry_by_search(
             self, archive: Archive, entry_path: str
@@ -246,8 +249,7 @@ class _ContentMixin:
         reject_path_traversal(entry_path)
 
         # Validate and resolve file path
-        validated_path = self.path_validator.validate_path(zim_file_path)
-        validated_path = self.path_validator.validate_zim_file(validated_path)
+        validated_path = self._validate_zim_path(zim_file_path)
 
         # Cheap response cache check: a hit avoids opening the archive
         # entirely, which is the whole point of caching here.
@@ -368,8 +370,7 @@ class _ContentMixin:
         if content_offset < 0:
             content_offset = 0
 
-        validated_path = self.path_validator.validate_path(zim_file_path)
-        validated_path = self.path_validator.validate_zim_file(validated_path)
+        validated_path = self._validate_zim_path(zim_file_path)
 
         # Cache key distinct from the legacy string cache so old persisted
         # entries (text payloads) don't collide with the new dict shape.
@@ -678,8 +679,7 @@ class _ContentMixin:
             # every entry in this group fails with the same error rather
             # than spending an archive open per entry.
             try:
-                validated_path = self.path_validator.validate_path(zim_file_path)
-                validated_path = self.path_validator.validate_zim_file(validated_path)
+                validated_path = self._validate_zim_path(zim_file_path)
             except Exception as e:  # noqa: BLE001 - per-group isolation
                 for index, zfp, entry_path in group:
                     results.append(
@@ -1177,8 +1177,7 @@ class _ContentMixin:
         reject_path_traversal(entry_path)
 
         # Validate and resolve file path
-        validated_path = self.path_validator.validate_path(zim_file_path)
-        validated_path = self.path_validator.validate_zim_file(validated_path)
+        validated_path = self._validate_zim_path(zim_file_path)
 
         # Cache key for invariant metadata (size, mime_type, etc.) — not data,
         # since data is potentially large and varies with max_size_bytes.
@@ -1384,8 +1383,7 @@ class _ContentMixin:
         reject_path_traversal(entry_path)
 
         # Validate and resolve file path
-        validated_path = self.path_validator.validate_path(zim_file_path)
-        validated_path = self.path_validator.validate_zim_file(validated_path)
+        validated_path = self._validate_zim_path(zim_file_path)
 
         try:
             with _zim_ops_mod.zim_archive(validated_path) as archive:

--- a/openzim_mcp/zim/content.py
+++ b/openzim_mcp/zim/content.py
@@ -120,8 +120,8 @@ class _ContentMixin:
         cache: "OpenZimMcpCache"
         content_processor: "ContentProcessor"
 
-        # Provided by _ArchiveAccessMixin on the concrete coordinator.
-        def _validate_zim_path(self, zim_file_path: str) -> Path: ...
+        def _validate_zim_path(self, zim_file_path: str) -> Path:
+            """Resolve via ``_ArchiveAccessMixin`` on the concrete coordinator."""
 
         # Provided by other mixins / coordinator class.
         def _find_entry_by_search(

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -9,7 +9,6 @@ without changes.
 """
 
 import contextlib
-import json
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
@@ -27,6 +26,7 @@ from openzim_mcp.exceptions import (
     OpenZimMcpValidationError,
 )
 from openzim_mcp.meta import attach_meta
+from openzim_mcp.zim._ops_base import _json
 
 if TYPE_CHECKING:
     from openzim_mcp.cache import OpenZimMcpCache
@@ -148,11 +148,7 @@ class _NamespaceMixin:
         responses out of these strings) keeps working unchanged. New
         callers should prefer ``list_namespaces_data``.
         """
-        return json.dumps(
-            self.list_namespaces_data(zim_file_path),
-            indent=2,
-            ensure_ascii=False,
-        )
+        return _json(self.list_namespaces_data(zim_file_path))
 
     def _list_archive_namespaces(self, archive: Archive) -> Dict[str, Any]:
         """List namespaces in the archive.
@@ -777,10 +773,8 @@ class _NamespaceMixin:
             OpenZimMcpFileNotFoundError: If ZIM file not found
             OpenZimMcpArchiveError: If browsing fails
         """
-        return json.dumps(
-            self.browse_namespace_data(zim_file_path, namespace, limit, offset),
-            indent=2,
-            ensure_ascii=False,
+        return _json(
+            self.browse_namespace_data(zim_file_path, namespace, limit, offset)
         )
 
     def _browse_namespace_entries(  # NOSONAR(python:S3776)
@@ -1903,10 +1897,8 @@ class _NamespaceMixin:
         Raises:
             OpenZimMcpValidationError: If ``limit`` is outside ``1..500``.
         """
-        return json.dumps(
+        return _json(
             self.walk_namespace_data(
                 zim_file_path, namespace, cursor_state=cursor, limit=limit
-            ),
-            indent=2,
-            ensure_ascii=False,
+            )
         )

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -92,6 +92,9 @@ class _NamespaceMixin:
         cache: "OpenZimMcpCache"
         content_processor: "ContentProcessor"
 
+        # Provided by _ArchiveAccessMixin on the concrete coordinator.
+        def _validate_zim_path(self, zim_file_path: str) -> Path: ...
+
     def list_namespaces_data(self, zim_file_path: str) -> "ListNamespacesResponse":
         """Structured variant of ``list_namespaces``.
 
@@ -112,8 +115,7 @@ class _NamespaceMixin:
             OpenZimMcpArchiveError: If namespace listing fails
         """
         # Validate and resolve file path
-        validated_path = self.path_validator.validate_path(zim_file_path)
-        validated_path = self.path_validator.validate_zim_file(validated_path)
+        validated_path = self._validate_zim_path(zim_file_path)
 
         # Cache key bumped to v2b (Phase B) so v1.x cached responses (old
         # shape: entry_count key) don't leak through after the rename to ``total``.
@@ -637,8 +639,7 @@ class _NamespaceMixin:
             )
 
         # Validate and resolve file path
-        validated_path = self.path_validator.validate_path(zim_file_path)
-        validated_path = self.path_validator.validate_zim_file(validated_path)
+        validated_path = self._validate_zim_path(zim_file_path)
 
         # Cursor integrity: a cursor issued for archive A must not be
         # honoured when resubmitted against archive B (same guard as
@@ -1495,8 +1496,7 @@ class _NamespaceMixin:
         if namespace:
             namespace = self._canonicalise_namespace(namespace.strip())
 
-        validated = self.path_validator.validate_path(zim_file_path)
-        validated = self.path_validator.validate_zim_file(validated)
+        validated = self._validate_zim_path(zim_file_path)
 
         # Cursor integrity: a v2 cursor encodes the namespace it was
         # issued for and the archive identity. Rejecting on mismatch

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -92,8 +92,8 @@ class _NamespaceMixin:
         cache: "OpenZimMcpCache"
         content_processor: "ContentProcessor"
 
-        # Provided by _ArchiveAccessMixin on the concrete coordinator.
-        def _validate_zim_path(self, zim_file_path: str) -> Path: ...
+        def _validate_zim_path(self, zim_file_path: str) -> Path:
+            """Resolve via ``_ArchiveAccessMixin`` on the concrete coordinator."""
 
     def list_namespaces_data(self, zim_file_path: str) -> "ListNamespacesResponse":
         """Structured variant of ``list_namespaces``.

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -12,7 +12,6 @@ the ``zim_operations`` module at call time rather than capturing a
 reference at import time.
 """
 
-import json
 import logging
 import urllib.parse
 from dataclasses import dataclass
@@ -29,6 +28,7 @@ from openzim_mcp.exceptions import (
 )
 from openzim_mcp.meta import attach_meta
 from openzim_mcp.title_promotion import find_title_match
+from openzim_mcp.zim._ops_base import _json
 
 # Mirror ``openzim_mcp.zim.archive.MAX_REDIRECT_DEPTH`` without importing
 # it directly — archive.py imports this module, so the reverse-import
@@ -1954,10 +1954,8 @@ class _SearchMixin:
             OpenZimMcpValidationError: If ``limit`` is outside ``1..50``.
             OpenZimMcpArchiveError: If suggestion generation fails
         """
-        return json.dumps(
-            self.get_search_suggestions_data(zim_file_path, partial_query, limit),
-            indent=2,
-            ensure_ascii=False,
+        return _json(
+            self.get_search_suggestions_data(zim_file_path, partial_query, limit)
         )
 
     def _generate_search_suggestions(  # NOSONAR(python:S3776)
@@ -3011,10 +3009,8 @@ class _SearchMixin:
             JSON string with query, ranked results, fast_path_hit flag,
             files_searched.
         """
-        return json.dumps(
-            self.find_entry_by_title_data(zim_file_path, title, cross_file, limit),
-            indent=2,
-            ensure_ascii=False,
+        return _json(
+            self.find_entry_by_title_data(zim_file_path, title, cross_file, limit)
         )
 
     def _find_entry_by_search(self, archive: Archive, entry_path: str) -> Optional[str]:
@@ -3342,11 +3338,7 @@ class _SearchMixin:
             JSON with per-file result groups (each ``result`` is itself a
             structured search payload) and aggregate counts.
         """
-        return json.dumps(
-            self.search_all_data(query, limit_per_file),
-            indent=2,
-            ensure_ascii=False,
-        )
+        return _json(self.search_all_data(query, limit_per_file))
 
     def search_top_k(self, archive: "Archive", query: str, *, k: int) -> list[dict]:
         """Top-K Xapian results from an open archive as a flat dict list.

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -27,6 +27,7 @@ from openzim_mcp.exceptions import (
     OpenZimMcpValidationError,
 )
 from openzim_mcp.meta import attach_meta
+from openzim_mcp.text_utils import tokenize_for_relevance
 from openzim_mcp.title_promotion import find_title_match
 from openzim_mcp.zim._ops_base import _json
 
@@ -123,14 +124,6 @@ def _format_filter_text(namespace: Optional[str], content_type: Optional[str]) -
     return f" (filters: {', '.join(parts)})" if parts else ""
 
 
-# Tokens this short can't reliably indicate query relevance — "in", "of",
-# "the", "is" appear everywhere. The token-match relevance check ignores
-# them so a query like "of mice and men" doesn't get flagged low-relevance
-# because the content-bearing tokens ("mice", "men") matched but the
-# stopwords technically didn't.
-_RELEVANCE_TOKEN_MIN_LEN = 3
-
-
 # Wikipedia / MediaWiki pseudo-namespaces excluded from suggestion + title
 # probe results. These live in the C namespace (not separate ZIM
 # namespaces) but use a colon-prefixed title convention to mark
@@ -172,17 +165,6 @@ def _is_pseudo_namespace_entry(
     return any(title.startswith(p) for p in prefixes)
 
 
-def _tokenize_for_relevance(text: str) -> set[str]:
-    """Lowercase alphanumeric tokens of length >= _RELEVANCE_TOKEN_MIN_LEN."""
-    import re as _re
-
-    return {
-        tok
-        for tok in _re.findall(r"[a-z0-9]+", text.lower())
-        if len(tok) >= _RELEVANCE_TOKEN_MIN_LEN
-    }
-
-
 def _all_results_weakly_match(results: List[Dict[str, Any]], query: str) -> bool:
     """Return True iff NONE of the search results carry any query token.
 
@@ -198,12 +180,12 @@ def _all_results_weakly_match(results: List[Dict[str, Any]], query: str) -> bool
     """
     if not results:
         return False
-    query_tokens = _tokenize_for_relevance(query)
+    query_tokens = tokenize_for_relevance(query)
     if not query_tokens:
         return False
     for r in results:
         haystack = f"{r.get('path', '')} {r.get('title', '')}"
-        r_tokens = _tokenize_for_relevance(haystack)
+        r_tokens = tokenize_for_relevance(haystack)
         if query_tokens & r_tokens:
             return False
     return True

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -359,6 +359,9 @@ class _SearchMixin:
         cache: "OpenZimMcpCache"
         content_processor: "ContentProcessor"
 
+        # Provided by _ArchiveAccessMixin on the concrete coordinator.
+        def _validate_zim_path(self, zim_file_path: str) -> Path: ...
+
         def list_zim_files_data(
             self, name_filter: Optional[str] = None
         ) -> List[Dict[str, Any]]:
@@ -438,8 +441,7 @@ class _SearchMixin:
             limit = self.config.content.default_search_limit
 
         # Validate and resolve file path
-        validated_path = self.path_validator.validate_path(zim_file_path)
-        validated_path = self.path_validator.validate_zim_file(validated_path)
+        validated_path = self._validate_zim_path(zim_file_path)
 
         # Cursor integrity: reject cursors issued against a different archive
         # (cf. pagination.py module docstring — search_zim_file is in the list
@@ -1179,8 +1181,7 @@ class _SearchMixin:
             )
 
         # Validate and resolve file path
-        validated_path = self.path_validator.validate_path(zim_file_path)
-        validated_path = self.path_validator.validate_zim_file(validated_path)
+        validated_path = self._validate_zim_path(zim_file_path)
 
         # Check cache (legacy markdown cache, separate from the v2b dict cache).
         # Post-b1 P3-D1: include display_query in the cache key. Two calls
@@ -1305,8 +1306,7 @@ class _SearchMixin:
             )
 
         # Validate and resolve file path
-        validated_path = self.path_validator.validate_path(zim_file_path)
-        validated_path = self.path_validator.validate_zim_file(validated_path)
+        validated_path = self._validate_zim_path(zim_file_path)
 
         # Cursor integrity: reject cursors issued against a different archive.
         if cursor_archive_identity is not None:
@@ -1879,8 +1879,7 @@ class _SearchMixin:
             return cast("SearchSuggestionsResponse", attach_meta(empty_payload))
 
         # Validate and resolve file path
-        validated_path = self.path_validator.validate_path(zim_file_path)
-        validated_path = self.path_validator.validate_zim_file(validated_path)
+        validated_path = self._validate_zim_path(zim_file_path)
 
         # Cache key bumped to v2b (Phase B) so v1.x cached responses (old
         # shape: suggestions/count keys) don't leak through after the upgrade.
@@ -2716,8 +2715,7 @@ class _SearchMixin:
         if cross_file:
             files = [f["path"] for f in self.list_zim_files_data() if f.get("path")]
         else:
-            validated = self.path_validator.validate_path(zim_file_path)
-            validated = self.path_validator.validate_zim_file(validated)
+            validated = self._validate_zim_path(zim_file_path)
             files = [str(validated)]
 
         aggregate_results: List[Dict[str, Any]] = []

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -359,8 +359,8 @@ class _SearchMixin:
         cache: "OpenZimMcpCache"
         content_processor: "ContentProcessor"
 
-        # Provided by _ArchiveAccessMixin on the concrete coordinator.
-        def _validate_zim_path(self, zim_file_path: str) -> Path: ...
+        def _validate_zim_path(self, zim_file_path: str) -> Path:
+            """Resolve via ``_ArchiveAccessMixin`` on the concrete coordinator."""
 
         def list_zim_files_data(
             self, name_filter: Optional[str] = None

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -89,6 +89,9 @@ class _StructureMixin:
         cache: "OpenZimMcpCache"
         content_processor: "ContentProcessor"
 
+        # Provided by _ArchiveAccessMixin on the concrete coordinator.
+        def _validate_zim_path(self, zim_file_path: str) -> Path: ...
+
         def _resolve_entry_with_fallback(
             self, archive: Archive, entry_path: str
         ) -> Tuple[Any, str]:
@@ -109,8 +112,7 @@ class _StructureMixin:
         reject_path_traversal(entry_path)
 
         # Validate and resolve file path
-        validated_path = self.path_validator.validate_path(zim_file_path)
-        validated_path = self.path_validator.validate_zim_file(validated_path)
+        validated_path = self._validate_zim_path(zim_file_path)
 
         try:
             with _zim_ops_mod.zim_archive(validated_path) as archive:
@@ -287,8 +289,7 @@ class _StructureMixin:
         reject_path_traversal(entry_path)
 
         # Validate and resolve file path
-        validated_path = self.path_validator.validate_path(zim_file_path)
-        validated_path = self.path_validator.validate_zim_file(validated_path)
+        validated_path = self._validate_zim_path(zim_file_path)
 
         # Cursor integrity (Phase B #11): a cursor issued for archive A
         # must not be honoured when resubmitted against archive B.
@@ -436,8 +437,7 @@ class _StructureMixin:
         reject_path_traversal(entry_path)
 
         # Validate and resolve file path
-        validated_path = self.path_validator.validate_path(zim_file_path)
-        validated_path = self.path_validator.validate_zim_file(validated_path)
+        validated_path = self._validate_zim_path(zim_file_path)
 
         try:
             with _zim_ops_mod.zim_archive(validated_path) as archive:
@@ -567,8 +567,7 @@ class _StructureMixin:
         """
         try:
             reject_path_traversal(entry_path)
-            validated_path = self.path_validator.validate_path(zim_file_path)
-            validated_path = self.path_validator.validate_zim_file(validated_path)
+            validated_path = self._validate_zim_path(zim_file_path)
             with _zim_ops_mod.zim_archive(validated_path) as archive:
                 return self._get_section_data(
                     archive,
@@ -837,8 +836,7 @@ class _StructureMixin:
         # (validated inside extract_article_links_data) but silently fails
         # in _resolve_outbound_titles, which would otherwise call
         # ``Path("~/zims/foo.zim")`` directly — Path does not expand ``~``.
-        validated_path = self.path_validator.validate_path(zim_file_path)
-        validated_path = self.path_validator.validate_zim_file(validated_path)
+        validated_path = self._validate_zim_path(zim_file_path)
         validated_str = str(validated_path)
 
         outbound: List[Dict[str, Any]] = []

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -10,7 +10,6 @@ existing test patches against the shim's symbols continue to work
 without changes.
 """
 
-import json
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
@@ -26,6 +25,7 @@ from openzim_mcp.exceptions import (
 from openzim_mcp.meta import attach_meta
 from openzim_mcp.pagination import Cursor
 from openzim_mcp.responses import ToolErrorPayload, tool_error
+from openzim_mcp.zim._ops_base import _json
 from openzim_mcp.zim.content import reject_path_traversal
 
 if TYPE_CHECKING:
@@ -147,11 +147,7 @@ class _StructureMixin:
             OpenZimMcpFileNotFoundError: If ZIM file not found
             OpenZimMcpArchiveError: If structure extraction fails
         """
-        return json.dumps(
-            self.get_article_structure_data(zim_file_path, entry_path),
-            indent=2,
-            ensure_ascii=False,
-        )
+        return _json(self.get_article_structure_data(zim_file_path, entry_path))
 
     def _extract_article_structure_data(
         self,
@@ -410,16 +406,14 @@ class _StructureMixin:
             OpenZimMcpFileNotFoundError: If ZIM file not found
             OpenZimMcpArchiveError: If link extraction fails
         """
-        return json.dumps(
+        return _json(
             self.extract_article_links_data(
                 zim_file_path,
                 entry_path,
                 limit=limit,
                 offset=offset,
                 kind=kind,
-            ),
-            indent=2,
-            ensure_ascii=False,
+            )
         )
 
     def get_table_of_contents_data(
@@ -475,11 +469,7 @@ class _StructureMixin:
             OpenZimMcpFileNotFoundError: If ZIM file not found
             OpenZimMcpArchiveError: If TOC extraction fails
         """
-        return json.dumps(
-            self.get_table_of_contents_data(zim_file_path, entry_path),
-            indent=2,
-            ensure_ascii=False,
-        )
+        return _json(self.get_table_of_contents_data(zim_file_path, entry_path))
 
     def _extract_table_of_contents_data(
         self,
@@ -991,11 +981,7 @@ class _StructureMixin:
 
         Find articles related to entry_path via outbound links.
         """
-        return json.dumps(
-            self.get_related_articles_data(zim_file_path, entry_path, limit),
-            indent=2,
-            ensure_ascii=False,
-        )
+        return _json(self.get_related_articles_data(zim_file_path, entry_path, limit))
 
     @staticmethod
     def _resolve_link_to_entry_path(url: str, source_entry_path: str) -> Optional[str]:

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -89,8 +89,8 @@ class _StructureMixin:
         cache: "OpenZimMcpCache"
         content_processor: "ContentProcessor"
 
-        # Provided by _ArchiveAccessMixin on the concrete coordinator.
-        def _validate_zim_path(self, zim_file_path: str) -> Path: ...
+        def _validate_zim_path(self, zim_file_path: str) -> Path:
+            """Resolve via ``_ArchiveAccessMixin`` on the concrete coordinator."""
 
         def _resolve_entry_with_fallback(
             self, archive: Archive, entry_path: str

--- a/tests/test_cursor_decode.py
+++ b/tests/test_cursor_decode.py
@@ -332,3 +332,13 @@ def test_two_mismatch_branches_return_identical_payload():
     # Same template modulo the cursor_q value.
     assert a["message"].replace("'algebra'", "Q") == b["message"].replace("'ab'", "Q")
     assert a["context"].replace("'algebra'", "Q") == b["context"].replace("'ab'", "Q")
+
+
+def test_whitespace_only_cursor_q_skips_overlap_check():
+    # A whitespace-only ``s.q`` has no meaningful tokens, so the q-overlap
+    # mismatch check is intentionally skipped and the cursor is accepted
+    # (offset still extracted). Pins the ``cursor_q.strip()`` guard branch.
+    token = _encode({"v": 2, "t": "search_zim_file", "s": {"o": 3, "q": "  "}})
+    out = decode_offset_cursor(token, query="zzz", q_emitting_tools=Q_EMITTING)
+    assert isinstance(out, CursorDecodeResult)
+    assert out.offset == 3

--- a/tests/test_cursor_decode.py
+++ b/tests/test_cursor_decode.py
@@ -1,6 +1,6 @@
 """Unit tests for :mod:`openzim_mcp.cursor_decode`.
 
-These pin the six structured ``cursor_decode`` error payloads, the happy-path
+These pin the structured ``cursor_decode`` error payloads, the happy-path
 offset/ns/ai/tool projection, and the token-overlap-vs-substring query-mismatch
 branching extracted verbatim from the former inline block at the top of
 ``SimpleToolsHandler.handle_zim_query``. Error message strings are copied

--- a/tests/test_cursor_decode.py
+++ b/tests/test_cursor_decode.py
@@ -1,0 +1,334 @@
+"""Unit tests for :mod:`openzim_mcp.cursor_decode`.
+
+These pin the six structured ``cursor_decode`` error payloads, the happy-path
+offset/ns/ai/tool projection, and the token-overlap-vs-substring query-mismatch
+branching extracted verbatim from the former inline block at the top of
+``SimpleToolsHandler.handle_zim_query``. Error message strings are copied
+verbatim from the source — they are asserted by the wider simple-tools suite,
+so any drift here is a behavior change.
+"""
+
+import base64
+import json
+
+from openzim_mcp.cursor_decode import CursorDecodeResult, decode_offset_cursor
+
+# Mirrors SimpleToolsHandler._Q_EMITTING_CURSOR_TOOLS.
+Q_EMITTING = frozenset({"search_zim_file", "search_with_filters"})
+
+
+def _encode(payload: dict, *, strip_pad: bool = True) -> str:
+    """base64-urlsafe encode a JSON cursor payload (optionally unpadded,
+    matching real ``Cursor.encode`` output which strips ``=``)."""
+    raw = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+    return raw.rstrip("=") if strip_pad else raw
+
+
+def _is_error(result) -> bool:
+    return isinstance(result, dict) and result.get("error") is True
+
+
+# ---------------------------------------------------------------------------
+# Error case 1: length cap (2048)
+# ---------------------------------------------------------------------------
+
+
+def test_token_over_length_cap_errors():
+    token = "A" * 2049
+    out = decode_offset_cursor(token, query="anything", q_emitting_tools=Q_EMITTING)
+    assert _is_error(out)
+    assert out["operation"] == "cursor_decode"
+    assert out["message"] == (
+        "The `cursor` value exceeds the maximum length. "
+        "Drop the cursor and call again with an explicit "
+        "`offset` (or no pagination arg)."
+    )
+    assert out["context"] == f"cursor={token[:64]}..."
+
+
+def test_token_at_length_cap_is_not_rejected_for_length():
+    # Exactly 2048 chars is allowed past the length gate (it then fails
+    # the decode step, not the length step).
+    token = "A" * 2048
+    out = decode_offset_cursor(token, query="x", q_emitting_tools=Q_EMITTING)
+    assert _is_error(out)
+    # Not the length message — it fell through to undecodable.
+    assert out["message"] != (
+        "The `cursor` value exceeds the maximum length. "
+        "Drop the cursor and call again with an explicit "
+        "`offset` (or no pagination arg)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Error case 2: undecodable base64/json
+# ---------------------------------------------------------------------------
+
+
+def test_undecodable_token_errors():
+    # Not valid base64+JSON.
+    token = "!!!not-base64!!!"
+    out = decode_offset_cursor(token, query="x", q_emitting_tools=Q_EMITTING)
+    assert _is_error(out)
+    assert out["operation"] == "cursor_decode"
+    assert out["message"] == (
+        "The `cursor` value could not be decoded. Drop "
+        "the cursor and call again with an explicit "
+        "`offset` (or no pagination arg)."
+    )
+    assert out["context"] == f"cursor={token[:64]}"
+
+
+def test_valid_base64_invalid_json_errors():
+    token = base64.urlsafe_b64encode(b"not json at all").decode().rstrip("=")
+    out = decode_offset_cursor(token, query="x", q_emitting_tools=Q_EMITTING)
+    assert _is_error(out)
+    assert out["message"].startswith("The `cursor` value could not be decoded.")
+
+
+# ---------------------------------------------------------------------------
+# Error case 3: missing `s` envelope
+# ---------------------------------------------------------------------------
+
+
+def test_missing_s_envelope_errors():
+    token = _encode({"malformed": True})
+    out = decode_offset_cursor(token, query="x", q_emitting_tools=Q_EMITTING)
+    assert _is_error(out)
+    assert out["operation"] == "cursor_decode"
+    assert out["message"] == (
+        "The `cursor` payload is missing the expected "
+        "`s` envelope. Drop the cursor and call "
+        "again with an explicit `offset` (or no "
+        "pagination arg)."
+    )
+    assert out["context"] == f"cursor={token[:64]}"
+
+
+def test_top_level_not_dict_errors_as_missing_s():
+    # A JSON list decodes but has no `.get` -> the helper treats a
+    # non-dict payload as a missing `s` envelope (state stays None).
+    token = _encode([1, 2, 3])
+    out = decode_offset_cursor(token, query="x", q_emitting_tools=Q_EMITTING)
+    assert _is_error(out)
+    assert "missing the expected" in out["message"]
+
+
+def test_s_not_a_dict_errors_as_missing_s():
+    token = _encode({"s": "scalar"})
+    out = decode_offset_cursor(token, query="x", q_emitting_tools=Q_EMITTING)
+    assert _is_error(out)
+    assert "missing the expected" in out["message"]
+
+
+# ---------------------------------------------------------------------------
+# Error case 4: missing/invalid `s.o`
+# ---------------------------------------------------------------------------
+
+_INVALID_SO_MESSAGE = (
+    "The `cursor` payload's `s.o` (offset) is "
+    "missing or invalid. Drop the cursor and "
+    "call again with an explicit `offset` (or "
+    "no pagination arg)."
+)
+
+
+def test_so_missing_errors():
+    token = _encode({"s": {"q": "x"}})
+    out = decode_offset_cursor(token, query="x", q_emitting_tools=Q_EMITTING)
+    assert _is_error(out)
+    assert out["message"] == _INVALID_SO_MESSAGE
+    assert out["context"] == f"cursor={token[:64]}"
+
+
+def test_so_not_int_errors():
+    token = _encode({"s": {"o": "5"}})
+    out = decode_offset_cursor(token, query="x", q_emitting_tools=Q_EMITTING)
+    assert _is_error(out)
+    assert out["message"] == _INVALID_SO_MESSAGE
+
+
+def test_so_negative_errors():
+    token = _encode({"s": {"o": -1}})
+    out = decode_offset_cursor(token, query="x", q_emitting_tools=Q_EMITTING)
+    assert _is_error(out)
+    assert out["message"] == _INVALID_SO_MESSAGE
+
+
+def test_so_bool_is_rejected():
+    # bool is an int subclass; isinstance(True, int) is True, but the
+    # original code accepted that (True == offset 1). Pin current behavior:
+    # True is accepted as offset 1 (>= 0). This documents the edge.
+    token = _encode({"s": {"o": True}})
+    out = decode_offset_cursor(token, query="x", q_emitting_tools=Q_EMITTING)
+    assert isinstance(out, CursorDecodeResult)
+    assert out.offset == 1
+
+
+# ---------------------------------------------------------------------------
+# Happy path: offset + optional ns/ai/tool
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_offset_only():
+    token = _encode({"v": 2, "s": {"o": 7}})
+    out = decode_offset_cursor(token, query="x", q_emitting_tools=Q_EMITTING)
+    assert isinstance(out, CursorDecodeResult)
+    assert out.offset == 7
+    assert out.ns is None
+    assert out.ai is None
+    assert out.tool is None
+
+
+def test_happy_path_populates_ns_ai_tool():
+    token = _encode(
+        {
+            "v": 2,
+            "t": "walk_namespace",
+            "s": {"o": 5, "ns": "M", "ai": "deadbeef"},
+        }
+    )
+    out = decode_offset_cursor(token, query="x", q_emitting_tools=Q_EMITTING)
+    assert isinstance(out, CursorDecodeResult)
+    assert out.offset == 5
+    assert out.ns == "M"
+    assert out.ai == "deadbeef"
+    assert out.tool == "walk_namespace"
+
+
+def test_happy_path_omits_empty_ns_ai_tool():
+    # Empty strings and non-string values are NOT projected (truthy check).
+    token = _encode(
+        {
+            "v": 2,
+            "t": "",
+            "s": {"o": 0, "ns": "", "ai": 123},
+        }
+    )
+    out = decode_offset_cursor(token, query="x", q_emitting_tools=Q_EMITTING)
+    assert isinstance(out, CursorDecodeResult)
+    assert out.offset == 0
+    assert out.ns is None
+    assert out.ai is None
+    assert out.tool is None
+
+
+# ---------------------------------------------------------------------------
+# Query-mismatch (q-emitting tool path)
+# ---------------------------------------------------------------------------
+
+
+def test_query_mismatch_no_shared_token_errors():
+    # cursor q='algebra', current query 'photosynthesis' — no shared
+    # >=3-char token, q-emitting tool -> reject.
+    token = _encode({"v": 2, "t": "search_zim_file", "s": {"o": 3, "q": "algebra"}})
+    out = decode_offset_cursor(
+        token, query="photosynthesis", q_emitting_tools=Q_EMITTING
+    )
+    assert _is_error(out)
+    assert out["operation"] == "cursor_decode"
+    assert out["message"] == (
+        "Cursor was issued for query 'algebra'; "
+        "current request shares no terms "
+        "with it. Drop the cursor and start "
+        "the search over for the new query."
+    )
+    assert out["context"] == "cursor_q='algebra'"
+
+
+def test_query_mismatch_default_tool_field_absent_still_checks():
+    # No `t` field -> cursor_t_emits_q is True (treated as q-emitting),
+    # so the q-overlap check still runs.
+    token = _encode({"v": 2, "s": {"o": 3, "q": "algebra"}})
+    out = decode_offset_cursor(
+        token, query="photosynthesis", q_emitting_tools=Q_EMITTING
+    )
+    assert _is_error(out)
+    assert "shares no terms" in out["message"]
+
+
+def test_query_shared_token_accepts():
+    # cursor q='berlin germany', query 'berlin culture' share 'berlin'.
+    token = _encode(
+        {"v": 2, "t": "search_zim_file", "s": {"o": 3, "q": "berlin germany"}}
+    )
+    out = decode_offset_cursor(
+        token, query="berlin culture", q_emitting_tools=Q_EMITTING
+    )
+    assert isinstance(out, CursorDecodeResult)
+    assert out.offset == 3
+
+
+def test_short_token_substring_fallback_accepts():
+    # cursor q has only short (<3 char) tokens ('bi') -> bidirectional
+    # substring fallback (no >=3-char token gates the token branch).
+    # 'bi' is a substring of 'biology' -> accept.
+    token = _encode({"v": 2, "t": "search_zim_file", "s": {"o": 3, "q": "bi"}})
+    out = decode_offset_cursor(token, query="biology", q_emitting_tools=Q_EMITTING)
+    assert isinstance(out, CursorDecodeResult)
+    assert out.offset == 3
+
+
+def test_short_token_substring_fallback_rejects_when_unrelated():
+    # cursor q='ab' (only short tokens), query 'xyz' — neither is a
+    # substring of the other -> reject via the substring fallback,
+    # returning the SAME mismatch payload as the token branch.
+    token = _encode({"v": 2, "t": "search_zim_file", "s": {"o": 3, "q": "ab"}})
+    out = decode_offset_cursor(token, query="xyz", q_emitting_tools=Q_EMITTING)
+    assert _is_error(out)
+    assert out["message"] == (
+        "Cursor was issued for query 'ab'; "
+        "current request shares no terms "
+        "with it. Drop the cursor and start "
+        "the search over for the new query."
+    )
+    assert out["context"] == "cursor_q='ab'"
+
+
+# ---------------------------------------------------------------------------
+# Q-check SKIPPED for non-q-emitting tools
+# ---------------------------------------------------------------------------
+
+
+def test_q_check_skipped_for_non_q_emitting_tool():
+    # cursor claims tool 'walk_namespace' (NOT q-emitting) but carries
+    # an adversarial s.q='biology' that shares nothing with the query.
+    # The dispatcher must NOT error here — the handler-level
+    # tool-mismatch fires instead. So decode succeeds with the offset
+    # and the projected tool name.
+    token = _encode(
+        {"v": 2, "t": "walk_namespace", "s": {"o": 5, "q": "biology", "ns": "M"}}
+    )
+    out = decode_offset_cursor(
+        token, query="photosynthesis", q_emitting_tools=Q_EMITTING
+    )
+    assert isinstance(out, CursorDecodeResult)
+    assert out.offset == 5
+    assert out.tool == "walk_namespace"
+    assert out.ns == "M"
+
+
+def test_q_check_runs_for_browse_when_in_q_emitting_set():
+    # Sanity: q-emitting set membership is what gates the check. If a
+    # tool name is in the passed set, the q-check fires for it.
+    custom = frozenset({"my_tool"})
+    token = _encode({"v": 2, "t": "my_tool", "s": {"o": 3, "q": "algebra"}})
+    out = decode_offset_cursor(token, query="photosynthesis", q_emitting_tools=custom)
+    assert _is_error(out)
+    assert "shares no terms" in out["message"]
+
+
+def test_two_mismatch_branches_return_identical_payload():
+    # The token-overlap branch and the substring-fallback branch must
+    # produce byte-identical payloads for the same cursor_q. Compare the
+    # message+context skeleton (substituting the differing cursor_q).
+    tok_branch = _encode(
+        {"v": 2, "t": "search_zim_file", "s": {"o": 3, "q": "algebra"}}
+    )
+    sub_branch = _encode({"v": 2, "t": "search_zim_file", "s": {"o": 3, "q": "ab"}})
+    a = decode_offset_cursor(tok_branch, query="zzz", q_emitting_tools=Q_EMITTING)
+    b = decode_offset_cursor(sub_branch, query="zzz", q_emitting_tools=Q_EMITTING)
+    assert _is_error(a) and _is_error(b)
+    # Same template modulo the cursor_q value.
+    assert a["message"].replace("'algebra'", "Q") == b["message"].replace("'ab'", "Q")
+    assert a["context"].replace("'algebra'", "Q") == b["context"].replace("'ab'", "Q")

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -1,0 +1,66 @@
+"""Tests for openzim_mcp.text_utils.tokenize_for_relevance."""
+
+import pytest
+
+from openzim_mcp.text_utils import RELEVANCE_TOKEN_MIN_LEN, tokenize_for_relevance
+
+
+def test_basic_tokenization():
+    result = tokenize_for_relevance("Berlin Culture 2024")
+    assert result == {"berlin", "culture", "2024"}
+
+
+def test_short_tokens_dropped():
+    result = tokenize_for_relevance("a of to xyz")
+    assert result == {"xyz"}
+
+
+def test_casing_lowered():
+    result = tokenize_for_relevance("Python JAVA Rust")
+    assert result == {"python", "java", "rust"}
+
+
+def test_punctuation_splits():
+    result = tokenize_for_relevance("hello, world! foo-bar")
+    assert result == {"hello", "world", "foo", "bar"}
+
+
+def test_unicode_non_alnum_splits():
+    # Non-ASCII characters are not [a-z0-9], so they act as separators.
+    result = tokenize_for_relevance("café résumé")
+    # "caf" and "r" and "sum" and "e" - let's verify: "café" → "caf" + "e"
+    # "résumé" → "r" (dropped <3) + "sum" + "e" (dropped <3)
+    assert result == {"caf", "sum"}
+
+
+def test_empty_string():
+    assert tokenize_for_relevance("") == set()
+
+
+def test_returns_set():
+    result = tokenize_for_relevance("the quick brown fox")
+    assert isinstance(result, set)
+
+
+def test_duplicates_deduplicated():
+    result = tokenize_for_relevance("fox fox fox")
+    assert result == {"fox"}
+
+
+def test_digits_included():
+    result = tokenize_for_relevance("v1 abc123 99")
+    # "v1" len=2 → dropped, "abc123" len=6 → kept, "99" len=2 → dropped
+    assert result == {"abc123"}
+
+
+def test_default_min_len_constant():
+    assert RELEVANCE_TOKEN_MIN_LEN == 3
+
+
+def test_custom_min_len():
+    result = tokenize_for_relevance("a to the fox", min_len=2)
+    assert result == {"to", "the", "fox"}
+
+
+def test_only_short_tokens():
+    assert tokenize_for_relevance("a b c") == set()

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -1,7 +1,5 @@
 """Tests for openzim_mcp.text_utils.tokenize_for_relevance."""
 
-import pytest
-
 from openzim_mcp.text_utils import RELEVANCE_TOKEN_MIN_LEN, tokenize_for_relevance
 
 

--- a/tests/test_tools_common.py
+++ b/tests/test_tools_common.py
@@ -1,0 +1,132 @@
+"""Unit tests for :mod:`openzim_mcp.tools._common`.
+
+Covers ``tool_error_response`` (including the per-tool logger-name guard from
+commit 0530bd7) and ``load_description``.
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+
+import pytest
+
+from openzim_mcp.tools._common import load_description, tool_error_response
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeServer:
+    """Minimal stand-in for OpenZimMcpServer sufficient to exercise _common."""
+
+    def __init__(self, sentinel: str = "SENTINEL") -> None:
+        self._sentinel = sentinel
+        self.calls: list[dict] = []
+
+    def _create_enhanced_error_message(
+        self, *, operation: str, error: Exception, context: str
+    ) -> str:
+        self.calls.append(
+            {"operation": operation, "error": error, "context": context}
+        )
+        return self._sentinel
+
+
+# ---------------------------------------------------------------------------
+# tool_error_response tests
+# ---------------------------------------------------------------------------
+
+
+def test_tool_error_response_returns_sentinel() -> None:
+    server = _FakeServer(sentinel="MY_SENTINEL")
+    err = ValueError("boom")
+    result = tool_error_response(
+        server, operation="zim_links", error=err, context="ctx"
+    )
+    assert result == "MY_SENTINEL"
+
+
+def test_tool_error_response_passes_kwargs() -> None:
+    server = _FakeServer()
+    err = ValueError("boom")
+    tool_error_response(server, operation="zim_links", error=err, context="ctx")
+
+    assert len(server.calls) == 1
+    call = server.calls[0]
+    assert call["operation"] == "zim_links"
+    assert call["error"] is err
+    assert call["context"] == "ctx"
+
+
+def test_tool_error_response_context_defaults_to_empty_string() -> None:
+    """context=None should coerce to '' before forwarding."""
+    server = _FakeServer()
+    tool_error_response(server, operation="zim_query", error=RuntimeError("x"))
+
+    assert server.calls[0]["context"] == ""
+
+
+def test_tool_error_response_logs_under_per_tool_logger(caplog: pytest.LogCaptureFixture) -> None:
+    """KEY REGRESSION GUARD (commit 0530bd7): the log record must be emitted under
+    ``openzim_mcp.tools.<operation>`` — NOT the flattened ``openzim_mcp.tools``
+    parent — so each tool's log records keep their module-level identity."""
+    server = _FakeServer()
+    err = ValueError("boom")
+
+    with caplog.at_level(logging.ERROR, logger="openzim_mcp.tools.zim_links"):
+        tool_error_response(server, operation="zim_links", error=err, context="ctx")
+
+    # At least one record must have the exact per-tool logger name.
+    tool_records = [r for r in caplog.records if r.name == "openzim_mcp.tools.zim_links"]
+    assert tool_records, (
+        "Expected a log record under 'openzim_mcp.tools.zim_links'; "
+        f"got names: {[r.name for r in caplog.records]}"
+    )
+
+    record = tool_records[0]
+    assert record.levelno == logging.ERROR
+    # The rendered message must identify the operation and the error.
+    assert record.getMessage() == "Error in zim_links: boom"
+
+
+def test_tool_error_response_log_message_format(caplog: pytest.LogCaptureFixture) -> None:
+    """Message format ``'Error in <op>: <err>'`` must hold for other operations too."""
+    server = _FakeServer()
+
+    with caplog.at_level(logging.ERROR, logger="openzim_mcp.tools.zim_query"):
+        tool_error_response(
+            server, operation="zim_query", error=RuntimeError("oops"), context=""
+        )
+
+    tool_records = [r for r in caplog.records if r.name == "openzim_mcp.tools.zim_query"]
+    assert tool_records
+    assert tool_records[0].getMessage() == "Error in zim_query: oops"
+
+
+# ---------------------------------------------------------------------------
+# load_description tests
+# ---------------------------------------------------------------------------
+
+
+def test_load_description_returns_file_contents() -> None:
+    """load_description('zim_links') must return the same bytes as reading the
+    .md file directly — no truncation, no transformation."""
+    direct = (
+        pathlib.Path(__file__).parent.parent
+        / "openzim_mcp"
+        / "tools"
+        / "zim_links_description.md"
+    ).read_text(encoding="utf-8")
+
+    via_helper = load_description("zim_links")
+
+    assert via_helper == direct
+
+
+def test_load_description_missing_name_raises() -> None:
+    """A nonexistent description name must raise FileNotFoundError."""
+    with pytest.raises(FileNotFoundError):
+        load_description("nonexistent_tool_xyz")

--- a/tests/test_tools_common.py
+++ b/tests/test_tools_common.py
@@ -13,7 +13,6 @@ import pytest
 
 from openzim_mcp.tools._common import load_description, tool_error_response
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -29,9 +28,7 @@ class _FakeServer:
     def _create_enhanced_error_message(
         self, *, operation: str, error: Exception, context: str
     ) -> str:
-        self.calls.append(
-            {"operation": operation, "error": error, "context": context}
-        )
+        self.calls.append({"operation": operation, "error": error, "context": context})
         return self._sentinel
 
 
@@ -69,7 +66,9 @@ def test_tool_error_response_context_defaults_to_empty_string() -> None:
     assert server.calls[0]["context"] == ""
 
 
-def test_tool_error_response_logs_under_per_tool_logger(caplog: pytest.LogCaptureFixture) -> None:
+def test_tool_error_response_logs_under_per_tool_logger(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """KEY REGRESSION GUARD (commit 0530bd7): the log record must be emitted under
     ``openzim_mcp.tools.<operation>`` — NOT the flattened ``openzim_mcp.tools``
     parent — so each tool's log records keep their module-level identity."""
@@ -80,7 +79,9 @@ def test_tool_error_response_logs_under_per_tool_logger(caplog: pytest.LogCaptur
         tool_error_response(server, operation="zim_links", error=err, context="ctx")
 
     # At least one record must have the exact per-tool logger name.
-    tool_records = [r for r in caplog.records if r.name == "openzim_mcp.tools.zim_links"]
+    tool_records = [
+        r for r in caplog.records if r.name == "openzim_mcp.tools.zim_links"
+    ]
     assert tool_records, (
         "Expected a log record under 'openzim_mcp.tools.zim_links'; "
         f"got names: {[r.name for r in caplog.records]}"
@@ -92,7 +93,9 @@ def test_tool_error_response_logs_under_per_tool_logger(caplog: pytest.LogCaptur
     assert record.getMessage() == "Error in zim_links: boom"
 
 
-def test_tool_error_response_log_message_format(caplog: pytest.LogCaptureFixture) -> None:
+def test_tool_error_response_log_message_format(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Message format ``'Error in <op>: <err>'`` must hold for other operations too."""
     server = _FakeServer()
 
@@ -101,7 +104,9 @@ def test_tool_error_response_log_message_format(caplog: pytest.LogCaptureFixture
             server, operation="zim_query", error=RuntimeError("oops"), context=""
         )
 
-    tool_records = [r for r in caplog.records if r.name == "openzim_mcp.tools.zim_query"]
+    tool_records = [
+        r for r in caplog.records if r.name == "openzim_mcp.tools.zim_query"
+    ]
     assert tool_records
     assert tool_records[0].getMessage() == "Error in zim_query: oops"
 

--- a/tests/zim/test_archive_access.py
+++ b/tests/zim/test_archive_access.py
@@ -1,11 +1,33 @@
-"""Tests for _ArchiveAccessMixin._validate_zim_path."""
+"""Tests for _ArchiveAccessMixin._validate_zim_path and _json."""
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
-from openzim_mcp.zim._ops_base import _ArchiveAccessMixin
+from openzim_mcp.zim._ops_base import _ArchiveAccessMixin, _json
+
+
+class TestJsonHelper:
+    """Tests for the module-level _json serialization helper."""
+
+    def test_matches_reference_dumps(self) -> None:
+        """_json must produce bit-identical output to json.dumps with indent=2, ensure_ascii=False."""
+        payload = {"a": "é", "n": 1}
+        expected = json.dumps(payload, indent=2, ensure_ascii=False)
+        assert _json(payload) == expected
+
+    def test_non_ascii_preserved_literally(self) -> None:
+        """The non-ASCII character é must appear literally, not as \\uXXXX."""
+        result = _json({"a": "é"})
+        assert "é" in result
+        assert "\\u" not in result
+
+    def test_indent_is_two_spaces(self) -> None:
+        """Output must use 2-space indentation."""
+        result = _json({"k": 1})
+        assert '  "k": 1' in result
 
 
 class _Stub(_ArchiveAccessMixin):

--- a/tests/zim/test_archive_access.py
+++ b/tests/zim/test_archive_access.py
@@ -1,0 +1,77 @@
+"""Tests for _ArchiveAccessMixin._validate_zim_path."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from openzim_mcp.zim._ops_base import _ArchiveAccessMixin
+
+
+class _Stub(_ArchiveAccessMixin):
+    """Minimal host that provides a fake path_validator."""
+
+    def __init__(self, path_validator: MagicMock) -> None:
+        self.path_validator = path_validator
+
+
+class TestArchiveAccessMixin:
+    """Tests for _ArchiveAccessMixin._validate_zim_path."""
+
+    @pytest.fixture
+    def fake_validator(self) -> MagicMock:
+        validator = MagicMock()
+        intermediate = Path("/allowed/archive.zim")
+        final = Path("/allowed/archive.zim")
+        validator.validate_path.return_value = intermediate
+        validator.validate_zim_file.return_value = final
+        return validator
+
+    @pytest.fixture
+    def stub(self, fake_validator: MagicMock) -> _Stub:
+        return _Stub(fake_validator)
+
+    def test_calls_validate_path_then_validate_zim_file(
+        self, stub: _Stub, fake_validator: MagicMock
+    ) -> None:
+        """validate_path is called with the raw arg; its result is forwarded to validate_zim_file."""
+        arg = "/some/path/archive.zim"
+        intermediate = fake_validator.validate_path.return_value
+
+        result = stub._validate_zim_path(arg)
+
+        fake_validator.validate_path.assert_called_once_with(arg)
+        fake_validator.validate_zim_file.assert_called_once_with(intermediate)
+        assert result == fake_validator.validate_zim_file.return_value
+
+    def test_returns_final_path(
+        self, stub: _Stub, fake_validator: MagicMock
+    ) -> None:
+        """The return value is whatever validate_zim_file returns."""
+        expected = Path("/resolved/archive.zim")
+        fake_validator.validate_zim_file.return_value = expected
+
+        result = stub._validate_zim_path("/any/path.zim")
+
+        assert result is expected
+
+    def test_validate_path_exception_propagates_unwrapped(
+        self, stub: _Stub, fake_validator: MagicMock
+    ) -> None:
+        """An exception from validate_path is not caught or wrapped."""
+        fake_validator.validate_path.side_effect = ValueError("bad path")
+
+        with pytest.raises(ValueError, match="bad path"):
+            stub._validate_zim_path("/bad/path.zim")
+
+        # validate_zim_file must not be called if the first step fails.
+        fake_validator.validate_zim_file.assert_not_called()
+
+    def test_validate_zim_file_exception_propagates_unwrapped(
+        self, stub: _Stub, fake_validator: MagicMock
+    ) -> None:
+        """An exception from validate_zim_file is not caught or wrapped."""
+        fake_validator.validate_zim_file.side_effect = RuntimeError("not a zim")
+
+        with pytest.raises(RuntimeError, match="not a zim"):
+            stub._validate_zim_path("/ok/path.zim")

--- a/tests/zim/test_archive_access.py
+++ b/tests/zim/test_archive_access.py
@@ -66,9 +66,7 @@ class TestArchiveAccessMixin:
         fake_validator.validate_zim_file.assert_called_once_with(intermediate)
         assert result == fake_validator.validate_zim_file.return_value
 
-    def test_returns_final_path(
-        self, stub: _Stub, fake_validator: MagicMock
-    ) -> None:
+    def test_returns_final_path(self, stub: _Stub, fake_validator: MagicMock) -> None:
         """The return value is whatever validate_zim_file returns."""
         expected = Path("/resolved/archive.zim")
         fake_validator.validate_zim_file.return_value = expected


### PR DESCRIPTION
Tier 2 of the refactor sweep. **Behavior-preserving** — full suite green (`2723 passed, 236 skipped`), mypy/flake8/black clean. Net **+68 production LOC** across 4 new focused, unit-tested helper modules, **+641 test LOC**, and **simple_tools.py shrinks 3742 → 3535 (−207)**.

### What's consolidated
| Helper | Replaces | Impact |
|---|---|---|
| `cursor_decode.decode_offset_cursor` | ~220-line inline block at the top of `handle_zim_query` | **simple_tools.py −207**; cursor wire-contract now an isolated, unit-tested module; two byte-identical query-mismatch payloads deduped to one; removed an always-true `isinstance(state, dict)` guard |
| `zim/_ops_base._validate_zim_path` | the `validate_path`+`validate_zim_file` pair repeated 22× | single source for the path-validation prologue |
| `zim/_ops_base._json` | `json.dumps(…, indent=2, ensure_ascii=False)` repeated ~12× | single serialization policy |
| `tools/_common.{load_description, tool_error_response}` | per-wrapper description-read + broad-except envelope, ×8 | one place for the tool error envelope; dead per-module loggers removed |
| `text_utils.tokenize_for_relevance` | duplicated `re.findall(r"[a-z0-9]+")` + `len ≥ 3` in `zim/search.py` and `cursor_decode.py` | kills a duplicated magic threshold |

### Scope notes
- **Deliberately did NOT** consolidate the archive try/except **epilogue**. Unlike the prologue, the epilogues carry site-specific re-wrap messages and varying catch behavior, so a shared context manager only fit a minority of sites, added LOC, and produced large re-indentation diffs. Prologue-only is the clean win.
- **No decorator over the FastMCP tool functions** — `@server.mcp.tool` builds the MCP schema from the function signature, so the tool wrappers keep their exact signatures and inline `try/except`; only the description-load and except-body are shared.

### Behavior preservation
Every cursor-decode error string, JSON output, tool-error payload, exception type/passthrough, and log-record name is preserved (the existing suite asserts these). The new modules add 641 lines of tests (cursor_decode, text_utils, _ops_base, tool_error_response incl. a per-tool-logger-name regression guard).

A multi-agent adversarial review of the full diff found **0 behavior-changing issues**. Two intentional, non-observable refinements worth noting:
- Tool error logging now uses lazy `%`-args instead of eager f-strings (rendered output and logger name identical).
- `decode_offset_cursor` is a pure function, so on a cursor-error path it no longer mutates the caller's `options` dict before returning the error — unobservable (the caller builds a fresh `options` per request and discards it on error).

Commits are one-consolidation-each for easy review.