### PR TITLE
fix: pyjwt 2.13.0 security floor + repair manifest-mode release tagging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,13 @@ include = ["openzim_mcp*"]
 [tool.setuptools.package-data]
 openzim_mcp = ["data/*.txt", "tools/*.md"]
 
-
+[tool.uv]
+# pyjwt is pulled in transitively via mcp[cli] (which depends on pyjwt[crypto]).
+# Floor it at 2.13.0 so the release pip-audit gate stays clear of
+# PYSEC-2026-175 / -177 / -178 / -179 — four advisories against pyjwt 2.12.1,
+# all fixed in 2.13.0. mcp itself sets no upper bound, so this only raises the
+# floor. Drop this constraint once mcp's own pin guarantees >= 2.13.0.
+constraint-dependencies = ["pyjwt>=2.13.0"]
 
 [tool.black]
 line-length = 88

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,6 @@
   "packages": {
     ".": {
       "release-type": "python",
-      "package-name": "openzim-mcp",
       "changelog-sections": [
         {
           "type": "feat",

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,9 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
+[manifest]
+constraints = [{ name = "pyjwt", specifier = ">=2.13.0" }]
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
@@ -1170,7 +1173,7 @@ wheels = [
 
 [[package]]
 name = "openzim-mcp"
-version = "2.0.5"
+version = "2.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -1621,11 +1624,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Context

v2.1.5 bumped on `main` (pyproject + manifest + CHANGELOG) but was **never tagged or published** — the post-merge `Release Please` run reported success yet set `release_created=false`, so no tag, no PyPI, no GitHub Release. The manual tag-push that followed surfaced a *second*, unrelated blocker in the release gate. This PR fixes both root causes and rolls forward to a clean **2.1.6**.

## Two fixes

**1. `fix(release)` — drop `package-name` from `release-please-config.json`**

PR #256 switched release-please to pure manifest mode, which finally honors the config. That activated `package-name: "openzim-mcp"` as the strategy's *component*. The release PR's branch (`release-please--branches--main`) and title (`chore: release ${version}`) carry no component, so release-please's **unconditional** component-equality check (`'' !== 'openzim-mcp'`, not gated by `include-component-in-tag`) built zero releases and aborted with `untagged, merged release PRs outstanding`. Removing `package-name` resolves the component to empty, matching the branch — verified against release-please v17.6.0 `src/strategies/base.ts`. Tag stays `v<version>` (`include-component-in-tag: false`); PyPI/wheel naming come from `pyproject.toml`, so this is safe for the single root package.

**2. `fix(deps)` — floor pyjwt at `>=2.13.0`**

The `Release` workflow's `Test before release` gate runs `pip-audit`, which now fails on four advisories against `pyjwt 2.12.1` (PYSEC-2026-175 / -177 / -178 / -179), all fixed in **2.13.0**. pyjwt is transitive via `mcp[cli]`; floored via `[tool.uv] constraint-dependencies` rather than a direct dep.

## On merge

release-please opens a **2.1.6** release PR; merging that PR should now tag + publish cleanly to PyPI + ghcr `:2.1.6`/`:latest` + a GitHub Release with assets. 2.1.6 is the live validation of fix #1 (the tag/release half isn't dry-run-testable).

2.1.5 stays a superseded tombstone: the `v2.1.5` tag and ghcr `:2.1.5` exist (built with the old pyjwt) but never reached PyPI/GH-release. `:latest` moves to the clean 2.1.6 image.

## Verification

- `make security` → **No known vulnerabilities found** (was: 4 pyjwt advisories → exit 2)
- `make lint` → clean (isort + black, 236 files unchanged)
- `release-please-config.json` validated; minimal lock diff (only pyjwt `2.12.1→2.13.0`)