### PR TITLE
refactor: unify last-good redirect walkers + conservative comment trim (Tier 4)

### DIFF
--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -27,6 +27,7 @@ from openzim_mcp.exceptions import (
 )
 from openzim_mcp.meta import attach_meta
 from openzim_mcp.zim._ops_base import _json
+from openzim_mcp.zim.redirects import best_effort_redirect_chain
 
 if TYPE_CHECKING:
     from openzim_mcp.cache import OpenZimMcpCache
@@ -1110,23 +1111,10 @@ class _NamespaceMixin:
             logger.debug(f"main_entry resolution failed: {e}")
             return None
         # Follow the redirect chain so the rendered row points at the
-        # actual page rather than the redirect stub.
-        hops = 0
-        seen: set = set()
-        try:
-            while getattr(entry, "is_redirect", False) and hops < 10:
-                p = getattr(entry, "path", None)
-                if p is None or p in seen:
-                    break
-                seen.add(p)
-                entry = entry.get_redirect_entry()
-                hops += 1
-        except Exception as redirect_err:
-            # Best-effort redirect chase: if a hop raises (e.g. a stale
-            # redirect entry on a partially-rewritten archive), fall back
-            # to the last resolved ``entry`` rather than failing the whole
-            # main-page lookup.
-            logger.debug(f"main_entry redirect chase aborted: {redirect_err}")
+        # actual page rather than the redirect stub. Best-effort: a stale
+        # redirect on a partially-rewritten archive degrades to the last
+        # good entry rather than failing the whole main-page lookup.
+        entry = best_effort_redirect_chain(entry)
         title = getattr(entry, "title", None) or "Main Page"
         try:
             preview, content_type = self._render_entry_preview(entry, "W/mainPage")

--- a/openzim_mcp/zim/redirects.py
+++ b/openzim_mcp/zim/redirects.py
@@ -6,16 +6,20 @@ This module holds the single *strict* resolver — the one that raises on a
 cycle or an over-long chain — that the content / archive / resource read
 paths share.
 
-Three intentionally-different best-effort variants are NOT folded in here,
-because they must never raise (a malformed redirect should degrade, not
-fail the whole call):
+This module also holds the *best-effort* resolver,
+``best_effort_redirect_chain``, which NEVER raises and NEVER returns
+``None``: on a cycle, an over-long chain, a ``None`` next-hop, or a raising
+hop it returns the last good entry, so a malformed redirect degrades
+instead of failing the whole call. It backs the speculative title-matching
+path (``_SearchMixin._follow_redirect_chain``, now a thin wrapper) and the
+synthetic main-page row (``_NamespaceMixin._materialise_new_scheme_main_entry``).
 
-* ``_ArchiveMixin._extract_zim_metadata`` — skips a bad chain and omits
-  that metadata key.
-* ``_NamespaceMixin._materialise_new_scheme_main_entry`` — returns the last
-  good entry so main-page listing still works.
-* ``_SearchMixin._follow_redirect_chain`` — returns the last good entry so
-  speculative title matching always has something to name.
+One best-effort variant stays intentionally separate because its failure
+mode differs — it SKIPS-AND-OMITS rather than returning a last-good entry:
+
+* ``_ArchiveMixin._read_old_scheme_metadata_value`` — on a cycle or an
+  over-long chain it returns ``None`` so the caller OMITS that metadata key
+  entirely, rather than rendering a stale redirect stub.
 """
 
 from typing import Any
@@ -51,3 +55,42 @@ def resolve_redirect_chain(entry: Any, *, context: str) -> Any:
             f"Redirect chain too deep (>{max_depth}) {context}"
         )
     return entry
+
+
+def best_effort_redirect_chain(entry: Any) -> Any:
+    """Walk ``entry``'s ``is_redirect`` chain to its canonical target, best-effort.
+
+    The forgiving sibling of :func:`resolve_redirect_chain`: it NEVER raises
+    and NEVER returns ``None``. On a clean chain it returns the canonical
+    (non-redirect) :class:`Entry`. On any failure — a hop that raises, a
+    ``None`` next-hop, a missing/``None`` path, a cycle, or a chain longer
+    than ``CONTENT.MAX_REDIRECT_DEPTH`` — it returns the last real entry it
+    reached so the caller always has something to name (``.path`` /
+    ``.title``).
+
+    Used by speculative title-matching (search) and synthetic main-page
+    rendering (namespace), where a malformed redirect should degrade
+    gracefully rather than fail the whole call.
+    """
+    max_depth = CONTENT.MAX_REDIRECT_DEPTH
+    target = entry
+    last_good = entry
+    seen: set = set()
+    first_path = getattr(target, "path", None)
+    if first_path is not None:
+        seen.add(first_path)
+    for _ in range(max_depth):
+        if not getattr(target, "is_redirect", False):
+            return target
+        try:
+            target = target.get_redirect_entry()
+        except Exception:
+            return last_good
+        if target is None:
+            return last_good
+        tp = getattr(target, "path", None)
+        if tp is None or tp in seen:
+            return last_good
+        seen.add(tp)
+        last_good = target
+    return target

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
 from libzim.reader import Archive  # type: ignore[import-untyped]
 
 import openzim_mcp.zim_operations as _zim_ops_mod
-from openzim_mcp.defaults import CONTENT as _CONTENT_DEFAULTS
 from openzim_mcp.exceptions import (
     OpenZimMcpArchiveError,
     OpenZimMcpValidationError,
@@ -30,11 +29,7 @@ from openzim_mcp.meta import attach_meta
 from openzim_mcp.text_utils import tokenize_for_relevance
 from openzim_mcp.title_promotion import find_title_match
 from openzim_mcp.zim._ops_base import _json
-
-# Mirror ``openzim_mcp.zim.archive.MAX_REDIRECT_DEPTH`` without importing
-# it directly — archive.py imports this module, so the reverse-import
-# would be circular at module-init time.
-MAX_REDIRECT_DEPTH = _CONTENT_DEFAULTS.MAX_REDIRECT_DEPTH
+from openzim_mcp.zim.redirects import best_effort_redirect_chain
 
 if TYPE_CHECKING:
     from openzim_mcp.cache import OpenZimMcpCache
@@ -2646,40 +2641,16 @@ class _SearchMixin:
 
     @staticmethod
     def _follow_redirect_chain(entry: Any) -> Any:
-        """Walk an entry's ``is_redirect`` chain to its canonical target.
+        """Best-effort redirect walk — thin wrapper over the shared helper.
 
-        Bounded by ``MAX_REDIRECT_DEPTH``; tolerates cycles by tracking
-        seen paths. Returns the last *real* entry on any failure so the
-        caller always gets something it can name — never ``None``.
-
-        Post-a14 sweep self-audit: the prior implementation could
-        return ``None`` when ``get_redirect_entry()`` returned None
-        (observed on archives with broken redirect chains). That
-        crashed every downstream ``entry.path`` access. The
-        ``last_good`` tracking keeps the most recent non-None Entry so
-        the caller can still emit a hit.
+        Delegates to
+        :func:`openzim_mcp.zim.redirects.best_effort_redirect_chain`.
+        Retained as a method so the existing call sites (and the
+        monkeypatch in ``test_find_entry_by_title_characterization``) keep
+        working unchanged. Returns the last real entry on any failure;
+        never raises, never returns ``None``.
         """
-        target = entry
-        last_good = entry
-        seen: set = set()
-        first_path = getattr(target, "path", None)
-        if first_path is not None:
-            seen.add(first_path)
-        for _ in range(MAX_REDIRECT_DEPTH):
-            if not getattr(target, "is_redirect", False):
-                return target
-            try:
-                target = target.get_redirect_entry()
-            except Exception:
-                return last_good
-            if target is None:
-                return last_good
-            tp = getattr(target, "path", None)
-            if tp is None or tp in seen:
-                return last_good
-            seen.add(tp)
-            last_good = target
-        return target
+        return best_effort_redirect_chain(entry)
 
     def _fast_path_row(
         self, archive: Any, title: str, file_path: str

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -273,11 +273,8 @@ def _format_filtered_response(
         )
         # A14: when the result set is much larger than a small model can
         # productively page through, nudge toward refining the query
-        # instead. Pre-A14, a "notable people from X" search returning
-        # 4000 hits would lead an 8B model to either give up or mechanically
-        # page until its context budget died. The O2 saturation warning at
-        # ≥1M hits caught only stop-word collisions; mid-tier hit counts
-        # had no equivalent guidance.
+        # instead. Mid-tier hit counts otherwise get no guidance — the O2
+        # saturation warning only fires at ≥1M hits (stop-word collisions).
         if _is_large_result_set(scan.filtered_count, len(results)):
             parts.append(_refinement_nudge() + "\n")
     else:
@@ -2488,7 +2485,6 @@ class _SearchMixin:
             (extra ``o`` removed).
           * Single character insertion — ``"Photosythesis"`` →
             ``"Photosynthesis"`` (missing ``n`` between ``y`` and ``t``).
-            This was the named regression target of Phase A #14.
           * Single character substitution — ``"Wikipidia"`` →
             ``"Wikipedia"`` (i → e at position 5).
 

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -10,7 +10,10 @@ import pytest
 
 from openzim_mcp.defaults import CONTENT
 from openzim_mcp.exceptions import OpenZimMcpArchiveError
-from openzim_mcp.zim.redirects import resolve_redirect_chain
+from openzim_mcp.zim.redirects import (
+    best_effort_redirect_chain,
+    resolve_redirect_chain,
+)
 
 
 class _FakeEntry:
@@ -61,3 +64,126 @@ def test_raises_when_chain_exceeds_depth() -> None:
     with pytest.raises(OpenZimMcpArchiveError, match="too deep") as exc:
         resolve_redirect_chain(node, context="starting at C/n0")
     assert "starting at C/n0" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# best_effort_redirect_chain — the forgiving sibling that NEVER raises and
+# NEVER returns None (backs speculative title-matching + synthetic main-page
+# rendering, where a malformed redirect should degrade rather than fail).
+# ---------------------------------------------------------------------------
+
+
+class _BestEffortEntry:
+    """Redirect node that can also model a raising or ``None``-returning hop."""
+
+    def __init__(
+        self,
+        path: str,
+        *,
+        redirect_to: "_BestEffortEntry | None" = None,
+        raises: bool = False,
+        returns_none: bool = False,
+    ) -> None:
+        self.path = path
+        self._target = redirect_to
+        self._raises = raises
+        self._returns_none = returns_none
+
+    @property
+    def is_redirect(self) -> bool:
+        return self._raises or self._returns_none or self._target is not None
+
+    def get_redirect_entry(self) -> "_BestEffortEntry | None":
+        if self._raises:
+            raise RuntimeError("redirect fetch failed")
+        if self._returns_none:
+            return None
+        return self._target
+
+
+def test_best_effort_returns_same_object_on_direct_hit() -> None:
+    entry = _BestEffortEntry("C/Article")
+    assert best_effort_redirect_chain(entry) is entry
+
+
+def test_best_effort_follows_chain_to_canonical() -> None:
+    target = _BestEffortEntry("C/Canonical")
+    mid = _BestEffortEntry("C/Mid", redirect_to=target)
+    head = _BestEffortEntry("C/Head", redirect_to=mid)
+    assert best_effort_redirect_chain(head) is target
+
+
+def test_best_effort_returns_last_good_on_cycle_never_raises() -> None:
+    # A -> B -> A. Contrast resolve_redirect_chain which RAISES on a cycle;
+    # the best-effort walker returns the last good entry (B, the most recent
+    # entry that passed the seen-check) and never raises.
+    a = _BestEffortEntry("C/A")
+    b = _BestEffortEntry("C/B", redirect_to=a)
+    a._target = b
+    result = best_effort_redirect_chain(a)
+    assert result is b
+
+
+def test_best_effort_returns_entry_when_chain_exceeds_depth() -> None:
+    # A non-cyclic chain longer than the cap returns a (still-redirect)
+    # entry rather than raising or looping forever.
+    tail = _BestEffortEntry("C/tail")
+    node = tail
+    for i in range(CONTENT.MAX_REDIRECT_DEPTH + 3):
+        node = _BestEffortEntry(f"C/r{i}", redirect_to=node)
+    result = best_effort_redirect_chain(node)
+    assert result is not None
+
+
+def test_best_effort_returns_last_good_when_hop_raises() -> None:
+    mid = _BestEffortEntry("C/Mid", raises=True)
+    head = _BestEffortEntry("C/Head", redirect_to=mid)
+    # head -> mid (advanced to, last_good); mid's hop raises -> return mid.
+    assert best_effort_redirect_chain(head) is mid
+
+
+def test_best_effort_returns_last_good_on_none_hop_never_none() -> None:
+    # post-a14 regression guard: a chain whose next hop is None must yield
+    # the prior entry, never None (None crashed every downstream .path).
+    mid = _BestEffortEntry("C/Mid", returns_none=True)
+    head = _BestEffortEntry("C/Head", redirect_to=mid)
+    assert best_effort_redirect_chain(head) is mid
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: _BestEffortEntry("C/x", raises=True),
+        lambda: _BestEffortEntry("C/x", returns_none=True),
+    ],
+)
+def test_best_effort_never_returns_none(factory) -> None:
+    assert best_effort_redirect_chain(factory()) is not None
+
+
+def test_best_effort_cap_equals_content_max_redirect_depth() -> None:
+    # Exactly MAX_REDIRECT_DEPTH redirect hops then a canonical resolves;
+    # one more hop does NOT (pins the cap to the CONTENT default rather than
+    # a drifting inline literal).
+    def _chain(redirect_hops: int) -> _BestEffortEntry:
+        node: _BestEffortEntry = _BestEffortEntry("C/Canonical")
+        for i in range(redirect_hops):
+            node = _BestEffortEntry(f"C/r{i}", redirect_to=node)
+        return node
+
+    resolved = best_effort_redirect_chain(_chain(CONTENT.MAX_REDIRECT_DEPTH))
+    assert resolved.path == "C/Canonical"
+    over = best_effort_redirect_chain(_chain(CONTENT.MAX_REDIRECT_DEPTH + 1))
+    assert over.path != "C/Canonical"
+
+
+def test_search_follow_redirect_chain_delegates_to_helper() -> None:
+    # The SearchMixin method is retained as a thin wrapper (preserves the
+    # five internal call sites and the monkeypatch in
+    # test_find_entry_by_title_characterization). It must return exactly
+    # what the shared helper returns.
+    from openzim_mcp.zim.search import _SearchMixin
+
+    target = _BestEffortEntry("C/Canonical")
+    head = _BestEffortEntry("C/Head", redirect_to=target)
+    assert _SearchMixin._follow_redirect_chain(head) is target


### PR DESCRIPTION
## Tier 4 — Redirect consolidation + conservative comment trim

The final planned tier of the refactor sweep. **Behavior-preserving** — verified by the existing suite (2,778 passing, +10 new redirect tests) plus a multi-agent adversarial review (0 behavior changes on any real archive).

### 4.1 — Unify the two identical "last-good" redirect walkers

Two behaviorally-equivalent best-effort walkers now delegate to one shared helper, `best_effort_redirect_chain(entry)` in `zim/redirects.py` — it **never raises and never returns `None`**, bounded by `CONTENT.MAX_REDIRECT_DEPTH`, returning the last real entry on a cycle / over-long chain / `None` hop / raising hop.

- `_SearchMixin._follow_redirect_chain` → **thin wrapper** over the helper. Kept as a method so its five internal call sites and the `test_find_entry_by_title_characterization` monkeypatch are unaffected. Its now-dead local `MAX_REDIRECT_DEPTH` mirror (and the `_CONTENT_DEFAULTS` import it alone used) are removed — the public re-export `zim_operations.MAX_REDIRECT_DEPTH` comes from `archive.py`, untouched.
- `_NamespaceMixin._materialise_new_scheme_main_entry` → inline redirect loop replaced with one call. The shared helper adopts search's stricter **never-`None`** contract, which is *strictly safer* for this site (the old inline loop could leave `entry=None` on a `None` hop; the post-loop code already tolerated that via `getattr(...) or "Main Page"` + a try/except preview, so the row shape is identical — just a fuller title/preview in the rare degenerate case).
- The `archive.py` metadata walker (`_read_old_scheme_metadata_value`) stays **separate by design** — its failure mode *skips-and-omits* the metadata key rather than returning a last-good entry. The `redirects.py` module docstring is updated to reflect that only this skip-variant remains separate (and the stale method name in the old docstring is fixed).

New unit tests pin the `best_effort_redirect_chain` contract (direct hit identity, clean chain, cycle → last-good without raising, depth cap == `CONTENT.MAX_REDIRECT_DEPTH`, raising hop → last-good, `None` hop → never `None`, and the search-wrapper delegation).

### 4.2 — Conservative dated-comment trim (`search.py`)

Only **two** purely-historical comments trimmed (17 other dated comments examined were kept — they pair an issue tag with a live invariant or regression guard):

- the large-result-set nudge: dropped the "Pre-A14 … 8B model … 4000 hits" narration; kept the current-behavior statement and the live O2-threshold rationale.
- a typo-example bullet: dropped "This was the named regression target of Phase A #14" (the same fact is restated in the live loop body).

### Verification

- `pytest -m 'not live'` → 2778 passed, 236 skipped
- `make lint` (flake8 + isort + black over `openzim_mcp` **and** `tests`) → clean
- `mypy openzim_mcp` → clean (66 files)
- Adversarial review → no behavior change; remaining notes are cosmetic / corrupt-archive-only edge cases judged "strictly-safer-and-equivalent on any real archive"
