### PR TITLE
feat: finer-grained build link-graph CLI errors (v2.5 #16)

### DIFF
--- a/docs/specs/2026-06-08-v2.5-build-cli-finer-errors-design.md
+++ b/docs/specs/2026-06-08-v2.5-build-cli-finer-errors-design.md
@@ -1,0 +1,66 @@
+# Finer `build link-graph` CLI errors (v2.5 #16 follow-up) — design
+
+**Milestone:** v2.5.0a3 · **Issue:** #16 follow-up (noted in PR #274) · **Date:** 2026-06-08
+
+## Problem
+
+`openzim-mcp build link-graph <archive>` reports failures coarsely. [`openzim_mcp/cli/build.py`](../../openzim_mcp/cli/build.py) has two `except` clauses: `FileExistsError` (exit 1) and a single `except Exception` catch-all (exit 2). As a result, four distinct, user-actionable failure modes collapse into one generic `error: link-graph build failed: <e>` line:
+
+- **Missing archive** — `zim_archive(Path(...))` wraps the open failure as `OpenZimMcpArchiveError("Failed to open ZIM archive: <path>")`, indistinguishable from a corrupt file.
+- **Not a valid ZIM** — same generic message.
+- **Unwritable output / stale temp** — `sqlite3.connect(tmp_path)` or `os.remove(tmp_path)` raises with no output-path context (`unable to open database file`).
+- **Sidecar already exists** — the `FileExistsError` message echoes the builder's API-oriented `pass force=True to overwrite`, but the CLI flag is `--force`.
+
+There is no pre-flight check, so even "file not found" surfaces from deep inside the libzim open path.
+
+## Scope decisions (settled in brainstorming)
+
+- **All changes live in the CLI layer** ([`cli/build.py`](../../openzim_mcp/cli/build.py)). The builder's exceptions and messages are correct for programmatic callers and stay untouched.
+- **Pre-flight separates "missing" from "exists-but-invalid"** so those two get distinct messages.
+- **Classified `except` blocks** map each builder failure to a specific, actionable message.
+- **Documented exit-code scheme.** No change to the build logic, no new flags.
+
+## Behaviour
+
+`_link_graph` computes the resolved output path up front (so error messages can name it), runs a pre-flight check, then calls `build_link_graph` inside classified `except` blocks.
+
+| Condition | Message (to stderr) | Exit |
+| --- | --- | --- |
+| `archive` path does not exist | `error: archive not found: <path>` | 1 |
+| `archive` exists but is not a file | `error: not a file: <path>` | 1 |
+| `build_link_graph` raises `OpenZimMcpArchiveError` (file exists, open failed) | `error: not a valid ZIM archive: <path>` | 1 |
+| `build_link_graph` raises `FileExistsError` (sidecar exists, no `--force`) | `error: sidecar already exists: <out>; pass --force to overwrite.` | 1 |
+| `build_link_graph` raises `sqlite3.OperationalError` or `OSError` | `error: cannot write sidecar to <out>: <reason>` | 1 |
+| any other exception | `error: link-graph build failed: <e>` (the existing catch-all) | 2 |
+| success | `built <out>: N nodes, M edges, B bytes` | 0 |
+
+**Exit codes:** `0` success · `1` user-fixable precondition (not found / not a file / not a valid ZIM / exists-without-force / cannot-write) · `2` unexpected build failure. (argparse retains its own exit `2` for usage errors — distinct surface.)
+
+The pre-flight runs **before** `build_link_graph`, so a missing path never reaches the libzim open path. `FileExistsError` is a subclass of `OSError`, so its `except` clause is ordered **before** the `(sqlite3.OperationalError, OSError)` clause. `OpenZimMcpArchiveError` is caught only after the pre-flight has confirmed the file exists, so it always means "exists but not a valid ZIM."
+
+## Architecture
+
+Single function touched: `_link_graph(args)` in [`cli/build.py`](../../openzim_mcp/cli/build.py).
+
+- Compute `out = args.output or sidecar_path_for(args.archive)` before the try (import `sidecar_path_for` from `openzim_mcp.linkgraph.reader`).
+- Pre-flight: `os.path.exists` / `os.path.isfile` on `args.archive`.
+- `try: build_link_graph(...)` with the ordered `except` chain above.
+- Import `OpenZimMcpArchiveError` from `openzim_mcp.exceptions` and `sqlite3` at module top.
+
+No change to `build_main`, the builder, the schema, or any tool.
+
+## Testing strategy (TDD)
+
+In [`tests/linkgraph/test_build_cli.py`](../../tests/linkgraph/test_build_cli.py), using `capsys` to assert on stderr and `tmp_path` for files:
+
+1. **Missing archive.** A path that does not exist → exit `1`, stderr contains `archive not found`, and `build_link_graph` is **not** called (patched mock `assert_not_called`).
+2. **Not a valid ZIM.** A real file containing non-ZIM bytes (`b"not a zim"`), **not** mocked → `build_link_graph` runs, `zim_archive` raises `OpenZimMcpArchiveError` → exit `1`, stderr contains `not a valid ZIM archive`.
+3. **Sidecar exists without `--force`.** `build_link_graph` patched `side_effect=FileExistsError(...)` → exit `1`, stderr contains `pass --force` (the CLI's own message, not the builder's `force=True`).
+4. **Cannot write.** `build_link_graph` patched `side_effect=sqlite3.OperationalError("unable to open database file")` → exit `1`, stderr contains `cannot write sidecar`.
+5. **Regression.** The existing success / `--force` / unknown-artifact tests still pass (the empty `.zim` fixtures exist as files, so the pre-flight passes and the mocked builder runs).
+
+## Backward compatibility & non-goals
+
+- The success path output is unchanged. Existing tests that create an empty `.zim` and mock the builder still pass (the file exists, so pre-flight allows it).
+- Exit codes for the archive-open and write-failure cases move from `2` → `1` (regrouped as user-fixable preconditions). These CLI errors shipped only in v2.3.0; no established scripts depend on the old codes.
+- No change to the builder, schema, sidecar format, or any tool. No new flags. `builder.py`'s `FileExistsError` message stays API-oriented (correct for programmatic callers).

--- a/docs/superpowers/plans/2026-06-08-build-cli-finer-errors.md
+++ b/docs/superpowers/plans/2026-06-08-build-cli-finer-errors.md
@@ -1,0 +1,201 @@
+# Finer `build link-graph` CLI errors (#16) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the coarse `except Exception` catch-all in `openzim-mcp build link-graph` with a pre-flight check + classified `except` blocks so each failure mode (missing file, not-a-ZIM, sidecar-exists, cannot-write) gets a distinct, actionable message and a documented exit code.
+
+**Architecture:** All changes in `_link_graph` in `openzim_mcp/cli/build.py`. Compute the resolved output path up front, run a pre-flight existence/is-file check, then call `build_link_graph` inside an ordered `except` chain (`FileExistsError` → `OpenZimMcpArchiveError` → `(sqlite3.OperationalError, OSError)` → `Exception`). The builder, schema, and tools are untouched.
+
+**Tech Stack:** Python 3.12, argparse, pytest (`capsys`, `tmp_path`).
+
+**Spec:** [docs/specs/2026-06-08-v2.5-build-cli-finer-errors-design.md](../../specs/2026-06-08-v2.5-build-cli-finer-errors-design.md)
+
+---
+
+## Task 1: Add the failing CLI error tests
+
+**Files:**
+
+- Test: `tests/linkgraph/test_build_cli.py`
+
+- [ ] **Step 1: Add the four new tests**
+
+Append to `tests/linkgraph/test_build_cli.py` (the existing imports already cover `build_main` and `BuildStats`; add `import sqlite3` at the top):
+
+```python
+def test_build_missing_archive(tmp_path, capsys):
+    """A non-existent archive path is reported as 'archive not found' (exit 1)."""
+    missing = tmp_path / "nope.zim"
+    with patch("openzim_mcp.cli.build.build_link_graph") as mock_build:
+        rc = build_main(["link-graph", str(missing)])
+    assert rc == 1
+    assert "archive not found" in capsys.readouterr().err
+    mock_build.assert_not_called()
+
+
+def test_build_not_a_valid_zim(tmp_path, capsys):
+    """A real file that is not a ZIM is reported as 'not a valid ZIM' (exit 1)."""
+    bogus = tmp_path / "bogus.zim"
+    bogus.write_bytes(b"not a zim file at all")
+    rc = build_main(["link-graph", str(bogus)])
+    assert rc == 1
+    assert "not a valid ZIM archive" in capsys.readouterr().err
+
+
+def test_build_sidecar_exists_message_mentions_force(tmp_path, capsys):
+    """FileExistsError from the builder yields a --force hint (exit 1)."""
+    archive = tmp_path / "wiki.zim"
+    archive.write_bytes(b"")
+    with patch(
+        "openzim_mcp.cli.build.build_link_graph",
+        side_effect=FileExistsError("exists"),
+    ):
+        rc = build_main(["link-graph", str(archive)])
+    assert rc == 1
+    assert "pass --force" in capsys.readouterr().err
+
+
+def test_build_cannot_write_sidecar(tmp_path, capsys):
+    """A SQLite/OS write failure is reported with output context (exit 1)."""
+    archive = tmp_path / "wiki.zim"
+    archive.write_bytes(b"")
+    with patch(
+        "openzim_mcp.cli.build.build_link_graph",
+        side_effect=sqlite3.OperationalError("unable to open database file"),
+    ):
+        rc = build_main(["link-graph", str(archive)])
+    assert rc == 1
+    assert "cannot write sidecar" in capsys.readouterr().err
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/linkgraph/test_build_cli.py -k "missing_archive or not_a_valid or mentions_force or cannot_write" -v --no-cov`
+Expected: FAIL — `test_build_missing_archive` calls the builder (no pre-flight yet); `not_a_valid` and `cannot_write` hit the generic catch-all (exit 2, wrong message); `mentions_force` prints the builder's `force=True` text, not `--force`.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add tests/linkgraph/test_build_cli.py
+git commit -m "test(build-cli): pin finer error messages for link-graph build"
+```
+
+---
+
+## Task 2: Rewrite `_link_graph` with pre-flight + classified errors
+
+**Files:**
+
+- Modify: `openzim_mcp/cli/build.py` (imports at top; `_link_graph` lines 16-39)
+
+- [ ] **Step 1: Update imports**
+
+Replace the import block (lines 9-13) with:
+
+```python
+import argparse
+import os
+import sqlite3
+import sys
+from typing import List, Optional
+
+from openzim_mcp.exceptions import OpenZimMcpArchiveError
+from openzim_mcp.linkgraph.builder import build_link_graph
+from openzim_mcp.linkgraph.reader import sidecar_path_for
+```
+
+- [ ] **Step 2: Replace `_link_graph`**
+
+Replace the whole `_link_graph` function (lines 16-39) with:
+
+```python
+def _link_graph(args: argparse.Namespace) -> int:
+    """Run the link-graph build for one archive and print a summary.
+
+    Exit codes: 0 success; 1 user-fixable precondition (archive not found /
+    not a file / not a valid ZIM / sidecar exists without --force / cannot
+    write the sidecar); 2 unexpected build failure.
+    """
+
+    def _progress(done: int, total: int) -> None:
+        """Emit a one-line progress message to stderr."""
+        if not args.quiet:
+            print(f"  …walked {done}/{total} entries", file=sys.stderr)
+
+    # Pre-flight separates "missing" from "exists-but-invalid" so each gets a
+    # distinct, actionable message instead of surfacing from deep in the
+    # libzim open path.
+    if not os.path.exists(args.archive):
+        print(f"error: archive not found: {args.archive}", file=sys.stderr)
+        return 1
+    if not os.path.isfile(args.archive):
+        print(f"error: not a file: {args.archive}", file=sys.stderr)
+        return 1
+
+    out = args.output or sidecar_path_for(args.archive)
+    try:
+        stats = build_link_graph(
+            args.archive, args.output, force=args.force, progress=_progress
+        )
+    except FileExistsError:
+        # FileExistsError is an OSError subclass, so it MUST precede the
+        # (sqlite3.OperationalError, OSError) clause below. The CLI builds its
+        # own --force message rather than echoing the builder's force=True text.
+        print(
+            f"error: sidecar already exists: {out}; pass --force to overwrite.",
+            file=sys.stderr,
+        )
+        return 1
+    except OpenZimMcpArchiveError:
+        # The pre-flight confirmed the file exists, so an open failure here
+        # means the file is not a valid ZIM archive.
+        print(f"error: not a valid ZIM archive: {args.archive}", file=sys.stderr)
+        return 1
+    except (sqlite3.OperationalError, OSError) as e:
+        print(f"error: cannot write sidecar to {out}: {e}", file=sys.stderr)
+        return 1
+    except Exception as e:  # noqa: BLE001 — operator CLI: report + nonzero exit
+        print(f"error: link-graph build failed: {e}", file=sys.stderr)
+        return 2
+    print(
+        f"built {out}: {stats.node_count} nodes, {stats.edge_count} edges, "
+        f"{stats.bytes_written} bytes"
+    )
+    return 0
+```
+
+- [ ] **Step 3: Run the new tests to verify they pass**
+
+Run: `uv run pytest tests/linkgraph/test_build_cli.py -v --no-cov`
+Expected: PASS (all — the 4 new plus the 4 existing success/force/exists/unknown-artifact tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add openzim_mcp/cli/build.py
+git commit -m "feat(build-cli): finer-grained link-graph build errors (#16)"
+```
+
+---
+
+## Task 3: Full verification
+
+- [ ] **Step 1: Run the linkgraph + CLI suite**
+
+Run: `uv run pytest tests/linkgraph/ -v --no-cov`
+Expected: PASS (all).
+
+- [ ] **Step 2: Lint + types**
+
+Run: `uv run flake8 openzim_mcp/cli/build.py tests/linkgraph/test_build_cli.py && uv run mypy openzim_mcp/cli/build.py`
+Expected: clean.
+
+- [ ] **Step 3: Full suite (no regressions)**
+
+Run: `uv run pytest -q --no-cov`
+Expected: all pass, 0 failed.
+
+- [ ] **Step 4: Smoke-test the real CLI messages**
+
+Run: `uv run openzim-mcp build link-graph /does/not/exist.zim; echo "exit=$?"`
+Expected: `error: archive not found: /does/not/exist.zim` on stderr, `exit=1`.

--- a/openzim_mcp/cli/build.py
+++ b/openzim_mcp/cli/build.py
@@ -7,31 +7,64 @@ sub-D-4) slot in beside ``link-graph``.
 from __future__ import annotations
 
 import argparse
+import os
+import sqlite3
 import sys
 from typing import List, Optional
 
+from openzim_mcp.exceptions import OpenZimMcpArchiveError
 from openzim_mcp.linkgraph.builder import build_link_graph
+from openzim_mcp.linkgraph.reader import sidecar_path_for
 
 
 def _link_graph(args: argparse.Namespace) -> int:
-    """Run the link-graph build for one archive and print a summary."""
+    """Run the link-graph build for one archive and print a summary.
+
+    Exit codes: 0 success; 1 user-fixable precondition (archive not found /
+    not a file / not a valid ZIM / sidecar exists without --force / cannot
+    write the sidecar); 2 unexpected build failure.
+    """
 
     def _progress(done: int, total: int) -> None:
         """Emit a one-line progress message to stderr."""
         if not args.quiet:
             print(f"  …walked {done}/{total} entries", file=sys.stderr)
 
+    # Pre-flight separates "missing" from "exists-but-invalid" so each gets a
+    # distinct, actionable message instead of surfacing from deep in the
+    # libzim open path.
+    if not os.path.exists(args.archive):
+        print(f"error: archive not found: {args.archive}", file=sys.stderr)
+        return 1
+    if not os.path.isfile(args.archive):
+        print(f"error: not a file: {args.archive}", file=sys.stderr)
+        return 1
+
+    out = args.output or sidecar_path_for(args.archive)
     try:
         stats = build_link_graph(
             args.archive, args.output, force=args.force, progress=_progress
         )
-    except FileExistsError as e:
-        print(f"error: {e}", file=sys.stderr)
+    except FileExistsError:
+        # FileExistsError is an OSError subclass, so it MUST precede the
+        # (sqlite3.OperationalError, OSError) clause below. The CLI builds its
+        # own --force message rather than echoing the builder's force=True text.
+        print(
+            f"error: sidecar already exists: {out}; pass --force to overwrite.",
+            file=sys.stderr,
+        )
+        return 1
+    except OpenZimMcpArchiveError:
+        # The pre-flight confirmed the file exists, so an open failure here
+        # means the file is not a valid ZIM archive.
+        print(f"error: not a valid ZIM archive: {args.archive}", file=sys.stderr)
+        return 1
+    except (sqlite3.OperationalError, OSError) as e:
+        print(f"error: cannot write sidecar to {out}: {e}", file=sys.stderr)
         return 1
     except Exception as e:  # noqa: BLE001 — operator CLI: report + nonzero exit
         print(f"error: link-graph build failed: {e}", file=sys.stderr)
         return 2
-    out = args.output or f"{args.archive}.linkgraph.sqlite"
     print(
         f"built {out}: {stats.node_count} nodes, {stats.edge_count} edges, "
         f"{stats.bytes_written} bytes"

--- a/tests/linkgraph/test_build_cli.py
+++ b/tests/linkgraph/test_build_cli.py
@@ -95,3 +95,25 @@ def test_build_cannot_write_sidecar(tmp_path, capsys):
         rc = build_main(["link-graph", str(archive)])
     assert rc == 1
     assert "cannot write sidecar" in capsys.readouterr().err
+
+
+def test_build_archive_is_a_directory(tmp_path, capsys):
+    """A directory passed as the archive is reported as 'not a file' (exit 1)."""
+    with patch("openzim_mcp.cli.build.build_link_graph") as mock_build:
+        rc = build_main(["link-graph", str(tmp_path)])
+    assert rc == 1
+    assert "not a file" in capsys.readouterr().err
+    mock_build.assert_not_called()
+
+
+def test_build_cannot_write_sidecar_oserror(tmp_path, capsys):
+    """A bare OSError from the builder is reported as 'cannot write sidecar' (exit 1)."""
+    archive = tmp_path / "wiki.zim"
+    archive.write_bytes(b"")
+    with patch(
+        "openzim_mcp.cli.build.build_link_graph",
+        side_effect=OSError("permission denied"),
+    ):
+        rc = build_main(["link-graph", str(archive)])
+    assert rc == 1
+    assert "cannot write sidecar" in capsys.readouterr().err

--- a/tests/linkgraph/test_build_cli.py
+++ b/tests/linkgraph/test_build_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from unittest.mock import patch
 
 from openzim_mcp.cli.build import build_main
@@ -49,3 +50,48 @@ def test_build_existing_without_force_returns_nonzero(tmp_path):
 def test_unknown_artifact_returns_nonzero():
     """An unknown build artifact returns a nonzero exit code."""
     assert build_main(["embeddings", "/x.zim"]) != 0
+
+
+def test_build_missing_archive(tmp_path, capsys):
+    """A non-existent archive path is reported as 'archive not found' (exit 1)."""
+    missing = tmp_path / "nope.zim"
+    with patch("openzim_mcp.cli.build.build_link_graph") as mock_build:
+        rc = build_main(["link-graph", str(missing)])
+    assert rc == 1
+    assert "archive not found" in capsys.readouterr().err
+    mock_build.assert_not_called()
+
+
+def test_build_not_a_valid_zim(tmp_path, capsys):
+    """A real file that is not a ZIM is reported as 'not a valid ZIM' (exit 1)."""
+    bogus = tmp_path / "bogus.zim"
+    bogus.write_bytes(b"not a zim file at all")
+    rc = build_main(["link-graph", str(bogus)])
+    assert rc == 1
+    assert "not a valid ZIM archive" in capsys.readouterr().err
+
+
+def test_build_sidecar_exists_message_mentions_force(tmp_path, capsys):
+    """A FileExistsError from the builder yields a --force hint (exit 1)."""
+    archive = tmp_path / "wiki.zim"
+    archive.write_bytes(b"")
+    with patch(
+        "openzim_mcp.cli.build.build_link_graph",
+        side_effect=FileExistsError("exists"),
+    ):
+        rc = build_main(["link-graph", str(archive)])
+    assert rc == 1
+    assert "pass --force" in capsys.readouterr().err
+
+
+def test_build_cannot_write_sidecar(tmp_path, capsys):
+    """A SQLite/OS write failure is reported with output context (exit 1)."""
+    archive = tmp_path / "wiki.zim"
+    archive.write_bytes(b"")
+    with patch(
+        "openzim_mcp.cli.build.build_link_graph",
+        side_effect=sqlite3.OperationalError("unable to open database file"),
+    ):
+        rc = build_main(["link-graph", str(archive)])
+    assert rc == 1
+    assert "cannot write sidecar" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Replaces the coarse `except Exception` catch-all in `openzim-mcp build link-graph` with a pre-flight check and a classified `except` chain, so each failure mode gets a distinct, actionable message and a documented exit code. Non-blocking #16 follow-up (noted in PR #274).

| Condition | Message (stderr) | Exit |
|---|---|---|
| archive missing | `archive not found: <path>` | 1 |
| archive not a file | `not a file: <path>` | 1 |
| not a valid ZIM | `not a valid ZIM archive: <path>` | 1 |
| sidecar exists, no `--force` | `sidecar already exists: <out>; pass --force to overwrite.` | 1 |
| sqlite/OS write failure | `cannot write sidecar to <out>: <reason>` | 1 |
| unexpected | `link-graph build failed: <e>` | 2 |

Exit codes: `0` success · `1` user-fixable precondition · `2` unexpected. `FileExistsError` (an `OSError` subclass) is ordered before the `(sqlite3.OperationalError, OSError)` clause. The CLI builds its own `--force` message rather than echoing the builder's API-oriented `force=True` text.

## Scope

All changes in `_link_graph` (`openzim_mcp/cli/build.py`) + tests. The builder, schema, and tools are untouched — the builder's exceptions/messages remain correct for programmatic callers.

- **Spec:** `docs/specs/2026-06-08-v2.5-build-cli-finer-errors-design.md`
- **Plan:** `docs/superpowers/plans/2026-06-08-build-cli-finer-errors.md`

## Test plan

- [x] TDD: 6 new CLI tests (missing / not-a-file / not-a-ZIM / exists / cannot-write sqlite / cannot-write OSError), asserting messages via `capsys` + exit codes; pre-flight asserts the builder is not called.
- [x] `uv run pytest -q --no-cov` → **2960 passed**.
- [x] `make lint` clean.
- [x] Two-stage review (spec compliance + code quality) — approved; the two branch-coverage tests were added per the quality review.