### PR TITLE
fix(release): run release-please in pure manifest mode so config + extra-files apply

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,10 +22,15 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v5
         with:
-          # Release type for Python packages
-          release-type: python
-
-          # Configuration file location
+          # Pure manifest mode. release-type, changelog-sections, extra-files
+          # (the llms.txt x-release-please-version bump) and every other knob
+          # all come from release-please-config.json.
+          #
+          # Do NOT re-add a `release-type:` input here. Passing release-type
+          # alongside config-file/manifest-file forces the action into simple
+          # mode, which silently IGNORES the config file — extra-files and
+          # changelog-sections never apply (that bug pinned website/public/
+          # llms.txt at an old version across v2.1.2–v2.1.4).
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ uv tool install openzim-mcp
 pip install openzim-mcp
 
 # Docker (multi-arch image, ghcr.io)
-docker pull ghcr.io/cameronrye/openzim-mcp:2.1.1
-docker run --rm -v /path/to/zim/files:/zim ghcr.io/cameronrye/openzim-mcp:2.1.1 /zim
+docker pull ghcr.io/cameronrye/openzim-mcp:2.1.4
+docker run --rm -v /path/to/zim/files:/zim ghcr.io/cameronrye/openzim-mcp:2.1.4 /zim
 ```
 
 Verify the install:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # openzim-mcp Roadmap
 
-**Status:** Latest release **v2.1.1** (2026-05-30) — PyPI `2.1.1` and `ghcr.io/cameronrye/openzim-mcp:2.1.1` / `:latest`, GitHub Release with assets. v2.0.0 GA shipped 2026-05-27 (as `:2.0.0`); the v2.0.x/v2.1.x line has been kept current via beta-sweep fixes plus the v2.1.0 native-libzim reader features.
+**Status:** Latest release **v2.1.4** (2026-06-02) — PyPI `2.1.4` and `ghcr.io/cameronrye/openzim-mcp:2.1.4` / `:latest`, GitHub Release with assets. v2.0.0 GA shipped 2026-05-27 (as `:2.0.0`); the v2.0.x/v2.1.x line has been kept current via beta-sweep fixes plus the v2.1.0 native-libzim reader features.
 
 This document tracks open work past v2.0.0. Everything here is **additive**: opt-in extras, optional sidecars, or dispatch tuning. None of it changes the v2 tool surface or response contract.
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,62 +7,62 @@
       "changelog-sections": [
         {
           "type": "feat",
-          "section": "### Added",
+          "section": "Added",
           "hidden": false
         },
         {
           "type": "fix",
-          "section": "### Fixed",
+          "section": "Fixed",
           "hidden": false
         },
         {
           "type": "perf",
-          "section": "### Performance",
+          "section": "Performance",
           "hidden": false
         },
         {
           "type": "deps",
-          "section": "### Dependencies",
+          "section": "Dependencies",
           "hidden": false
         },
         {
           "type": "revert",
-          "section": "### Reverted",
+          "section": "Reverted",
           "hidden": false
         },
         {
           "type": "docs",
-          "section": "### Documentation",
+          "section": "Documentation",
           "hidden": false
         },
         {
           "type": "style",
-          "section": "### Style",
+          "section": "Style",
           "hidden": true
         },
         {
           "type": "refactor",
-          "section": "### Refactored",
+          "section": "Refactored",
           "hidden": false
         },
         {
           "type": "test",
-          "section": "### Tests",
+          "section": "Tests",
           "hidden": true
         },
         {
           "type": "build",
-          "section": "### Build System",
+          "section": "Build System",
           "hidden": true
         },
         {
           "type": "ci",
-          "section": "### CI/CD",
+          "section": "CI/CD",
           "hidden": true
         },
         {
           "type": "chore",
-          "section": "### Maintenance",
+          "section": "Maintenance",
           "hidden": true
         }
       ],
@@ -75,7 +75,7 @@
       ],
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
-      "draft": true,
+      "draft": false,
       "prerelease": false,
       "draft-pull-request": false,
       "include-component-in-tag": false,
@@ -84,7 +84,7 @@
       "pull-request-header": "🤖 **Automated Release**\n\nThis PR was created automatically by release-please based on conventional commits since the last release.\n\n**Changes included:**",
       "separate-pull-requests": false,
       "tag-separator": "-",
-      "skip-github-release": true,
+      "skip-github-release": false,
       "release-search-depth": 400,
       "commit-search-depth": 500
     }

--- a/website/public/humans.txt
+++ b/website/public/humans.txt
@@ -60,8 +60,8 @@
 
 # SITE
 
-    Last update: 2026-05-31
+    Last update: 2026-06-02
     Language: English
     Doctype: HTML5
     IDE: Various (VS Code, Vim, etc.)
-    Version: 2.1.1
+    Version: 2.1.4

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -6,7 +6,7 @@
 
 OpenZIM MCP is a Model Context Protocol (MCP) server that enables AI models to access and search ZIM format knowledge bases offline. It provides intelligent, structured access patterns that LLMs need to effectively navigate vast knowledge repositories like Wikipedia, Wiktionary, and other offline content archives.
 
-**Version**: 2.1.1 <!-- x-release-please-version -->
+**Version**: 2.1.4 <!-- x-release-please-version -->
 **License**: MIT
 **Python**: 3.12+
 **Repository**: https://github.com/cameronrye/openzim-mcp

--- a/website/src/content/docs/http-and-docker-deployment.mdx
+++ b/website/src/content/docs/http-and-docker-deployment.mdx
@@ -38,7 +38,7 @@ This binds the loopback interface only. Put a TLS-terminating reverse proxy in f
 docker run --rm -p 8000:8000 \
   -v /srv/zim:/data:ro \
   -e OPENZIM_MCP_AUTH_TOKEN="$(openssl rand -hex 32)" \
-  ghcr.io/cameronrye/openzim-mcp:2.1.1
+  ghcr.io/cameronrye/openzim-mcp:2.1.4
 ```
 
 The published image:
@@ -258,7 +258,7 @@ spec:
     spec:
       containers:
         - name: openzim-mcp
-          image: ghcr.io/cameronrye/openzim-mcp:2.1.1
+          image: ghcr.io/cameronrye/openzim-mcp:2.1.4
           ports:
             - containerPort: 8000
           env:
@@ -338,7 +338,7 @@ This recipe puts OpenZIM MCP on a single host, reachable from the rest of your L
 ```yaml
 services:
   openzim-mcp:
-    image: ghcr.io/cameronrye/openzim-mcp:2.1.1
+    image: ghcr.io/cameronrye/openzim-mcp:2.1.4
     restart: unless-stopped
     ports:
       - "127.0.0.1:8000:8000"
@@ -472,7 +472,7 @@ This is the LAN compose file with two changes: a `caddy` service is added, and t
 ```yaml
 services:
   openzim-mcp:
-    image: ghcr.io/cameronrye/openzim-mcp:2.1.1
+    image: ghcr.io/cameronrye/openzim-mcp:2.1.4
     restart: unless-stopped
     expose:
       - "8000"

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -43,11 +43,11 @@ OpenZIM MCP provides **intelligent, structured access** that LLMs need:
 
 ## Project Status
 
-- **Version:** 2.1.1
+- **Version:** 2.1.4
 - **License:** MIT
 - **Python:** 3.12+
 - **Test Coverage:** 80%+
-- **Container:** `ghcr.io/cameronrye/openzim-mcp:2.1.1` + `:latest` (linux/amd64, linux/arm64)
+- **Container:** `ghcr.io/cameronrye/openzim-mcp:2.1.4` + `:latest` (linux/amd64, linux/arm64)
 
 ## Quick Links
 

--- a/website/src/content/docs/installation.mdx
+++ b/website/src/content/docs/installation.mdx
@@ -232,14 +232,14 @@ OpenZIM MCP ships a multi-arch image at `ghcr.io/cameronrye/openzim-mcp` (`linux
 
 ```bash
 # Pull
-docker pull ghcr.io/cameronrye/openzim-mcp:2.1.1
+docker pull ghcr.io/cameronrye/openzim-mcp:2.1.4
 
 # Run with HTTP transport, bound to all interfaces (the image default).
 # The server REFUSES to bind 0.0.0.0 without OPENZIM_MCP_AUTH_TOKEN.
 docker run --rm -p 8000:8000 \
   -v /srv/zim:/data:ro \
   -e OPENZIM_MCP_AUTH_TOKEN="$(openssl rand -hex 32)" \
-  ghcr.io/cameronrye/openzim-mcp:2.1.1
+  ghcr.io/cameronrye/openzim-mcp:2.1.4
 ```
 
 The image entrypoint is `python -m openzim_mcp /data`, so mount your ZIM directory at `/data`. Default env vars in the image: `OPENZIM_MCP_TRANSPORT=http`, `OPENZIM_MCP_HOST=0.0.0.0`, `OPENZIM_MCP_PORT=8000`.

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -75,7 +75,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
       "alternateName": "OpenZIM MCP Server",
       "description": "A modern, secure MCP server that enables AI models to access and search ZIM format knowledge bases offline with intelligent, structured access patterns",
       "url": "https://cameronrye.github.io/openzim-mcp/",
-      "softwareVersion": "2.1.1",
+      "softwareVersion": "2.1.4",
       "releaseNotes": "https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md",
       "applicationCategory": "DeveloperApplication",
       "applicationSubCategory": "AI Tools",
@@ -360,7 +360,7 @@ tests/test_phase_f_gate_decision_consistency.py</code></pre>
                 <pre><code>uv tool install openzim-mcp</code></pre>
               </div>
               <div class="tabs__panel" id="install-docker" role="tabpanel" aria-labelledby="tab-install-docker" hidden>
-                <pre><code>docker pull ghcr.io/cameronrye/openzim-mcp:2.1.1</code></pre>
+                <pre><code>docker pull ghcr.io/cameronrye/openzim-mcp:2.1.4</code></pre>
               </div>
               <div class="tabs__panel" id="install-source" role="tabpanel" aria-labelledby="tab-install-source" hidden>
                 <pre><code>git clone https://github.com/cameronrye/openzim-mcp.git


### PR DESCRIPTION
## Problem

`website/public/llms.txt` carries an `x-release-please-version` marker and is wired as a release-please `extra-files` entry, yet it never auto-bumped — it stayed pinned at `2.1.1` across v2.1.2, v2.1.3, and v2.1.4. Investigation found the cause is **not** the extra-files entry: the **entire `release-please-config.json` was being ignored**.

### Root cause

`.github/workflows/release-please.yml` ran `release-please-action@v5` with **both** `release-type: python` (a *simple-mode* input) **and** `config-file` + `manifest-file` (*manifest-mode* inputs). These are mutually-exclusive modes. The `release-type` input forces simple mode, where the action synthesizes a python-default config and discards `release-please-config.json` — `changelog-sections`, `extra-files`, `pull-request-title-pattern`, everything. Only `manifest-file` (version tracking) was honored.

Evidence (all consistent):
- `llms.txt` version line only ever changed in manual `docs:` commits, never a release commit.
- The last 3 release commits touched only `manifest` + `CHANGELOG` + `pyproject` (the python defaults).
- CHANGELOG headings used release-please **defaults** (`### Bug Fixes`, `### Reverts`) — the config asks for `### Fixed`, `### Reverted`.
- Release PR titles were `chore(main): release X.Y.Z` (default), not the config's `chore: release ${version}`.

## Fix

Switch to **pure manifest mode**:
- **Remove the `release-type: python` input** (with a prominent comment warning not to re-add it). `release-type: python` is already declared per-package in the config.
- **Strip the literal `### ` prefix** baked into all 12 `changelog-sections` titles. release-please wraps titles in `### `, so the config would have rendered `### ### Fixed` once honored. (Latent bug that only surfaces now that the config is actually read.)
- **Set `draft` and `skip-github-release` to `false`** so the GitHub-release half behaves exactly as it does today (release-please creates a non-draft release shell that `release.yml` uploads assets into). The config previously had these `true`, contradicting live behavior — the pipeline only worked because the whole config was ignored.

## Verification (dry-run)

`npx release-please@17 release-pr --dry-run --trace --target-branch=fix/release-please-manifest-mode` (the `fix:` commit forces a 2.1.5 candidate):

- ✅ `website/public/llms.txt  [class Generic extends DefaultUpdater]` → diff `-**Version**: 2.1.4` / `+**Version**: 2.1.5`
- ✅ Changelog renders `### Fixed` and `### Documentation` (configured names; no `### ###`)
- ✅ `pyproject` + manifest → `2.1.5`; `Would open 1 pull requests`; title `chore: release 2.1.5`

## Caveat — not dry-run-testable

The dry-run covers the **PR-creation** half only. The **GitHub-release / tag / asset-upload** half (manifest-release + `release.yml`) cannot be dry-run-tested. `draft`/`skip-github-release` were set to match current defaults to keep it identical, but **watch the first real 2.1.5 release** (PyPI + ghcr + GH release assets) and keep the v2.0.x asset-recovery steps handy.

Also folds in `cce6962` (manual version-fact sync to v2.1.4 — the workaround this PR makes unnecessary going forward).