### PR TITLE
fix(docker): default image to stdio so bare `docker run` works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,11 @@ RUN uv sync --frozen --no-dev
 # ---- final stage ----
 FROM python:3.13-slim
 
-# Create non-root user and install curl for HEALTHCHECK in a single layer
+# Create the non-root runtime user. No extra apt packages are needed —
+# the image defaults to stdio transport (see ENTRYPOINT note below), so
+# there is no HTTP server to health-probe and thus no need for curl.
 RUN groupadd --gid 10001 appuser \
- && useradd --uid 10001 --gid appuser --shell /bin/bash --create-home appuser \
- && apt-get update \
- && apt-get install -y --no-install-recommends curl \
- && rm -rf /var/lib/apt/lists/*
+ && useradd --uid 10001 --gid appuser --shell /bin/bash --create-home appuser
 
 WORKDIR /app
 
@@ -43,18 +42,22 @@ ENV PATH="/app/.venv/bin:$PATH"
 # Default mount point for ZIM files
 VOLUME ["/data"]
 
-# HTTP transport defaults — exposed bind requires OPENZIM_MCP_AUTH_TOKEN at
-# runtime; the safe-default startup check refuses to bind 0.0.0.0 without it.
-ENV OPENZIM_MCP_TRANSPORT=http \
-    OPENZIM_MCP_HOST=0.0.0.0 \
-    OPENZIM_MCP_PORT=8000
-
+# Document the HTTP port for the opt-in deployment path below. EXPOSE is
+# metadata only; it publishes nothing unless `docker run -p` maps it.
 EXPOSE 8000
 
 # Drop privileges
 USER appuser
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD curl -fsS http://localhost:8000/readyz || exit 1
-
+# Default to stdio transport (inherited from the code defaults — we set no
+# OPENZIM_MCP_TRANSPORT here), so `docker run -i --rm -v <zim>:/data <image>`
+# runs as a local MCP server over stdin/stdout. That is how Claude Desktop
+# and the Glama registry launch a containerized MCP server.
+#
+# To run the long-lived HTTP service instead, opt in at runtime:
+#   docker run --rm -p 8000:8000 \
+#     -e OPENZIM_MCP_TRANSPORT=http -e OPENZIM_MCP_HOST=0.0.0.0 \
+#     -e OPENZIM_MCP_AUTH_TOKEN=$(openssl rand -hex 32) \
+#     -v <zim>:/data <image>
+# (binding a non-loopback host without a token is refused by design.)
 ENTRYPOINT ["python", "-m", "openzim_mcp", "/data"]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
 </p>
 
+<p align="center">
+  <a href="https://glama.ai/mcp/servers/cameronrye/openzim-mcp">
+    <img width="380" height="200" src="https://glama.ai/mcp/servers/cameronrye/openzim-mcp/badge" alt="OpenZIM MCP server quality badge">
+  </a>
+</p>
+
 ---
 
 > 🆕 **8-tool advanced surface.** Phase F (v2.0.0) consolidated 22 advanced tools into 8 (`zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`). **New in v2.1:** native libzim archive validation via `zim_health(zim_file_path=...)`, plus archive identity / index introspection in `zim_metadata`. [Release notes →](CHANGELOG.md) [Docs →](https://cameronrye.github.io/openzim-mcp/docs/)
@@ -41,10 +47,12 @@ uv tool install openzim-mcp
 # pip
 pip install openzim-mcp
 
-# Docker (multi-arch image, ghcr.io)
-docker pull ghcr.io/cameronrye/openzim-mcp:2.1.7
-docker run --rm -v /path/to/zim/files:/zim ghcr.io/cameronrye/openzim-mcp:2.1.7 /zim
+# Docker (multi-arch image, ghcr.io) — runs as a local stdio MCP server
+docker pull ghcr.io/cameronrye/openzim-mcp
+docker run -i --rm -v /path/to/zim/files:/data ghcr.io/cameronrye/openzim-mcp
 ```
+
+The container defaults to **stdio** transport, so `docker run -i` speaks MCP over stdin/stdout — wire it into an MCP client the same way as the binary (see [Quick start](#quick-start)). For the long-running **HTTP** service (bearer auth, CORS, health endpoints), opt in at runtime with `-e OPENZIM_MCP_TRANSPORT=http -e OPENZIM_MCP_HOST=0.0.0.0 -e OPENZIM_MCP_AUTH_TOKEN=… -p 8000:8000`; see [HTTP & Docker deployment](https://cameronrye.github.io/openzim-mcp/docs/http-and-docker-deployment/).
 
 Verify the install:
 

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["cameronrye"]
+}

--- a/tests/live/README.md
+++ b/tests/live/README.md
@@ -42,7 +42,7 @@ auto-skip otherwise, so you don't need to remember to filter.
 | `test_live_prompts.py` | MCP prompts (`/research`, `/summarize`, `/explore`) including v1.0 sanitization (control-char strip, length cap, ask-for-input fallback) |
 | `test_live_subscriptions.py` | `MtimeWatcher` + `notifications/resources/updated` over streamable-HTTP |
 | `test_live_cache_persistence.py` | Cache `persistence_path` survives a graceful shutdown / restart |
-| `test_live_docker.py` | `docker build` + `docker run` smoke: image boots, runs as `appuser` (uid 10001), `/healthz`+`/readyz` work, bearer auth on `/mcp`, `HEALTHCHECK` directive present. Auto-skips when docker daemon unavailable. First build may take ~10 min; subsequent runs reuse layer cache (~20s). |
+| `test_live_docker.py` | `docker build` + `docker run` smoke: image boots, runs as `appuser` (uid 10001), `/healthz`+`/readyz` work and bearer auth on `/mcp` (HTTP opt-in path), and the image **defaults to stdio** (no transport baked into `ENV`) — a bare `docker run -i` completes the MCP `initialize` handshake. Auto-skips when docker daemon unavailable. First build may take ~10 min; subsequent runs reuse layer cache (~20s). |
 
 ## Intentionally not live-tested
 

--- a/tests/live/test_live_docker.py
+++ b/tests/live/test_live_docker.py
@@ -309,6 +309,10 @@ def test_container_speaks_mcp_over_stdio_by_default(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
+    # Pre-initialize so static analysis can see these are always bound; the
+    # except branch raises via pytest.fail (NoReturn) so they're never read
+    # unset, but CodeQL doesn't model pytest.fail's NoReturn.
+    stdout, stderr = b"", b""
     try:
         # Closing stdin (via communicate's input) signals EOF, so the stdio
         # server shuts down after answering initialize and stdout reaches EOF.

--- a/tests/live/test_live_docker.py
+++ b/tests/live/test_live_docker.py
@@ -321,7 +321,10 @@ def test_container_speaks_mcp_over_stdio_by_default(
         )
     except subprocess.TimeoutExpired:
         proc.kill()
-        out, err = proc.communicate()
+        try:
+            out, err = proc.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            out, err = b"", b""
         pytest.fail(
             "container did not answer the stdio initialize handshake within 90s "
             "(likely crashed on the HTTP bind check instead of running stdio).\n"

--- a/tests/live/test_live_docker.py
+++ b/tests/live/test_live_docker.py
@@ -1,10 +1,12 @@
 """Live Docker image build + run smoke test.
 
-Covers v1.0 item 3: the multi-stage, multi-arch Docker image published
-to ``ghcr.io/cameronrye/openzim-mcp``. Builds the image locally, runs
-it under HTTP transport with a temp auth token, polls ``/readyz``
-through the host port mapping, and asserts the container runs as the
-non-root ``appuser``.
+Covers the multi-stage, multi-arch Docker image published to
+``ghcr.io/cameronrye/openzim-mcp``. Builds the image locally and checks
+both transports: the default **stdio** path (a bare ``docker run -i``
+completes the MCP ``initialize`` handshake — how Claude Desktop / Glama
+launch it) and the opt-in **HTTP** path (run with a temp auth token,
+poll ``/readyz`` through the host port mapping), plus the non-root
+``appuser`` invariant.
 
 Skipped automatically when:
   - the ``docker`` CLI is not on ``PATH``
@@ -89,7 +91,14 @@ def built_image() -> str:
 
 @pytest.fixture
 def running_container(built_image: str, zim_dir: Path) -> Iterator[dict]:
-    """Run the image with HTTP transport + temp token; yield container info."""
+    """Run the image with HTTP transport (opt-in) + temp token; yield info.
+
+    The image defaults to stdio transport (see
+    ``test_container_speaks_mcp_over_stdio_by_default``), so the HTTP
+    deployment path is opted into explicitly here via
+    ``OPENZIM_MCP_TRANSPORT=http`` + ``OPENZIM_MCP_HOST=0.0.0.0`` so the
+    bound port is reachable through the host port mapping.
+    """
     container_name = f"oz-mcp-livetest-{uuid.uuid4().hex[:8]}"
     host_port = _find_free_loopback_port()
     token = secrets.token_urlsafe(32)
@@ -106,6 +115,10 @@ def running_container(built_image: str, zim_dir: Path) -> Iterator[dict]:
             f"127.0.0.1:{host_port}:8000",
             "-v",
             f"{zim_dir}:/data:ro",
+            "-e",
+            "OPENZIM_MCP_TRANSPORT=http",
+            "-e",
+            "OPENZIM_MCP_HOST=0.0.0.0",
             "-e",
             f"OPENZIM_MCP_AUTH_TOKEN={token}",
             built_image,
@@ -224,8 +237,16 @@ def test_container_mcp_endpoint_accepts_valid_token(
     )
 
 
-def test_image_has_healthcheck_directive(built_image: str) -> None:
-    """``docker inspect`` must show the HEALTHCHECK from the Dockerfile."""
+def test_image_does_not_force_http_transport(built_image: str) -> None:
+    """The image must NOT bake in HTTP transport / a public bind host.
+
+    Regression guard: the image used to ship ``OPENZIM_MCP_TRANSPORT=http``
+    and ``OPENZIM_MCP_HOST=0.0.0.0`` as ``ENV``. That made every tokenless
+    ``docker run`` crash on the safe-default bind check, and left the
+    server uninstallable by stdio MCP clients (Claude Desktop, Glama).
+    The image must inherit the code's stdio/127.0.0.1 defaults so HTTP is
+    an explicit opt-in, not the baked-in default.
+    """
     cp = subprocess.run(
         ["docker", "inspect", built_image],
         capture_output=True,
@@ -235,11 +256,94 @@ def test_image_has_healthcheck_directive(built_image: str) -> None:
     assert cp.returncode == 0
     inspected = json.loads(cp.stdout)
     assert inspected, "docker inspect returned empty array"
-    config = inspected[0].get("Config", {})
-    healthcheck = config.get("Healthcheck") or {}
-    test_field = healthcheck.get("Test") or []
-    assert test_field, f"image has no HEALTHCHECK directive: {config!r}"
-    # Joined check covers both shell-form and exec-form
-    assert "readyz" in " ".join(
-        test_field
-    ), f"healthcheck doesn't probe /readyz: {test_field!r}"
+    env = inspected[0].get("Config", {}).get("Env", []) or []
+    assert (
+        "OPENZIM_MCP_TRANSPORT=http" not in env
+    ), f"image forces HTTP transport via ENV; stdio clients can't run it: {env!r}"
+    assert (
+        "OPENZIM_MCP_HOST=0.0.0.0" not in env
+    ), f"image bakes in a public bind host via ENV: {env!r}"
+
+
+def test_container_speaks_mcp_over_stdio_by_default(
+    built_image: str, zim_dir: Path
+) -> None:
+    """A bare ``docker run -i`` (no transport env) speaks MCP over stdio.
+
+    This is how Claude Desktop and the Glama registry run a containerized
+    MCP server: ``docker run -i --rm -v ...:/data <image>`` with no auth
+    token and no port mapping, talking JSON-RPC over stdin/stdout. It must
+    complete the ``initialize`` handshake rather than crashing on the
+    HTTP safe-default bind check.
+    """
+    init_req = (
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "docker-stdio-livetest", "version": "0"},
+                },
+            }
+        )
+        + "\n"
+    )
+    initialized = (
+        json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}) + "\n"
+    )
+
+    proc = subprocess.Popen(
+        [
+            "docker",
+            "run",
+            "-i",
+            "--rm",
+            "-v",
+            f"{zim_dir}:/data:ro",
+            built_image,
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        # Closing stdin (via communicate's input) signals EOF, so the stdio
+        # server shuts down after answering initialize and stdout reaches EOF.
+        stdout, stderr = proc.communicate(
+            input=(init_req + initialized).encode(), timeout=90
+        )
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        out, err = proc.communicate()
+        pytest.fail(
+            "container did not answer the stdio initialize handshake within 90s "
+            "(likely crashed on the HTTP bind check instead of running stdio).\n"
+            f"--- stdout ---\n{out.decode(errors='replace')[-2000:]}\n"
+            f"--- stderr ---\n{err.decode(errors='replace')[-2000:]}"
+        )
+
+    resp = None
+    for line in stdout.decode(errors="replace").splitlines():
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if msg.get("id") == 0:
+            resp = msg
+            break
+
+    assert resp is not None, (
+        "no JSON-RPC initialize response on stdout — the container did not "
+        "run as a stdio MCP server.\n"
+        f"--- stdout ---\n{stdout.decode(errors='replace')[-2000:]}\n"
+        f"--- stderr ---\n{stderr.decode(errors='replace')[-2000:]}"
+    )
+    assert "result" in resp, f"initialize returned an error: {resp!r}"
+    result = resp["result"]
+    assert "protocolVersion" in result, f"missing protocolVersion: {result!r}"
+    assert result.get("serverInfo", {}).get(
+        "name"
+    ), f"initialize result missing serverInfo.name: {result!r}"

--- a/website/src/content/docs/http-and-docker-deployment.mdx
+++ b/website/src/content/docs/http-and-docker-deployment.mdx
@@ -55,6 +55,8 @@ The published image:
 
 Binding a non-loopback host (`0.0.0.0`) requires `OPENZIM_MCP_AUTH_TOKEN` as a safe default; the bind is refused without it.
 
+> **Upgrading an existing HTTP deployment?** Earlier images defaulted the *container* to HTTP, so a token-only `docker run -p 8000:8000 -e OPENZIM_MCP_AUTH_TOKEN=… <image>` was enough. The image now defaults to **stdio**, so that same command starts a stdio server instead — nothing listens on `:8000`. Add `-e OPENZIM_MCP_TRANSPORT=http -e OPENZIM_MCP_HOST=0.0.0.0` (as shown above) when you pull the new image.
+
 ## Authentication
 
 Bearer-token auth via `BearerTokenAuthMiddleware`:

--- a/website/src/content/docs/http-and-docker-deployment.mdx
+++ b/website/src/content/docs/http-and-docker-deployment.mdx
@@ -34,22 +34,26 @@ This binds the loopback interface only. Put a TLS-terminating reverse proxy in f
 
 ## Quick start (Docker)
 
+The image defaults to **stdio** transport (so `docker run -i` is a local MCP server — see [Installation](/openzim-mcp/docs/installation/)). Opt into the HTTP service explicitly:
+
 ```bash
 docker run --rm -p 8000:8000 \
   -v /srv/zim:/data:ro \
+  -e OPENZIM_MCP_TRANSPORT=http \
+  -e OPENZIM_MCP_HOST=0.0.0.0 \
   -e OPENZIM_MCP_AUTH_TOKEN="$(openssl rand -hex 32)" \
-  ghcr.io/cameronrye/openzim-mcp:2.1.7
+  ghcr.io/cameronrye/openzim-mcp
 ```
 
 The published image:
 
 - Multi-arch: `linux/amd64`, `linux/arm64`
 - Non-root: runs as `appuser` (uid 10001, gid 10001)
-- Built-in healthcheck: `curl -fsS http://localhost:8000/readyz`
-- Default env: `OPENZIM_MCP_TRANSPORT=http`, `OPENZIM_MCP_HOST=0.0.0.0`, `OPENZIM_MCP_PORT=8000`
+- Default transport: `stdio` — set `OPENZIM_MCP_TRANSPORT=http` and `OPENZIM_MCP_HOST=0.0.0.0` (as above) to run the HTTP service
+- No baked-in healthcheck (the image ships no `curl`); define one in your orchestrator/compose probing `GET /readyz` — see the compose example below
 - Entrypoint: `python -m openzim_mcp /data` (mount your ZIM directory at `/data`)
 
-The image binds `0.0.0.0` by default; the safe-default check requires `OPENZIM_MCP_AUTH_TOKEN` for that bind. To run without a token, override `-e OPENZIM_MCP_HOST=127.0.0.1`.
+Binding a non-loopback host (`0.0.0.0`) requires `OPENZIM_MCP_AUTH_TOKEN` as a safe default; the bind is refused without it.
 
 ## Authentication
 
@@ -346,10 +350,17 @@ services:
       - /srv/zim:/data:ro
       - openzim-cache:/home/appuser/.cache/openzim-mcp
     environment:
+      OPENZIM_MCP_TRANSPORT: "http"
+      OPENZIM_MCP_HOST: "0.0.0.0"
       OPENZIM_MCP_AUTH_TOKEN: "${OPENZIM_MCP_AUTH_TOKEN}"
       OPENZIM_MCP_CACHE__PERSISTENCE_ENABLED: "true"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:8000/readyz"]
+      # The image ships no curl; probe /readyz with the bundled Python.
+      test:
+        - "CMD"
+        - "python"
+        - "-c"
+        - "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/readyz').getcode()==200 else 1)"
       interval: 30s
       timeout: 5s
       retries: 3
@@ -364,10 +375,10 @@ volumes:
 What's intentional here:
 
 - **Pinned tag** (`:2.1.7`, not `:latest`). Upgrades are deliberate — `docker compose pull` is a thing you do, not a thing that happens to you.
-- **Host port bound to `127.0.0.1`.** The container listens on all interfaces (the image's default `OPENZIM_MCP_HOST=0.0.0.0`), but Docker's port publish restricts external exposure to loopback. The Tailscale variant below lifts this restriction by binding to a specific interface.
+- **Host port bound to `127.0.0.1`.** The container listens on all interfaces (`OPENZIM_MCP_HOST=0.0.0.0`, set in the environment block), but Docker's port publish restricts external exposure to loopback. The Tailscale variant below lifts this restriction by binding to a specific interface.
 - **Read-only ZIM mount** (`:ro`). The server only reads ZIM files; mounting read-only ensures a server compromise can't damage them.
-- **Token via env, not hard-coded.** Put it in a `.env` file next to the compose file (and add `.env` to `.gitignore`). The image's defaults already set `TRANSPORT=http`, `HOST=0.0.0.0`, `PORT=8000`, so they're not repeated here.
-- **Explicit healthcheck block.** The image already declares `HEALTHCHECK` in the Dockerfile, but compose needs an explicit block to surface status to `docker ps`.
+- **Token via env, not hard-coded.** Put it in a `.env` file next to the compose file (and add `.env` to `.gitignore`). The image defaults to `stdio`, so `TRANSPORT=http` and `HOST=0.0.0.0` are set explicitly in the environment block to select the HTTP service.
+- **Explicit healthcheck block.** The image ships no `HEALTHCHECK` (it defaults to stdio, where there is no HTTP endpoint to probe), so this block defines one — using the bundled Python rather than `curl`, which isn't installed.
 
 `/srv/zim` is an example. Adjust to wherever your ZIM files live.
 

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -32,7 +32,7 @@ OpenZIM MCP provides **intelligent, structured access** that LLMs need:
 - **Safe-default startup check** refuses to bind a non-localhost host without an auth token.
 - **Path and PID redaction** in error responses and diagnostics — rejected traversals no longer leak the canonical allowed-directory layout.
 - **Atomic rate limiting** — global + per-operation token-bucket acquire is single-pass; no transient over-consumption.
-- **Multi-arch Docker image** — `ghcr.io/cameronrye/openzim-mcp`, builds for `linux/amd64` and `linux/arm64`, runs as non-root with a built-in healthcheck.
+- **Multi-arch Docker image** — `ghcr.io/cameronrye/openzim-mcp`, builds for `linux/amd64` and `linux/arm64`, runs as non-root, and defaults to stdio (HTTP is an explicit opt-in).
 
 ## Use Cases
 

--- a/website/src/content/docs/installation.mdx
+++ b/website/src/content/docs/installation.mdx
@@ -228,21 +228,27 @@ uv sync
 
 ## Docker Installation
 
-OpenZIM MCP ships a multi-arch image at `ghcr.io/cameronrye/openzim-mcp` (`linux/amd64` + `linux/arm64`). Runs as non-root (uid 10001), includes a built-in healthcheck.
+OpenZIM MCP ships a multi-arch image at `ghcr.io/cameronrye/openzim-mcp` (`linux/amd64` + `linux/arm64`). Runs as non-root (uid 10001). The image defaults to **stdio** transport, so it drops into an MCP client like the binary does.
 
 ```bash
 # Pull
-docker pull ghcr.io/cameronrye/openzim-mcp:2.1.7
+docker pull ghcr.io/cameronrye/openzim-mcp
 
-# Run with HTTP transport, bound to all interfaces (the image default).
-# The server REFUSES to bind 0.0.0.0 without OPENZIM_MCP_AUTH_TOKEN.
-docker run --rm -p 8000:8000 \
-  -v /srv/zim:/data:ro \
-  -e OPENZIM_MCP_AUTH_TOKEN="$(openssl rand -hex 32)" \
-  ghcr.io/cameronrye/openzim-mcp:2.1.7
+# Run as a local stdio MCP server (default). -i keeps stdin open so the
+# client can speak JSON-RPC over stdin/stdout. Mount ZIM files at /data.
+docker run -i --rm -v /srv/zim:/data ghcr.io/cameronrye/openzim-mcp
 ```
 
-The image entrypoint is `python -m openzim_mcp /data`, so mount your ZIM directory at `/data`. Default env vars in the image: `OPENZIM_MCP_TRANSPORT=http`, `OPENZIM_MCP_HOST=0.0.0.0`, `OPENZIM_MCP_PORT=8000`.
+The image entrypoint is `python -m openzim_mcp /data`, so mount your ZIM directory at `/data`. To run the long-running **HTTP** service instead, opt in at runtime — the server refuses to bind a non-loopback host without `OPENZIM_MCP_AUTH_TOKEN`:
+
+```bash
+docker run --rm -p 8000:8000 \
+  -v /srv/zim:/data:ro \
+  -e OPENZIM_MCP_TRANSPORT=http \
+  -e OPENZIM_MCP_HOST=0.0.0.0 \
+  -e OPENZIM_MCP_AUTH_TOKEN="$(openssl rand -hex 32)" \
+  ghcr.io/cameronrye/openzim-mcp
+```
 
 For full deployment guidance (CORS, reverse proxy, healthchecks, systemd) see [HTTP and Docker Deployment](/openzim-mcp/docs/http-and-docker-deployment/).
 

--- a/website/src/content/docs/security-best-practices.mdx
+++ b/website/src/content/docs/security-best-practices.mdx
@@ -152,8 +152,8 @@ The published image (`ghcr.io/cameronrye/openzim-mcp`) is hardened by default:
 - **Non-root user** — `appuser` (uid 10001, gid 10001).
 - **Multi-stage build** — runtime image only contains the venv and source, no build tools.
 - **Multi-arch** — `linux/amd64`, `linux/arm64`.
-- **Built-in `HEALTHCHECK`** — `curl -fsS http://localhost:8000/readyz`.
-- **`HOST=0.0.0.0` default** — but the safe-default startup check refuses to bind without `OPENZIM_MCP_AUTH_TOKEN`. Set the token, or override `OPENZIM_MCP_HOST=127.0.0.1` for loopback-only.
+- **Minimal runtime** — no `curl` or other extra tooling in the final image; it ships no `HEALTHCHECK` (the default stdio transport has no HTTP endpoint to probe). For HTTP deployments, define a `/readyz` probe in your orchestrator (see [HTTP and Docker Deployment](/openzim-mcp/docs/http-and-docker-deployment/)).
+- **stdio by default** — opting into HTTP with `OPENZIM_MCP_HOST=0.0.0.0` triggers the safe-default startup check, which refuses to bind without `OPENZIM_MCP_AUTH_TOKEN`. Set the token, or keep the loopback-only default.
 
 See the [Dockerfile](https://github.com/cameronrye/openzim-mcp/blob/main/Dockerfile) for full details.
 


### PR DESCRIPTION
## Why

The Glama listing (`glama.ai/mcp/servers/cameronrye/openzim-mcp`) showed **"cannot be installed,"** and a bare `docker run ghcr.io/cameronrye/openzim-mcp` — including the README's own quickstart — crashed on startup:

```
Configuration error: HTTP transport bound to 0.0.0.0 requires authentication.
```

**Root cause:** the image baked in `OPENZIM_MCP_TRANSPORT=http` + `OPENZIM_MCP_HOST=0.0.0.0` as `ENV`, overriding the code's safe `stdio`/`127.0.0.1` defaults. The safe-default bind guard (`http_app.py:130`) then fatally refused to bind a public host without `OPENZIM_MCP_AUTH_TOKEN`. So every tokenless run failed, and stdio MCP clients (Claude Desktop, Glama) couldn't launch it at all.

> `make install` (`uv sync --no-dev`) was checked and is **not** broken — it installs cleanly; this was the installability problem behind both reports.

## What changed

- **Dockerfile:** drop the `http`/`0.0.0.0` `ENV` so the image inherits the code's **stdio** default. `docker run -i --rm -v <zim>:/data <image>` now runs as a local MCP server over stdin/stdout. HTTP is an explicit runtime opt-in (`-e OPENZIM_MCP_TRANSPORT=http -e OPENZIM_MCP_HOST=0.0.0.0 -e OPENZIM_MCP_AUTH_TOKEN=… -p 8000:8000`).
- Remove the stdio-incompatible `curl` `HEALTHCHECK` and the now-unused `curl` (smaller image, less CVE surface). Compose example uses a Python `/readyz` probe (verified working).
- **Docker live tests:** new `test_image_does_not_force_http_transport` (regression guard) and `test_container_speaks_mcp_over_stdio_by_default` (functional stdio handshake); existing HTTP tests opt into http explicitly. All 6 pass.
- **Docs aligned:** README quickstart + badge, `installation`, `http-and-docker-deployment` (incl. an upgrade/migration callout), `security-best-practices`, `index` landing page, and the live-test README.
- **`glama.json`** added to claim the registry listing.

## ⚠️ Breaking change for existing HTTP image deployments

The image's **default transport flips from http → stdio.** A token-only `docker run -p 8000:8000 -e OPENZIM_MCP_AUTH_TOKEN=… <image>` (which the old docs taught) now starts a **stdio** server — nothing listens on `:8000`. HTTP deployers must add `-e OPENZIM_MCP_TRANSPORT=http -e OPENZIM_MCP_HOST=0.0.0.0`. Documented in the deployment guide's upgrade note.

> Note: this affects only the **Docker image** default; the PyPI package / library behavior is unchanged (the binary already defaulted to stdio). If you want release-please to emit a BREAKING CHANGES block, add this footer to the squash commit body:
>
> `BREAKING CHANGE: the Docker image now defaults to stdio transport; HTTP deployments must opt in with -e OPENZIM_MCP_TRANSPORT=http -e OPENZIM_MCP_HOST=0.0.0.0 -e OPENZIM_MCP_AUTH_TOKEN=...`
>
> (On a ≥1.0 release-please project that bumps to **3.0.0** — a phantom major for PyPI users whose API didn't change. Keeping `fix(docker):` ships 2.2.1 with the migration in docs + this PR.)

## Testing

- `make test-live-docker` → **6 passed** (stdio + HTTP paths, non-root, auth).
- `make lint` clean; Astro docs site rebuilds clean (16 pages).
- Verified the compose Python `/readyz` healthcheck returns exit 0 inside the running image; confirmed `curl` is absent.
- A 4-dimension adversarial review (completeness sweep + Dockerfile/test/behavior-risk, each finding independently verified) drove the straggler-doc fixes above.

## Follow-ups (maintainer, manual)

1. Decide release semantics (see breaking-change note) and **merge** → release-please publishes the image with the stdio default.
2. On glama.ai: run **Claim ownership** (GitHub auth auto-verifies once `glama.json` is on `main`), then configure the Docker image in the dashboard.