### PR TITLE
ci: make reranker live tests resilient to HuggingFace download outages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -63,7 +63,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false
@@ -132,6 +132,35 @@ jobs:
       - name: Install dependencies with [reranker] extra
         run: |
           uv sync --extra reranker
+
+      - name: Pre-stage reranker test model (retry transient HF outages)
+        run: |
+          # The live reranker tests download Xenova/ms-marco-MiniLM-L-6-v2
+          # from HuggingFace at test time. HF's CDN intermittently 5xx's
+          # mid-run (CI run #800: one runner downloaded fine, another got a
+          # CloudFront error on the same commit). Pre-stage here with our
+          # own backoff — wider than fastembed's internal ~40s — to ride
+          # out transient blips before pytest runs. We deliberately never
+          # fail this step: if staging still can't complete, the
+          # `_require_live_model` fixture skips the download-dependent tests
+          # so an external outage never red-X's main.
+          staged=0
+          for attempt in 1 2 3 4 5; do
+            if uv run openzim-mcp download-models \
+                 --reranker-model-id Xenova/ms-marco-MiniLM-L-6-v2; then
+              echo "reranker model staged on attempt ${attempt}"
+              staged=1
+              break
+            fi
+            if [ "${attempt}" -lt 5 ]; then
+              backoff=$((attempt * 20))
+              echo "::warning::reranker model download attempt ${attempt} failed; retrying in ${backoff}s"
+              sleep "${backoff}"
+            fi
+          done
+          if [ "${staged}" -ne 1 ]; then
+            echo "::warning::reranker model could not be pre-staged after 5 attempts; live tests will skip if HuggingFace stays unreachable"
+          fi
 
       - name: Run ml tests including requires_reranker marker
         run: |
@@ -276,7 +305,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: comprehensive
           name: codecov-comprehensive
           fail_ci_if_error: false

--- a/tests/ml/_reranker_test_support.py
+++ b/tests/ml/_reranker_test_support.py
@@ -1,0 +1,75 @@
+"""Test-support helpers for the live reranker suite.
+
+Not a test module (underscore prefix → not collected). Houses the
+transient-download-failure classifier so it can be unit-tested in
+isolation AND imported by the live test fixture that decides whether a
+HuggingFace download failure should skip (transient outage) or fail
+(real regression)."""
+
+from __future__ import annotations
+
+import socket
+from typing import Iterator, Tuple, Type
+
+# Substrings (matched case-insensitively against the whole exception
+# chain) that mark a download/network failure outside our control. Kept
+# specific on purpose — `"could not load model"` and `"from any source"`
+# are FastEmbed's exact retries-exhausted phrasing, while a genuine
+# "model X is not supported" regression contains neither.
+_TRANSIENT_MESSAGE_MARKERS: Tuple[str, ...] = (
+    "could not download",
+    "could not load model",
+    "from any source",
+    "connection",
+    "timed out",
+    "timeout",
+    "temporarily unavailable",
+    "service unavailable",
+    "max retries",
+    "failed to establish",
+    "name resolution",
+    "getaddrinfo",
+    "network",
+    "remote end closed",
+    "ssl",
+    "502",
+    "503",
+    "504",
+    "429",
+)
+
+# Builtin types that are network failures by construction, regardless of
+# message. `socket.timeout` aliases `TimeoutError` on 3.10+ but is listed
+# explicitly for clarity.
+_TRANSIENT_EXC_TYPES: Tuple[Type[BaseException], ...] = (
+    ConnectionError,
+    TimeoutError,
+    socket.timeout,
+)
+
+
+def _iter_exception_chain(exc: BaseException) -> Iterator[BaseException]:
+    """Yield ``exc`` and every linked cause/context, guarding cycles.
+
+    FastEmbed often surfaces a generic ``RuntimeError`` whose
+    ``__cause__`` is the underlying ``ConnectionError`` — both links must
+    be inspected to classify correctly."""
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        yield current
+        current = current.__cause__ or current.__context__
+
+
+def is_transient_download_failure(exc: BaseException) -> bool:
+    """True when ``exc`` looks like a transient HuggingFace download /
+    network failure (skip the live test) rather than a genuine code or
+    API regression (fail the live test)."""
+    for link in _iter_exception_chain(exc):
+        if isinstance(link, _TRANSIENT_EXC_TYPES):
+            return True
+        message = str(link).lower()
+        if any(marker in message for marker in _TRANSIENT_MESSAGE_MARKERS):
+            return True
+    return False

--- a/tests/ml/test_reranker_live.py
+++ b/tests/ml/test_reranker_live.py
@@ -1,9 +1,12 @@
 """End-to-end tests against the real FastEmbed reranker.
 
-These tests SKIP when the [reranker] extra is not installed. CI runs
-them in a dedicated job (see .github/workflows/test.yml). They confirm
-the FastEmbed API surface matches our wrapper and that the reranker
-actually reorders results in a predictable way.
+These tests SKIP when the [reranker] extra is not installed, and the
+download-dependent ones also SKIP when the model can't be fetched from
+HuggingFace (transient CDN/network outage — not a regression; see the
+`_require_live_model` fixture). CI runs them in a dedicated job (see
+.github/workflows/test.yml), which pre-stages the model with retries
+first. They confirm the FastEmbed API surface matches our wrapper and
+that the reranker actually reorders results in a predictable way.
 
 Model note: tests use Xenova/ms-marco-MiniLM-L-6-v2 (~80 MB) instead
 of the production default (BAAI/bge-reranker-base, ~1 GB) to keep
@@ -15,7 +18,8 @@ import pytest
 
 from openzim_mcp.config import RerankerConfig
 from openzim_mcp.ml.fallback import reset_kill_switches
-from openzim_mcp.ml.reranker import BGEReranker
+from openzim_mcp.ml.reranker import BGEReranker, _load_model
+from tests.ml._reranker_test_support import is_transient_download_failure
 
 # Lightweight cross-encoder available in fastembed 0.8+; verified to
 # produce correct semantic ordering for the test fixtures below.
@@ -28,15 +32,40 @@ def _reset() -> None:
     reset_kill_switches()
 
 
+@pytest.fixture(scope="module")
+def _require_live_model() -> None:
+    """Probe the test model once before the download-dependent tests run.
+
+    If FastEmbed can't fetch it because HuggingFace is unreachable (a
+    transient CDN/network outage — exactly what broke CI run #800, where
+    one runner downloaded fine and another got a CloudFront error on the
+    same commit), SKIP rather than fail: an external outage is not a code
+    regression. Genuine load errors (renamed kwarg, dropped model, API
+    drift) are re-raised and still fail the suite — see
+    `is_transient_download_failure` for where that line is drawn.
+
+    On success the model lands in FastEmbed's cache, so each test's
+    `BGEReranker.get()` call is a warm-cache hit."""
+    try:
+        _load_model(_TEST_MODEL, None)
+    except Exception as exc:  # noqa: BLE001 — re-raised unless transient
+        if is_transient_download_failure(exc):
+            pytest.skip(
+                f"reranker test model unavailable — transient download/"
+                f"network failure, not a regression: {exc}"
+            )
+        raise
+
+
 @pytest.mark.requires_reranker
 class TestRerankerIntegration:
-    def test_get_loads_model_on_first_call(self) -> None:
+    def test_get_loads_model_on_first_call(self, _require_live_model: None) -> None:
         # Generous timeout for cold-cache CI runs.
         cfg = RerankerConfig(model_id=_TEST_MODEL, first_call_timeout_seconds=120.0)
         reranker = BGEReranker.get(cfg)
         assert reranker is not None
 
-    def test_reranks_known_corpus_correctly(self) -> None:
+    def test_reranks_known_corpus_correctly(self, _require_live_model: None) -> None:
         cfg = RerankerConfig(model_id=_TEST_MODEL, first_call_timeout_seconds=120.0)
         reranker = BGEReranker.get(cfg)
         assert reranker is not None
@@ -75,7 +104,7 @@ class TestRerankerIntegration:
         assert result[0]["path"] == "Chlorophyll"
         assert all("rerank_score" in c for c in result)
 
-    def test_score_pairs_returns_one_per_pair(self) -> None:
+    def test_score_pairs_returns_one_per_pair(self, _require_live_model: None) -> None:
         cfg = RerankerConfig(model_id=_TEST_MODEL, first_call_timeout_seconds=120.0)
         reranker = BGEReranker.get(cfg)
         assert reranker is not None

--- a/tests/ml/test_reranker_skip_classifier.py
+++ b/tests/ml/test_reranker_skip_classifier.py
@@ -1,0 +1,58 @@
+"""Unit tests for the transient-download-failure classifier.
+
+The live reranker tests (`test_reranker_live.py`) download a model from
+HuggingFace at test time. When HuggingFace's CDN is transiently
+unavailable (see CI run #800), that download fails and the tests must
+SKIP rather than fail — an external outage is not a code regression.
+
+But a *genuine* regression (FastEmbed renamed a kwarg, the model id is
+bad, the API shape drifted) must still FAIL loudly. The classifier under
+test is what draws that line, so it gets exhaustive coverage here: every
+"skip" verdict is a promise that we are not masking a real bug."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.ml._reranker_test_support import is_transient_download_failure
+
+
+class TestTransientDownloadFailureClassifier:
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            # The exact message FastEmbed raises after exhausting its
+            # download retries — the failure mode that broke CI #800.
+            RuntimeError(
+                "Could not load model Xenova/ms-marco-MiniLM-L-6-v2 " "from any source."
+            ),
+            ValueError("Could not download model from HuggingFace"),
+            ConnectionError("Connection reset by peer"),
+            TimeoutError("read operation timed out"),
+            OSError(
+                "HTTPSConnectionPool(host='huggingface.co', port=443): "
+                "Max retries exceeded"
+            ),
+            RuntimeError("Server returned 503 Service Temporarily Unavailable"),
+        ],
+    )
+    def test_transient_network_failures_are_skippable(self, exc: BaseException) -> None:
+        assert is_transient_download_failure(exc) is True
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            # A renamed kwarg — real API drift, must fail not skip.
+            TypeError(
+                "TextCrossEncoder.__init__() got an unexpected keyword "
+                "argument 'model_name'"
+            ),
+            # Model genuinely not in the registry — real regression.
+            ValueError("Model some/bad-model is not supported in TextCrossEncoder."),
+            # Inference-shape bug — real regression.
+            AssertionError("expected one score per pair"),
+            KeyError("rerank_score"),
+        ],
+    )
+    def test_genuine_regressions_are_not_skippable(self, exc: BaseException) -> None:
+        assert is_transient_download_failure(exc) is False


### PR DESCRIPTION
## Why

CI **#800** went red, but only the `Test [reranker] extra on Python 3.13` job failed — and only because the live reranker tests download `Xenova/ms-marco-MiniLM-L-6-v2` from HuggingFace *at test time*, and HF's CDN returned CloudFront 5xx errors on that runner mid-run.

This is conclusively a transient external outage, not a regression:

- The **identical commit** (`f7dd969`, a constants `__all__` facade unrelated to ML) downloaded the model fine and **passed all 4 live tests on the Python 3.12 runner of the same run**.
- The same commit also passed CI on its own PR branch minutes earlier.
- fastembed's internal retries (3s/9s/27s ≈ 40s) were exhausted, then `BGEReranker.get()` returned `None` → `assert reranker is not None` failed.

There was no model caching or download retry anywhere in CI, so any HF blip reds `main`.

## What

1. **Pre-stage with backoff retries** (`test-reranker` job): run `openzim-mcp download-models` for the test model before pytest, retrying with 20/40/60/80s backoff (wider than fastembed's internal window). The step never fails — it warms FastEmbed's cache so the tests run warm, or warns and defers to the skip below.
2. **Skip, don't fail, on genuine outages**: a module-scoped `_require_live_model` fixture probes the model once; if it can't be fetched due to a network/download failure it `pytest.skip`s the 3 download-dependent tests. A transient external outage no longer reds `main`.
3. **Keep regressions strict**: a unit-tested classifier (`is_transient_download_failure`) draws the skip/fail line — transient network failures skip, but genuine API drift (renamed kwarg, dropped model, shape bugs) still **fails**. The registry-guard test (`test_production_default_model_is_supported_by_fastembed`, no download) is untouched and stays strict.
4. **Codecov cleanup**: `file:` → `files:` on the three `codecov-action@v6` steps, removing the `Unexpected input(s) 'file'` warning that fired on every run.

## Verification

- `make lint` (flake8 + isort + black over `openzim_mcp` + `tests`) ✓
- `make type-check` ✓
- Full suite: **2845 passed, 216 skipped, 0 failed**
- New classifier tests: RED → GREEN; genuine-regression cases provably stay non-skippable
- `test.yml` YAML + embedded bash validated