### PR TITLE
docs: sync version facts to v2.1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ uv tool install openzim-mcp
 pip install openzim-mcp
 
 # Docker (multi-arch image, ghcr.io)
-docker pull ghcr.io/cameronrye/openzim-mcp:2.1.4
-docker run --rm -v /path/to/zim/files:/zim ghcr.io/cameronrye/openzim-mcp:2.1.4 /zim
+docker pull ghcr.io/cameronrye/openzim-mcp:2.1.7
+docker run --rm -v /path/to/zim/files:/zim ghcr.io/cameronrye/openzim-mcp:2.1.7 /zim
 ```
 
 Verify the install:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # openzim-mcp Roadmap
 
-**Status:** Latest release **v2.1.4** (2026-06-02) — PyPI `2.1.4` and `ghcr.io/cameronrye/openzim-mcp:2.1.4` / `:latest`, GitHub Release with assets. v2.0.0 GA shipped 2026-05-27 (as `:2.0.0`); the v2.0.x/v2.1.x line has been kept current via beta-sweep fixes plus the v2.1.0 native-libzim reader features.
+**Status:** Latest release **v2.1.7** (2026-06-04) — PyPI `2.1.7` and `ghcr.io/cameronrye/openzim-mcp:2.1.7` / `:latest`, GitHub Release with assets. v2.0.0 GA shipped 2026-05-27 (as `:2.0.0`); the v2.0.x/v2.1.x line has been kept current via beta-sweep fixes plus the v2.1.0 native-libzim reader features.
 
 This document tracks open work past v2.0.0. Everything here is **additive**: opt-in extras, optional sidecars, or dispatch tuning. None of it changes the v2 tool surface or response contract.
 

--- a/website/public/humans.txt
+++ b/website/public/humans.txt
@@ -64,4 +64,4 @@
     Language: English
     Doctype: HTML5
     IDE: Various (VS Code, Vim, etc.)
-    Version: 2.1.4
+    Version: 2.1.7

--- a/website/src/content/docs/http-and-docker-deployment.mdx
+++ b/website/src/content/docs/http-and-docker-deployment.mdx
@@ -38,7 +38,7 @@ This binds the loopback interface only. Put a TLS-terminating reverse proxy in f
 docker run --rm -p 8000:8000 \
   -v /srv/zim:/data:ro \
   -e OPENZIM_MCP_AUTH_TOKEN="$(openssl rand -hex 32)" \
-  ghcr.io/cameronrye/openzim-mcp:2.1.4
+  ghcr.io/cameronrye/openzim-mcp:2.1.7
 ```
 
 The published image:
@@ -258,7 +258,7 @@ spec:
     spec:
       containers:
         - name: openzim-mcp
-          image: ghcr.io/cameronrye/openzim-mcp:2.1.4
+          image: ghcr.io/cameronrye/openzim-mcp:2.1.7
           ports:
             - containerPort: 8000
           env:
@@ -338,7 +338,7 @@ This recipe puts OpenZIM MCP on a single host, reachable from the rest of your L
 ```yaml
 services:
   openzim-mcp:
-    image: ghcr.io/cameronrye/openzim-mcp:2.1.4
+    image: ghcr.io/cameronrye/openzim-mcp:2.1.7
     restart: unless-stopped
     ports:
       - "127.0.0.1:8000:8000"
@@ -363,7 +363,7 @@ volumes:
 
 What's intentional here:
 
-- **Pinned tag** (`:2.1.1`, not `:latest`). Upgrades are deliberate — `docker compose pull` is a thing you do, not a thing that happens to you.
+- **Pinned tag** (`:2.1.7`, not `:latest`). Upgrades are deliberate — `docker compose pull` is a thing you do, not a thing that happens to you.
 - **Host port bound to `127.0.0.1`.** The container listens on all interfaces (the image's default `OPENZIM_MCP_HOST=0.0.0.0`), but Docker's port publish restricts external exposure to loopback. The Tailscale variant below lifts this restriction by binding to a specific interface.
 - **Read-only ZIM mount** (`:ro`). The server only reads ZIM files; mounting read-only ensures a server compromise can't damage them.
 - **Token via env, not hard-coded.** Put it in a `.env` file next to the compose file (and add `.env` to `.gitignore`). The image's defaults already set `TRANSPORT=http`, `HOST=0.0.0.0`, `PORT=8000`, so they're not repeated here.
@@ -472,7 +472,7 @@ This is the LAN compose file with two changes: a `caddy` service is added, and t
 ```yaml
 services:
   openzim-mcp:
-    image: ghcr.io/cameronrye/openzim-mcp:2.1.4
+    image: ghcr.io/cameronrye/openzim-mcp:2.1.7
     restart: unless-stopped
     expose:
       - "8000"
@@ -558,7 +558,7 @@ docker compose pull
 docker compose up -d
 ```
 
-The image tag in `docker-compose.yml` is pinned (`:2.1.1`) — change it to the new version before pulling. Pinning is deliberate: `:latest` makes upgrades a surprise, and the release notes for each tag tell you when an upgrade involves a breaking change. The v1.x → v2.0.0 jump is a breaking rename of the advanced-mode tool surface (22 tools → 8); see the [CHANGELOG](https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md) before bumping.
+The image tag in `docker-compose.yml` is pinned (`:2.1.7`) — change it to the new version before pulling. Pinning is deliberate: `:latest` makes upgrades a surprise, and the release notes for each tag tell you when an upgrade involves a breaking change. The v1.x → v2.0.0 jump is a breaking rename of the advanced-mode tool surface (22 tools → 8); see the [CHANGELOG](https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md) before bumping.
 
 #### Watching logs
 

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -43,11 +43,11 @@ OpenZIM MCP provides **intelligent, structured access** that LLMs need:
 
 ## Project Status
 
-- **Version:** 2.1.4
+- **Version:** 2.1.7
 - **License:** MIT
 - **Python:** 3.12+
 - **Test Coverage:** 80%+
-- **Container:** `ghcr.io/cameronrye/openzim-mcp:2.1.4` + `:latest` (linux/amd64, linux/arm64)
+- **Container:** `ghcr.io/cameronrye/openzim-mcp:2.1.7` + `:latest` (linux/amd64, linux/arm64)
 
 ## Quick Links
 

--- a/website/src/content/docs/installation.mdx
+++ b/website/src/content/docs/installation.mdx
@@ -232,14 +232,14 @@ OpenZIM MCP ships a multi-arch image at `ghcr.io/cameronrye/openzim-mcp` (`linux
 
 ```bash
 # Pull
-docker pull ghcr.io/cameronrye/openzim-mcp:2.1.4
+docker pull ghcr.io/cameronrye/openzim-mcp:2.1.7
 
 # Run with HTTP transport, bound to all interfaces (the image default).
 # The server REFUSES to bind 0.0.0.0 without OPENZIM_MCP_AUTH_TOKEN.
 docker run --rm -p 8000:8000 \
   -v /srv/zim:/data:ro \
   -e OPENZIM_MCP_AUTH_TOKEN="$(openssl rand -hex 32)" \
-  ghcr.io/cameronrye/openzim-mcp:2.1.4
+  ghcr.io/cameronrye/openzim-mcp:2.1.7
 ```
 
 The image entrypoint is `python -m openzim_mcp /data`, so mount your ZIM directory at `/data`. Default env vars in the image: `OPENZIM_MCP_TRANSPORT=http`, `OPENZIM_MCP_HOST=0.0.0.0`, `OPENZIM_MCP_PORT=8000`.

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -23,9 +23,9 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
     <meta property="og:site_name" content="OpenZIM MCP">
     <meta property="og:url" content="https://cameronrye.github.io/openzim-mcp/">
     <meta property="og:title" content="OpenZIM MCP — Knowledge that works offline">
-    <meta property="og:description" content="MCP server for offline ZIM-archive access. 8-tool advanced surface, streamable HTTP, batch retrieval, per-entry resources, subscriptions. v2.1.1.">
+    <meta property="og:description" content="MCP server for offline ZIM-archive access. 8-tool advanced surface, streamable HTTP, batch retrieval, per-entry resources, subscriptions.">
     <meta property="og:image" content="https://cameronrye.github.io/openzim-mcp/assets/og-image.svg">
-    <meta property="og:image:alt" content="OpenZIM MCP 2.1.1 — Knowledge that works offline">
+    <meta property="og:image:alt" content="OpenZIM MCP — Knowledge that works offline">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:locale" content="en_US">
@@ -38,9 +38,9 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
     <meta name="twitter:creator" content="@cameronrye">
     <meta name="twitter:url" content="https://cameronrye.github.io/openzim-mcp/">
     <meta name="twitter:title" content="OpenZIM MCP — Knowledge that works offline">
-    <meta name="twitter:description" content="MCP server for offline ZIM-archive access. 8-tool advanced surface, streamable HTTP, batch retrieval, per-entry resources, subscriptions. v2.1.1.">
+    <meta name="twitter:description" content="MCP server for offline ZIM-archive access. 8-tool advanced surface, streamable HTTP, batch retrieval, per-entry resources, subscriptions.">
     <meta name="twitter:image" content="https://cameronrye.github.io/openzim-mcp/assets/og-image.svg">
-    <meta name="twitter:image:alt" content="OpenZIM MCP 2.1.1 — Knowledge that works offline">
+    <meta name="twitter:image:alt" content="OpenZIM MCP — Knowledge that works offline">
 
     <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico">
@@ -75,7 +75,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
       "alternateName": "OpenZIM MCP Server",
       "description": "A modern, secure MCP server that enables AI models to access and search ZIM format knowledge bases offline with intelligent, structured access patterns",
       "url": "https://cameronrye.github.io/openzim-mcp/",
-      "softwareVersion": "2.1.4",
+      "softwareVersion": "2.1.7",
       "releaseNotes": "https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md",
       "applicationCategory": "DeveloperApplication",
       "applicationSubCategory": "AI Tools",
@@ -147,7 +147,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
     <section id="hero" class="hero">
       <div class="container hero__inner">
         <div class="hero__content">
-          <span class="eyebrow">MCP&nbsp;SERVER · v2.1.1</span>
+          <span class="eyebrow">MCP&nbsp;SERVER</span>
           <h1 class="hero__title">Knowledge that works offline.</h1>
           <p class="hero__lead">
             OpenZIM MCP gives any AI model structured, secure access to ZIM archives —
@@ -169,7 +169,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
             </button>
           </div>
           <ul class="hero__stats">
-            <li><span class="hero__stat-num">v2.1.1</span><span class="hero__stat-label">Latest release</span></li>
+            <li><span class="hero__stat-num">v2.1.7</span><span class="hero__stat-label">Latest release</span></li>
             <li><span class="hero__stat-num">1 + 8</span><span class="hero__stat-label">Simple / advanced tools</span></li>
             <li><span class="hero__stat-num">80%+</span><span class="hero__stat-label">Test coverage</span></li>
             <li><span class="hero__stat-num">MIT</span><span class="hero__stat-label">License</span></li>
@@ -360,7 +360,7 @@ tests/test_phase_f_gate_decision_consistency.py</code></pre>
                 <pre><code>uv tool install openzim-mcp</code></pre>
               </div>
               <div class="tabs__panel" id="install-docker" role="tabpanel" aria-labelledby="tab-install-docker" hidden>
-                <pre><code>docker pull ghcr.io/cameronrye/openzim-mcp:2.1.4</code></pre>
+                <pre><code>docker pull ghcr.io/cameronrye/openzim-mcp:2.1.7</code></pre>
               </div>
               <div class="tabs__panel" id="install-source" role="tabpanel" aria-labelledby="tab-install-source" hidden>
                 <pre><code>git clone https://github.com/cameronrye/openzim-mcp.git


### PR DESCRIPTION
Sync stale version facts (2.1.4/2.1.1 → 2.1.7) and drop version tags from marketing surface descriptors. Files: README.md, docs/roadmap.md, website/public/humans.txt, website/src/pages/index.astro, website/src/content/docs/index.mdx, website/src/content/docs/http-and-docker-deployment.mdx, website/src/content/docs/installation.mdx.