### PR TITLE
chore: declare __all__ on the constants re-export facade (CodeQL #240)

### DIFF
--- a/openzim_mcp/constants.py
+++ b/openzim_mcp/constants.py
@@ -66,3 +66,53 @@ CACHE_HIGH_HIT_RATE_THRESHOLD = CACHE_PERFORMANCE.HIGH_HIT_RATE
 NAMESPACE_MAX_SAMPLE_SIZE = NAMESPACE_SAMPLING.MAX_SAMPLE_SIZE
 NAMESPACE_MAX_ENTRIES = NAMESPACE_SAMPLING.MAX_NAMESPACE_ENTRIES
 NAMESPACE_SAMPLE_ATTEMPTS_MULTIPLIER = NAMESPACE_SAMPLING.MAX_SAMPLE_ATTEMPTS_MULTIPLIER
+
+# Declare the full public surface. This module is a backward-compat facade:
+# the names below are re-exported for external consumers (and several are
+# imported by sibling modules), so they are intentionally "unused" within
+# this file. Listing them in ``__all__`` marks them as the public API,
+# which suppresses the CodeQL ``py/unused-import`` note (it honours
+# ``__all__`` membership) the same way the per-line ``# noqa: F401`` silences
+# flake8 — without deleting re-exports the package depends on.
+__all__ = [
+    # Structured defaults re-exported from ``defaults`` (new code should
+    # import these from ``openzim_mcp.defaults`` directly).
+    "BATCH",
+    "CACHE",
+    "CACHE_PERFORMANCE",
+    "CONTENT",
+    "FURNITURE_HEADING_DENYLIST",
+    "FURNITURE_HEADING_PREFIXES",
+    "INPUT_LIMITS",
+    "NAMESPACE_SAMPLING",
+    "RATE_LIMIT",
+    "SERVER",
+    "TIMEOUTS",
+    "TOOL_MODE_ADVANCED",
+    "TOOL_MODE_SIMPLE",
+    "UNWANTED_HTML_SELECTORS",
+    "VALID_TOOL_MODES",
+    "VALID_TRANSPORT_TYPES",
+    "ZIM_FILE_EXTENSION",
+    # Legacy flat constant names (derived above) kept for backward compat.
+    "DEFAULT_SNIPPET_LENGTH",
+    "DEFAULT_MAX_CONTENT_LENGTH",
+    "DEFAULT_SEARCH_LIMIT",
+    "DEFAULT_CACHE_SIZE",
+    "DEFAULT_CACHE_TTL",
+    "DEFAULT_MAX_BINARY_SIZE",
+    "MAX_BATCH_SIZE",
+    "INPUT_LIMIT_FILE_PATH",
+    "INPUT_LIMIT_QUERY",
+    "INPUT_LIMIT_ENTRY_PATH",
+    "INPUT_LIMIT_NAMESPACE",
+    "INPUT_LIMIT_CONTENT_TYPE",
+    "INPUT_LIMIT_PARTIAL_QUERY",
+    "REGEX_TIMEOUT_SECONDS",
+    "DEFAULT_MAIN_PAGE_TRUNCATION",
+    "CACHE_LOW_HIT_RATE_THRESHOLD",
+    "CACHE_HIGH_HIT_RATE_THRESHOLD",
+    "NAMESPACE_MAX_SAMPLE_SIZE",
+    "NAMESPACE_MAX_ENTRIES",
+    "NAMESPACE_SAMPLE_ATTEMPTS_MULTIPLIER",
+]

--- a/tests/test_constants_reexport.py
+++ b/tests/test_constants_reexport.py
@@ -1,0 +1,47 @@
+"""Pin the public surface of the ``constants`` backward-compat facade.
+
+``openzim_mcp.constants`` re-exports values from ``defaults`` for backward
+compatibility; sibling modules and external consumers import them from here.
+CodeQL's ``py/unused-import`` (alert #240) flagged the re-exports because the
+facade lacked an ``__all__``. The fix declares ``__all__`` rather than
+deleting the imports. These tests guard against a future "just delete the
+unused import" regression that would silently break the public API.
+"""
+
+from __future__ import annotations
+
+from openzim_mcp import constants
+
+
+def test_all_names_are_defined() -> None:
+    """Every name in ``__all__`` must resolve (guards F822-style drift and
+    accidental deletion of a re-export)."""
+    missing = [name for name in constants.__all__ if not hasattr(constants, name)]
+    assert not missing, f"__all__ lists undefined names: {missing}"
+
+
+def test_previously_flagged_reexports_present() -> None:
+    """The exact re-exports CodeQL #240 flagged must remain importable from
+    ``constants`` (they are consumed by server/security/main/content_processor
+    and the documented backward-compat surface)."""
+    flagged = [
+        "FURNITURE_HEADING_DENYLIST",
+        "FURNITURE_HEADING_PREFIXES",
+        "RATE_LIMIT",
+        "SERVER",
+        "TOOL_MODE_ADVANCED",
+        "TOOL_MODE_SIMPLE",
+        "UNWANTED_HTML_SELECTORS",
+        "VALID_TOOL_MODES",
+        "VALID_TRANSPORT_TYPES",
+        "ZIM_FILE_EXTENSION",
+    ]
+    for name in flagged:
+        assert name in constants.__all__, f"{name} dropped from constants.__all__"
+        assert hasattr(constants, name), f"{name} no longer importable from constants"
+
+
+def test_all_has_no_duplicates_and_is_public() -> None:
+    """``__all__`` entries are unique and public (no dunder/private names)."""
+    assert len(constants.__all__) == len(set(constants.__all__)), "duplicate in __all__"
+    assert all(not n.startswith("_") for n in constants.__all__)


### PR DESCRIPTION
Resolves CodeQL `py/unused-import` alert [#240](https://github.com/cameronrye/openzim-mcp/security/code-scanning/240).

`openzim_mcp/constants.py` is a **backward-compat re-export facade** (per its module docstring) — it imports values from `defaults.py` and re-exports them. The flagged names are not used *within* `constants.py`, but they are part of the public API and are imported from here by sibling modules (`server.py`, `security.py`, `main.py`, `content_processor.py`, `zim/*`, …) and external consumers. CodeQL flagged them because the module had no `__all__`; the per-line `# noqa: F401` silences flake8 but not CodeQL.

**Fix:** declare the full public surface in `__all__` (CodeQL honours `__all__` membership for `py/unused-import`) rather than deleting re-exports the package depends on.

- `__all__` lists all 17 re-exported defaults + 20 derived legacy constants (37 names; verified every entry resolves).
- New `tests/test_constants_reexport.py` pins the surface so a future "remove unused import" cleanup can't silently drop a re-export.

No behavior change. Full suite **2835 passed**; flake8/isort/black/mypy clean; bandit clean on `constants.py`.
