### PR TITLE
docs: sync README + website to the shipped v2.1.1 surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ---
 
-> 🆕 **v2.0.0 — 8-tool advanced surface.** Phase F consolidates 22 advanced tools into 8 (`zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`). [Full release notes →](CHANGELOG.md#200--2026-05-27--phase-f-stage-d-ships) [Docs →](https://cameronrye.github.io/openzim-mcp/docs/)
+> 🆕 **8-tool advanced surface.** Phase F (v2.0.0) consolidated 22 advanced tools into 8 (`zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`). **New in v2.1:** native libzim archive validation via `zim_health(zim_file_path=...)`, plus archive identity / index introspection in `zim_metadata`. [Release notes →](CHANGELOG.md) [Docs →](https://cameronrye.github.io/openzim-mcp/docs/)
 
 **OpenZIM MCP** is a modern, secure, high-performance [Model Context Protocol](https://modelcontextprotocol.io/) server that gives AI models structured, offline access to [ZIM format](https://en.wikipedia.org/wiki/ZIM_(file_format)) knowledge archives — Wikipedia, Wiktionary, Stack Exchange, and the rest of the [Kiwix Library](https://library.kiwix.org/).
 
@@ -42,8 +42,8 @@ uv tool install openzim-mcp
 pip install openzim-mcp
 
 # Docker (multi-arch image, ghcr.io)
-docker pull ghcr.io/cameronrye/openzim-mcp:2.0.0
-docker run --rm -v /path/to/zim/files:/zim ghcr.io/cameronrye/openzim-mcp:2.0.0 /zim
+docker pull ghcr.io/cameronrye/openzim-mcp:2.1.1
+docker run --rm -v /path/to/zim/files:/zim ghcr.io/cameronrye/openzim-mcp:2.1.1 /zim
 ```
 
 Verify the install:
@@ -92,12 +92,13 @@ For full control, run in Advanced mode to expose all 8 specialized tools:
 
 For HTTP transport (long-running service with bearer auth, CORS, and health endpoints) see [HTTP & Docker deployment](https://cameronrye.github.io/openzim-mcp/docs/http-and-docker-deployment/).
 
-## What's in v2.0.0
+## Highlights
 
 - **8-tool advanced surface** — `zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`. Down from 22; advanced-mode schema drops from ~36KB to ~23.5KB, clearing the [MCP Tax](https://www.mmntm.net/articles/mcp-context-tax) pain band. [API reference →](https://cameronrye.github.io/openzim-mcp/docs/api-reference/)
 - **Streamable HTTP transport** — bearer-token auth, CORS, health endpoints, multi-arch Docker image. [HTTP & Docker deployment →](https://cameronrye.github.io/openzim-mcp/docs/http-and-docker-deployment/)
 - **Per-entry MCP resources + subscriptions** — `zim://{name}/entry/{path}` with native MIME types; clients subscribe and receive `notifications/resources/updated` when archives change. [Resources, prompts & subscriptions →](https://cameronrye.github.io/openzim-mcp/docs/resources-prompts-subscriptions/)
 - **Simple-mode `zim_query`** — one natural-language tool that dispatches to the right operation, tuned for small-model deployment targets. [Quick start →](https://cameronrye.github.io/openzim-mcp/docs/quick-start/)
+- **Native libzim introspection (v2.1)** — `zim_health(zim_file_path=...)` validates an archive's integrity (`Archive.check()` + checksum), and `zim_metadata` now reports archive identity, full-text / title index capabilities, and an `M/Counter` mimetype breakdown. [API reference →](https://cameronrye.github.io/openzim-mcp/docs/api-reference/)
 
 ## Modes
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # openzim-mcp Roadmap
 
-**Status:** v2.0.0 shipped (2026-05-27) — PyPI `2.0.0`, `ghcr.io/cameronrye/openzim-mcp:2.0.0`, GitHub Release with assets.
+**Status:** Latest release **v2.1.1** (2026-05-30) — PyPI `2.1.1` and `ghcr.io/cameronrye/openzim-mcp:2.1.1` / `:latest`, GitHub Release with assets. v2.0.0 GA shipped 2026-05-27 (as `:2.0.0`); the v2.0.x/v2.1.x line has been kept current via beta-sweep fixes plus the v2.1.0 native-libzim reader features.
 
 This document tracks open work past v2.0.0. Everything here is **additive**: opt-in extras, optional sidecars, or dispatch tuning. None of it changes the v2 tool surface or response contract.
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -69,7 +69,7 @@
       "extra-files": [
         {
           "type": "generic",
-          "path": "website/llms.txt",
+          "path": "website/public/llms.txt",
           "glob": false
         }
       ],

--- a/website/public/humans.txt
+++ b/website/public/humans.txt
@@ -60,8 +60,8 @@
 
 # SITE
 
-    Last update: 2026-05-27
+    Last update: 2026-05-31
     Language: English
     Doctype: HTML5
     IDE: Various (VS Code, Vim, etc.)
-    Version: 2.0.0
+    Version: 2.1.1

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -6,7 +6,7 @@
 
 OpenZIM MCP is a Model Context Protocol (MCP) server that enables AI models to access and search ZIM format knowledge bases offline. It provides intelligent, structured access patterns that LLMs need to effectively navigate vast knowledge repositories like Wikipedia, Wiktionary, and other offline content archives.
 
-**Version**: 2.0.0 <!-- x-release-please-version -->
+**Version**: 2.1.1 <!-- x-release-please-version -->
 **License**: MIT
 **Python**: 3.12+
 **Repository**: https://github.com/cameronrye/openzim-mcp

--- a/website/src/content/docs/api-reference.mdx
+++ b/website/src/content/docs/api-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: API reference
-summary: Every v2.0.0 tool, prompt, and resource — 8 consolidated advanced tools, 3 slash-command prompts, 3 resource templates, plus the v1 → v2 migration table.
+summary: Every tool, prompt, and resource — 8 consolidated advanced tools, 3 slash-command prompts, 3 resource templates, plus the v1 → v2 migration table.
 group: Reference
 sidebar_order: 1
 ---
@@ -224,7 +224,13 @@ Combined archive metadata + namespaces. Collapses the v1 `get_zim_metadata` + `l
 zim_metadata(zim_file_path: str) -> Any
 ```
 
-**Returns:** structured response with archive M-namespace metadata (`title`, `language`, `creator`, `flavour`, `date`, etc.) and a deterministic namespace breakdown (surfaces minority namespaces — `M`, `W`, `X`, `I` — that random sampling could miss).
+**Returns:** structured response with:
+
+- **`metadata`** — archive M-namespace fields (`title`, `language`, `creator`, `flavour`, `date`, etc.).
+- **`namespaces`** — a deterministic namespace breakdown (surfaces minority namespaces — `M`, `W`, `X`, `I` — that random sampling could miss).
+- **`archive_identity`** — `{uuid, is_multipart}`, the libzim archive identity (*added in v2.1*).
+- **`index_capabilities`** — `{has_fulltext_index, has_title_index}`: whether full-text search and title suggestions will work against this archive (*added in v2.1*).
+- **`counter_breakdown`** — `{mimetype: count}` parsed from the `M/Counter` metadata, so you can profile an archive's content composition without walking it. Omitted when the archive has no `M/Counter` entry (*added in v2.1*).
 
 ---
 
@@ -258,15 +264,18 @@ Relative hrefs are resolved against the source entry's directory; redirects are 
 
 ### `zim_health`
 
-Combined server health, configuration, and loaded archives. Collapses the v1 `get_server_health` + `get_server_configuration` + `list_zim_files` tools into a single call.
+Two calls in one. With **no argument**, returns combined server health, configuration, and loaded archives (collapses the v1 `get_server_health` + `get_server_configuration` + `list_zim_files` tools). With a **`zim_file_path`**, validates and diagnoses that one archive instead (*added in v2.1*).
 
 ```python
-zim_health() -> Any
+zim_health(zim_file_path: Optional[str] = None) -> Any
 ```
 
-No parameters.
+| Argument | Behavior |
+|----------|----------|
+| *(omitted)* | Combined server-state report: `{health, configuration, loaded_archives}`. |
+| `zim_file_path` | Per-archive integrity/identity check via libzim — runs `Archive.check()` and reports checksum, index capabilities, and identity. Lets a caller tell a valid archive from a corrupt one. |
 
-**Returns:** structured response with this shape (abbreviated):
+**Server-state response** (no argument) — shape (abbreviated):
 
 ```json
 {
@@ -297,6 +306,24 @@ No parameters.
 ```
 
 `process_id` / `server_pid` are **always** `"[REDACTED]"` — diagnostic output frequently lands in bug reports. Allowed directories are shown as `...basename` to avoid leaking the canonical layout.
+
+**Archive-validation response** (with `zim_file_path`, *added in v2.1*):
+
+```json
+{
+  "is_valid": true,
+  "has_checksum": true,
+  "checksum": "<hex>",
+  "has_fulltext_index": true,
+  "has_title_index": true,
+  "uuid": "<archive uuid>",
+  "is_multipart": false,
+  "path": "...archive.zim",
+  "name": "archive.zim"
+}
+```
+
+`is_valid` is the result of libzim's `Archive.check()` structural-integrity probe — a quick way to tell a valid archive from a corrupt or truncated one. A non-indexed archive reports `has_fulltext_index: false`; full-text `zim_search` against it then degrades gracefully to a `no_xapian_index` reason instead of erroring.
 
 ---
 

--- a/website/src/content/docs/architecture-overview.mdx
+++ b/website/src/content/docs/architecture-overview.mdx
@@ -1,13 +1,13 @@
 ---
 title: Architecture overview
-summary: Module map, transports, and the zim/ package layout for OpenZIM MCP v2.0.0 — including the 8-tool consolidated surface, caching, smart-retrieval fallback, MCP transport layer, and subscription watcher.
+summary: Module map, transports, and the zim/ package layout for OpenZIM MCP — including the 8-tool consolidated surface, caching, smart-retrieval fallback, MCP transport layer, and subscription watcher.
 group: Operations
 sidebar_order: 3
 ---
 
 Module map, transports, and the `zim/` package layout.
 
-> **Notation:** examples on this page use Python pseudo-call syntax for tool calls. The MCP wire format is JSON-RPC; your client handles the framing. Tool names match the v2.0.0 8-tool surface (`zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`).
+> **Notation:** examples on this page use Python pseudo-call syntax for tool calls. The MCP wire format is JSON-RPC; your client handles the framing. Tool names match the 8-tool advanced surface (`zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`).
 
 > **Source of truth:** [openzim_mcp/](https://github.com/cameronrye/openzim-mcp/tree/main/openzim_mcp). The README's [Project Structure section](https://github.com/cameronrye/openzim-mcp#project-structure) mirrors the on-disk layout — this page explains *why* it's organized that way.
 
@@ -92,10 +92,9 @@ v2.0.0 collapsed the 22-tool v1 advanced surface into 8 tools. Each consolidated
 
   ┌──────────────────────────────┐
   │  zim_health                  │
-  │  • view="health"  (default)  │
-  │  • view="config"             │
-  │  • view="archives"           │
-  │  • consolidated payload too  │
+  │  • no arg → health + config  │
+  │    + archives (one payload)  │
+  │  • path → archive validation │
   └──────────────────────────────┘
 ```
 

--- a/website/src/content/docs/configuration.mdx
+++ b/website/src/content/docs/configuration.mdx
@@ -1,11 +1,11 @@
 ---
 title: Configuration
-summary: Every supported environment variable, CLI flag, and configuration field for OpenZIM MCP v2.0.0 — transport, cache, content, rate limiting, subscriptions, and deployment profiles.
+summary: Every supported environment variable, CLI flag, and configuration field for OpenZIM MCP — transport, cache, content, rate limiting, subscriptions, and deployment profiles.
 group: Reference
 sidebar_order: 2
 ---
 
-Every supported environment variable, CLI flag, and configuration field for OpenZIM MCP v2.0.0.
+Every supported environment variable, CLI flag, and configuration field for OpenZIM MCP.
 
 > **Source of truth:** [openzim_mcp/config.py](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/config.py) and [openzim_mcp/defaults.py](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/defaults.py). If this page disagrees with code, code wins — please file an issue.
 
@@ -25,7 +25,7 @@ A bad value raises `OpenZimMcpConfigurationError` at startup with a human-readab
 
 ```bash
 # Default: simple — exposes one natural-language tool (zim_query)
-# Set to advanced for the full v2.0.0 8-tool surface
+# Set to advanced for the full 8-tool advanced surface
 export OPENZIM_MCP_TOOL_MODE=advanced
 ```
 
@@ -316,7 +316,7 @@ ExecStart=/usr/local/bin/openzim-mcp /srv/zim
 
 ## Stale env vars (not in code)
 
-The following env-var namespaces appeared in pre-1.0 / early-v2 documentation and **do not exist** in the v2.0.0 codebase. If a tool or example tells you to set them, the source is stale:
+The following env-var namespaces appeared in pre-1.0 / early-v2 documentation and **do not exist** in the current codebase. If a tool or example tells you to set them, the source is stale:
 
 - `OPENZIM_MCP_INSTANCE__*` — multi-instance conflict tracking was removed entirely.
 - `OPENZIM_MCP_SECURITY__*` — there is no `SecurityConfig`. Path validation, input sanitization, and limits are all controlled by the values listed above.

--- a/website/src/content/docs/faq.mdx
+++ b/website/src/content/docs/faq.mdx
@@ -7,7 +7,7 @@ sidebar_order: 2
 
 Common questions and answers about OpenZIM MCP.
 
-> **Notation:** examples on this page use Python pseudo-call syntax (`zim_query(query="...")`). Argument names match the v2.0.0 8-tool surface.
+> **Notation:** examples on this page use Python pseudo-call syntax (`zim_query(query="...")`). Argument names match the 8-tool advanced surface.
 
 ## General questions
 
@@ -105,7 +105,7 @@ Prompts (`/research`, `/summarize`, `/explore`) and resources (`zim://files`, `z
 
 The [MCP Tax](https://www.mmntm.net/articles/mcp-context-tax) is the context cost an MCP server's tool schemas impose on every LLM request — the LLM has to read every tool description and parameter spec before it can pick one. There's an empirically observed pain band around 25–50KB of schema where small models start dropping accuracy and tool-call latency climbs.
 
-v1.x's 22-tool advanced surface was roughly 36KB of schema — squarely in the pain band. v2.0.0's 8-tool surface is roughly 23.5KB — just under the band. Same functionality, lower context tax, fewer wrong-tool calls. The detailed argument shapes still live inside the consolidated tools (in the `mode` / `view` discriminator), so frontier models keep their granularity.
+v1.x's 22-tool advanced surface was roughly 36KB of schema — squarely in the pain band. The v2 8-tool surface is roughly 23.5KB — just under the band. Same functionality, lower context tax, fewer wrong-tool calls. The detailed argument shapes still live inside the consolidated tools (in the `mode` / `view` discriminator), so frontier models keep their granularity.
 
 ### How do I search for content?
 

--- a/website/src/content/docs/http-and-docker-deployment.mdx
+++ b/website/src/content/docs/http-and-docker-deployment.mdx
@@ -1,13 +1,13 @@
 ---
 title: HTTP and Docker deployment
-summary: Run OpenZIM MCP v2.0.0 as a long-running networked service — streamable HTTP transport, bearer-token auth, CORS, health probes, the published Docker image, and end-to-end deployment recipes (LAN, Tailscale, VPS with TLS).
+summary: Run OpenZIM MCP as a long-running networked service — streamable HTTP transport, bearer-token auth, CORS, health probes, the published Docker image, and end-to-end deployment recipes (LAN, Tailscale, VPS with TLS).
 group: Guides
 sidebar_order: 3
 ---
 
-How to run OpenZIM MCP v2.0.0 as a long-running networked service. Covers the streamable HTTP transport, the published Docker image, operational concerns (TLS, reverse proxy, health probes, systemd), and end-to-end deployment recipes for LAN, Tailscale tailnet, and public VPS topologies.
+How to run OpenZIM MCP as a long-running networked service. Covers the streamable HTTP transport, the published Docker image, operational concerns (TLS, reverse proxy, health probes, systemd), and end-to-end deployment recipes for LAN, Tailscale tailnet, and public VPS topologies.
 
-> **Notation:** examples on this page use JSON-RPC tool-call framing (`{"name": "...", "arguments": {...}}`) for protocol-level snippets and shell snippets for environment / HTTP commands. Tool surfaces referenced match the v2.0.0 8-tool surface.
+> **Notation:** examples on this page use JSON-RPC tool-call framing (`{"name": "...", "arguments": {...}}`) for protocol-level snippets and shell snippets for environment / HTTP commands. Tool surfaces referenced match the 8-tool advanced surface.
 
 > **Source of truth:** [openzim_mcp/http_app.py](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/http_app.py) and the [Dockerfile](https://github.com/cameronrye/openzim-mcp/blob/main/Dockerfile).
 
@@ -38,7 +38,7 @@ This binds the loopback interface only. Put a TLS-terminating reverse proxy in f
 docker run --rm -p 8000:8000 \
   -v /srv/zim:/data:ro \
   -e OPENZIM_MCP_AUTH_TOKEN="$(openssl rand -hex 32)" \
-  ghcr.io/cameronrye/openzim-mcp:2.0.0
+  ghcr.io/cameronrye/openzim-mcp:2.1.1
 ```
 
 The published image:
@@ -258,7 +258,7 @@ spec:
     spec:
       containers:
         - name: openzim-mcp
-          image: ghcr.io/cameronrye/openzim-mcp:2.0.0
+          image: ghcr.io/cameronrye/openzim-mcp:2.1.1
           ports:
             - containerPort: 8000
           env:
@@ -338,7 +338,7 @@ This recipe puts OpenZIM MCP on a single host, reachable from the rest of your L
 ```yaml
 services:
   openzim-mcp:
-    image: ghcr.io/cameronrye/openzim-mcp:2.0.0
+    image: ghcr.io/cameronrye/openzim-mcp:2.1.1
     restart: unless-stopped
     ports:
       - "127.0.0.1:8000:8000"
@@ -363,7 +363,7 @@ volumes:
 
 What's intentional here:
 
-- **Pinned tag** (`:2.0.0`, not `:latest`). Upgrades are deliberate — `docker compose pull` is a thing you do, not a thing that happens to you.
+- **Pinned tag** (`:2.1.1`, not `:latest`). Upgrades are deliberate — `docker compose pull` is a thing you do, not a thing that happens to you.
 - **Host port bound to `127.0.0.1`.** The container listens on all interfaces (the image's default `OPENZIM_MCP_HOST=0.0.0.0`), but Docker's port publish restricts external exposure to loopback. The Tailscale variant below lifts this restriction by binding to a specific interface.
 - **Read-only ZIM mount** (`:ro`). The server only reads ZIM files; mounting read-only ensures a server compromise can't damage them.
 - **Token via env, not hard-coded.** Put it in a `.env` file next to the compose file (and add `.env` to `.gitignore`). The image's defaults already set `TRANSPORT=http`, `HOST=0.0.0.0`, `PORT=8000`, so they're not repeated here.
@@ -472,7 +472,7 @@ This is the LAN compose file with two changes: a `caddy` service is added, and t
 ```yaml
 services:
   openzim-mcp:
-    image: ghcr.io/cameronrye/openzim-mcp:2.0.0
+    image: ghcr.io/cameronrye/openzim-mcp:2.1.1
     restart: unless-stopped
     expose:
       - "8000"
@@ -558,7 +558,7 @@ docker compose pull
 docker compose up -d
 ```
 
-The image tag in `docker-compose.yml` is pinned (`:2.0.0`) — change it to the new version before pulling. Pinning is deliberate: `:latest` makes upgrades a surprise, and the release notes for each tag tell you when an upgrade involves a breaking change. The v1.x → v2.0.0 jump is a breaking rename of the advanced-mode tool surface (22 tools → 8); see the [CHANGELOG](https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md) before bumping.
+The image tag in `docker-compose.yml` is pinned (`:2.1.1`) — change it to the new version before pulling. Pinning is deliberate: `:latest` makes upgrades a surprise, and the release notes for each tag tell you when an upgrade involves a breaking change. The v1.x → v2.0.0 jump is a breaking rename of the advanced-mode tool surface (22 tools → 8); see the [CHANGELOG](https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md) before bumping.
 
 #### Watching logs
 

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -1,13 +1,13 @@
 ---
 title: Introduction
-summary: OpenZIM MCP is a secure, high-performance MCP server giving AI models offline access to ZIM-format knowledge bases via 8 consolidated v2.0.0 tools.
+summary: OpenZIM MCP is a secure, high-performance MCP server giving AI models offline access to ZIM-format knowledge bases via 8 consolidated tools.
 group: Get started
 sidebar_order: 1
 ---
 
 **OpenZIM MCP** is a modern, secure, and high-performance MCP (Model Context Protocol) server that enables AI models to access and search [ZIM format](https://en.wikipedia.org/wiki/ZIM_(file_format)) knowledge bases offline.
 
-> **v2.0.0 — 8-tool advanced surface.** Phase F collapses the prior 22-tool advanced surface into 8 consolidated tools — `zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`. The advanced-mode wire footprint drops from ~36KB to ~23.5KB, clearing the [MCP Tax](https://www.mmntm.net/articles/mcp-context-tax) pain band (25–50KB schema) for small-model dispatch. Simple mode (`zim_query` only) is unchanged. [What's new in v2.0.0 →](https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md#200--2026-05-27--phase-f-stage-d-ships)
+> **8-tool advanced surface.** Phase F (v2.0.0) consolidated the prior 22-tool advanced surface into 8 tools — `zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`. The advanced-mode wire footprint drops from ~36KB to ~23.5KB, clearing the [MCP Tax](https://www.mmntm.net/articles/mcp-context-tax) pain band (25–50KB schema) for small-model dispatch. Simple mode (`zim_query` only) is unchanged. **New in v2.1:** native libzim archive validation via `zim_health(zim_file_path=...)`, plus identity / index introspection in `zim_metadata`. [What's new →](https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md)
 >
 > Still running v1.x? Highlights for [v1.2.0](https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md#120) and [v1.0.0](https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md#100-2026-05-01) remain documented in the changelog. v1.x is in maintenance mode (security + data-corruption + pre-v2.0.0 crash fixes accepted; no new features) until the FIRST of `{v2.5.0 ships, 2026-11-27}`.
 
@@ -17,7 +17,7 @@ sidebar_order: 1
 
 OpenZIM MCP provides **intelligent, structured access** that LLMs need:
 
-- **Dual-mode surface** — Simple mode (default) exposes a single natural-language tool (`zim_query`) for smaller LLMs; Advanced mode exposes the 8 specialized v2.0.0 tools for hosts that can pick from a richer surface.
+- **Dual-mode surface** — Simple mode (default) exposes a single natural-language tool (`zim_query`) for smaller LLMs; Advanced mode exposes the 8 specialized tools for hosts that can pick from a richer surface.
 - **Smart navigation** — browse by namespace (articles, metadata, media) instead of blind searching. `zim_browse(mode="walk")` does deterministic cursor-paginated iteration.
 - **Multi-archive search** — `zim_search(cross_file=True)` queries every ZIM file at once; `zim_search(mode="title")` resolves titles directly without full-text scoring.
 - **Smart retrieval** — automatic fallback from direct path access to search-derived term resolution, with archive-scoped path-mapping cache and bounded redirect-chain following.
@@ -43,11 +43,11 @@ OpenZIM MCP provides **intelligent, structured access** that LLMs need:
 
 ## Project Status
 
-- **Version:** 2.0.0
+- **Version:** 2.1.1
 - **License:** MIT
 - **Python:** 3.12+
 - **Test Coverage:** 80%+
-- **Container:** `ghcr.io/cameronrye/openzim-mcp:2.0.0` + `:latest` (linux/amd64, linux/arm64)
+- **Container:** `ghcr.io/cameronrye/openzim-mcp:2.1.1` + `:latest` (linux/amd64, linux/arm64)
 
 ## Quick Links
 

--- a/website/src/content/docs/installation.mdx
+++ b/website/src/content/docs/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Installation
-summary: Install OpenZIM MCP v2.0.0 from PyPI (uv or pip), Docker, or source on Windows, macOS, or Linux, then wire it into Claude Desktop or any MCP client.
+summary: Install OpenZIM MCP from PyPI (uv or pip), Docker, or source on Windows, macOS, or Linux, then wire it into Claude Desktop or any MCP client.
 group: Get started
 sidebar_order: 2
 ---
@@ -232,14 +232,14 @@ OpenZIM MCP ships a multi-arch image at `ghcr.io/cameronrye/openzim-mcp` (`linux
 
 ```bash
 # Pull
-docker pull ghcr.io/cameronrye/openzim-mcp:2.0.0
+docker pull ghcr.io/cameronrye/openzim-mcp:2.1.1
 
 # Run with HTTP transport, bound to all interfaces (the image default).
 # The server REFUSES to bind 0.0.0.0 without OPENZIM_MCP_AUTH_TOKEN.
 docker run --rm -p 8000:8000 \
   -v /srv/zim:/data:ro \
   -e OPENZIM_MCP_AUTH_TOKEN="$(openssl rand -hex 32)" \
-  ghcr.io/cameronrye/openzim-mcp:2.0.0
+  ghcr.io/cameronrye/openzim-mcp:2.1.1
 ```
 
 The image entrypoint is `python -m openzim_mcp /data`, so mount your ZIM directory at `/data`. Default env vars in the image: `OPENZIM_MCP_TRANSPORT=http`, `OPENZIM_MCP_HOST=0.0.0.0`, `OPENZIM_MCP_PORT=8000`.
@@ -294,7 +294,7 @@ make test
 2026-05-27 15:30:00,001 - openzim_mcp.main - INFO - Allowed directories: /path/to/zim/files
 ```
 
-Default mode is **Simple** (one natural-language tool). For all 8 v2.0.0 tools (`zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`), pass `--mode advanced`.
+Default mode is **Simple** (one natural-language tool). For all 8 tools (`zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`), pass `--mode advanced`.
 
 ## MCP Client Configuration
 

--- a/website/src/content/docs/llm-integration-patterns.mdx
+++ b/website/src/content/docs/llm-integration-patterns.mdx
@@ -1,13 +1,13 @@
 ---
 title: LLM integration patterns
-summary: Proven patterns for wiring OpenZIM MCP v2.0.0 into LLM applications — simple-mode dispatch, advanced-mode 8-tool composition, progressive discovery, batching, and error handling.
+summary: Proven patterns for wiring OpenZIM MCP into LLM applications — simple-mode dispatch, advanced-mode 8-tool composition, progressive discovery, batching, and error handling.
 group: Guides
 sidebar_order: 1
 ---
 
 Best practices and patterns for integrating OpenZIM MCP with large language models.
 
-> **Notation:** examples on this page use Python pseudo-call syntax (`zim_query(request="...")`, `zim_search(query="...", ...)`). The MCP wire format is JSON-RPC `{"name": "...", "arguments": {...}}` — your MCP client handles the framing. The argument names and types match the v2.0.0 8-tool surface (`zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`).
+> **Notation:** examples on this page use Python pseudo-call syntax (`zim_query(request="...")`, `zim_search(query="...", ...)`). The MCP wire format is JSON-RPC `{"name": "...", "arguments": {...}}` — your MCP client handles the framing. The argument names and types match the 8-tool advanced surface (`zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`).
 
 ## Overview
 
@@ -553,7 +553,7 @@ Subscribe to `zim://files` or `zim://{name}` for `notifications/resources/update
 
 In simple mode (the default) only `zim_query` is exposed — pass a natural-language request and the server's intent parser routes to the right underlying operation. If your host LLM is small or struggles with large tool catalogues, prefer simple mode and let the parser do the routing. For LLMs that handle the full 8-tool surface, switch to advanced mode (`OPENZIM_MCP_TOOL_MODE=advanced`) for fine-grained control.
 
-**The v2.0.0 8-tool surface fits comfortably below the [MCP Tax](https://www.mmntm.net/articles/mcp-context-tax) pain band (~23.5KB vs the 25–50KB band)** — most 7-8B class open-weights models dispatch reliably against it. The 22-tool v1 surface (~36KB) sat squarely inside the band; if you saw dispatch confusion on v1 with a small model, v2 should be substantially better.
+**The 8-tool advanced surface fits comfortably below the [MCP Tax](https://www.mmntm.net/articles/mcp-context-tax) pain band (~23.5KB vs the 25–50KB band)** — most 7-8B class open-weights models dispatch reliably against it. The 22-tool v1 surface (~36KB) sat squarely inside the band; if you saw dispatch confusion on v1 with a small model, v2 should be substantially better.
 
 ### Contextual content assembly
 
@@ -574,7 +574,7 @@ def create_comprehensive_answer(zim_path, entry_path):
 
 **Next steps:**
 
-- **[API reference](/openzim-mcp/docs/api-reference/)** — full v2.0.0 tool signatures.
+- **[API reference](/openzim-mcp/docs/api-reference/)** — full tool signatures.
 - **[Performance optimization](/openzim-mcp/docs/performance-optimization/)** — cache tuning, rate limiting, batching.
 - **[Smart retrieval](/openzim-mcp/docs/smart-retrieval/)** — how the search-fallback path resolution works.
 

--- a/website/src/content/docs/performance-optimization.mdx
+++ b/website/src/content/docs/performance-optimization.mdx
@@ -1,13 +1,13 @@
 ---
 title: Performance optimization
-summary: Cache tuning, rate limiting, batching, and deployment-profile guidance for OpenZIM MCP v2.0.0 — including HTTP transport, monitoring endpoints, and latency targets.
+summary: Cache tuning, rate limiting, batching, and deployment-profile guidance for OpenZIM MCP — including HTTP transport, monitoring endpoints, and latency targets.
 group: Guides
 sidebar_order: 4
 ---
 
-Cache tuning, rate limiting, batching, and request-pattern guidance for OpenZIM MCP v2.0.0.
+Cache tuning, rate limiting, batching, and request-pattern guidance for OpenZIM MCP.
 
-> **Notation:** examples on this page use Python pseudo-call syntax (`zim_get(entry_path="...")`) for tool calls and shell snippets for environment / HTTP commands. The MCP wire format is JSON-RPC; your client handles the framing. Tool names and argument shapes match the v2.0.0 8-tool surface.
+> **Notation:** examples on this page use Python pseudo-call syntax (`zim_get(entry_path="...")`) for tool calls and shell snippets for environment / HTTP commands. The MCP wire format is JSON-RPC; your client handles the framing. Tool names and argument shapes match the 8-tool advanced surface.
 
 ## Where time goes
 
@@ -37,7 +37,7 @@ export OPENZIM_MCP_CACHE__PERSISTENCE_ENABLED=true    # cache survives restarts
 | Memory-constrained (RPi, small VPS) | `MAX_SIZE=25-50`, `TTL_SECONDS=900-1800` |
 | Volatile content (frequent ZIM swaps) | shorter TTL or rely on subscriptions to invalidate downstream |
 
-Cache stats surface in `zim_health().cache_performance` (`enabled`, `size`, `max_size`, `ttl_seconds`, `hits`, `misses`, `hit_rate`). There are no `warm_cache` / `cache_stats` / `cache_clear` tools in v2.0.0 — restart to flush.
+Cache stats surface in `zim_health().cache_performance` (`enabled`, `size`, `max_size`, `ttl_seconds`, `hits`, `misses`, `hit_rate`). There are no `warm_cache` / `cache_stats` / `cache_clear` tools — restart to flush.
 
 **Persistence path:** defaults to `~/.cache/openzim-mcp` (resolved to absolute). For containerized deployments, mount a volume there or override `OPENZIM_MCP_CACHE__PERSISTENCE_PATH`.
 
@@ -212,7 +212,7 @@ Wire `/healthz` and `/readyz` into your platform's uptime monitor. For Prometheu
 
 ### Pre-warming on startup
 
-There is no `warm_cache` tool in v2.0.0. To pre-warm, call the entry tools yourself at startup:
+There is no `warm_cache` tool. To pre-warm, call the entry tools yourself at startup:
 
 ```python
 # Wake the cache for high-value articles

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -1,11 +1,11 @@
 ---
 title: Quick start
-summary: Run OpenZIM MCP v2.0.0 in 5 minutes — start the server in simple mode, dispatch a zim_query, and try one advanced-mode zim_search example.
+summary: Run OpenZIM MCP in 5 minutes — start the server in simple mode, dispatch a zim_query, and try one advanced-mode zim_search example.
 group: Get started
 sidebar_order: 3
 ---
 
-Get up and running with OpenZIM MCP in just a few minutes. This tutorial walks through your first successful setup and usage in **simple mode** (the default, one natural-language tool), then shows one **advanced mode** example using the v2.0.0 8-tool surface.
+Get up and running with OpenZIM MCP in just a few minutes. This tutorial walks through your first successful setup and usage in **simple mode** (the default, one natural-language tool), then shows one **advanced mode** example using the 8-tool advanced surface.
 
 ## What you'll learn
 
@@ -195,7 +195,7 @@ In simple mode, the server exposes one tool. Phrase the request in plain languag
 
 ## Step 5: Try advanced mode (`zim_search` + friends)
 
-When you need precise control — a specific search mode, cross-file scope, suggestion-style title resolution — start the server in **advanced mode**, which exposes the full v2.0.0 8-tool surface: `zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`.
+When you need precise control — a specific search mode, cross-file scope, suggestion-style title resolution — start the server in **advanced mode**, which exposes the full 8-tool advanced surface: `zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`.
 
 ```bash
 openzim-mcp --mode advanced ~/zim-files
@@ -240,7 +240,7 @@ You now have OpenZIM MCP running successfully. Here's what to explore next:
 
 ### Learn more
 
-- **[API Reference](/openzim-mcp/docs/api-reference/)** — every tool, prompt, and resource (v2.0.0 8-tool surface)
+- **[API Reference](/openzim-mcp/docs/api-reference/)** — every tool, prompt, and resource (8-tool advanced surface)
 - **[LLM Integration Patterns](/openzim-mcp/docs/llm-integration-patterns/)** — best practices for AI integration
 - **[Configuration Guide](/openzim-mcp/docs/configuration/)** — customize your setup
 

--- a/website/src/content/docs/resources-prompts-subscriptions.mdx
+++ b/website/src/content/docs/resources-prompts-subscriptions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Resources, prompts & subscriptions
-summary: MCP resources (zim://files, zim://{name}, zim://{name}/entry/{path}), slash-command prompts (/research, /summarize, /explore), and the polling subscription system in v2.0.0.
+summary: MCP resources (zim://files, zim://{name}, zim://{name}/entry/{path}), slash-command prompts (/research, /summarize, /explore), and the polling subscription system.
 group: Reference
 sidebar_order: 3
 ---
@@ -96,7 +96,7 @@ For LLM workflows that need processed text + smart fallback, prefer the tool. Fo
 
 ## Prompts
 
-MCP prompts are pre-built workflows clients can invoke as slash commands. Each one returns a list of messages instructing the LLM to chain a specific multi-step ZIM operation against the v2.0.0 8-tool surface.
+MCP prompts are pre-built workflows clients can invoke as slash commands. Each one returns a list of messages instructing the LLM to chain a specific multi-step ZIM operation against the 8-tool advanced surface.
 
 > **Hardening:** user-supplied arguments are sanitized before interpolation — control characters replaced with spaces, backticks stripped (template delimiter), length capped at 200 characters. Apostrophes and double quotes are *preserved* (real entry paths contain them, e.g. `C/Schrödinger's_cat`). If args reduce to empty after sanitization, the prompt body asks the user to re-supply them.
 

--- a/website/src/content/docs/security-best-practices.mdx
+++ b/website/src/content/docs/security-best-practices.mdx
@@ -1,13 +1,13 @@
 ---
 title: Security best practices
-summary: OpenZIM MCP v2.0.0 security model and operator hardening — path validation, redaction, input sanitization, bearer-token auth, CORS, rate limiting, container hardening, and a production checklist.
+summary: OpenZIM MCP security model and operator hardening — path validation, redaction, input sanitization, bearer-token auth, CORS, rate limiting, container hardening, and a production checklist.
 group: Guides
 sidebar_order: 5
 ---
 
-OpenZIM MCP's security model and operator-level hardening. This page covers the in-process protections (path validation, redaction, input sanitization, prompt hardening, rate limiting) and the network-layer protections (bearer-token auth, CORS, safe-default startup, container hardening) that ship in v2.0.0.
+OpenZIM MCP's security model and operator-level hardening. This page covers the in-process protections (path validation, redaction, input sanitization, prompt hardening, rate limiting) and the network-layer protections (bearer-token auth, CORS, safe-default startup, container hardening) that ship in the v2 release.
 
-> **Notation:** examples on this page use JSON-RPC tool-call framing (`{"name": "...", "arguments": {...}}`) and shell snippets. Tool names referenced match the v2.0.0 8-tool surface (`zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`).
+> **Notation:** examples on this page use JSON-RPC tool-call framing (`{"name": "...", "arguments": {...}}`) and shell snippets. Tool names referenced match the 8-tool advanced surface (`zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`).
 
 > **Source of truth:** [openzim_mcp/security.py](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/security.py), [openzim_mcp/http_app.py](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/http_app.py), and the [SECURITY.md](https://github.com/cameronrye/openzim-mcp/blob/main/SECURITY.md) policy. Vulnerability reports go through [GitHub Private Vulnerability Reporting](https://github.com/cameronrye/openzim-mcp/security/advisories/new).
 
@@ -211,7 +211,7 @@ Response timeline (per [SECURITY.md](https://github.com/cameronrye/openzim-mcp/b
 
 ## Security review highlights
 
-These are the load-bearing protections that distinguish v2.0.0's posture:
+These are the load-bearing protections that distinguish v2's posture:
 
 - Path/PID redaction in error and diagnostics responses (regex handles wrapped/quoted/URL-encoded paths).
 - `OPTIONS /mcp` locked behind auth (closed preflight-bypass attack surface).

--- a/website/src/content/docs/smart-retrieval.mdx
+++ b/website/src/content/docs/smart-retrieval.mdx
@@ -1,13 +1,13 @@
 ---
 title: Smart retrieval
-summary: How OpenZIM MCP v2.0.0 resolves entry paths when direct access fails — the four-step fallback inside zim_get, the path-mapping cache, and how to debug resolutions.
+summary: How OpenZIM MCP resolves entry paths when direct access fails — the four-step fallback inside zim_get, the path-mapping cache, and how to debug resolutions.
 group: Guides
 sidebar_order: 2
 ---
 
 How OpenZIM MCP resolves entry paths when direct access fails — and how to debug it when it doesn't.
 
-> **Notation:** examples on this page use Python pseudo-call syntax (`zim_get(entry_path="...")`). The wire format is MCP JSON-RPC; your client handles the framing. Tool names and argument shapes match the v2.0.0 8-tool surface.
+> **Notation:** examples on this page use Python pseudo-call syntax (`zim_get(entry_path="...")`). The wire format is MCP JSON-RPC; your client handles the framing. Tool names and argument shapes match the 8-tool advanced surface.
 
 > **Source of truth:** [openzim_mcp/zim/content.py](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/zim/content.py) (`_get_entry_content`) and [openzim_mcp/zim/search.py](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/zim/search.py) (`_extract_search_terms_from_path`, `_find_entry_by_search`).
 
@@ -15,7 +15,7 @@ How OpenZIM MCP resolves entry paths when direct access fails — and how to deb
 
 ZIM entry paths aren't always predictable. Wikipedia's "Photosynthesis" might live at `A/Photosynthesis`, `C/Photosynthesis`, `Photosynthesis`, or under a slug variant. Smart retrieval is the fallback path that turns "I have a guess at the path" into "here's the article" without forcing the LLM to do trial-and-error.
 
-In v2.0.0 the fallback is consolidated into `zim_get` — it runs automatically whenever `zim_get` is called with an `entry_path` that doesn't match directly. It applies to every view mode of `zim_get` (`view="content"` default, `view="summary"`, `view="toc"`, `view="structure"`), the binary form (`zim_get(binary=True, ...)`), and to `zim_links` (which resolves the source entry before extracting links).
+The fallback is consolidated into `zim_get` — it runs automatically whenever `zim_get` is called with an `entry_path` that doesn't match directly. It applies to every view mode of `zim_get` (`view="full"` default, `view="summary"`, `view="toc"`, `view="structure"`), the binary form (`zim_get(binary=True, ...)`), and to `zim_links` (which resolves the source entry before extracting links).
 
 Internally these all share `_resolve_entry_with_fallback` in `zim/structure.py`.
 
@@ -131,7 +131,7 @@ When something resolves "wrong":
 
 1. Get the right path with `zim_search(zim_file_path=..., query="Photosynthesis", mode="title")` — title-indexed lookup, doesn't go through smart retrieval.
 2. Or browse the namespace: `zim_browse(zim_file_path=..., namespace="C", mode="page", limit=20)`.
-3. Restart the server to flush the cache (there's no `cache_clear` tool in v2.0.0).
+3. Restart the server to flush the cache (there's no `cache_clear` tool).
 
 ## Troubleshooting
 

--- a/website/src/content/docs/troubleshooting.mdx
+++ b/website/src/content/docs/troubleshooting.mdx
@@ -1,17 +1,17 @@
 ---
 title: Troubleshooting
-summary: Common failure modes for OpenZIM MCP v2.0.0 — installation, ZIM file access, MCP client config, search/content issues, HTTP transport, cache, subscriptions, and the structured error payload shape.
+summary: Common failure modes for OpenZIM MCP — installation, ZIM file access, MCP client config, search/content issues, HTTP transport, cache, subscriptions, and the structured error payload shape.
 group: Operations
 sidebar_order: 1
 ---
 
-Common issues, error messages, and solutions for OpenZIM MCP v2.0.0.
+Common issues, error messages, and solutions for OpenZIM MCP.
 
-> **Notation:** examples on this page use Python pseudo-call syntax (`zim_health()`, `zim_search(query="...", mode="...")`). The MCP wire format is JSON-RPC `{"name": "...", "arguments": {...}}` — your MCP client handles the framing. Tool names match the v2.0.0 8-tool surface (`zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`).
+> **Notation:** examples on this page use Python pseudo-call syntax (`zim_health()`, `zim_search(query="...", mode="...")`). The MCP wire format is JSON-RPC `{"name": "...", "arguments": {...}}` — your MCP client handles the framing. Tool names match the 8-tool advanced surface (`zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`).
 
-## Error response shape (v2.0.0)
+## Error response shape
 
-Before diving into specific failure modes — v2.0.0 changed how errors come back from tools. Every tool catches exceptions and returns a structured `ToolErrorPayload` instead of raising:
+Before diving into specific failure modes — v2 changed how errors come back from tools. Every tool catches exceptions and returns a structured `ToolErrorPayload` instead of raising:
 
 ```json
 {
@@ -43,7 +43,7 @@ First, run the server health check to identify issues:
 "Check the server health and configuration"
 ```
 
-This will run `zim_health`, which in v2.0.0 returns combined health, configuration, and loaded-archives data in one response (consolidating three separate v1 tools into a single call).
+This will run `zim_health`, which returns combined health, configuration, and loaded-archives data in one response (consolidating three separate v1 tools into a single call).
 
 If the server is running over HTTP, you can also probe `/healthz` and `/readyz` directly without a token — both are auth-exempt.
 
@@ -411,7 +411,7 @@ Look for error patterns in server output:
 ### Before asking for help
 
 1. **Check this guide**: Review relevant sections above
-2. **Run diagnostics**: Use `zim_health` (v2.0.0 consolidates server health, configuration, and loaded-archives into one tool with `view="health" | "config" | "archives"`)
+2. **Run diagnostics**: Use `zim_health` — with no argument it consolidates server health, configuration, and loaded-archives into a single response (three v1 tools in one call); pass a `zim_file_path` to validate one archive (`Archive.check()` + checksum + index/identity)
 3. **Check logs**: Look for error messages — error text is safe to copy verbatim (paths and PIDs are redacted)
 4. **Test minimal case**: Reproduce with simple setup
 

--- a/website/src/content/docs/worked-examples.mdx
+++ b/website/src/content/docs/worked-examples.mdx
@@ -1,13 +1,13 @@
 ---
 title: Worked examples
-summary: Five end-to-end case studies showing the OpenZIM MCP v2.0.0 8-tool surface in action — search, get, summarize, browse namespaces, and follow related links across a Wikipedia ZIM archive.
+summary: Five end-to-end case studies showing the OpenZIM MCP 8-tool advanced surface in action — search, get, summarize, browse namespaces, and follow related links across a Wikipedia ZIM archive.
 group: Guides
 sidebar_order: 6
 ---
 
-Five case studies that walk through real retrieval workflows against a Wikipedia ZIM archive. Each one starts from a research question, threads the v2.0.0 advanced-mode tools (`zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`) into an end-to-end answer, and notes the response shape at each step.
+Five case studies that walk through real retrieval workflows against a Wikipedia ZIM archive. Each one starts from a research question, threads the advanced-mode tools (`zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`) into an end-to-end answer, and notes the response shape at each step.
 
-> **Notation:** examples on this page use Python pseudo-call syntax (`zim_search(zim_file_path="...", query="...")`). The MCP wire format is JSON-RPC `{"name": "...", "arguments": {...}}` — your MCP client handles the framing. Argument names and types match the v2.0.0 8-tool surface.
+> **Notation:** examples on this page use Python pseudo-call syntax (`zim_search(zim_file_path="...", query="...")`). The MCP wire format is JSON-RPC `{"name": "...", "arguments": {...}}` — your MCP client handles the framing. Argument names and types match the 8-tool advanced surface.
 
 > All examples assume a Wikipedia ZIM file at `C:\zim\wikipedia_en_100_2025-08.zim`. Substitute your own archive path. Sample responses are truncated for readability.
 
@@ -38,7 +38,7 @@ Response (truncated):
 }
 ```
 
-`zim_health` is one tool with three views (`view="health"`, `view="config"`, `view="archives"`; default is the consolidated payload above) — server status, configuration, and loaded archives in a single call.
+`zim_health` returns server status, configuration, and loaded archives together in one consolidated payload (the shape above) — three v1 tools folded into a single call, with no view selector. Pass a `zim_file_path` to validate one archive instead (integrity + checksum + index/identity).
 
 ---
 
@@ -515,7 +515,7 @@ Simple mode is the default (one tool exposed) and is the right choice when your 
 
 **Next steps:**
 
-- **[API reference](/openzim-mcp/docs/api-reference/)** — full v2.0.0 tool signatures and argument shapes.
+- **[API reference](/openzim-mcp/docs/api-reference/)** — full tool signatures and argument shapes.
 - **[Smart retrieval](/openzim-mcp/docs/smart-retrieval/)** — the four-step fallback inside `zim_get`.
 - **[LLM integration patterns](/openzim-mcp/docs/llm-integration-patterns/)** — simple vs advanced mode, progressive discovery, batching, error handling.
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -23,9 +23,9 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
     <meta property="og:site_name" content="OpenZIM MCP">
     <meta property="og:url" content="https://cameronrye.github.io/openzim-mcp/">
     <meta property="og:title" content="OpenZIM MCP — Knowledge that works offline">
-    <meta property="og:description" content="MCP server for offline ZIM-archive access. 8-tool advanced surface, streamable HTTP, batch retrieval, per-entry resources, subscriptions. v2.0.0.">
+    <meta property="og:description" content="MCP server for offline ZIM-archive access. 8-tool advanced surface, streamable HTTP, batch retrieval, per-entry resources, subscriptions. v2.1.1.">
     <meta property="og:image" content="https://cameronrye.github.io/openzim-mcp/assets/og-image.svg">
-    <meta property="og:image:alt" content="OpenZIM MCP 2.0.0 — Knowledge that works offline">
+    <meta property="og:image:alt" content="OpenZIM MCP 2.1.1 — Knowledge that works offline">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:locale" content="en_US">
@@ -38,9 +38,9 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
     <meta name="twitter:creator" content="@cameronrye">
     <meta name="twitter:url" content="https://cameronrye.github.io/openzim-mcp/">
     <meta name="twitter:title" content="OpenZIM MCP — Knowledge that works offline">
-    <meta name="twitter:description" content="MCP server for offline ZIM-archive access. 8-tool advanced surface, streamable HTTP, batch retrieval, per-entry resources, subscriptions. v2.0.0.">
+    <meta name="twitter:description" content="MCP server for offline ZIM-archive access. 8-tool advanced surface, streamable HTTP, batch retrieval, per-entry resources, subscriptions. v2.1.1.">
     <meta name="twitter:image" content="https://cameronrye.github.io/openzim-mcp/assets/og-image.svg">
-    <meta name="twitter:image:alt" content="OpenZIM MCP 2.0.0 — Knowledge that works offline">
+    <meta name="twitter:image:alt" content="OpenZIM MCP 2.1.1 — Knowledge that works offline">
 
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico">
@@ -75,7 +75,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
       "alternateName": "OpenZIM MCP Server",
       "description": "A modern, secure MCP server that enables AI models to access and search ZIM format knowledge bases offline with intelligent, structured access patterns",
       "url": "https://cameronrye.github.io/openzim-mcp/",
-      "softwareVersion": "2.0.0",
+      "softwareVersion": "2.1.1",
       "releaseNotes": "https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md",
       "applicationCategory": "DeveloperApplication",
       "applicationSubCategory": "AI Tools",
@@ -147,7 +147,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
     <section id="hero" class="hero">
       <div class="container hero__inner">
         <div class="hero__content">
-          <span class="eyebrow">MCP&nbsp;SERVER · v2.0.0</span>
+          <span class="eyebrow">MCP&nbsp;SERVER · v2.1.1</span>
           <h1 class="hero__title">Knowledge that works offline.</h1>
           <p class="hero__lead">
             OpenZIM MCP gives any AI model structured, secure access to ZIM archives —
@@ -169,7 +169,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
             </button>
           </div>
           <ul class="hero__stats">
-            <li><span class="hero__stat-num">v2.0.0</span><span class="hero__stat-label">Latest release</span></li>
+            <li><span class="hero__stat-num">v2.1.1</span><span class="hero__stat-label">Latest release</span></li>
             <li><span class="hero__stat-num">1 + 8</span><span class="hero__stat-label">Simple / advanced tools</span></li>
             <li><span class="hero__stat-num">80%+</span><span class="hero__stat-label">Test coverage</span></li>
             <li><span class="hero__stat-num">MIT</span><span class="hero__stat-label">License</span></li>
@@ -285,7 +285,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
       <div class="container">
         <span class="v2__watermark" aria-hidden="true">2.0</span>
         <header class="section__header">
-          <span class="eyebrow">The 2.0 release</span>
+          <span class="eyebrow">The v2 surface</span>
           <h2>Eight tools. Same surface area.</h2>
           <p>v2.0.0 collapses the 22-tool advanced mode into 8 consolidated tools — schema text drops from ~36KB to ~23.5KB, clearing the <a href="https://www.mmntm.net/articles/mcp-context-tax">MCP Tax</a> pain band for small-model dispatch.</p>
         </header>
@@ -323,6 +323,18 @@ openzim-mcp --mode advanced /data/zim/
             <pre><code>tests/dispatch_eval/gate_0b_decision.json
 tests/test_phase_f_gate_decision_consistency.py</code></pre>
           </li>
+
+          <li class="v2__card">
+            <span class="v2__card-dot" aria-hidden="true"></span>
+            <h3>New in v2.1 · native libzim</h3>
+            <p>Per-archive validation through <code>zim_health(zim_file_path=…)</code> (<code>Archive.check()</code> + checksum), plus archive identity, full-text / title index capabilities, and an <code>M/Counter</code> mimetype breakdown surfaced in <code>zim_metadata</code>.</p>
+            <pre><code>{`{
+  "name": "zim_health",
+  "arguments": {
+    "zim_file_path": "wiki.zim"
+  }
+}`}</code></pre>
+          </li>
         </ul>
       </div>
     </section>
@@ -348,7 +360,7 @@ tests/test_phase_f_gate_decision_consistency.py</code></pre>
                 <pre><code>uv tool install openzim-mcp</code></pre>
               </div>
               <div class="tabs__panel" id="install-docker" role="tabpanel" aria-labelledby="tab-install-docker" hidden>
-                <pre><code>docker pull ghcr.io/cameronrye/openzim-mcp:2.0.0</code></pre>
+                <pre><code>docker pull ghcr.io/cameronrye/openzim-mcp:2.1.1</code></pre>
               </div>
               <div class="tabs__panel" id="install-source" role="tabpanel" aria-labelledby="tab-install-source" hidden>
                 <pre><code>git clone https://github.com/cameronrye/openzim-mcp.git


### PR DESCRIPTION
## What

Brings the published documentation (README + Astro website) in sync with the shipped **v2.1.1** state. The docs had drifted: they still described the v2.0.0 GA, while v2.1.0 (native libzim reader features) and v2.1.1 have since shipped.

## Changes

**Version facts → 2.1.1**
- README Docker tags; docs `Version` + `Container` fields; landing-page `softwareVersion`, hero eyebrow, "Latest release" stat, and OG/Twitter metadata; `llms.txt` and `humans.txt`.

**Document the v2.1.0 surface additions (API reference)**
- `zim_health(zim_file_path=...)` per-archive validation + the `ArchiveValidationResponse` shape.
- `zim_metadata`'s new `archive_identity` / `index_capabilities` / `counter_breakdown` sections.
- Brief "New in v2.1" note on the README, docs landing, and a card on the marketing landing page.

**Accuracy fixes (verified against code)**
- `zim_health` was documented with a `view="health"|"config"|"archives"` parameter that **doesn't exist** (3 pages) — it returns health/config/archives in one payload, or validates an archive when given a path. Corrected.
- `smart-retrieval` documented `zim_get`'s default view as `"content"`; the actual default is `"full"`. Corrected.

**Maintainability**
- De-versioned the "8-tool surface" descriptors (`v2.0.0 8-tool surface` → `the 8-tool advanced surface`) so they stop going stale each release. Genuine historical v2.0.0 references (e.g. "v2.0.0 collapsed the 22-tool surface", "pre-v2.0.0 crash fixes") are preserved.
- **Fixed a release-please config bug**: `extra-files` pointed at `website/llms.txt`, but the file lives at `website/public/llms.txt` — so the `x-release-please-version` marker had been silently orphaned since v2.0.0. Now corrected, so `llms.txt` auto-bumps on future releases.

## Verification
- `npm run build` (Astro) succeeds — 16 pages, no errors.
- `grep` sweep confirms no stale `:2.0.0` Docker tags or `Version: 2.0.0` fields remain; surviving `v2.0.0` mentions are all genuine historical facts.
- An adversarial multi-reviewer pass over the diff (tech-accuracy vs code, version-consistency, link-integrity, prose) surfaced 3 issues — all fixed in this branch (the two accuracy fixes above + a self-contradiction in the roadmap status line).

## Note
`uv.lock` has a pre-existing, unrelated change in the working tree (editable version 2.0.5 → 2.1.1) — deliberately **excluded** from this docs PR.
