### PR TITLE
fix: guard synthesize tail-promotion against off-topic tail-hijacks

### DIFF
--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -31,14 +31,12 @@ from openzim_mcp import bundle as _bundle_mod
 from openzim_mcp.text_utils import tokenize_for_relevance
 from openzim_mcp.title_promotion import (
     accept_possessive_promotion,
+    accept_tail_promotion,
     find_title_match,
     has_apostrophe_possessive,
-    has_digit_specificity_match,
-    has_topic_prefix_canonical_extension,
     is_strong_title_match,
-    is_tangential_multi_token_shape,
     iter_query_tails,
-    probed_head_matches_promoted,
+    passes_z4,
 )
 from openzim_mcp.tool_schemas import (
     Citation,
@@ -1053,28 +1051,20 @@ def _promote_title_match(
             continue
         if not accept_possessive_promotion(full_probe, query):
             continue
-        # Post-b11 Z4 layer (symmetric to simple_tools.py Pass 0):
-        # multi-token canonical tangential check + three exemptions
-        # (biographical-canonical, digit-specificity, type-extension).
-        # The synthesize Pass 0 has the same shape as simple_tools Pass
-        # 0 and is vulnerable to the same Z4 silent-wrong-answer
-        # pattern. The local ``_probe`` closure forwards to
-        # ``find_title_match`` against the same archive so the
-        # biographical exemption can probe head/tail tokens consistently
-        # with simple_tools.
-        if not has_apostrophe_possessive(query) and is_tangential_multi_token_shape(
-            full_probe, query
-        ):
 
-            def _z4_probe(tok: str, _vp: Path = vp) -> Optional[dict]:
-                return find_title_match(search_handler, str(_vp), tok)
+        # Post-b11 Z4 layer, shared with the tell_me_about path via
+        # ``title_promotion.passes_z4`` (post-v2.1.3 anti-drift extraction
+        # — Pass 0 previously hand-inlined this same check). Rejects a
+        # multi-token tangential canonical unless a biographical /
+        # digit-specificity / type-extension exemption applies; possessive
+        # queries bypass Z4 inside ``passes_z4``. ``_z4_probe`` forwards to
+        # ``find_title_match`` against the same archive so the exemption
+        # probes stay consistent with simple_tools.
+        def _z4_probe(tok: str, _vp: Path = vp) -> Optional[dict]:
+            return find_title_match(search_handler, str(_vp), tok)
 
-            if not (
-                probed_head_matches_promoted(query, full_probe, _z4_probe)
-                or has_digit_specificity_match(full_probe, query)
-                or has_topic_prefix_canonical_extension(full_probe, query)
-            ):
-                continue
+        if not passes_z4(full_probe, query, _z4_probe):
+            continue
         full_path = str(full_probe["path"])
         existing_paths_p0 = {(name, str(h.get("path", ""))) for name, h in top_hits}
         if (archive_name, full_path) in existing_paths_p0:
@@ -1128,6 +1118,22 @@ def _promote_title_match(
                 continue
             promoted_path = str(promoted.get("path", ""))
             if not promoted_path:
+                continue
+
+            # Post-v2.1.3 D1: guard the tail promotion with the SAME
+            # tail-hijack / multi-entity gate the tell_me_about path uses
+            # (``accept_tail_promotion``). Without it, an off-topic
+            # single-token tail that happens to be an exact article title
+            # (``ssh connection refused`` -> the punk band ``Refused``)
+            # was promoted to rank 0 AND tagged ``promoted``, so
+            # ``_drop_cross_archive_leakage`` exempted it from the
+            # cross-archive relevance floor — surfacing irrelevant
+            # content as the primary citation. The probe resolves a topic
+            # token against the SAME archive the candidate came from.
+            def _tail_probe(tok: str, _p: Path = _vp) -> Optional[dict]:
+                return find_title_match(search_handler, str(_p), tok)
+
+            if not accept_tail_promotion(promoted, query, _tail_probe):
                 continue
             if (archive_name, promoted_path) in existing_paths:
                 # Already present — re-rank it to first instead of duplicating.

--- a/openzim_mcp/title_promotion.py
+++ b/openzim_mcp/title_promotion.py
@@ -992,6 +992,71 @@ def _accept_possessive_redirect(promoted: Dict[str, Any], topic: str) -> bool:
     return bool(possessors & cand_tokens)
 
 
+def passes_z4(
+    promoted: Dict[str, Any],
+    topic: str,
+    title_probe: Callable[[str], Optional[Dict[str, Any]]],
+) -> bool:
+    """Post-b11 Z4 layer, shared by the tell_me_about
+    (``topic_preprocessing.promote_topic_via_title_index``) and
+    synthesize (``synthesize._promote_title_match``) promotion paths so
+    the two cannot drift.
+
+    Accept the promotion UNLESS it is a multi-token tangential canonical
+    (``is_tangential_multi_token_shape``) with none of the three
+    exemptions: biographical-canonical (a topic token probes to the same
+    canonical), digit-specificity (numbered instance), or type-extension
+    (canonical's leading tokens are a 2+-token contiguous topic slice).
+    Possessive topics bypass Z4 — their own accept gate
+    (``accept_possessive_promotion``) handles them.
+    """
+    if has_apostrophe_possessive(topic):
+        return True
+    if not is_tangential_multi_token_shape(promoted, topic):
+        return True
+    if probed_head_matches_promoted(topic, promoted, title_probe):
+        return True
+    if has_digit_specificity_match(promoted, topic):
+        return True
+    if has_topic_prefix_canonical_extension(promoted, topic):
+        return True
+    return False
+
+
+def accept_tail_promotion(
+    promoted: Dict[str, Any],
+    topic: str,
+    title_probe: Callable[[str], Optional[Dict[str, Any]]],
+) -> bool:
+    """Acceptance gate for a tail-iteration title promotion.
+
+    Shared by the tell_me_about tail loop (Pass 1 / Pass 2 of
+    ``promote_topic_via_title_index``) and the synthesize tail loop
+    (``_promote_title_match``) so a tail-hijack cannot slip through one
+    path while the other guards it — the post-b4 D3 / "synthesize never
+    got the treatment" drift class. ``title_probe`` resolves a single
+    topic token to a title-index hit (or ``None``); it is used by the
+    multi-entity discriminator and the Z4 biographical exemption.
+
+    Possessive topics defer entirely to ``accept_possessive_promotion``
+    (the b6/b7/b8 possessor-token rules). Non-possessive topics apply
+    the base accept gate; if it rejects as a single-token tail-hijack
+    (``Stalin USSR Russia`` -> ``Russia``, ``ssh connection refused`` ->
+    ``Refused``), the b10 single-entity escape re-accepts ONLY when the
+    topic is genuine filler-prose around one entity (fewer than two
+    OTHER strong entities probe successfully — ``what is the population
+    of detroit`` -> ``Detroit`` stays accepted). Otherwise the Z4
+    multi-token tangential layer applies.
+    """
+    if has_apostrophe_possessive(topic):
+        return accept_possessive_promotion(promoted, topic)
+    if not accept_possessive_promotion(promoted, topic):
+        if not is_tail_hijack_shape(promoted, topic):
+            return False
+        return count_non_tail_strong_entities(topic, title_probe, limit=2) < 2
+    return passes_z4(promoted, topic, title_probe)
+
+
 def iter_query_tails(
     query: str,
     *,

--- a/openzim_mcp/topic_preprocessing.py
+++ b/openzim_mcp/topic_preprocessing.py
@@ -32,16 +32,12 @@ from typing import Any, Dict, Optional
 
 from .title_promotion import (
     accept_possessive_promotion,
-    count_non_tail_strong_entities,
+    accept_tail_promotion,
     find_title_match,
     has_apostrophe_possessive,
-    has_digit_specificity_match,
-    has_topic_prefix_canonical_extension,
-    is_tail_hijack_shape,
-    is_tangential_multi_token_shape,
     iter_query_tails,
     iter_query_windows,
-    probed_head_matches_promoted,
+    passes_z4,
 )
 
 # Preserve the pre-extraction log-record ``name`` field so the operator-
@@ -116,54 +112,34 @@ def promote_topic_via_title_index(
     def _probe(token_str: str) -> Optional[Dict[str, Any]]:
         return find_title_match(zim_operations, zim_file_path, token_str)
 
-    # Post-b11 Z4 layer. Multi-token tangential canonicals
-    # (``Lenin Russia`` → ``Leninist_Komsomol_of_the_Russian_Federation``,
-    # ``Tesla electricity`` → ``Tesla's_Wireless_Electricity``,
-    # ``Mozart Vienna`` → ``Mozarthaus_Vienna``,
-    # ``Beethoven symphony`` → ``Symphony_No._1_(Beethoven)``,
-    # ``Marie Curie radioactivity`` → ``Radioactive_(Redniss_book)``)
-    # surface where ``is_tail_hijack_shape`` doesn't fire (canonical
-    # is multi-token). Z4 rejects them UNLESS one of three
-    # exemptions applies: biographical-canonical (head probe
-    # matches promoted), digit-specificity (numbered-instance
-    # signal), or type-extension (canonical's leading tokens are
-    # a 2+-token contiguous topic slice with extras only at
-    # suffix — preserves ``Big Rapids Michigan Ferris State`` →
-    # ``Ferris_State_University``). The Z4 check is applied at
-    # every pass (0, 1, 2, 3) so the defect class can't slip
-    # through a different gate.
+    # Post-b11 Z4 layer + b10 Z3 multi-entity discriminator. The actual
+    # logic lives in ``title_promotion.passes_z4`` /
+    # ``title_promotion.accept_tail_promotion`` so the synthesize tail
+    # loop (``_promote_title_match``) shares the SAME gate and the two
+    # promotion paths can't drift (the post-b4 D3 /
+    # "synthesize never got the treatment" class — re-confirmed by the
+    # post-v2.1.3 sweep's HIGH ``ssh connection refused`` -> ``Refused``
+    # inversion). These thin closures just bind the per-call ``topic``
+    # and ``_probe`` so the four pass call-sites below stay terse.
+    #
+    # ``_passes_z4`` (Pass 0 / Pass 3): reject multi-token tangential
+    # canonicals (``Lenin Russia`` -> ``Leninist_Komsomol_...``,
+    # ``Mozart Vienna`` -> ``Mozarthaus_Vienna``) unless one of three
+    # exemptions applies (biographical-canonical, digit-specificity,
+    # type-extension like ``Big Rapids Michigan Ferris State`` ->
+    # ``Ferris_State_University``).
     def _passes_z4(promoted_arg: Dict[str, Any]) -> bool:
-        if has_apostrophe_possessive(topic):
-            return True
-        if not is_tangential_multi_token_shape(promoted_arg, topic):
-            return True
-        if probed_head_matches_promoted(topic, promoted_arg, _probe):
-            return True
-        if has_digit_specificity_match(promoted_arg, topic):
-            return True
-        if has_topic_prefix_canonical_extension(promoted_arg, topic):
-            return True
-        return False
+        return passes_z4(promoted_arg, topic, _probe)
 
-    # Post-b10 Z3 multi-entity discriminator wrapper. Pass 1 / Pass 2
-    # consult this gate, which layers the b10 single-entity escape
-    # over the b9 unconditional tail-hijack rejection, then applies
-    # the b11 Z4 check on top. Pass 0 / Pass 3 use the bare
-    # ``accept_possessive_promotion`` + ``_passes_z4`` pair (no
-    # single-entity escape — that escape exists for Pass 1's
-    # 1-token-tail filler-prose pattern, not for Pass 0's full-
-    # topic probe).
+    # ``_accept_with_multi_entity_check`` (Pass 1 / Pass 2): layers the
+    # b10 single-entity escape over the b9 tail-hijack rejection, then
+    # Z4. Pass 0 / Pass 3 use the bare ``accept_possessive_promotion`` +
+    # ``_passes_z4`` pair (no single-entity escape — that escape exists
+    # for Pass 1's 1-token-tail filler-prose pattern only).
     def _accept_with_multi_entity_check(
         promoted_arg: Dict[str, Any],
     ) -> bool:
-        if has_apostrophe_possessive(topic):
-            return accept_possessive_promotion(promoted_arg, topic)
-        base_accept = accept_possessive_promotion(promoted_arg, topic)
-        if not base_accept:
-            if not is_tail_hijack_shape(promoted_arg, topic):
-                return False
-            return count_non_tail_strong_entities(topic, _probe, limit=2) < 2
-        return _passes_z4(promoted_arg)
+        return accept_tail_promotion(promoted_arg, topic, _probe)
 
     # Pass 0 acceptance: base accept gate + Z4 layer. Stalin USSR
     # Russia → Russia (tail-hijack) is rejected here unconditionally

--- a/tests/test_post_b9_beta_fixes.py
+++ b/tests/test_post_b9_beta_fixes.py
@@ -457,14 +457,20 @@ class TestStructuralGuards:
         live Z3 silent-wrong-answer code path (1-token tail
         ``"russia"`` → direct match → returned without gating).
 
-        Post-b10 update: Pass 1 / Pass 2 now go through the
+        Post-b10 update: Pass 1 / Pass 2 go through the
         ``_accept_with_multi_entity_check`` wrapper (defined inside
-        ``_promote_topic_via_title_index``) which calls
-        ``accept_possessive_promotion`` once. So the dispatcher
-        source has three direct ``accept_possessive_promotion(`` call
-        sites — Pass 0, the wrapper, and Pass 3 — plus the helper
-        invocation. The pin asserts the wrapper is wired by name AND
-        every gate path is present.
+        ``_promote_topic_via_title_index``).
+
+        Post-v2.1.3 update: the wrapper body and the Z4 layer were
+        extracted to the SHARED ``title_promotion.accept_tail_promotion``
+        / ``title_promotion.passes_z4`` gate so the synthesize tail loop
+        (``_promote_title_match``) consults the identical logic and the
+        two promotion paths can't drift (the post-v2.1.3 HIGH
+        ``ssh connection refused`` -> ``Refused`` cross-archive
+        inversion). Pass 0 / Pass 3 still call
+        ``accept_possessive_promotion`` directly; Pass 1 / Pass 2 route
+        through the wrapper, which delegates to ``accept_tail_promotion``.
+        The pin asserts every gate path is still present.
         """
         # Phase F: orchestrator body lives in
         # ``openzim_mcp.topic_preprocessing.promote_topic_via_title_index``.
@@ -473,22 +479,28 @@ class TestStructuralGuards:
         from openzim_mcp.topic_preprocessing import promote_topic_via_title_index
 
         source = inspect.getsource(promote_topic_via_title_index)
-        # Pass 0, the multi-entity wrapper (which calls
-        # accept_possessive_promotion once), and Pass 3 → 3 direct
-        # ``accept_possessive_promotion(`` callsites.
+        # Post-v2.1.3: the wrapper body + Z4 layer were extracted to the
+        # shared title_promotion.accept_tail_promotion / passes_z4 gate
+        # (so the synthesize tail loop shares identical logic). Pass 0
+        # and Pass 3 still gate directly with accept_possessive_promotion.
         count = source.count("accept_possessive_promotion(")
-        assert count >= 3, (
+        assert count >= 2, (
             f"promote_topic_via_title_index must call "
-            f"accept_possessive_promotion on every pass; found "
-            f"{count} call(s), expected >= 3 (pass-0, multi-entity "
-            f"wrapper covering pass-1 + pass-2, pass-3)."
+            f"accept_possessive_promotion directly on pass-0 and pass-3; "
+            f"found {count} call(s), expected >= 2."
         )
         # The multi-entity wrapper must be wired by name into both
-        # Pass 1 (iter_query_tails) and Pass 2 (iter_query_windows).
+        # Pass 1 (iter_query_tails) and Pass 2 (iter_query_windows), and
+        # must delegate to the shared accept_tail_promotion gate.
         assert "_accept_with_multi_entity_check" in source, (
             "promote_topic_via_title_index must define + use the "
             "_accept_with_multi_entity_check wrapper to gate Pass 1 "
             "and Pass 2 with the post-b10 multi-entity discriminator"
+        )
+        assert "accept_tail_promotion(" in source, (
+            "the multi-entity wrapper must delegate to the shared "
+            "title_promotion.accept_tail_promotion gate (post-v2.1.3 "
+            "anti-drift extraction shared with synthesize)"
         )
 
     def test_possessive_redirect_has_canonical_possessor_fallback(self) -> None:

--- a/tests/test_post_v2_1_3_beta_fixes.py
+++ b/tests/test_post_v2_1_3_beta_fixes.py
@@ -1,0 +1,218 @@
+"""Post-v2.1.3 live-beta-sweep regression suite.
+
+The v2.1.3 live beta sweep (remote dual-archive library: Wikipedia
+2026-02 + superuser.com 2026-02) surfaced a HIGH-severity synthesize
+defect:
+
+  D1 — synthesize promotes an off-topic single-token exact-title match
+  to the PRIMARY citation. ``synthesize("ssh connection refused")``
+  returned the Wikipedia article ``Refused`` (a Swedish hardcore punk
+  band) at rank 1 / score 1.0, demoting the two genuinely relevant
+  superuser.com SSH troubleshooting Q&As to ranks 2-3. The answer led
+  with band metadata cited as the authoritative source.
+
+Root cause: ``synthesize._promote_title_match``'s tail-iteration loop
+(the ``iter_query_tails`` probe) promoted the single-token tail
+``"refused"`` -> exact-title article with NO tangential/tail-hijack
+guard, then tagged it ``promoted`` so ``_drop_cross_archive_leakage``
+exempted it from the cross-archive relevance floor. The sibling
+``simple_tools`` / ``topic_preprocessing`` tail loop already guards this
+case via the b9/b10 tail-hijack + multi-entity discriminator
+(``_accept_with_multi_entity_check``); the synthesize tail loop was the
+narrow-scope sibling that never got the treatment (cf. post-b4 D3,
+which flagged the same "synthesize never got the pass-0 treatment"
+shape).
+
+The fix mirrors that guard in the synthesize tail loop via the shared
+``accept_tail_promotion`` gate, so the two promotion paths can no longer
+drift. Critically, the guard must NOT over-reject legitimate
+single-entity-in-filler-prose tails (``population of detroit`` ->
+``Detroit``) or multi-token entity tails (``big rapids michigan`` ->
+``Big_Rapids,_Michigan``) — those regression cases are pinned below.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock, patch
+
+
+class _Archive:
+    """Minimal stand-in for a libzim ``Archive`` handle."""
+
+    def __init__(self, label: str) -> None:
+        self.label = label
+
+
+class TestD1SynthesizeTailHijackGuard:
+    """D1: the synthesize tail loop must not promote an off-topic
+    single-token tail-hijack when the multi-token query carries 2+ other
+    strong entities."""
+
+    def test_ssh_connection_refused_does_not_promote_band(self) -> None:
+        from openzim_mcp.synthesize import _promote_title_match
+
+        wiki = _Archive("wiki")
+        su = _Archive("su")
+
+        def fake_title_match_hit(archive: Any, title: str) -> Optional[Dict[str, Any]]:
+            # Only the bare 1-token tail "refused" resolves as an exact
+            # title — to the off-topic Swedish punk band, on Wikipedia.
+            if archive is wiki and title == "refused":
+                return {
+                    "path": "Refused",
+                    "snippet": "Refused are a Swedish hardcore punk band ...",
+                    "score": 1.0,
+                }
+            return None
+
+        def fake_find_title_match(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            t = topic.lower()
+            # Pass-0 full-query probe: no canonical for the full query.
+            if t == "ssh connection refused":
+                return None
+            # Per-token probes consumed by the multi-entity discriminator.
+            # The probed token must appear in the resolved path/pre-path
+            # tokens to be counted as a strong entity.
+            if t == "ssh":
+                return {
+                    "path": "Secure_Shell",
+                    "title": "Secure Shell",
+                    "match_type": "redirect",
+                    "pre_redirect_path": "SSH",
+                }
+            if t == "connection":
+                return {
+                    "path": "Connection",
+                    "title": "Connection",
+                    "match_type": "direct",
+                }
+            return None
+
+        handler = MagicMock()
+        handler.title_match_hit = fake_title_match_hit
+
+        # A weak BM25 top hit (no query-token overlap) so the
+        # is_strong_title_match short-circuit does not fire and the
+        # promotion path actually runs.
+        top_hits = [
+            (
+                "su",
+                {
+                    "path": "questions/977104/ssh-connect-issue",
+                    "title": "SSH connect issue",
+                    "snippet": "connect to host localhost port 22 ...",
+                    "score": 0.3,
+                },
+            )
+        ]
+
+        with patch(
+            "openzim_mcp.synthesize.find_title_match",
+            side_effect=fake_find_title_match,
+        ):
+            result = _promote_title_match(
+                top_hits,
+                query="ssh connection refused",
+                archives=[(wiki, "/wiki.zim"), (su, "/su.zim")],
+                archives_searched=["wiki", "su"],
+                search_handler=handler,
+            )
+
+        promoted_paths = [hit.get("path") for _name, hit in result]
+        assert "Refused" not in promoted_paths, (
+            "off-topic single-token tail-hijack 'Refused' must not be "
+            f"promoted for a multi-entity query; got {promoted_paths!r}"
+        )
+        assert result[0][1]["path"] == "questions/977104/ssh-connect-issue", (
+            "the relevant BM25 hit must stay at rank 0; got "
+            f"{result[0][1]['path']!r}"
+        )
+
+
+class TestD1GuardDoesNotOverReject:
+    """The tail-hijack guard must preserve LEGITIMATE tail promotions:
+    single-entity-in-filler-prose and multi-token entity tails."""
+
+    def _run(
+        self,
+        query: str,
+        title_hits: Dict[str, Dict[str, Any]],
+        token_probes: Dict[str, Dict[str, Any]],
+    ) -> list:
+        from openzim_mcp.synthesize import _promote_title_match
+
+        wiki = _Archive("wiki")
+
+        def fake_title_match_hit(archive: Any, title: str) -> Optional[Dict[str, Any]]:
+            return title_hits.get(title)
+
+        def fake_find_title_match(
+            zim_ops: Any,
+            zim_file_path: str,
+            topic: str,
+            *,
+            cross_file: bool = False,
+            min_score: float = 1.0,
+        ) -> Optional[Dict[str, Any]]:
+            # Pass-0 full-query probe always misses here so the tail loop runs.
+            if topic.lower() == query.lower():
+                return None
+            return token_probes.get(topic.lower())
+
+        handler = MagicMock()
+        handler.title_match_hit = fake_title_match_hit
+        weak_top = [("wiki", {"path": "Some_BM25_Noise", "title": "x", "score": 0.1})]
+        with patch(
+            "openzim_mcp.synthesize.find_title_match",
+            side_effect=fake_find_title_match,
+        ):
+            return _promote_title_match(
+                weak_top,
+                query=query,
+                archives=[(wiki, "/wiki.zim")],
+                archives_searched=["wiki"],
+                search_handler=handler,
+            )
+
+    def test_population_of_detroit_still_promotes_detroit(self) -> None:
+        # Filler prose around ONE entity: only "population" is a
+        # non-stop-word non-tail token, so the b10 single-entity escape
+        # re-accepts the tail-hijack-shaped "Detroit".
+        result = self._run(
+            "what is the population of detroit",
+            title_hits={"detroit": {"path": "Detroit", "snippet": "", "score": 1.0}},
+            token_probes={
+                "population": {"path": "Population", "match_type": "direct"},
+            },
+        )
+        assert result[0][1]["path"] == "Detroit", (
+            f"legitimate filler-prose tail promotion was wrongly rejected; "
+            f"got {[h.get('path') for _n, h in result]!r}"
+        )
+
+    def test_big_rapids_michigan_multi_token_tail_still_promotes(self) -> None:
+        # Multi-token entity tail whose tokens are a subset of the topic:
+        # not a tail-hijack, not Z4-tangential -> still promoted.
+        result = self._run(
+            "famous people from big rapids michigan",
+            title_hits={
+                "big rapids michigan": {
+                    "path": "Big_Rapids,_Michigan",
+                    "snippet": "",
+                    "score": 1.0,
+                }
+            },
+            token_probes={},
+        )
+        assert result[0][1]["path"] == "Big_Rapids,_Michigan", (
+            f"legitimate multi-token entity tail promotion was wrongly "
+            f"rejected; got {[h.get('path') for _n, h in result]!r}"
+        )


### PR DESCRIPTION
## Post-v2.1.3 live beta-test sweep

A live sweep of v2.1.3 against the dual-archive library (Wikipedia 2026-02 + superuser.com 2026-02) confirmed all three v2.1.3 fixes working (synthesize cross-archive leak gate, browse/walk asset filter + scan-fill, MedlinePlus furniture non-regression) and the full recurring regression battery green. It surfaced one **HIGH** synthesize defect.

### D1 (HIGH) — fixed here
`synthesize("ssh connection refused")` returned the Wikipedia article **`Refused`** (a Swedish hardcore punk band) as the **rank-1 primary citation**, demoting the two genuinely relevant superuser.com SSH troubleshooting Q&As to ranks 2–3; the answer led with band metadata cited as authoritative.

**Root cause:** `synthesize._promote_title_match`'s tail-iteration loop promoted the single-token tail `"refused"` → exact-title article with **no tail-hijack guard**, then tagged it `promoted`, so `_drop_cross_archive_leakage` exempted it from the cross-archive relevance floor.

The `tell_me_about` path (`topic_preprocessing.promote_topic_via_title_index`) already guards this via its b9/b10 tail-hijack + multi-entity discriminator. The synthesize path never got the treatment — the same "synthesize never got the treatment" drift class flagged by post-b4 D3.

### Fix — shared anti-drift gate
- Extract the gate (`accept_tail_promotion`) and the Z4 layer (`passes_z4`) into `title_promotion.py` as shared, behavior-preserving functions.
- Rewire `topic_preprocessing` to delegate to them (Pass 0–3).
- Route **both** synthesize promotion points — pass-0 (previously hand-inlined) and the tail loop — through the same shared gate, so the two paths can no longer drift.

For `"ssh connection refused"`: non-possessive → `accept_possessive_promotion` rejects the single-token tail-hijack → 2 strong non-tail entities (`ssh`, `connection`) → the b10 single-entity escape does **not** fire → promotion rejected → the relevant superuser hits stay at the top. Legitimate promotions are preserved (`population of detroit` → `Detroit` single-entity escape; `big rapids michigan` → `Big_Rapids,_Michigan` multi-token subset), pinned by tests.

### Tests
- `tests/test_post_v2_1_3_beta_fixes.py`: D1 repro (rejects `Refused`) + two over-rejection regression guards.
- Updated the post-b9 structural pin to track the extraction (Pass 1/2 now delegate to the shared `accept_tail_promotion`).
- Full suite: **2832 passed, 216 skipped**. flake8 / isort / black / mypy clean.

### Deferred follow-ups (need deploy-and-reprobe against the live archive)
- **D2 (MED):** `synthesize("Einstein's theory")` → bare `Theory` instead of `Theory_of_relativity`. The mis-promotion originates in a pass-0 possessive acceptance whose `match_type` depends on what libzim's suggestion/typo engine returns on the live 118 GB archive — **not reproducible from the local checkout**. Same-archive (no cross-archive inversion), strictly less harmful than D1; the canonical remains reachable via `tell_me_about` / `search` / `find` / `get`.
- **2-token sibling of D1:** `synthesize("connection refused")` is still uncaught — the tail-hijack discriminator has a deliberate `<3-token` floor (the b4 `Berlin Germany → Berlin` carve-out). A 2-token-safe fix needs a cross-archive-aware guard that won't regress that carve-out.
