### PR TITLE
ci: keep uv.lock in lockstep with each release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -112,6 +112,55 @@ jobs:
               console.log('Failed to add comment:', error.message);
             }
 
+  # Keep uv.lock's root-package version in lockstep with each release PR.
+  # release-please bumps pyproject.toml but cannot touch the auto-generated
+  # uv.lock: there is no x-release-please annotation hook for a TOML lockfile,
+  # and uv would strip any comment we added. So the lockfile's own ``version``
+  # field drifts one release behind every cut (it sat at 2.2.1 while
+  # pyproject.toml was already 2.2.2). Whenever release-please opens/updates the
+  # release PR, regenerate uv.lock on that branch and commit it back so the bump
+  # ships inside the same PR. ``uv lock`` rewrites only the root version line
+  # here — dependencies are re-resolved only if pyproject's requirements
+  # changed — so this is a one-line, churn-free commit. GITHUB_TOKEN pushes do
+  # not retrigger CI, but release PRs never run the required checks anyway (they
+  # are merged via admin), so nothing is gated on this commit. Worst case (this
+  # job fails): the lockfile drifts for that release exactly as it does today —
+  # a release is never blocked or broken by this job.
+  sync-uv-lock:
+    runs-on: ubuntu-latest
+    needs: release-please
+    if: needs.release-please.outputs.pr && !needs.release-please.outputs.release_created
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: release-please--branches--main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Regenerate uv.lock for the bumped version
+        run: uv lock
+
+      - name: Commit lockfile if it changed
+        run: |
+          if git diff --quiet uv.lock; then
+            echo "uv.lock already in sync — nothing to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          git commit -m "chore: sync uv.lock to release version"
+          git push origin HEAD:release-please--branches--main
+
   # Validate version synchronization after release creation
   validate-release:
     runs-on: ubuntu-latest

--- a/uv.lock
+++ b/uv.lock
@@ -1176,7 +1176,7 @@ wheels = [
 
 [[package]]
 name = "openzim-mcp"
-version = "2.2.1"
+version = "2.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Problem

release-please bumps `pyproject.toml` (and `llms.txt` via its `extra-files`) on every release, but it cannot touch the auto-generated `uv.lock` — there is no `x-release-please` annotation hook for a TOML lockfile, and `uv` would strip any comment we added. As a result the lockfile's own `version` field drifts one release behind every cut: it currently sits at **2.2.1** while `pyproject.toml` is already **2.2.2** (`uv lock --check` flags this).

## Change

1. **Resync the current lockfile** to `2.2.2` (one-line bump) so `main` is internally consistent now.
2. **Add a `sync-uv-lock` job** to `release-please.yml`. Whenever release-please opens/updates the release PR (`pr` set, `release_created` false — same guard as `notify-release-pr`), the job checks out the `release-please--branches--main` branch, runs `uv lock`, and commits/pushes the regenerated lockfile back, so the version bump ships **inside the same release PR**.

## Why this is safe

- `uv lock` is conservative: it does **not** upgrade pinned dependencies (only `--upgrade` does). Verified empirically — bumping the root version and running `uv lock` produces an **exactly one-line diff** (the `openzim-mcp` version field), no dependency or `revision`-field churn.
- The pushed commit is a `chore:` on the release branch only; it gets squashed into the release commit on merge and never enters release-please's `main` commit scan, so it cannot pollute the changelog or trigger a new release.
- `GITHUB_TOKEN` pushes don't retrigger CI, but release PRs don't run the required checks anyway (they're merged via admin), so nothing is gated on this commit.
- Worst case (job fails): the lockfile drifts for that release exactly as it does today — **a release is never blocked or broken by this job**.

## Test plan

- [x] `uv lock --check` confirms the drift; `uv lock` reproduces the one-line fix.
- [x] YAML parses; prettier + all pre-commit hooks pass.
- [ ] After merge: confirm release-please re-runs, the `sync-uv-lock` job succeeds, and release PR #273 picks up `uv.lock` → 2.3.0.