### PR TITLE
chore: sync uv.lock with the 2.2.1 release

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1176,7 +1176,7 @@ wheels = [
 
 [[package]]
 name = "openzim-mcp"
-version = "2.2.0"
+version = "2.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## What

Regenerate `uv.lock` so the local package is pinned at `2.2.1`, matching `pyproject.toml`.

## Why

The 2.2.1 release bumped the project version but did not regenerate the lockfile, leaving `uv.lock` pinning the local package at `2.2.0`. As a result `uv lock --check` reports the lockfile as out of date, and any `uv sync --locked` / lock-freshness step works against a stale lock.

## Change

One line in `uv.lock`: `version = "2.2.0"` → `"2.2.1"`. `uv lock --check` passes after the change.