### PR TITLE
feat: link-graph sidecar v2 — builder_version + per-edge anchor_text (v2.5 #16)

### DIFF
--- a/docs/specs/2026-06-09-v2.5-linkgraph-sidecar-v2-design.md
+++ b/docs/specs/2026-06-09-v2.5-linkgraph-sidecar-v2-design.md
@@ -1,0 +1,70 @@
+# Link-graph sidecar v2 — `builder_version` + per-edge `anchor_text` (v2.5 #16 follow-ups) — design
+
+**Milestone:** v2.5.0a3 · **Issue:** #16 follow-ups (noted in PR #274) · **Date:** 2026-06-09
+
+## Problem
+
+Two non-blocking follow-ups from the inbound link-graph sidecar (#16, shipped in v2.3.0):
+
+1. **Unused `builder_version`.** The original link-graph design listed `builder_version` among the intended `meta` rows, but the builder never writes it ([`builder.py`](../../openzim_mcp/linkgraph/builder.py) writes only `schema_version`, `archive_uuid`, `built_at`, `node_count`, `edge_count`). A sidecar therefore records nothing about which openzim-mcp version produced it — useful diagnostic context when inspecting or debugging a sidecar.
+
+2. **No per-edge anchor text.** The `edges` table stores `(target_id, source_id)` only. The visible link text ("anchor") is computed during parsing but discarded ([`structure.py:1200`](../../openzim_mcp/zim/structure.py) reads only the resolved `url`). Inbound results can name *which* pages link to an entry, but not *how* they refer to it — the anchor text is high-value context for an LLM ("X links here as 'the Battle of Hastings'").
+
+Both change the on-disk sidecar, so they ship together as **schema v2** with a single `SCHEMA_VERSION` bump.
+
+## Scope decisions (settled in brainstorming)
+
+- **One format change, `SCHEMA_VERSION 1 → 2`.** The `anchor_text` column is an incompatible layout change; bundling `builder_version` (a `meta` row, no DDL change) into the same version keeps a single rebuild event.
+- **Existing v1 sidecars are not migrated.** The reader's existing strict check (`meta.schema_version == SCHEMA_VERSION`) already refuses a mismatched sidecar and returns graceful absence; the operator rebuilds with `openzim-mcp build link-graph`. No migration code.
+- **`builder_version` is diagnostic only.** The staleness/fingerprint contract stays **UUID + schema_version**. The reader does not gate on `builder_version`.
+- **First-seen anchor per `(source, target)`.** The builder already dedups targets within a source; the anchor kept is the one from the first occurrence in document order. One edge → one anchor.
+- **Additive at the tool surface.** `zim_links(direction="inbound")` gains an `anchor_text` field per linker; ranking, pagination, and the rest of the response are unchanged.
+
+## Architecture
+
+### 1. Schema — [`openzim_mcp/linkgraph/schema.py`](../../openzim_mcp/linkgraph/schema.py)
+
+- `SCHEMA_VERSION = 2`.
+- `edges` DDL gains a column: `CREATE TABLE edges (target_id INTEGER NOT NULL, source_id INTEGER NOT NULL, anchor_text TEXT NOT NULL DEFAULT '') STRICT;`. `NOT NULL DEFAULT ''` keeps the reader NULL-free (links with no visible text store `''`). The `edges_by_target` index is unchanged.
+- Add a `BUILDER_VERSION` token sourced from `openzim_mcp.__version__` (a module-level constant in `schema.py`, imported by the builder), so the version is recorded next to the schema constant it travels with.
+
+### 2. Parser — [`openzim_mcp/zim/structure.py`](../../openzim_mcp/zim/structure.py), `_StructureMixin._parse_internal_link_targets`
+
+- Return `List[Tuple[str, str]]` of `(resolved_target_path, anchor_text)` instead of `List[str]`. The anchor is the link's visible text (`link.get("text", "")`, already available in `links_data["internal_links"]`), trimmed; `''` when absent. Redirect canonicalization and dedup are unchanged — dedup is still keyed on the resolved target, keeping the first anchor seen for each target.
+- This method is used only by the builder and its 4 parser tests (verified), so the return-shape change is contained. (Rename to `_parse_internal_link_edges` for accuracy is a plan decision; behaviour is what matters here.)
+
+### 3. Builder — [`openzim_mcp/linkgraph/builder.py`](../../openzim_mcp/linkgraph/builder.py)
+
+- `iter_article_links` yields `(source_path, [(target, anchor), ...])`.
+- `build_from_link_stream`'s inner loop dedups on `target` (unchanged), and the edge batch becomes 3-tuples `(target_id, source_id, anchor)`; the insert becomes `INSERT INTO edges(target_id, source_id, anchor_text) VALUES (?,?,?)`.
+- Add the `("builder_version", BUILDER_VERSION)` row to the `meta` `executemany`.
+- `inbound_degree` is still a `COUNT` over edges — unaffected by the new column.
+
+### 4. Reader — [`openzim_mcp/linkgraph/reader.py`](../../openzim_mcp/linkgraph/reader.py), `query_inbound`
+
+- `SELECT n.path, n.inbound_degree, e.anchor_text ... ORDER BY n.inbound_degree DESC, n.path ASC`.
+- Row dict gains `anchor_text`: `{"path": p, "inbound_degree": d, "anchor_text": a}`.
+- `SCHEMA_VERSION` import already drives the strict check at `open_for`; bumping the constant is all that is needed for staleness refusal of v1 sidecars.
+
+### 5. Data layer — `get_inbound_links_data` ([`structure.py`](../../openzim_mcp/zim/structure.py))
+
+- Forward `anchor_text` from each `page.rows` item into the result object (e.g. `{"path", "title", "inbound_degree", "anchor_text"}`). Title resolution and ordering are unchanged.
+
+## Runtime data flow
+
+Build: parse article → `(target, anchor)` pairs → intern ids, dedup per source → `edges(target_id, source_id, anchor_text)` + `meta(builder_version=…)`. Read: `zim_links(direction="inbound", entry_path=X)` → reader `query_inbound` joins `edges`→`nodes`, returns each linker with its `anchor_text` → ranked by `inbound_degree`, cursor-paginated as today, each linker now carrying the text it used to link to X.
+
+## Testing strategy (TDD)
+
+- **Schema:** `SCHEMA_VERSION == 2`; a fresh DB has an `edges.anchor_text` column (`PRAGMA table_info`).
+- **Parser:** `_parse_internal_link_targets` returns `(target, anchor)` pairs; the 4 existing parser tests updated to the new shape; a link with no visible text yields `''`; dedup keeps the first anchor for a repeated target.
+- **Builder:** a built sidecar has `anchor_text` populated per edge and a `builder_version` meta row equal to `openzim_mcp.__version__`; `edge_count`/`node_count` unchanged from v1 for the same input.
+- **Reader:** `query_inbound` rows include `anchor_text`; a v1-shaped sidecar (schema_version=1) is refused by `open_for` (graceful absence), forcing rebuild.
+- **Inbound data:** `get_inbound_links_data` surfaces `anchor_text` per linker; ranking/pagination unchanged.
+- **Live (gated):** end-to-end build + inbound roundtrip asserts anchors flow through (extends the existing `tests/live/test_live_inbound_linkgraph.py`).
+
+## Backward compatibility & non-goals
+
+- **v1 sidecars stop loading** (schema_version mismatch) and rebuild on next build — the intended staleness behavior; adoption is ~zero (feature shipped in v2.3.0).
+- Additive `anchor_text` field on inbound results; no removal or reshaping of existing fields. Ranking, pagination, outbound, and the `build` CLI are unchanged.
+- No `meta`-based reader gating on `builder_version`; no sidecar migration; no anchor normalization beyond trim (raw visible text, first-seen per edge).

--- a/docs/superpowers/plans/2026-06-09-linkgraph-sidecar-v2.md
+++ b/docs/superpowers/plans/2026-06-09-linkgraph-sidecar-v2.md
@@ -1,0 +1,410 @@
+# Link-graph sidecar v2 (#16) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `builder_version` meta row and a per-edge `anchor_text` column to the link-graph sidecar, bumping `SCHEMA_VERSION` 1→2 (old sidecars refuse + rebuild). Surface the anchor text on inbound results.
+
+**Architecture:** Schema v2 (`edges.anchor_text TEXT NOT NULL DEFAULT ''`, `SCHEMA_VERSION = 2`). The parser yields `(target, anchor)` pairs; the builder writes the 3-column edge + a `builder_version` meta row; the reader SELECTs the anchor; `get_inbound_links_data` surfaces it. Existing v1 sidecars hit the reader's existing strict `schema_version` check and rebuild.
+
+**Tech Stack:** Python 3.12, SQLite (STRICT tables), pytest.
+
+**Spec:** [docs/specs/2026-06-09-v2.5-linkgraph-sidecar-v2-design.md](../../specs/2026-06-09-v2.5-linkgraph-sidecar-v2-design.md)
+
+---
+
+## Task 1: Schema v2 — version bump + `anchor_text` column
+
+**Files:**
+
+- Modify: `openzim_mcp/linkgraph/schema.py` (`SCHEMA_VERSION` line 16; `edges` DDL in `_DDL`)
+- Test: `tests/linkgraph/test_schema.py`
+
+- [ ] **Step 1: Write/adjust the failing tests**
+
+In `tests/linkgraph/test_schema.py`, update any assertion that `SCHEMA_VERSION == 1` to `== 2`, and add a column test:
+
+```python
+def test_edges_has_anchor_text_column(tmp_path):
+    import sqlite3
+    from openzim_mcp.linkgraph.schema import create_schema
+
+    conn = sqlite3.connect(":memory:")
+    create_schema(conn)
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(edges)")}
+    assert cols == {"target_id", "source_id", "anchor_text"}
+
+
+def test_schema_version_is_2():
+    from openzim_mcp.linkgraph.schema import SCHEMA_VERSION
+
+    assert SCHEMA_VERSION == 2
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/linkgraph/test_schema.py -v --no-cov`
+Expected: FAIL — `anchor_text` column absent; `SCHEMA_VERSION` is 1.
+
+- [ ] **Step 3: Bump version + add the column**
+
+In `openzim_mcp/linkgraph/schema.py`: change `SCHEMA_VERSION = 1` to `SCHEMA_VERSION = 2`, and change the `edges` line in `_DDL` to:
+
+```sql
+CREATE TABLE edges (target_id INTEGER NOT NULL, source_id INTEGER NOT NULL,
+                    anchor_text TEXT NOT NULL DEFAULT '') STRICT;
+```
+
+(The `edges_by_target` index and the explanatory comment above the table are unchanged.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/linkgraph/test_schema.py -v --no-cov`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add openzim_mcp/linkgraph/schema.py tests/linkgraph/test_schema.py
+git commit -m "feat(linkgraph): schema v2 — edges.anchor_text + SCHEMA_VERSION=2"
+```
+
+---
+
+## Task 2: Parser yields `(target, anchor)`; builder writes anchors + `builder_version`
+
+This is the coupled core: the parser's output shape change and its only consumer (the builder) move together so the suite stays green.
+
+**Files:**
+
+- Modify: `openzim_mcp/zim/structure.py` (`_parse_internal_link_targets` lines 1137-1230)
+- Modify: `openzim_mcp/linkgraph/builder.py` (imports; `build_from_link_stream` signature/loop/insert/meta lines 40-108; `iter_article_links` lines 142-177)
+- Test: `tests/linkgraph/test_link_parser.py`, `tests/linkgraph/test_builder.py`
+
+- [ ] **Step 1: Write the failing parser test**
+
+In `tests/linkgraph/test_link_parser.py`, the existing tests call `_StructureMixin._parse_internal_link_targets(...)` and expect `List[str]`. Rename all references to `_parse_internal_link_edges` and update expectations to `(target, anchor)` pairs. Add a new test capturing anchor text and the no-text/dedup cases:
+
+```python
+def test_parse_edges_captures_anchor_text():
+    html = (
+        '<a href="A/Cat">the cat page</a>'
+        '<a href="A/Dog"><img src="d.png"></a>'  # no visible text -> ''
+        '<a href="A/Cat">cat again</a>'           # dup target -> first anchor kept
+    )
+    edges = _StructureMixin._parse_internal_link_edges(
+        html, source_path="A/Index", archive=None
+    )
+    assert edges == [("A/Cat", "the cat page"), ("A/Dog", "")]
+```
+
+(Update the other parser tests in this file: each `_parse_internal_link_targets(...)` → `_parse_internal_link_edges(...)`, and each expected `["A/Foo", ...]` becomes `[("A/Foo", "<anchor>"), ...]`. For tests that only care about targets, assert on `[t for t, _ in edges]`.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/linkgraph/test_link_parser.py -v --no-cov`
+Expected: FAIL — `_parse_internal_link_edges` does not exist.
+
+- [ ] **Step 3: Rewrite the parser to return pairs**
+
+In `openzim_mcp/zim/structure.py`, rename `_parse_internal_link_targets` to `_parse_internal_link_edges`, change the return annotation to `List[Tuple[str, str]]`, update the docstring's first line to "Return one source entry's deduped, canonical INTERNAL `(target, anchor_text)` edges.", and replace the dedup loop (lines 1202-1230) with:
+
+```python
+        seen: set = set()
+        edges: List[Tuple[str, str]] = []
+        for link in links_data["internal_links"]:
+            target = _StructureMixin._resolve_link_to_entry_path(
+                link.get("url", ""), source_path
+            )
+            if not target or target == source_path:
+                continue
+            if _StructureMixin._is_non_article_target(target):
+                continue
+            anchor = (link.get("text") or "").strip()
+            if archive is not None:
+                # Canonicalize through the redirect chain so the builder
+                # inverts edges against the served (non-redirect) path.
+                # Best-effort: a missing entry or malformed chain falls
+                # back to the path-normalized target rather than dropping
+                # an otherwise-valid edge.
+                try:
+                    entry = archive.get_entry_by_path(target)
+                    resolved = best_effort_redirect_chain(entry)
+                    resolved_path = getattr(resolved, "path", None)
+                    if resolved_path:
+                        target = resolved_path
+                except Exception as e:
+                    logger.debug(f"redirect canonicalization for {target} failed: {e}")
+            if target in seen or target == source_path:
+                continue
+            seen.add(target)
+            edges.append((target, anchor))
+        return edges
+```
+
+Ensure `Tuple` is imported in `structure.py` (it uses `typing`; add `Tuple` to the import if absent).
+
+- [ ] **Step 4: Run the parser tests to verify pass**
+
+Run: `uv run pytest tests/linkgraph/test_link_parser.py -v --no-cov`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing builder test**
+
+In `tests/linkgraph/test_builder.py`, add (and update the synthetic-stream tests to pass `(target, anchor)` pairs instead of bare strings — e.g. a stream item `("A", ["B", "C"])` becomes `("A", [("B", ""), ("C", "")])`):
+
+```python
+def test_builder_writes_anchor_text_and_builder_version(tmp_path):
+    import sqlite3
+    import openzim_mcp
+    from openzim_mcp.linkgraph.builder import build_from_link_stream
+
+    out = str(tmp_path / "a.zim.linkgraph.sqlite")
+    stream = [("A/Src", [("A/Tgt", "see Tgt")])]
+    build_from_link_stream(out, archive_uuid="uuid-1", link_stream=stream)
+
+    conn = sqlite3.connect(out)
+    anchors = conn.execute("SELECT anchor_text FROM edges").fetchall()
+    assert anchors == [("see Tgt",)]
+    meta = dict(conn.execute("SELECT key, value FROM meta"))
+    assert meta["builder_version"] == openzim_mcp.__version__
+    assert meta["schema_version"] == "2"
+```
+
+- [ ] **Step 6: Run to verify failure**
+
+Run: `uv run pytest tests/linkgraph/test_builder.py::test_builder_writes_anchor_text_and_builder_version -v --no-cov`
+Expected: FAIL — `build_from_link_stream` iterates `for target in targets` (unpacking a 2-tuple as a string) / no `builder_version` row.
+
+- [ ] **Step 7: Update the builder**
+
+In `openzim_mcp/linkgraph/builder.py`:
+
+Add the version import after line 26:
+
+```python
+from openzim_mcp import __version__
+```
+
+Change `build_from_link_stream`'s signature (lines 40-47) to:
+
+```python
+def build_from_link_stream(
+    out_path: str,
+    *,
+    archive_uuid: str,
+    link_stream: Iterable[Tuple[str, List[Tuple[str, str]]]],
+    force: bool = False,
+    now_iso: Optional[str] = None,
+    builder_version: Optional[str] = None,
+) -> BuildStats:
+```
+
+Change the batch type (line 71) to `batch: List[Tuple[int, int, str]] = []`, and the inner loop (lines 72-90) to:
+
+```python
+        for source_path, targets in link_stream:
+            source_id = _intern(source_path)
+            seen: set[str] = set()
+            for target, anchor in targets:
+                if target == source_path or target in seen:
+                    continue
+                seen.add(target)
+                target_id = _intern(target)
+                batch.append((target_id, source_id, anchor))
+                edge_count += 1
+                if len(batch) >= _BATCH:
+                    conn.executemany(
+                        "INSERT INTO edges(target_id, source_id, anchor_text) "
+                        "VALUES (?,?,?)",
+                        batch,
+                    )
+                    batch.clear()
+        if batch:
+            conn.executemany(
+                "INSERT INTO edges(target_id, source_id, anchor_text) VALUES (?,?,?)",
+                batch,
+            )
+```
+
+Add the `builder_version` row to the `meta` `executemany` (after the `edge_count` row, line 106):
+
+```python
+                ("edge_count", str(edge_count)),
+                ("builder_version", builder_version or __version__),
+```
+
+Change `iter_article_links`'s return annotation (line 142) to `Iterator[Tuple[str, List[Tuple[str, str]]]]`, and its body (lines 174-177) to:
+
+```python
+        edges = _StructureMixin._parse_internal_link_edges(
+            html, source_path=path, archive=archive
+        )
+        yield (path, edges)
+```
+
+- [ ] **Step 8: Run the builder tests to verify pass**
+
+Run: `uv run pytest tests/linkgraph/test_builder.py -v --no-cov`
+Expected: PASS (all — the new test plus the updated synthetic-stream tests).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add openzim_mcp/zim/structure.py openzim_mcp/linkgraph/builder.py tests/linkgraph/test_link_parser.py tests/linkgraph/test_builder.py
+git commit -m "feat(linkgraph): parse (target, anchor) edges; write anchor_text + builder_version"
+```
+
+---
+
+## Task 3: Reader returns `anchor_text`
+
+**Files:**
+
+- Modify: `openzim_mcp/linkgraph/reader.py` (`query_inbound` lines 83-93)
+- Test: `tests/linkgraph/test_reader.py`
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/linkgraph/test_reader.py`, add (modelled on the file's existing build-then-read pattern; pass `(target, anchor)` pairs to the builder):
+
+```python
+def test_query_inbound_includes_anchor_text(tmp_path):
+    from openzim_mcp.linkgraph.builder import build_from_link_stream
+    from openzim_mcp.linkgraph.reader import LinkGraphReader
+
+    out = str(tmp_path / "a.zim.linkgraph.sqlite")
+    stream = [("A/Src", [("A/Tgt", "anchor for tgt")])]
+    build_from_link_stream(out, archive_uuid="u", link_stream=stream)
+    # open_for fingerprints on the live archive uuid; read the sidecar directly
+    import sqlite3
+
+    reader = LinkGraphReader(sqlite3.connect(out))
+    try:
+        page = reader.query_inbound("A/Tgt", limit=10, offset=0)
+    finally:
+        reader.close()
+    assert page.total == 1
+    assert page.rows[0]["path"] == "A/Src"
+    assert page.rows[0]["anchor_text"] == "anchor for tgt"
+```
+
+(If `LinkGraphReader.__init__` is not directly constructible in the existing tests, follow whatever helper `test_reader.py` already uses to obtain a reader over a built sidecar, and add the `anchor_text` assertion to it.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/linkgraph/test_reader.py::test_query_inbound_includes_anchor_text -v --no-cov`
+Expected: FAIL — `KeyError: 'anchor_text'` (the row dict has only `path`, `inbound_degree`).
+
+- [ ] **Step 3: Add `anchor_text` to the query + row dict**
+
+In `openzim_mcp/linkgraph/reader.py`, change the `query_inbound` SELECT (lines 83-92) and row build (line 93):
+
+```python
+        cur = self._conn.execute(
+            """
+            SELECT n.path, n.inbound_degree, e.anchor_text
+              FROM edges e JOIN nodes n ON n.id = e.source_id
+             WHERE e.target_id = ?
+             ORDER BY n.inbound_degree DESC, n.path ASC
+             LIMIT ? OFFSET ?
+            """,
+            (target_id, limit, offset),
+        )
+        rows = [
+            {"path": p, "inbound_degree": d, "anchor_text": a}
+            for (p, d, a) in cur.fetchall()
+        ]
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/linkgraph/test_reader.py -v --no-cov`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add openzim_mcp/linkgraph/reader.py tests/linkgraph/test_reader.py
+git commit -m "feat(linkgraph): reader surfaces per-edge anchor_text"
+```
+
+---
+
+## Task 4: Data layer surfaces `anchor_text` on inbound results
+
+**Files:**
+
+- Modify: `openzim_mcp/zim/structure.py` (`get_inbound_links_data` results build, lines 1006-1013)
+- Test: `tests/linkgraph/test_inbound_data.py`
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/linkgraph/test_inbound_data.py`, add an assertion (extend the file's existing inbound-data fixture/flow; if it builds a sidecar with a known anchor, assert it surfaces). Minimal addition modelled on the existing tests:
+
+```python
+def test_inbound_results_include_anchor_text(tmp_path, monkeypatch):
+    # Reuse this file's existing helper that builds a sidecar + calls
+    # get_inbound_links_data. Assert each result item carries 'anchor_text'.
+    result = _run_inbound(tmp_path, monkeypatch)  # existing helper in this file
+    assert all("anchor_text" in item for item in result["results"])
+```
+
+(If `test_inbound_data.py` has no reusable helper, model the test on its existing happy-path test: build a sidecar via `build_from_link_stream` with a `(target, anchor)` stream, point `get_inbound_links_data` at it, and assert `result["results"][0]["anchor_text"]` equals the seeded anchor.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/linkgraph/test_inbound_data.py -k anchor -v --no-cov`
+Expected: FAIL — results lack `anchor_text`.
+
+- [ ] **Step 3: Forward `anchor_text` into each result**
+
+In `openzim_mcp/zim/structure.py`, change the `results` list comprehension (lines 1006-1013):
+
+```python
+        results: List[Dict[str, Any]] = [
+            {
+                "path": r["path"],
+                "title": r["path"],
+                "inbound_degree": r["inbound_degree"],
+                "anchor_text": r["anchor_text"],
+            }
+            for r in page.rows
+        ]
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/linkgraph/test_inbound_data.py -v --no-cov`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add openzim_mcp/zim/structure.py tests/linkgraph/test_inbound_data.py
+git commit -m "feat(linkgraph): surface anchor_text on inbound link results"
+```
+
+---
+
+## Task 5: Full verification
+
+- [ ] **Step 1: Run the linkgraph suite**
+
+Run: `uv run pytest tests/linkgraph/ -v --no-cov`
+Expected: PASS (all).
+
+- [ ] **Step 2: Lint + types**
+
+Run: `uv run flake8 openzim_mcp/linkgraph openzim_mcp/zim/structure.py tests/linkgraph && uv run mypy openzim_mcp/linkgraph openzim_mcp/zim/structure.py`
+Expected: clean.
+
+- [ ] **Step 3: Full suite (no regressions)**
+
+Run: `uv run pytest -q --no-cov`
+Expected: all pass, 0 failed.
+
+- [ ] **Step 4: Check the live test references the new shape**
+
+Inspect `tests/live/test_live_inbound_linkgraph.py`. If it asserts on inbound result item keys, add an `anchor_text` assertion; if it only checks the happy path, leave it. Do NOT remove or weaken existing live assertions. Run (gated; may skip without a live archive):
+`uv run pytest tests/live/test_live_inbound_linkgraph.py -v --no-cov`
+Expected: PASS or SKIP (skip is acceptable when no live archive is present).

--- a/openzim_mcp/linkgraph/builder.py
+++ b/openzim_mcp/linkgraph/builder.py
@@ -23,6 +23,8 @@ from typing import (
     Tuple,
 )
 
+from openzim_mcp import __version__
+
 from .schema import SCHEMA_VERSION, apply_build_pragmas, create_schema
 
 _BATCH = 50_000
@@ -41,9 +43,10 @@ def build_from_link_stream(
     out_path: str,
     *,
     archive_uuid: str,
-    link_stream: Iterable[Tuple[str, List[str]]],
+    link_stream: Iterable[Tuple[str, List[Tuple[str, str]]]],
     force: bool = False,
     now_iso: Optional[str] = None,
+    builder_version: Optional[str] = None,
 ) -> BuildStats:
     """Invert ``link_stream`` into the sidecar at ``out_path`` (atomic write)."""
     if Path(out_path).exists() and not force:
@@ -68,25 +71,28 @@ def build_from_link_stream(
         apply_build_pragmas(conn)
         create_schema(conn)
         edge_count = 0
-        batch: List[Tuple[int, int]] = []
+        batch: List[Tuple[int, int, str]] = []
         for source_path, targets in link_stream:
             source_id = _intern(source_path)
             seen: set[str] = set()
-            for target in targets:
+            for target, anchor in targets:
                 if target == source_path or target in seen:
                     continue
                 seen.add(target)
                 target_id = _intern(target)
-                batch.append((target_id, source_id))
+                batch.append((target_id, source_id, anchor))
                 edge_count += 1
                 if len(batch) >= _BATCH:
                     conn.executemany(
-                        "INSERT INTO edges(target_id, source_id) VALUES (?,?)", batch
+                        "INSERT INTO edges(target_id, source_id, anchor_text) "
+                        "VALUES (?,?,?)",
+                        batch,
                     )
                     batch.clear()
         if batch:
             conn.executemany(
-                "INSERT INTO edges(target_id, source_id) VALUES (?,?)", batch
+                "INSERT INTO edges(target_id, source_id, anchor_text) VALUES (?,?,?)",
+                batch,
             )
         conn.executemany(
             "INSERT INTO nodes(id, path) VALUES (?,?)",
@@ -104,6 +110,7 @@ def build_from_link_stream(
                 ("built_at", now_iso or datetime.now(timezone.utc).isoformat()),
                 ("node_count", str(len(ids))),
                 ("edge_count", str(edge_count)),
+                ("builder_version", builder_version or __version__),
             ],
         )
         conn.commit()
@@ -139,12 +146,12 @@ def _is_content_source(path: str, *, has_new_scheme: bool) -> bool:
     return namespace.upper() == "C"
 
 
-def iter_article_links(archive: Any) -> Iterator[Tuple[str, List[str]]]:
-    """Yield ``(source_path, [canonical internal target paths])`` per content entry.
+def iter_article_links(archive: Any) -> Iterator[Tuple[str, List[Tuple[str, str]]]]:
+    """Yield ``(source_path, [(target, anchor_text), ...])`` per content entry.
 
     Walk the open archive once via ``_get_entry_by_id`` over ``entry_count``,
     keep only content sources (scheme-aware: see ``_is_content_source``), skip
-    redirects-as-source, and reuse ``_parse_internal_link_targets`` for
+    redirects-as-source, and reuse ``_parse_internal_link_edges`` for
     extraction + redirect canonicalization. The yielded ``source_path`` is the
     raw ``entry.path`` exactly as libzim returns it for that scheme
     (``"C/Evolution"`` old-scheme, ``"Evolution"`` new-scheme) so it stays
@@ -171,10 +178,10 @@ def iter_article_links(archive: Any) -> Iterator[Tuple[str, List[str]]]:
             html = bytes(entry.get_item().content).decode("utf-8", "replace")
         except Exception:  # nosec B112 - skip entry whose content won't read
             continue
-        targets = _StructureMixin._parse_internal_link_targets(
+        edges = _StructureMixin._parse_internal_link_edges(
             html, source_path=path, archive=archive
         )
-        yield (path, targets)
+        yield (path, edges)
 
 
 def build_link_graph(
@@ -198,7 +205,7 @@ def build_link_graph(
         archive_uuid = str(archive.uuid)
         total = int(getattr(archive, "entry_count", 0) or 0)
 
-        def _stream() -> Iterator[Tuple[str, List[str]]]:
+        def _stream() -> Iterator[Tuple[str, List[Tuple[str, str]]]]:
             for i, pair in enumerate(iter_article_links(archive)):
                 # ``i and`` guards against the spurious 0 % 10_000 == 0 call at
                 # the very first entry; report every 10,000 thereafter.

--- a/openzim_mcp/linkgraph/reader.py
+++ b/openzim_mcp/linkgraph/reader.py
@@ -82,7 +82,7 @@ class LinkGraphReader:
         ).fetchone()[0]
         cur = self._conn.execute(
             """
-            SELECT n.path, n.inbound_degree
+            SELECT n.path, n.inbound_degree, e.anchor_text
               FROM edges e JOIN nodes n ON n.id = e.source_id
              WHERE e.target_id = ?
              ORDER BY n.inbound_degree DESC, n.path ASC
@@ -90,7 +90,10 @@ class LinkGraphReader:
             """,
             (target_id, limit, offset),
         )
-        rows = [{"path": p, "inbound_degree": d} for (p, d) in cur.fetchall()]
+        rows = [
+            {"path": p, "inbound_degree": d, "anchor_text": a}
+            for (p, d, a) in cur.fetchall()
+        ]
         return InboundPage(rows=rows, total=int(total))
 
     def close(self) -> None:

--- a/openzim_mcp/linkgraph/schema.py
+++ b/openzim_mcp/linkgraph/schema.py
@@ -13,7 +13,7 @@ import sqlite3
 
 # Bump on any incompatible layout change; the reader rejects mismatches and
 # forces an operator rebuild.
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 _DDL = """
 CREATE TABLE meta  (key TEXT PRIMARY KEY, value TEXT) STRICT;
@@ -24,7 +24,8 @@ CREATE TABLE nodes (id INTEGER PRIMARY KEY, path TEXT NOT NULL UNIQUE,
 -- visits each source entry exactly once), so a uniqueness index would only
 -- slow the bulk insert without changing the data. inbound_degree is a plain
 -- COUNT over these rows, so the by-construction uniqueness keeps it accurate.
-CREATE TABLE edges (target_id INTEGER NOT NULL, source_id INTEGER NOT NULL) STRICT;
+CREATE TABLE edges (target_id INTEGER NOT NULL, source_id INTEGER NOT NULL,
+                    anchor_text TEXT NOT NULL DEFAULT '') STRICT;
 CREATE INDEX edges_by_target ON edges(target_id);
 """
 

--- a/openzim_mcp/linkgraph/schema.py
+++ b/openzim_mcp/linkgraph/schema.py
@@ -2,9 +2,10 @@
 
 Layout is integer-keyed: ``nodes`` interns each entry path to a small id and
 carries the precomputed ``inbound_degree`` used to rank linkers by importance;
-``edges`` stores ``(target_id, source_id)`` pairs indexed by target for the
-inbound lookup. ``meta`` holds the archive UUID + schema version the reader
-fingerprints against (strict staleness check).
+``edges`` stores ``(target_id, source_id, anchor_text)`` rows indexed by target
+for the inbound lookup (``anchor_text`` is the visible link text of each edge).
+``meta`` holds the archive UUID + schema version the reader fingerprints against
+(strict staleness check).
 """
 
 from __future__ import annotations

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -1134,13 +1134,13 @@ class _StructureMixin:
         return resolved
 
     @staticmethod
-    def _parse_internal_link_targets(
+    def _parse_internal_link_edges(
         html: str,
         *,
         source_path: str,
         archive: "Optional[Archive]",
-    ) -> List[str]:
-        """Return one source entry's deduped, canonical INTERNAL link targets.
+    ) -> List[Tuple[str, str]]:
+        """Return one source entry's deduped, canonical INTERNAL ``(target, anchor_text)`` edges.
 
         Parses ``html`` with the same anchor classifier the bundle uses
         (``ContentProcessor._classify_anchor``), so "internal" here means
@@ -1200,7 +1200,7 @@ class _StructureMixin:
             _classify_anchor(link, links_data)
 
         seen: set = set()
-        targets: List[str] = []
+        edges: List[Tuple[str, str]] = []
         for link in links_data["internal_links"]:
             target = _StructureMixin._resolve_link_to_entry_path(
                 link.get("url", ""), source_path
@@ -1209,6 +1209,7 @@ class _StructureMixin:
                 continue
             if _StructureMixin._is_non_article_target(target):
                 continue
+            anchor = (link.get("text") or "").strip()
             if archive is not None:
                 # Canonicalize through the redirect chain so the builder
                 # inverts edges against the served (non-redirect) path.
@@ -1226,5 +1227,5 @@ class _StructureMixin:
             if target in seen or target == source_path:
                 continue
             seen.add(target)
-            targets.append(target)
-        return targets
+            edges.append((target, anchor))
+        return edges

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -1008,6 +1008,7 @@ class _StructureMixin:
                 "path": r["path"],
                 "title": r["path"],
                 "inbound_degree": r["inbound_degree"],
+                "anchor_text": r["anchor_text"],
             }
             for r in page.rows
         ]

--- a/tests/linkgraph/test_builder.py
+++ b/tests/linkgraph/test_builder.py
@@ -14,8 +14,8 @@ from openzim_mcp.linkgraph.reader import sidecar_path_for
 
 def _stream():
     # A->T, B->T, A->B  =>  T linked by {A,B}; B linked by {A}
-    yield ("C/A", ["C/T", "C/B"])
-    yield ("C/B", ["C/T"])
+    yield ("C/A", [("C/T", ""), ("C/B", "")])
+    yield ("C/B", [("C/T", "")])
     yield ("C/T", [])
 
 
@@ -47,7 +47,7 @@ def test_build_rejects_self_links_and_dedups(tmp_path: Path) -> None:
     out = sidecar_path_for(tmp_path / "x.zim")
 
     def stream():
-        yield ("C/A", ["C/A", "C/T", "C/T"])  # self-link + duplicate
+        yield ("C/A", [("C/A", ""), ("C/T", ""), ("C/T", "")])  # self-link + duplicate
 
     stats = build_from_link_stream(out, archive_uuid="u1", link_stream=stream())
     assert stats.edge_count == 1  # only A->T survives
@@ -103,14 +103,14 @@ def test_iter_article_links_walks_content_entries() -> None:
     archive.has_new_namespace_scheme = False
     archive.entry_count = len(entries)
     archive._get_entry_by_id.side_effect = lambda i: entries[i]
-    # _parse_internal_link_targets canonicalizes each target through the
+    # _parse_internal_link_edges canonicalizes each target through the
     # redirect chain via archive.get_entry_by_path. With no such entry in
     # this fake archive the lookup raises and the path-normalized target
     # ("C/T") survives unchanged — the honest "target not found" path.
     archive.get_entry_by_path.side_effect = KeyError("no entry")
 
     pairs = list(iter_article_links(archive))
-    assert ("C/A", ["C/T"]) in pairs
+    assert ("C/A", [("C/T", "t")]) in pairs
     assert all(src.startswith("C/") for src, _ in pairs)
     assert not any(src == "C/Redir" for src, _ in pairs)
 
@@ -138,6 +138,23 @@ def test_iter_article_links_new_scheme_has_no_prefix() -> None:
     archive.get_entry_by_path.side_effect = KeyError("no entry")
 
     pairs = list(iter_article_links(archive))
-    assert ("Evolution", ["Photosynthesis"]) in pairs
+    assert ("Evolution", [("Photosynthesis", "p")]) in pairs
     assert all(not src.startswith("C/") for src, _ in pairs)
     assert not any(src == "Redir" for src, _ in pairs)
+
+
+def test_builder_writes_anchor_text_and_builder_version(tmp_path: Path) -> None:
+    """Builder stores anchor_text per edge and writes a builder_version meta row."""
+    import openzim_mcp
+
+    out = str(tmp_path / "a.zim.linkgraph.sqlite")
+    stream = [("A/Src", [("A/Tgt", "see Tgt")])]
+    build_from_link_stream(out, archive_uuid="uuid-1", link_stream=iter(stream))
+
+    conn = sqlite3.connect(out)
+    anchors = conn.execute("SELECT anchor_text FROM edges").fetchall()
+    assert anchors == [("see Tgt",)]
+    meta = dict(conn.execute("SELECT key, value FROM meta"))
+    assert meta["builder_version"] == openzim_mcp.__version__
+    assert meta["schema_version"] == "2"
+    conn.close()

--- a/tests/linkgraph/test_inbound_data.py
+++ b/tests/linkgraph/test_inbound_data.py
@@ -71,11 +71,11 @@ def _build_sidecar(
     archive_path: Path,
     *,
     uuid: str,
-    stream: List[Tuple[str, List[str]]],
+    stream: List[Tuple[str, List[Tuple[str, str]]]],
 ) -> None:
     """Build a real sidecar next to ``archive_path`` from a synthetic stream."""
 
-    def _iter() -> Iterator[Tuple[str, List[str]]]:
+    def _iter() -> Iterator[Tuple[str, List[Tuple[str, str]]]]:
         yield from stream
 
     build_from_link_stream(
@@ -96,11 +96,11 @@ def test_inbound_returns_ranked_results(
         archive,
         uuid="u1",
         stream=[
-            ("C/A", ["C/T"]),
-            ("C/B", ["C/T"]),
-            ("C/C1", ["C/A"]),
-            ("C/C2", ["C/A"]),
-            ("C/C3", ["C/B"]),
+            ("C/A", [("C/T", "")]),
+            ("C/B", [("C/T", "")]),
+            ("C/C1", [("C/A", "")]),
+            ("C/C2", [("C/A", "")]),
+            ("C/C3", [("C/B", "")]),
         ],
     )
     _patch_archive_open(monkeypatch, uuid="u1")
@@ -142,8 +142,8 @@ def test_inbound_paginates_emits_cursor(
         archive,
         uuid="u1",
         stream=[
-            ("C/A", ["C/T"]),
-            ("C/B", ["C/T"]),
+            ("C/A", [("C/T", "")]),
+            ("C/B", [("C/T", "")]),
         ],
     )
     _patch_archive_open(monkeypatch, uuid="u1")

--- a/tests/linkgraph/test_inbound_data.py
+++ b/tests/linkgraph/test_inbound_data.py
@@ -133,6 +133,28 @@ def test_inbound_missing_sidecar_raises_unavailable(
         )
 
 
+def test_inbound_results_include_anchor_text(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Each inbound result carries anchor_text from the stored edge."""
+    archive = tmp_path / "x.zim"
+    _build_sidecar(
+        archive,
+        uuid="u1",
+        stream=[
+            ("C/A", [("C/T", "the target page")]),
+        ],
+    )
+    _patch_archive_open(monkeypatch, uuid="u1")
+
+    result = _StructureMixin.get_inbound_links_data(
+        _stub_self(archive), str(archive), "C/T", limit=10, offset=0
+    )
+
+    assert result["total"] == 1
+    assert result["results"][0]["anchor_text"] == "the target page"
+
+
 def test_inbound_paginates_emits_cursor(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/linkgraph/test_link_parser.py
+++ b/tests/linkgraph/test_link_parser.py
@@ -1,4 +1,4 @@
-"""The shared internal-link parser returns canonical target paths.
+"""The shared internal-link parser returns canonical (target, anchor) edge pairs.
 
 Encodes the REAL classification + canonicalization rules used by
 ``extract_article_links``'s internal bucket (via ``ContentProcessor``
@@ -37,40 +37,54 @@ def test_parse_internal_targets_internal_only_deduped() -> None:
         '<a href="#section">anchor</a>'  # bare fragment -> not navigable
         '<a href="Bar">Bar</a>'
     )
-    targets = _StructureMixin._parse_internal_link_targets(
+    edges = _StructureMixin._parse_internal_link_edges(
         html, source_path="C/Source", archive=None
     )
     # Hrefs resolve relative to dirname("C/Source") == "C".
-    assert targets == ["C/Foo", "C/Bar"]
+    assert [t for t, _ in edges] == ["C/Foo", "C/Bar"]
 
 
 def test_parse_internal_targets_resolves_relative_against_source() -> None:
     """Relative hrefs resolve against the source path's directory (archive=None)."""
     html = '<a href="Other">other</a><a href="../Up">up</a>'
-    targets = _StructureMixin._parse_internal_link_targets(
+    edges = _StructureMixin._parse_internal_link_edges(
         html, source_path="A/dir/Source", archive=None
     )
     # "Other" -> A/dir/Other ; "../Up" -> A/Up (posixpath normalization).
-    assert targets == ["A/dir/Other", "A/Up"]
+    assert [t for t, _ in edges] == ["A/dir/Other", "A/Up"]
 
 
 def test_parse_internal_targets_drops_self_reference() -> None:
     """A link whose resolved target equals the source path is dropped."""
     # "Source" resolves to dirname("C/Source")/Source == "C/Source" (self).
     html = '<a href="Source">self</a><a href="Keep">keep</a>'
-    targets = _StructureMixin._parse_internal_link_targets(
+    edges = _StructureMixin._parse_internal_link_edges(
         html, source_path="C/Source", archive=None
     )
-    assert targets == ["C/Keep"]
+    assert [t for t, _ in edges] == ["C/Keep"]
 
 
 def test_parse_internal_targets_empty_html_is_empty_list() -> None:
     """Empty / link-free HTML yields an empty list, not an error."""
     assert (
-        _StructureMixin._parse_internal_link_targets(
+        _StructureMixin._parse_internal_link_edges(
             "<html><body><p>no links</p></body></html>",
             source_path="C/Source",
             archive=None,
         )
         == []
     )
+
+
+def test_parse_edges_captures_anchor_text() -> None:
+    """Parser returns (target, anchor) pairs; image-only links yield empty anchor."""
+    # href "Cat" resolves against dirname("A/Index") == "A" -> "A/Cat"
+    html = (
+        '<a href="Cat">the cat page</a>'
+        '<a href="Dog"><img src="d.png"></a>'  # no visible text -> ''
+        '<a href="Cat">cat again</a>'  # dup target -> first anchor kept
+    )
+    edges = _StructureMixin._parse_internal_link_edges(
+        html, source_path="A/Index", archive=None
+    )
+    assert edges == [("A/Cat", "the cat page"), ("A/Dog", "")]

--- a/tests/linkgraph/test_reader.py
+++ b/tests/linkgraph/test_reader.py
@@ -107,3 +107,22 @@ def test_query_inbound_unknown_target_is_empty_not_error(tmp_path: Path) -> None
     page = reader.query_inbound("C/Nonexistent", limit=10, offset=0)
     assert page.rows == [] and page.total == 0
     reader.close()
+
+
+def test_query_inbound_includes_anchor_text(tmp_path: Path) -> None:
+    """Row dicts include anchor_text from the edge that linked to the target."""
+    import sqlite3 as _sqlite3
+
+    from openzim_mcp.linkgraph.builder import build_from_link_stream
+
+    out = str(tmp_path / "a.zim.linkgraph.sqlite")
+    stream = [("A/Src", [("A/Tgt", "anchor for tgt")])]
+    build_from_link_stream(out, archive_uuid="u", link_stream=iter(stream))
+    reader = LinkGraphReader(_sqlite3.connect(out))
+    try:
+        page = reader.query_inbound("A/Tgt", limit=10, offset=0)
+    finally:
+        reader.close()
+    assert page.total == 1
+    assert page.rows[0]["path"] == "A/Src"
+    assert page.rows[0]["anchor_text"] == "anchor for tgt"

--- a/tests/linkgraph/test_schema.py
+++ b/tests/linkgraph/test_schema.py
@@ -32,6 +32,19 @@ def test_schema_version_is_a_positive_int() -> None:
     assert isinstance(SCHEMA_VERSION, int) and SCHEMA_VERSION >= 1
 
 
+def test_edges_has_anchor_text_column(tmp_path) -> None:
+    """Edges table carries target_id, source_id, and anchor_text columns."""
+    conn = sqlite3.connect(":memory:")
+    create_schema(conn)
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(edges)")}
+    assert cols == {"target_id", "source_id", "anchor_text"}
+
+
+def test_schema_version_is_2() -> None:
+    """SCHEMA_VERSION equals 2."""
+    assert SCHEMA_VERSION == 2
+
+
 def test_apply_build_pragmas_runs_without_error() -> None:
     """Build pragmas apply cleanly on a fresh connection."""
     conn = sqlite3.connect(":memory:")


### PR DESCRIPTION
## Summary

Two #16 follow-ups (noted in PR #274), shipped as one on-disk format change (`SCHEMA_VERSION 1→2`):

1. **`builder_version` meta row** — the builder now records `openzim_mcp.__version__` in the sidecar's `meta` table (diagnostic; the staleness contract stays UUID + schema_version).
2. **Per-edge `anchor_text`** — `edges` gains an `anchor_text TEXT NOT NULL DEFAULT ''` column. The parser now yields `(target, anchor)` pairs (the visible link text, previously computed and discarded), the builder writes it, and `zim_links(direction="inbound")` surfaces an `anchor_text` field on each linker — so a caller sees *how* each page refers to the target, not just *that* it links.

## Behaviour

- Parser `_parse_internal_link_targets` → `_parse_internal_link_edges`, returning `List[(target, anchor)]`; anchor is the trimmed link text (`''` when absent); dedup keeps the first anchor per `(source, target)`.
- Builder: 3-column edge insert + `builder_version` meta row. `inbound_degree`, ranking, and pagination unchanged.
- Reader `query_inbound` SELECTs `anchor_text`; `get_inbound_links_data` adds `anchor_text` to each result (additive field).
- **`SCHEMA_VERSION 1→2`:** existing v1 sidecars hit the reader's existing strict `schema_version` check → graceful absence → operator rebuilds with `build link-graph`. No migration code (intended staleness behaviour; the feature shipped only in v2.3.0).

- **Spec:** `docs/specs/2026-06-09-v2.5-linkgraph-sidecar-v2-design.md`
- **Plan:** `docs/superpowers/plans/2026-06-09-linkgraph-sidecar-v2.md`

## Test plan

- [x] TDD across schema → parser+builder → reader → data layer; 6 new tests (anchor capture / no-text→'' / first-anchor dedup; builder writes anchor + builder_version + schema_version=2; reader & data-layer surface anchor end-to-end; schema column + version).
- [x] `uv run pytest -q --no-cov` → **2966 passed**.
- [x] `make lint` clean.
- [x] Two-stage review (spec compliance + code quality) — approved; only nits (a stale docstring) fixed.