### PR TITLE
fix(synthesize): resolve 2-token tail-hijack defect class (#252, #253)

### DIFF
--- a/docs/superpowers/plans/2026-06-03-synthesize-tail-hijack-fix.md
+++ b/docs/superpowers/plans/2026-06-03-synthesize-tail-hijack-fix.md
@@ -1,0 +1,437 @@
+# Synthesize 2-token Tail-Hijack Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `synthesize` promoting an off-topic generic article (`Refused`, `Theory`, `Cave`) to rank 1 for short queries, and surface the correct canonical instead.
+
+**Architecture:** Two independent fixes in the synthesize path. Fix 1 closes the cross-archive leak gate against single-token-tail promotions from a non-primary archive (#253). Fix 2 threads the *original* (apostrophe-preserving) query into `_promote_title_match` and adds a "tail-rescue": before accepting a generic single-token tail promotion, probe the full original query for a more-specific multi-token canonical and promote that instead (#252 + `Plato's cave` class).
+
+**Tech Stack:** Python 3.12, pytest, `unittest.mock`. Pure stdlib; no new deps.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-03-synthesize-tail-hijack-fix-design.md`
+
+**Live oracle (deployed v2.1.6 server, dual-archive wiki + superuser) — pinned facts the mocks must encode:**
+- `find_title_match("einstein's theory")` (apostrophe preserved) → `Theory_of_relativity` @ 1.00.
+- `find_title_match("einstein theory")` (stripped) → `The_Einstein_Theory_of_Relativity` @ 0.95 (a film), `Theory_of_relativity` only @ 0.63.
+- `find_title_match("plato's cave")` / `("plato cave")` → `Allegory_of_the_cave` @ ~0.95.
+- `find_title_match("connection refused")` on wiki → `Refused` (single token); the relevant content is in superuser.
+- `find_title_match("planet earth")` → `Earth` (single token — the carve-out: no more-specific canonical, must stay promoted).
+
+---
+
+## File Structure
+
+- Modify: `openzim_mcp/title_promotion.py` — add `is_single_token_tail_match(promoted, topic)` (floor-free shape predicate) for Fix 1.
+- Modify: `openzim_mcp/synthesize.py` — `_drop_cross_archive_leakage` (Fix 1); `_promote_title_match` signature + tail-rescue (Fix 2); `synthesize_query` signature to forward `original_query`.
+- Modify: `openzim_mcp/simple_tools.py` — `_handle_synthesize_query` passes the raw user query as `original_query` into the synthesize call.
+- Test: `tests/test_post_v2_1_4_beta_fixes.py` — new sweep regression file (sibling of `test_post_v2_1_3_beta_fixes.py`).
+- Reuse: `tests/_promote_fixtures.py` patterns; `tests/test_synthesize.py` for `_promote_title_match` / `_drop_cross_archive_leakage` call shapes.
+
+---
+
+## Task 1: Fix 1 — leak gate drops non-primary single-token-tail promotions
+
+**Files:**
+- Modify: `openzim_mcp/title_promotion.py` (add predicate after `is_tail_hijack_shape`, ~line 480)
+- Modify: `openzim_mcp/synthesize.py:1339-1342` (the kept-loop in `_drop_cross_archive_leakage`)
+- Test: `tests/test_post_v2_1_4_beta_fixes.py`
+
+- [ ] **Step 1: Write the failing predicate test**
+
+In `tests/test_post_v2_1_4_beta_fixes.py`:
+
+```python
+from openzim_mcp.title_promotion import is_single_token_tail_match
+
+
+def test_single_token_tail_match_fires_on_2token_query():
+    # "connection refused" -> "Refused": the #253 shape the floored
+    # is_tail_hijack_shape MISSES because the query has only 2 tokens.
+    assert is_single_token_tail_match({"path": "Refused"}, "connection refused")
+
+
+def test_single_token_tail_match_ignores_multitoken_canonical():
+    # darwins evolution -> On_the_Origin_of_Species: multi-token canonical,
+    # the legitimate lexically-disjoint promotion exemption.
+    assert not is_single_token_tail_match(
+        {"path": "On_the_Origin_of_Species"}, "darwins evolution"
+    )
+
+
+def test_single_token_tail_match_requires_tail_position():
+    # head-position single token is not a tail hijack ("Berlin Germany"->Berlin)
+    assert not is_single_token_tail_match({"path": "Berlin"}, "berlin germany")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_post_v2_1_4_beta_fixes.py -k single_token_tail_match -v`
+Expected: FAIL with `ImportError: cannot import name 'is_single_token_tail_match'`.
+
+- [ ] **Step 3: Implement the predicate**
+
+In `openzim_mcp/title_promotion.py`, after `is_tail_hijack_shape` (~line 480):
+
+```python
+def is_single_token_tail_match(promoted: Dict[str, Any], topic: str) -> bool:
+    """Floor-free sibling of :func:`is_tail_hijack_shape`: the promoted
+    canonical is a single token equal to the topic's LAST token,
+    regardless of topic length.
+
+    ``is_tail_hijack_shape`` carries a ``< 3 token`` floor (the b4
+    ``Berlin Germany`` carve-out) because, on the tell_me_about SOURCE
+    gate, a 2-token tail can be legitimate. The cross-archive LEAK gate
+    has an extra signal — provenance — so it can safely act on the
+    2-token shape too (``connection refused`` -> ``Refused`` from a
+    NON-PRIMARY archive). Used only by :func:`_drop_cross_archive_leakage`;
+    the source gate keeps the floored predicate.
+    """
+    topic_tokens_seq = _TAIL_TOKEN_RE.findall(topic.lower())
+    if not topic_tokens_seq:
+        return False
+    cand_tokens_seq = _TAIL_TOKEN_RE.findall(str(promoted.get("path", "")).lower())
+    return len(cand_tokens_seq) == 1 and cand_tokens_seq == topic_tokens_seq[-1:]
+```
+
+- [ ] **Step 4: Run predicate test to verify pass**
+
+Run: `uv run pytest tests/test_post_v2_1_4_beta_fixes.py -k single_token_tail_match -v`
+Expected: 3 PASS.
+
+- [ ] **Step 5: Write the failing leak-gate integration test**
+
+Append to `tests/test_post_v2_1_4_beta_fixes.py`:
+
+```python
+from openzim_mcp.synthesize import _drop_cross_archive_leakage
+
+
+def test_leak_gate_drops_nonprimary_promoted_tail_hijack():
+    # superuser is primary (path overlap {connection, refused} = 2);
+    # wiki/Refused is a tagged promoted hit but a single-token tail from
+    # the non-primary archive -> must be dropped despite the `promoted` tag.
+    top_hits = [
+        ("wikipedia", {"path": "Refused", "promoted": True, "snippet": "", "score": 1.0}),
+        ("superuser", {"path": "questions/1/ssh-connection-refused", "snippet": "", "score": 0.5}),
+    ]
+    kept = _drop_cross_archive_leakage(
+        top_hits,
+        query="connection refused",
+        fallback_used="rrf_fusion",
+        max_secondary_archive_hits=1,
+        min_overlap=1,
+    )
+    paths = [h["path"] for _, h in kept]
+    assert "Refused" not in paths
+    assert "questions/1/ssh-connection-refused" in paths
+
+
+def test_leak_gate_keeps_multitoken_promoted_exemption():
+    # darwins evolution -> On_the_Origin_of_Species (promoted, lexically
+    # disjoint, multi-token) must KEEP its exemption.
+    top_hits = [
+        ("wikipedia", {"path": "On_the_Origin_of_Species", "promoted": True, "snippet": "", "score": 1.0}),
+        ("superuser", {"path": "questions/2/git-merge", "snippet": "", "score": 0.5}),
+    ]
+    kept = _drop_cross_archive_leakage(
+        top_hits,
+        query="darwins evolution",
+        fallback_used="rrf_fusion",
+        max_secondary_archive_hits=1,
+        min_overlap=1,
+    )
+    assert "On_the_Origin_of_Species" in [h["path"] for _, h in kept]
+```
+
+- [ ] **Step 6: Run to verify the leak-gate test fails**
+
+Run: `uv run pytest tests/test_post_v2_1_4_beta_fixes.py -k leak_gate -v`
+Expected: `test_leak_gate_drops_nonprimary_promoted_tail_hijack` FAILS (Refused kept); the keep test PASSES (current behaviour already exempts it).
+
+- [ ] **Step 7: Implement the leak-gate change**
+
+In `openzim_mcp/synthesize.py`, add the import at the top with the other `title_promotion` imports:
+
+```python
+from .title_promotion import (
+    ...
+    is_single_token_tail_match,
+    ...
+)
+```
+
+Replace the kept-loop body at `_drop_cross_archive_leakage` (currently `synthesize.py:1339-1342`):
+
+```python
+    for archive_name, hit in top_hits:
+        # A `promoted` hit normally bypasses the relevance floor (a
+        # possessive/variant canonical can be lexically disjoint from the
+        # query). EXCEPTION: a single-token-tail promotion from a
+        # NON-PRIMARY archive is the cross-archive leak signature
+        # (`connection refused` -> wiki `Refused` while the relevant hits
+        # are in superuser). The path-overlap floor can't catch it — the
+        # tail token IS a query token — so drop it outright here.
+        if archive_name != primary_archive and hit.get("promoted") and (
+            is_single_token_tail_match(hit, query)
+        ):
+            continue
+        if hit.get("promoted") or archive_name == primary_archive:
+            kept.append((archive_name, hit))
+            continue
+        if per_archive_kept[archive_name] >= max_secondary_archive_hits:
+            continue
+        if all_zero or _overlap(hit) >= min_overlap:
+            kept.append((archive_name, hit))
+            per_archive_kept[archive_name] += 1
+    return kept or top_hits[:1]
+```
+
+- [ ] **Step 8: Run the full new file to verify pass**
+
+Run: `uv run pytest tests/test_post_v2_1_4_beta_fixes.py -v`
+Expected: all PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add openzim_mcp/title_promotion.py openzim_mcp/synthesize.py tests/test_post_v2_1_4_beta_fixes.py
+git commit -m "fix(synthesize): drop non-primary single-token-tail leaks (#253)"
+```
+
+---
+
+## Task 2: Thread the original (apostrophe-preserving) query into `_promote_title_match`
+
+The promotion path currently receives the *extracted topic* (apostrophe already stripped). Fix 2's rescue probe needs the raw query so `find_title_match` can resolve the specific canonical (`einstein's theory` -> `Theory_of_relativity`, which the stripped `einstein theory` cannot reach). This task is a pure signature/plumbing change with no behaviour change yet.
+
+**Files:**
+- Modify: `openzim_mcp/synthesize.py` — `synthesize_query(...)` (line 1654) and `_promote_title_match(...)` (line 958) gain an `original_query: str` keyword (default to `query` for backwards-compat).
+- Modify: `openzim_mcp/simple_tools.py` — `_handle_synthesize_query` passes the raw user `query` as `original_query`.
+- Test: `tests/test_post_v2_1_4_beta_fixes.py`
+
+- [ ] **Step 1: Write a test asserting `original_query` defaults to `query` (no behaviour change)**
+
+```python
+def test_promote_title_match_accepts_original_query_kw():
+    # Plumbing-only: passing original_query must not change a no-op promote.
+    from openzim_mcp.synthesize import _promote_title_match
+    top_hits = [("wikipedia", {"path": "Berlin", "snippet": "", "score": 1.0})]
+    # Berlin is already a strong title match for "berlin" -> short-circuit,
+    # returns input unchanged regardless of original_query.
+    out = _promote_title_match(
+        top_hits,
+        query="berlin",
+        original_query="berlin",
+        archives=[],
+        archives_searched=[],
+        search_handler=object(),
+    )
+    assert out == top_hits
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/test_post_v2_1_4_beta_fixes.py -k original_query_kw -v`
+Expected: FAIL — `_promote_title_match() got an unexpected keyword argument 'original_query'`.
+
+- [ ] **Step 3: Add the keyword to both functions**
+
+In `openzim_mcp/synthesize.py`, `_promote_title_match` signature (line 958):
+
+```python
+def _promote_title_match(
+    top_hits: list[tuple[str, dict]],
+    *,
+    query: str,
+    original_query: str | None = None,
+    archives: list[tuple[Archive, Path]],
+    archives_searched: list[str],
+    search_handler: Any,
+) -> list[tuple[str, dict]]:
+```
+
+At the top of the body, normalize: `rescue_query = original_query if original_query is not None else query`.
+
+In `synthesize_query` (line 1654), add `original_query: str | None = None` to the signature and forward it to BOTH `_promote_title_match` calls (lines 1708 and 1752): `original_query=original_query`.
+
+- [ ] **Step 4: Pass the raw query from the handler**
+
+In `openzim_mcp/simple_tools.py`, find the `synthesize_query(...)` call inside the synthesize execution (search for `synthesize_query(`), and add `original_query=query` where `query` is the raw user query received by `_handle_synthesize_query`. (The BM25 `query`/topic argument stays as-is; only the new kwarg is added.)
+
+- [ ] **Step 5: Run to verify pass + no regressions**
+
+Run: `uv run pytest tests/test_post_v2_1_4_beta_fixes.py -k original_query_kw tests/test_synthesize.py -v`
+Expected: PASS, no regressions in `test_synthesize.py`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add openzim_mcp/synthesize.py openzim_mcp/simple_tools.py tests/test_post_v2_1_4_beta_fixes.py
+git commit -m "refactor(synthesize): thread original query into _promote_title_match"
+```
+
+---
+
+## Task 3: Fix 2 — tail-rescue promotes the more-specific full-query canonical
+
+**Files:**
+- Modify: `openzim_mcp/synthesize.py` — `_promote_title_match` tail loop (around line 1136, where `accept_tail_promotion` gates a single-token tail).
+- Test: `tests/test_post_v2_1_4_beta_fixes.py`
+
+**Logic:** In the tail loop, when the candidate `promoted` is a single token equal to the tail (`is_single_token_tail_match(promoted, query)`), before accepting it, probe `find_title_match(search_handler, vp, rescue_query, min_score=0.95)` (the *original* query). If that returns a **multi-token** canonical whose tokens **include the tail token**, promote the rescued canonical instead (build its hit via `title_match_hit(archive, rescued_title)` like pass-0 does, tag `_mark_promoted`). Otherwise fall through to the existing `accept_tail_promotion` gate.
+
+- [ ] **Step 1: Write the failing rescue tests**
+
+```python
+from unittest.mock import MagicMock
+from openzim_mcp.synthesize import _promote_title_match
+
+
+def _rescue_handler(title_index_by_query, hit_by_title):
+    """Mock search_handler: find_entry_by_title_data keyed by query,
+    title_match_hit keyed by resolved title."""
+    m = MagicMock()
+
+    def fake_fetbd(_vp, q, *, cross_file=False, limit=3):
+        row = title_index_by_query.get(q.lower())
+        return {"results": [row] if row else []}
+
+    m.find_entry_by_title_data.side_effect = fake_fetbd
+    m.title_match_hit.side_effect = lambda _archive, title: hit_by_title.get(title.lower())
+    return m
+
+
+def test_einsteins_theory_rescues_theory_of_relativity():
+    # tail "theory" -> generic "Theory"; original "einstein's theory"
+    # resolves to the more-specific multi-token canonical containing "theory".
+    handler = _rescue_handler(
+        title_index_by_query={
+            "einstein's theory": {"path": "Theory_of_relativity", "title": "Theory of relativity", "score": 1.0},
+            "theory": {"path": "Theory", "title": "Theory", "score": 1.0},
+        },
+        hit_by_title={
+            "theory": {"path": "Theory", "snippet": "...", "score": 1.0},
+            "theory of relativity": {"path": "Theory_of_relativity", "snippet": "...", "score": 1.0},
+        },
+    )
+    archive = object()
+    out = _promote_title_match(
+        [("wikipedia", {"path": "Einstein", "snippet": "", "score": 0.5})],
+        query="einstein theory",          # stripped topic (what synthesize gets today)
+        original_query="einstein's theory",  # raw query (apostrophe preserved)
+        archives=[(archive, "wiki.zim")],
+        archives_searched=["wikipedia"],
+        search_handler=handler,
+    )
+    assert out[0][1]["path"] == "Theory_of_relativity"
+    assert out[0][1].get("promoted") is True
+
+
+def test_planet_earth_keeps_bare_tail_no_rescue():
+    # original "planet earth" resolves only to single-token "Earth" -> no
+    # more-specific canonical -> keep the legitimate bare-tail promotion.
+    handler = _rescue_handler(
+        title_index_by_query={
+            "planet earth": {"path": "Earth", "title": "Earth", "score": 1.0},
+            "earth": {"path": "Earth", "title": "Earth", "score": 1.0},
+        },
+        hit_by_title={"earth": {"path": "Earth", "snippet": "...", "score": 1.0}},
+    )
+    archive = object()
+    out = _promote_title_match(
+        [("wikipedia", {"path": "Planet", "snippet": "", "score": 0.5})],
+        query="planet earth",
+        original_query="planet earth",
+        archives=[(archive, "wiki.zim")],
+        archives_searched=["wikipedia"],
+        search_handler=handler,
+    )
+    assert out[0][1]["path"] == "Earth"
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `uv run pytest tests/test_post_v2_1_4_beta_fixes.py -k "rescues or keeps_bare_tail" -v`
+Expected: `test_einsteins_theory_rescues_theory_of_relativity` FAILS (promotes `Theory`, not `Theory_of_relativity`); `test_planet_earth_keeps_bare_tail_no_rescue` PASSES.
+
+- [ ] **Step 3: Implement the rescue in the tail loop**
+
+In `_promote_title_match`, inside the tail loop, immediately BEFORE the `if not accept_tail_promotion(...)` gate (around `synthesize.py:1136`), insert:
+
+```python
+            # Fix 2 tail-rescue: if we're about to promote a generic
+            # single-token tail, the apostrophe-stripped topic may have
+            # buried the real canonical (e.g. "einstein's theory" ->
+            # Theory_of_relativity @1.0, unreachable from "einstein
+            # theory"). Probe the ORIGINAL query; if it resolves to a
+            # more-specific MULTI-token canonical that contains the tail
+            # token, promote THAT instead — bypassing the Z4/possessive
+            # gates that wrongly reject correct-but-tangential canonicals.
+            if is_single_token_tail_match(promoted, query):
+                rescued = find_title_match(
+                    search_handler, str(_vp), rescue_query, min_score=0.95
+                )
+                if isinstance(rescued, dict) and rescued.get("path"):
+                    rescued_tokens = _TAIL_TOKEN_RE.findall(
+                        str(rescued["path"]).lower()
+                    )
+                    tail_tok = _TAIL_TOKEN_RE.findall(promoted_path.lower())
+                    if len(rescued_tokens) > 1 and tail_tok and tail_tok[0] in rescued_tokens:
+                        rescued_hit = _build_pass0_promoted_hit(
+                            rescued, archive, title_match_hit
+                        )
+                        return [(archive_name, _mark_promoted(rescued_hit)), *top_hits]
+```
+
+Add `_TAIL_TOKEN_RE` to the `title_promotion` imports in `synthesize.py` if not already imported (it is exported from `title_promotion`).
+
+- [ ] **Step 4: Run to verify rescue tests pass**
+
+Run: `uv run pytest tests/test_post_v2_1_4_beta_fixes.py -k "rescues or keeps_bare_tail" -v`
+Expected: both PASS.
+
+- [ ] **Step 5: Run the FULL existing synthesize + promotion suites for regressions**
+
+Run: `uv run pytest tests/test_synthesize.py tests/test_synthesize_title_promotion_v2a9.py tests/test_post_b4_beta_fixes.py tests/test_post_b6_beta_fixes.py tests/test_post_b8_beta_fixes.py tests/test_post_b9_beta_fixes.py tests/test_post_b10_beta_fixes.py tests/test_post_b11_beta_fixes.py tests/test_post_v2_1_3_beta_fixes.py -v`
+Expected: all PASS (no possessive/Z4/tail invariant regressions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add openzim_mcp/synthesize.py tests/test_post_v2_1_4_beta_fixes.py
+git commit -m "fix(synthesize): rescue more-specific canonical over generic tail (#252)"
+```
+
+---
+
+## Task 4: Full suite, lint, and live validation
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full local gate (matches CI)**
+
+Run: `make lint && make type-check && uv run pytest -q`
+Expected: lint clean (flake8 + isort + black over `openzim_mcp tests`), mypy clean, all tests pass. Fix any Sonar-style regex (no new unbounded quantifiers — `is_single_token_tail_match` reuses the existing bounded `_TAIL_TOKEN_RE`) and CodeQL uninitialized-local issues.
+
+- [ ] **Step 2: Live before/after reprobe against the deployed server**
+
+After deploy, re-run the four defect probes + four invariants via the connected `zim_query` tool (synthesize=True where noted):
+- `connection refused` (synth) → relevant superuser SSH at rank 1, no `Refused`. **[#253]**
+- `Einstein's theory` (synth) → `Theory_of_relativity` at rank 1. **[#252]**
+- `Plato's cave` (synth) → `Allegory_of_the_cave` at rank 1. **[#252 class]**
+- `ssh connection refused` (synth) → superuser SSH (unchanged). **[invariant]**
+- `planet earth` (synth) → `Earth` (unchanged). **[invariant]**
+- `Berlin Germany` (synth) → `Berlin` (unchanged). **[invariant]**
+
+Record the before/after in the PR body. NOTE: these are not reproducible from a checkout — the live reprobe is the only end-to-end proof.
+
+- [ ] **Step 3: Open the PR** with the live before/after table; close #252 and #253 on merge.
+
+---
+
+## Self-Review (completed during plan authoring)
+
+- **Spec coverage:** Fix 1 (Sub-case A / #253) → Task 1. Fix 2 (Sub-case B / #252 + Plato) → Tasks 2-3. Testing layers (mock unit + invariants + live) → Tasks 1-4. Carve-out (`planet earth → Earth`) → Task 3 Step 1 `test_planet_earth_keeps_bare_tail_no_rescue` + Task 1 multi-token keep test. No gaps.
+- **Placeholder scan:** none — every step has concrete code/commands.
+- **Type consistency:** `is_single_token_tail_match(promoted, topic)` signature identical across Task 1 definition and its uses; `original_query` kw consistent across Tasks 2-3; `rescue_query` derived once in Task 2 Step 3 and used in Task 3 Step 3.
+- **Known follow-up:** if the live reprobe (Task 4 Step 2) shows `Einstein's theory` still not resolving (e.g. the apostrophe is stripped *before* `original_query` is captured), the rescue degrades to suppression (drop `Theory`, BM25 fallback) — never worse than today; capture the live `find_title_match` shape and adjust the rescue guard.

--- a/docs/superpowers/specs/2026-06-03-synthesize-tail-hijack-fix-design.md
+++ b/docs/superpowers/specs/2026-06-03-synthesize-tail-hijack-fix-design.md
@@ -1,0 +1,68 @@
+# Synthesize 2-token tail-hijack defect class — design
+
+**Date:** 2026-06-03
+**Issues:** #252 (`Einstein's theory → Theory`), #253 (`connection refused → Refused`)
+**Scope:** `openzim_mcp/synthesize.py` + `openzim_mcp/title_promotion.py` internals only. No tool-surface or response-contract change.
+
+## Problem
+
+`synthesize` promotes an off-topic generic article to rank 1 for several short queries, burying the relevant content. Confirmed live against the deployed v2.1.6 server (dual-archive: `wikipedia_en_all_maxi_2026-02` + `superuser.com_en_all_2026-02`):
+
+| Query | Promoted rank-1 (wrong) | Correct canonical (buried/absent) |
+| --- | --- | --- |
+| `connection refused` | `wikipedia/Refused` (punk band, score 1.0) | `superuser/.../ssh-channel-3-tunnel-connection-refused` (rank 2) |
+| `Einstein's theory` | `wikipedia/Theory` (score 1.5) | `Theory_of_relativity` (absent from results) |
+| `einstein theory` | `wikipedia/Theory` (score 1.5) | same as above — identical output |
+| `Plato's cave` | `wikipedia/Cave` (score 1.0) | `Allegory_of_the_cave` (rank 3) |
+
+The two filed issues are instances of one class: a **2-token tail-hijack** — the query's last token (`refused` / `theory` / `cave`) exact-title-matches a generic article, which is promoted at score 1.0 (title-match base) × up-to-1.5 (section-affinity boost).
+
+Counter-evidence that bounds the fix: `ssh connection refused` (3-token) is already correct (returns the superuser SSH articles, no `Refused`) — the v2.1.4 tail-hijack guard works for ≥3 tokens. And the standalone `find article titled Einstein's theory` resolves correctly to `Theory_of_relativity` (score 1.00) — so the correct canonical IS retrievable; only the synthesize promotion path lands on the generic tail.
+
+## Root cause
+
+**Enabling cause:** the `< 3 token` floor in `title_promotion._accept_non_possessive` (`title_promotion.py:441`): `if len(topic_tokens_seq) < 3: return True`. The v2.1.4/#250 tail-hijack rejection only fires for 3+ token queries, so any 2-token query's generic-tail promotion is waved through. The floor exists to protect legitimate 2-token tails (`planet earth → Earth`, `Berlin Germany → Berlin`).
+
+The class splits into two sub-cases with **different clean fix sites**:
+
+- **Sub-case A — cross-archive** (#253). `connection refused → Refused` is a Wikipedia hit while the relevant content is in superuser. `_promote_title_match` tags the hit `promoted`, and `_drop_cross_archive_leakage` (`synthesize.py:1340`) **unconditionally exempts** `promoted` hits from the cross-archive path-overlap floor, so `Refused` survives at rank 1.
+
+- **Sub-case B — same-archive** (#252 + `Plato's cave` + `einstein theory`). All hits are Wikipedia, so the cross-archive leak gate cannot see it. The promotion path lands on the generic single-token tail (`Theory`/`Cave`) instead of the more-specific full-query canonical (`Theory_of_relativity`/`Allegory_of_the_cave`). The filed-issue hypothesis (a possessive `match_type` fallback) is **disproven**: the standalone title lookup resolves correctly, so the divergence is between synthesize's promotion path and the working title-lookup, NOT in `find_title_match`'s backend. The exact normalization point (apostrophe handling in topic extraction vs `find_title_match` `min_score`/`match_type`) is pinned in implementation step 1.
+
+## Decided strategy
+
+- Sub-case B: **resolve to the correct canonical** (surface `Theory_of_relativity` / `Allegory_of_the_cave` at rank 1), not mere suppression.
+- Carve-out: **cross-archive-aware / more-specific-canonical-aware only** — preserve legitimate same-archive 2-token tails (`planet earth → Earth`), where no more-specific canonical exists.
+
+## Fix 1 — cross-archive leak gate (Sub-case A, #253)
+
+In `_drop_cross_archive_leakage`, replace the unconditional `promoted` exemption at the loop body (`synthesize.py:1340`):
+
+- A `promoted` hit from the **primary** archive keeps the exemption (unchanged).
+- A `promoted` hit from a **non-primary** archive keeps the exemption **unless** it is a single-token tail-hijack shape (canonical is one token equal to the query's last token, via the existing `is_tail_hijack_shape` predicate). In that case it is **dropped outright** — it is neither exempted nor saved by the path-overlap floor.
+
+The path-overlap floor cannot rescue this case and must be bypassed: `Refused`'s only query overlap is the tail token `refused` itself (`overlap == 1`, the same token that mis-promoted it), so an overlap floor of 1 would keep it (issue #253 notes this explicitly). The discriminator is therefore the **shape + provenance** (single-token-tail canonical from a non-primary archive = the leak signature), not lexical overlap. This preserves the lexically-disjoint multi-token promoted exemption (`darwins evolution → On_the_Origin_of_Species` — multi-token canonical, not tail-hijack shape) and every same-archive (primary) promotion. Low risk.
+
+Edge case checked: a legitimate same-archive 2-token tail like `planet earth → Earth` keeps its promotion because that archive is **primary** (highest query/path overlap), so the non-primary condition never fires for it.
+
+## Fix 2 — resolve correct canonical (Sub-case B, #252 class)
+
+**Step 1 (pin the divergence).** Reproduce with a local mock of `zim_operations.find_entry_by_title_data` encoding the live-observed result shapes, plus 2-3 targeted live probes (`Newton's gravity`, `Marie Curie's discovery`, bare-tail lookups) to confirm whether pass-0 receives the specific canonical and rejects it (possessor-not-in-path gate) or receives the generic tail directly, and whether the apostrophe survives to `_promote_title_match`.
+
+**Step 2 (fix).** Make the full-query canonical win over the generic single-token tail. When a candidate promotion's canonical is a single generic token equal to the query tail, first check whether the **full query** resolves (via the title index) to a more-specific multi-token canonical; if so, promote that canonical instead. When no more-specific canonical exists (`planet earth → Earth`), keep the bare tail — this is the cross-archive-aware/more-specific carve-out that protects the legitimate case.
+
+The precise edit (a new shared `title_promotion` predicate vs an inline check in `_promote_title_match` pass-0) is settled in the implementation plan once Step 1 pins the path, so the change stays in one place shared by the tell_me_about and synthesize paths (the established anti-drift pattern: `accept_tail_promotion` / `passes_z4`).
+
+## Testing
+
+These defects are **not reproducible from a local checkout** (they depend on the live 118 GB title index) — the reason they were deferred. Validation is three-layered:
+
+1. **Unit tests with a mock `zim_operations`** encoding the live-observed `find_entry_by_title_data` shapes for `einstein's theory`, `plato's cave`, `connection refused`. Assert: correct canonical at rank 1 (Sub-case B) / leak dropped (Sub-case A).
+2. **Invariant regression tests (must stay green):** `planet earth → Earth`, `Berlin Germany → Berlin`, `ssh connection refused → superuser` (3-token guard), `darwins evolution → On_the_Origin_of_Species` (leak-gate multi-token exemption). Reuse/extend the existing `tests/` suites for `title_promotion` and `synthesize`.
+3. **Live before/after reprobe** against the deployed server — the only true end-to-end validation, run before merge. Probe set: the four defect queries + the four invariants.
+
+## Non-goals / risk
+
+- No reranker, no semantic retrieval, no tool-surface change.
+- If Step 1 shows the correct canonical genuinely isn't retrievable for a given query, that query degrades to **suppression** (drop the junk, fall back to BM25) — never a worse answer than today.
+- CI gate awareness (per project memory): full `make lint` (package + tests), Sonar S5852/ReDoS on any new regex, CodeQL uninitialized-local, Windows cp1252.

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -34,6 +34,7 @@ from openzim_mcp.title_promotion import (
     accept_tail_promotion,
     find_title_match,
     has_apostrophe_possessive,
+    is_single_token_tail_match,
     is_strong_title_match,
     iter_query_tails,
     passes_z4,
@@ -1337,6 +1338,19 @@ def _drop_cross_archive_leakage(
     kept: list[tuple[str, dict]] = []
     per_archive_kept: dict[str, int] = defaultdict(int)
     for archive_name, hit in top_hits:
+        # A `promoted` hit normally bypasses the relevance floor (a
+        # possessive/variant canonical can be lexically disjoint from the
+        # query). EXCEPTION (#253): a single-token-tail promotion from a
+        # NON-PRIMARY archive is the cross-archive leak signature
+        # (`connection refused` -> wiki `Refused` while the relevant hits
+        # are in superuser). The path-overlap floor can't catch it — the
+        # tail token IS a query token — so drop it outright here.
+        if (
+            archive_name != primary_archive
+            and hit.get("promoted")
+            and is_single_token_tail_match(hit, query)
+        ):
+            continue
         if hit.get("promoted") or archive_name == primary_archive:
             kept.append((archive_name, hit))
             continue

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 from openzim_mcp import bundle as _bundle_mod
 from openzim_mcp.text_utils import tokenize_for_relevance
 from openzim_mcp.title_promotion import (
+    _TAIL_TOKEN_RE,
     accept_possessive_promotion,
     accept_tail_promotion,
     find_title_match,
@@ -996,6 +997,7 @@ def _promote_title_match(
     from the stripped ``einstein theory``). Defaults to ``query`` for
     backwards-compat callers that don't supply it.
     """
+    rescue_query = original_query if original_query is not None else query
     if top_hits:
         top_hit_0 = top_hits[0][1]
         top_path = str(top_hit_0.get("path", ""))
@@ -1141,6 +1143,39 @@ def _promote_title_match(
             # token against the SAME archive the candidate came from.
             def _tail_probe(tok: str, _p: Path = _vp) -> Optional[dict]:
                 return find_title_match(search_handler, str(_p), tok)
+
+            # Fix 2 tail-rescue (#252): if we're about to promote a generic
+            # single-token tail, the apostrophe-stripped topic may have
+            # buried the real canonical (``einstein's theory`` ->
+            # Theory_of_relativity @1.0, unreachable from the stripped
+            # ``einstein theory`` which only resolves the bare ``Theory``).
+            # Probe the ORIGINAL apostrophe-preserving query; if it resolves
+            # to a more-specific MULTI-token canonical that CONTAINS the tail
+            # token, promote THAT instead — bypassing the gate that would
+            # otherwise wave the generic tail through. When no more-specific
+            # canonical exists (``planet earth`` -> ``Earth``, single token),
+            # fall through and keep the legitimate bare-tail promotion.
+            if is_single_token_tail_match(promoted, query):
+                rescued = find_title_match(
+                    search_handler, str(_vp), rescue_query, min_score=0.95
+                )
+                if isinstance(rescued, dict) and rescued.get("path"):
+                    rescued_tokens = _TAIL_TOKEN_RE.findall(
+                        str(rescued["path"]).lower()
+                    )
+                    tail_tok = _TAIL_TOKEN_RE.findall(promoted_path.lower())
+                    if (
+                        len(rescued_tokens) > 1
+                        and tail_tok
+                        and tail_tok[0] in rescued_tokens
+                    ):
+                        rescued_hit = _build_pass0_promoted_hit(
+                            rescued, archive, title_match_hit
+                        )
+                        return [
+                            (archive_name, _mark_promoted(rescued_hit)),
+                            *top_hits,
+                        ]
 
             if not accept_tail_promotion(promoted, query, _tail_probe):
                 continue

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -1155,14 +1155,41 @@ def _promote_title_match(
             # otherwise wave the generic tail through. When no more-specific
             # canonical exists (``planet earth`` -> ``Earth``, single token),
             # fall through and keep the legitimate bare-tail promotion.
-            if is_single_token_tail_match(promoted, query):
-                rescued = find_title_match(
-                    search_handler, str(_vp), rescue_query, min_score=0.95
-                )
+            #
+            # Fix A (#252 review): gate the rescue on the ORIGINAL query
+            # being an apostrophe-possessive. The rescue deliberately
+            # bypasses the ``passes_z4`` / ``accept_possessive_promotion``
+            # gates (the correct canonical like ``Allegory_of_the_cave``
+            # is "tangential" and those gates wrongly reject it). Without a
+            # guard, a NON-possessive multi-token query could over-promote
+            # a tangential canonical (``planet earth orbit`` ->
+            # ``Low_Earth_Orbit``). The defect class this fixes is
+            # specifically apostrophe-stripped possessives, so restrict it.
+            if is_single_token_tail_match(
+                promoted, query
+            ) and has_apostrophe_possessive(rescue_query):
+                # Fix B (#252 review): match the established probe pattern in
+                # this loop — wrap the rescue ``find_title_match`` so a
+                # transient backend failure blanks the rescue rather than
+                # bubbling up.
+                try:
+                    rescued = find_title_match(
+                        search_handler, str(_vp), rescue_query, min_score=0.95
+                    )
+                except Exception as exc:
+                    logger.debug(
+                        "_promote_title_match: rescue probe failed for %r: %s",
+                        rescue_query,
+                        exc,
+                    )
+                    rescued = None
                 if isinstance(rescued, dict) and rescued.get("path"):
                     rescued_tokens = _TAIL_TOKEN_RE.findall(
                         str(rescued["path"]).lower()
                     )
+                    # ``tail_tok`` is length-1 by the
+                    # ``is_single_token_tail_match`` invariant above, so
+                    # ``tail_tok[0]`` is the only (and the bare-tail) token.
                     tail_tok = _TAIL_TOKEN_RE.findall(promoted_path.lower())
                     if (
                         len(rescued_tokens) > 1

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -960,6 +960,7 @@ def _promote_title_match(
     top_hits: list[tuple[str, dict]],
     *,
     query: str,
+    original_query: Optional[str] = None,
     archives: list[tuple[Archive, Path]],
     archives_searched: list[str],
     search_handler: Any,
@@ -987,6 +988,13 @@ def _promote_title_match(
     that resolves any tail wins. This picks the most specific entity
     that exists in any archive, biasing toward earlier-configured
     archives only when tails of equal length tie.
+
+    ``original_query`` is the raw, apostrophe-preserving user query
+    (``query`` is the BM25/topic-extracted form which has already had
+    the apostrophe stripped). Fix 2's tail-rescue probes it so
+    ``einstein's theory`` can reach ``Theory_of_relativity`` (unreachable
+    from the stripped ``einstein theory``). Defaults to ``query`` for
+    backwards-compat callers that don't supply it.
     """
     if top_hits:
         top_hit_0 = top_hits[0][1]
@@ -1722,6 +1730,7 @@ def synthesize_query(
     top_hits = _promote_title_match(
         top_hits,
         query=query,
+        original_query=original_query,
         archives=archives,
         archives_searched=archives_searched,
         search_handler=search_handler,
@@ -1766,6 +1775,7 @@ def synthesize_query(
         promoted = _promote_title_match(
             [],
             query=query,
+            original_query=original_query,
             archives=archives,
             archives_searched=archives_searched,
             search_handler=search_handler,

--- a/openzim_mcp/title_promotion.py
+++ b/openzim_mcp/title_promotion.py
@@ -479,6 +479,27 @@ def is_tail_hijack_shape(promoted: Dict[str, Any], topic: str) -> bool:
     return len(cand_tokens_seq) == 1 and cand_tokens_seq == topic_tokens_seq[-1:]
 
 
+def is_single_token_tail_match(promoted: Dict[str, Any], topic: str) -> bool:
+    """Floor-free sibling of :func:`is_tail_hijack_shape`: the promoted
+    canonical is a single token equal to the topic's LAST token,
+    regardless of topic length.
+
+    ``is_tail_hijack_shape`` carries a ``< 3 token`` floor (the b4
+    ``Berlin Germany`` carve-out) because, on the tell_me_about SOURCE
+    gate, a 2-token tail can be legitimate. The cross-archive LEAK gate
+    has an extra signal — provenance — so it can safely act on the
+    2-token shape too (``connection refused`` -> ``Refused`` from a
+    NON-PRIMARY archive). Used only by
+    ``synthesize._drop_cross_archive_leakage`` (Fix 1, #253) and the Fix 2
+    tail-rescue probe; the source gate keeps the floored predicate.
+    """
+    topic_tokens_seq = _TAIL_TOKEN_RE.findall(topic.lower())
+    if not topic_tokens_seq:
+        return False
+    cand_tokens_seq = _TAIL_TOKEN_RE.findall(str(promoted.get("path", "")).lower())
+    return len(cand_tokens_seq) == 1 and cand_tokens_seq == topic_tokens_seq[-1:]
+
+
 # English stop-word inventory used by the multi-entity discriminator
 # to skip tokens that are not entities even when libzim's title index
 # happens to resolve them (``What``, ``Is``, ``The``, ``Of`` all exist

--- a/tests/test_post_v2_1_4_beta_fixes.py
+++ b/tests/test_post_v2_1_4_beta_fixes.py
@@ -215,3 +215,51 @@ def test_planet_earth_keeps_bare_tail_no_rescue() -> None:
         search_handler=handler,
     )
     assert out[0][1]["path"] == "Earth"
+
+
+def test_possessive_rescue_skips_when_canonical_lacks_tail_token() -> None:
+    # Fix D (#252 review): possessive original query whose canonical does
+    # NOT contain the tail token must NOT be rescued. ``einstein's theory``
+    # (stripped ``einstein theory``) resolves to ``Special_relativity``
+    # (tokens ``special``, ``relativity`` — no ``theory``). The rescue must
+    # not promote it. Because the query is an apostrophe-possessive, the
+    # tail loop runs with ``min_len=2`` and never probes the bare ``theory``
+    # tail, so the generic ``Theory`` is not promoted either — the result
+    # falls through to the untouched BM25 ranking. This is a regression
+    # guard: it already passes against the post-Fix-A/B/C code (the rescue's
+    # ``tail_tok[0] in rescued_tokens`` check would reject ``Special_relativity``
+    # anyway, and the ``min_len=2`` floor keeps the rescue from even being
+    # reached), so it documents that no path promotes the tail-less canonical.
+    from openzim_mcp.synthesize import _promote_title_match
+
+    handler = _rescue_handler(
+        title_index_by_query={
+            # Original possessive resolves to a multi-token canonical that
+            # does NOT contain the tail token "theory".
+            "einstein's theory": {
+                "path": "Special_relativity",
+                "title": "Special relativity",
+                "score": 1.0,
+            },
+            "theory": {"path": "Theory", "title": "Theory", "score": 1.0},
+        },
+        hit_by_title={
+            "theory": {"path": "Theory", "snippet": "...", "score": 1.0},
+            "special relativity": {
+                "path": "Special_relativity",
+                "snippet": "...",
+                "score": 1.0,
+            },
+        },
+    )
+    archive = object()
+    out = _promote_title_match(
+        [("wikipedia", {"path": "Some_BM25_Noise", "snippet": "", "score": 0.5})],
+        query="einstein theory",  # stripped topic
+        original_query="einstein's theory",  # raw possessive query
+        archives=[(archive, "wiki.zim")],
+        archives_searched=["wikipedia"],
+        search_handler=handler,
+    )
+    # The rescue must NOT fire: the canonical lacks the tail token.
+    assert out[0][1]["path"] != "Special_relativity"

--- a/tests/test_post_v2_1_4_beta_fixes.py
+++ b/tests/test_post_v2_1_4_beta_fixes.py
@@ -33,6 +33,9 @@ the live 118 GB title index); the mocks below encode the live-observed
 
 from __future__ import annotations
 
+from typing import Any, Dict
+from unittest.mock import MagicMock
+
 from openzim_mcp.title_promotion import is_single_token_tail_match
 
 
@@ -126,3 +129,89 @@ def test_promote_title_match_accepts_original_query_kw() -> None:
         search_handler=object(),
     )
     assert out == top_hits
+
+
+def _rescue_handler(
+    title_index_by_query: Dict[str, Dict[str, Any]],
+    hit_by_title: Dict[str, Dict[str, Any]],
+) -> Any:
+    """Mock search_handler: find_entry_by_title_data keyed by query,
+    title_match_hit keyed by resolved title."""
+    m = MagicMock()
+
+    def fake_fetbd(
+        _vp: str, q: str, *, cross_file: bool = False, limit: int = 3
+    ) -> Dict[str, Any]:
+        row = title_index_by_query.get(q.lower())
+        return {"results": [row] if row else []}
+
+    m.find_entry_by_title_data.side_effect = fake_fetbd
+    m.title_match_hit.side_effect = lambda _archive, title: hit_by_title.get(
+        title.lower()
+    )
+    return m
+
+
+def test_einsteins_theory_rescues_theory_of_relativity() -> None:
+    # tail "theory" -> generic "Theory"; original "einstein's theory"
+    # resolves to the more-specific multi-token canonical containing "theory".
+    from openzim_mcp.synthesize import _promote_title_match
+
+    handler = _rescue_handler(
+        title_index_by_query={
+            "einstein's theory": {
+                "path": "Theory_of_relativity",
+                "title": "Theory of relativity",
+                "score": 1.0,
+            },
+            "theory": {"path": "Theory", "title": "Theory", "score": 1.0},
+        },
+        hit_by_title={
+            "theory": {"path": "Theory", "snippet": "...", "score": 1.0},
+            "theory of relativity": {
+                "path": "Theory_of_relativity",
+                "snippet": "...",
+                "score": 1.0,
+            },
+        },
+    )
+    archive = object()
+    # A weak BM25 top hit that does NOT strong-title-match the 2-token
+    # query (a bare "Einstein" would prefix-match "einstein theory" and
+    # short-circuit _promote_title_match before the tail loop runs).
+    out = _promote_title_match(
+        [("wikipedia", {"path": "Some_BM25_Noise", "snippet": "", "score": 0.5})],
+        query="einstein theory",  # stripped topic (what synthesize gets today)
+        original_query="einstein's theory",  # raw query (apostrophe preserved)
+        archives=[(archive, "wiki.zim")],
+        archives_searched=["wikipedia"],
+        search_handler=handler,
+    )
+    assert out[0][1]["path"] == "Theory_of_relativity"
+    assert out[0][1].get("promoted") is True
+
+
+def test_planet_earth_keeps_bare_tail_no_rescue() -> None:
+    # original "planet earth" resolves only to single-token "Earth" -> no
+    # more-specific canonical -> keep the legitimate bare-tail promotion.
+    from openzim_mcp.synthesize import _promote_title_match
+
+    handler = _rescue_handler(
+        title_index_by_query={
+            "planet earth": {"path": "Earth", "title": "Earth", "score": 1.0},
+            "earth": {"path": "Earth", "title": "Earth", "score": 1.0},
+        },
+        hit_by_title={"earth": {"path": "Earth", "snippet": "...", "score": 1.0}},
+    )
+    archive = object()
+    # Weak BM25 top hit (a bare "Planet" would prefix-match "planet earth"
+    # and short-circuit before the promotion path runs).
+    out = _promote_title_match(
+        [("wikipedia", {"path": "Some_BM25_Noise", "snippet": "", "score": 0.5})],
+        query="planet earth",
+        original_query="planet earth",
+        archives=[(archive, "wiki.zim")],
+        archives_searched=["wikipedia"],
+        search_handler=handler,
+    )
+    assert out[0][1]["path"] == "Earth"

--- a/tests/test_post_v2_1_4_beta_fixes.py
+++ b/tests/test_post_v2_1_4_beta_fixes.py
@@ -108,3 +108,21 @@ def test_leak_gate_keeps_multitoken_promoted_exemption() -> None:
         min_overlap=1,
     )
     assert "On_the_Origin_of_Species" in [h["path"] for _, h in kept]
+
+
+def test_promote_title_match_accepts_original_query_kw() -> None:
+    # Plumbing-only: passing original_query must not change a no-op promote.
+    from openzim_mcp.synthesize import _promote_title_match
+
+    top_hits = [("wikipedia", {"path": "Berlin", "snippet": "", "score": 1.0})]
+    # Berlin is already a strong title match for "berlin" -> short-circuit,
+    # returns input unchanged regardless of original_query.
+    out = _promote_title_match(
+        top_hits,
+        query="berlin",
+        original_query="berlin",
+        archives=[],
+        archives_searched=[],
+        search_handler=object(),
+    )
+    assert out == top_hits

--- a/tests/test_post_v2_1_4_beta_fixes.py
+++ b/tests/test_post_v2_1_4_beta_fixes.py
@@ -1,0 +1,110 @@
+"""Post-v2.1.4 live-beta-sweep regression suite.
+
+The v2.1.4 live beta sweep (deployed v2.1.6 server, dual-archive library:
+Wikipedia 2026-02 + superuser.com 2026-02) surfaced two synthesize
+defects of one class — a **2-token tail-hijack** where the query's last
+token exact-title-matches a generic article that is then promoted to
+rank 1, burying the relevant content:
+
+  #253 — ``synthesize("connection refused")`` promotes the Wikipedia
+  article ``Refused`` (a punk band) at rank 1 while the relevant
+  superuser.com SSH troubleshooting Q&As are buried. The hit is a
+  single-token tail from a NON-PRIMARY archive, tagged ``promoted``, so
+  ``_drop_cross_archive_leakage`` unconditionally exempts it from the
+  cross-archive path-overlap floor.
+
+  #252 — ``synthesize("Einstein's theory")`` promotes the generic
+  ``Theory`` instead of the more-specific ``Theory_of_relativity`` (same
+  class as ``Plato's cave`` -> ``Cave`` vs ``Allegory_of_the_cave``).
+  The apostrophe-stripped topic (``einstein theory``) cannot reach the
+  specific canonical that the apostrophe-preserving original query
+  (``einstein's theory``) resolves to at score 1.0.
+
+The two filed issues share the enabling cause: the ``< 3 token`` floor
+in ``title_promotion._accept_non_possessive`` waves any 2-token query's
+generic-tail promotion through. The floor protects legitimate 2-token
+tails (``planet earth`` -> ``Earth``, ``Berlin Germany`` -> ``Berlin``),
+so the fix must stay cross-archive-aware / more-specific-canonical-aware.
+
+These defects are NOT reproducible from a local checkout (they depend on
+the live 118 GB title index); the mocks below encode the live-observed
+``find_title_match`` / ``title_match_hit`` result shapes.
+"""
+
+from __future__ import annotations
+
+from openzim_mcp.title_promotion import is_single_token_tail_match
+
+
+def test_single_token_tail_match_fires_on_2token_query() -> None:
+    # "connection refused" -> "Refused": the #253 shape the floored
+    # is_tail_hijack_shape MISSES because the query has only 2 tokens.
+    assert is_single_token_tail_match({"path": "Refused"}, "connection refused")
+
+
+def test_single_token_tail_match_ignores_multitoken_canonical() -> None:
+    # darwins evolution -> On_the_Origin_of_Species: multi-token canonical,
+    # the legitimate lexically-disjoint promotion exemption.
+    assert not is_single_token_tail_match(
+        {"path": "On_the_Origin_of_Species"}, "darwins evolution"
+    )
+
+
+def test_single_token_tail_match_requires_tail_position() -> None:
+    # head-position single token is not a tail hijack ("Berlin Germany"->Berlin)
+    assert not is_single_token_tail_match({"path": "Berlin"}, "berlin germany")
+
+
+def test_leak_gate_drops_nonprimary_promoted_tail_hijack() -> None:
+    # superuser is primary (path overlap {connection, refused} = 2);
+    # wiki/Refused is a tagged promoted hit but a single-token tail from
+    # the non-primary archive -> must be dropped despite the `promoted` tag.
+    from openzim_mcp.synthesize import _drop_cross_archive_leakage
+
+    top_hits = [
+        (
+            "wikipedia",
+            {"path": "Refused", "promoted": True, "snippet": "", "score": 1.0},
+        ),
+        (
+            "superuser",
+            {"path": "questions/1/ssh-connection-refused", "snippet": "", "score": 0.5},
+        ),
+    ]
+    kept = _drop_cross_archive_leakage(
+        top_hits,
+        query="connection refused",
+        fallback_used="rrf_fusion",
+        max_secondary_archive_hits=1,
+        min_overlap=1,
+    )
+    paths = [h["path"] for _, h in kept]
+    assert "Refused" not in paths
+    assert "questions/1/ssh-connection-refused" in paths
+
+
+def test_leak_gate_keeps_multitoken_promoted_exemption() -> None:
+    # darwins evolution -> On_the_Origin_of_Species (promoted, lexically
+    # disjoint, multi-token) must KEEP its exemption.
+    from openzim_mcp.synthesize import _drop_cross_archive_leakage
+
+    top_hits = [
+        (
+            "wikipedia",
+            {
+                "path": "On_the_Origin_of_Species",
+                "promoted": True,
+                "snippet": "",
+                "score": 1.0,
+            },
+        ),
+        ("superuser", {"path": "questions/2/git-merge", "snippet": "", "score": 0.5}),
+    ]
+    kept = _drop_cross_archive_leakage(
+        top_hits,
+        query="darwins evolution",
+        fallback_used="rrf_fusion",
+        max_secondary_archive_hits=1,
+        min_overlap=1,
+    )
+    assert "On_the_Origin_of_Species" in [h["path"] for _, h in kept]


### PR DESCRIPTION
## Summary

Fixes two synthesize defects confirmed live on the deployed v2.1.6 server (dual-archive wiki + superuser), both instances of one **2-token tail-hijack** class — a generic last token gets promoted as an exact title match, burying the relevant content.

- **#253 (cross-archive leak)** — `connection refused` → wiki `Refused` (punk band) at rank 1. `_drop_cross_archive_leakage` now drops a `promoted` hit from a **non-primary** archive when it's a single-token-tail shape (new floor-free `is_single_token_tail_match` predicate). The multi-token promoted exemption (`darwins evolution → On_the_Origin_of_Species`) and same-archive/primary promotions are preserved.
- **#252 (same-archive, resolve-correct)** — `Einstein's theory` → bare `Theory`; same class as `Plato's cave` → `Cave`. The apostrophe is stripped in topic extraction, so the possessive machinery never engages and the generic tail wins. New **tail-rescue**: before promoting a generic single-token tail, probe the **original apostrophe-preserving** query; if it resolves to a more-specific multi-token canonical containing the tail token, promote that instead (`Theory_of_relativity` / `Allegory_of_the_cave`). Gated to apostrophe-possessive originals so the `planet earth → Earth` carve-out is untouched.

Design + plan: `docs/superpowers/specs/2026-06-03-synthesize-tail-hijack-fix-design.md`, `docs/superpowers/plans/2026-06-03-synthesize-tail-hijack-fix.md`.

## Test Plan

Local (done): unit tests in `tests/test_post_v2_1_4_beta_fixes.py` (9 passing, proven to fail pre-fix), full gate green (`make lint && make type-check && uv run pytest -q` → 2854 passed, mypy clean). Two independent reviews (spec compliance + code quality) passed.

**⚠️ Merge gate — live before/after reprobe (required; these defects are not reproducible from a checkout).** After deploying this branch, confirm via the `zim_query` tool (`synthesize=True`):

- [ ] `connection refused` → relevant superuser SSH at rank 1, no `Refused`  **[#253]**
- [ ] `Einstein's theory` → `Theory_of_relativity` at rank 1  **[#252]**
- [ ] `Plato's cave` → `Allegory_of_the_cave` at rank 1  **[#252 class]**
- [ ] `ssh connection refused` → superuser SSH (unchanged)  **[invariant]**
- [ ] `planet earth` → `Earth` (unchanged)  **[invariant]**
- [ ] `Berlin Germany` → `Berlin` (unchanged)  **[invariant]**

Closes #252, #253.