### PR TITLE
feat: dispatch-eval honours either_acceptable for prose sub-modes (v2.5 #199)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
       - id: debug-statements
       - id: name-tests-test
         args: ["--pytest-test-first"]
+        exclude: ^tests/dispatch_eval/(analyze|runner|check_transport|oneof_parse_benchmark)\.py$
 
   # Python code formatting — keep in lockstep with the dev-deps pin in
   # pyproject.toml so ``make format`` and pre-commit don't drift.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,11 @@ repos:
       - id: debug-statements
       - id: name-tests-test
         args: ["--pytest-test-first"]
-        exclude: ^tests/dispatch_eval/(analyze|runner|check_transport|oneof_parse_benchmark)\.py$
+        # tests/dispatch_eval/ holds support modules (analyze, runner,
+        # check_probe_coverage, gate_0_1_emission_spike, check_transport,
+        # oneof_parse_benchmark) that are NOT pytest files; exclude every
+        # non-``test_`` Python module there so editing one is committable.
+        exclude: ^tests/dispatch_eval/(?!test_).*\.py$
 
   # Python code formatting — keep in lockstep with the dev-deps pin in
   # pyproject.toml so ``make format`` and pre-commit don't drift.

--- a/docs/specs/2026-06-09-v2.5-dispatch-eval-either-acceptable-design.md
+++ b/docs/specs/2026-06-09-v2.5-dispatch-eval-either-acceptable-design.md
@@ -1,0 +1,64 @@
+# Dispatch-eval honours `either_acceptable` (v2.5 #199) — design
+
+**Milestone:** v2.5.0a3 · **Issue:** #199 · **Date:** 2026-06-09
+
+## Problem
+
+The v2.0.0rc1 dispatch sweep flagged three new Phase-F operation classes with low *measured* accuracy: `zim_get-summary` 20%, `zim_get-structure` 53%, `zim_get-main-page` 76%. The model, asked "give me a summary of X", routes to `zim_query` (the documented natural-language entry path, which returns a working answer) instead of `zim_get(view="summary")`.
+
+This is a **measurement artifact**, not a dispatch defect. Every one of those probes is already tagged `"tool_eligibility": "either_acceptable"` in `probes.jsonl` — the probe author's declaration that *either* `zim_get` *or* `zim_query` is a correct outcome. But the scorer does not honour that flag: `dispatch_correct` is computed strictly as `name == expected_tool` ([`runner.py:956`](../../tests/dispatch_eval/runner.py)) and recorded into each run; `analyze.py` only special-cases `tool_eligibility == "zim_query_preferred"` ([`analyze.py:362`](../../tests/dispatch_eval/analyze.py)), never `either_acceptable`. So a `zim_query` answer on an `either_acceptable` probe is scored as a miss, dragging the three classes down.
+
+## Scope decisions (settled in brainstorming)
+
+- **Path B — honour the existing `either_acceptable` flag in the analysis layer.** This implements the probe set's already-declared intent; it changes **no** production/dispatch code and **no** `*_description.md`, so the D14b prototype-parity guard does not fire. (Path A — tuning `zim_get`'s description to pull the model toward `zim_get` — is deferred; it changes production behaviour and risks regressing other classes, and is only warranted if a class stays below the floor *after* relaxation.)
+- **Policy lives in `analyze.py`, not the runner.** The runner keeps recording the raw fact (`name == expected_tool`); analysis applies the eligibility policy. This re-scores the *committed* run model-lessly **and** any fresh run, with one definition.
+- **Uniform application.** Every `either_acceptable` probe (309 of them) gets the relaxation, not just the three weak classes — that is the flag's meaning. It can only flip an outcome from incorrect→correct, so no class can regress, and a dispatch to a genuinely wrong tool (e.g. `main-page → zim_metadata`) still counts as a miss.
+
+## Architecture
+
+Single function touched: `aggregate_cell` in [`tests/dispatch_eval/analyze.py`](../../tests/dispatch_eval/analyze.py).
+
+Add a small helper and use its result everywhere `o.dispatch_correct` currently drives scoring:
+
+```python
+def _effective_dispatch_correct(o: "Outcome", probe: Dict[str, Any]) -> bool:
+    """dispatch_correct, relaxed to honour the probe's tool_eligibility.
+
+    A probe tagged ``either_acceptable`` declares that BOTH its
+    ``expected_tool`` and ``zim_query`` (the natural-language entry path)
+    are correct outcomes, so a ``zim_query`` dispatch counts as correct.
+    Any other tool still misses.
+    """
+    if o.dispatch_correct:
+        return True
+    if probe.get("tool_eligibility") == "either_acceptable" and o.tool_called == "zim_query":
+        return True
+    return False
+```
+
+In `aggregate_cell`'s per-outcome loop, replace the three uses of `o.dispatch_correct` (overall `summary.dispatch_correct`, the `composite_correct` conjunct, and the per-class `per_class_correct` increment) with `eff = _effective_dispatch_correct(o, probe)` computed once. `probe` is already fetched in the loop for per-class accounting (`probe = probe_meta.get(o.probe_id, {})`); move that fetch above the counters so `eff` can use it. `parameter_validity`, `spurious_route`, and the `zim_query_preferred` Criterion-C block are unchanged.
+
+No other file changes. The `Outcome` already carries `tool_called`; `probe_meta` already carries `tool_eligibility`.
+
+## Probe audit
+
+Confirm the `either_acceptable` assignment is appropriate before relying on it. Verified in brainstorming: all `zim_get-summary` (20), `-structure` (21), `-toc` (21), and `-main-page` (20) probes are `either_acceptable`; 309 probes carry the flag overall, 203 are `zim_query_preferred`. The relaxation accepts only `zim_query` as the alternative (not any tool), so it cannot mask a dispatch to a wrong tool.
+
+## Verification
+
+**(1) Model-less, deterministic — the authoritative proof.** Re-analyse the committed rc1 run with the patched `analyze.py`:
+
+```
+uv run python tests/dispatch_eval/analyze.py --sweep-mode \
+  --runs tests/dispatch_eval/runs/rc1__advanced__qwen3-8b-q4__2026-05-27T03-31-27Z.jsonl
+```
+
+The dispatch surface has not changed since that run (no `*_description.md` edits; the link-graph and section work did not touch dispatch prose), so it is representative of current behaviour. **Target:** `zim_get-summary`, `zim_get-structure`, `zim_get-main-page` each ≥ 70%, and no class regresses (the relaxation is monotonic, so none can).
+
+**(2) Model-verified confirmation.** Run a fresh sweep against the live surface via the configured endpoint (`OZM_VLLM_BASE_URL=https://chat.owl-atlas.ts.net/v1`, `OZM_OWL_ATLAS_API_KEY` set, model `qwen3-8b-q4`) and analyse it the same way. The node serves Qwen3-8B-Q4 with slow (~76 tok/s) prompt processing, so the cold first call (full 8-tool prompt) needs a high `OZM_DISPATCH_TIMEOUT_S`; once llama.cpp caches the shared tool prefix, subsequent calls are fast. Sweep breadth is scaled to node throughput (the three weak classes at minimum); the result confirms the floor holds on live data. If any weak class is still < 70% after relaxation — i.e. the model dispatches to a *third* tool — that is a real signal and escalates to path A.
+
+## Backward compatibility & non-goals
+
+- **No production/dispatch change**, no tool-surface change, no description edits → D14b parity guard untouched, no re-snapshot.
+- The runner's recorded `dispatch_correct` is unchanged (raw fact); only the analysis interpretation is relaxed. Existing `test_analyze.py` cases that assert strict scoring on non-`either_acceptable` probes are unaffected.
+- Path A (description tuning) is out of scope unless the fresh sweep proves a class still below the floor after relaxation.

--- a/docs/specs/2026-06-09-v2.5-dispatch-eval-either-acceptable-design.md
+++ b/docs/specs/2026-06-09-v2.5-dispatch-eval-either-acceptable-design.md
@@ -12,7 +12,7 @@ This is a **measurement artifact**, not a dispatch defect. Every one of those pr
 
 - **Path B — honour the existing `either_acceptable` flag in the analysis layer.** This implements the probe set's already-declared intent; it changes **no** production/dispatch code and **no** `*_description.md`, so the D14b prototype-parity guard does not fire. (Path A — tuning `zim_get`'s description to pull the model toward `zim_get` — is deferred; it changes production behaviour and risks regressing other classes, and is only warranted if a class stays below the floor *after* relaxation.)
 - **Policy lives in `analyze.py`, not the runner.** The runner keeps recording the raw fact (`name == expected_tool`); analysis applies the eligibility policy. This re-scores the *committed* run model-lessly **and** any fresh run, with one definition.
-- **Uniform application.** Every `either_acceptable` probe (309 of them) gets the relaxation, not just the three weak classes — that is the flag's meaning. It can only flip an outcome from incorrect→correct, so no class can regress, and a dispatch to a genuinely wrong tool (e.g. `main-page → zim_metadata`) still counts as a miss.
+- **Scoped to the prose sub-mode classes.** `either_acceptable` is tagged across the *entire* F2 surface — including `zim_get-binary`, `zim_get-batch`, `zim_browse-page/walk`, `zim_metadata`, `zim_health`, `zim_links-outbound/related` — but for those a `zim_query` *search* does **not** fulfil the request ("fetch the image at I/Einstein.jpg" is not answered by a search). So the relaxation accepts `zim_query` **only** for the natural-language content sub-modes #199 is about: `zim_get-summary`, `zim_get-structure`, `zim_get-toc`, `zim_get-main-page`. This is the issue's "ambiguous prose probes" scope. Keeping the operational classes strict means a routing regression toward `zim_query` on binary/batch/browse/metadata/health stays visible in the overall and per-class rates. The relaxation only ever flips incorrect→correct, so no class can regress; a dispatch to a third tool (e.g. `main-page → zim_metadata`) still misses.
 
 ## Architecture
 
@@ -21,17 +21,30 @@ Single function touched: `aggregate_cell` in [`tests/dispatch_eval/analyze.py`](
 Add a small helper and use its result everywhere `o.dispatch_correct` currently drives scoring:
 
 ```python
-def _effective_dispatch_correct(o: "Outcome", probe: Dict[str, Any]) -> bool:
-    """dispatch_correct, relaxed to honour the probe's tool_eligibility.
+# Prose content sub-modes where zim_query genuinely fulfils the request.
+_ZIM_QUERY_FALLBACK_CLASSES = frozenset(
+    {"zim_get-summary", "zim_get-structure", "zim_get-toc", "zim_get-main-page"}
+)
 
-    A probe tagged ``either_acceptable`` declares that BOTH its
-    ``expected_tool`` and ``zim_query`` (the natural-language entry path)
-    are correct outcomes, so a ``zim_query`` dispatch counts as correct.
-    Any other tool still misses.
+def _effective_dispatch_correct(o: "Outcome", probe: Dict[str, Any]) -> bool:
+    """dispatch_correct, relaxed for the prose sub-mode classes (#199).
+
+    A probe in one of the prose sub-mode classes ("summarize / outline / TOC /
+    main-page") tagged ``either_acceptable`` is acceptably answered by either
+    its ``expected_tool`` OR ``zim_query`` (the natural-language entry path), so
+    a ``zim_query`` dispatch counts as correct. Any other tool — or a
+    ``zim_query`` dispatch on a non-prose either_acceptable probe (binary /
+    batch / browse / metadata / health) — still misses.
     """
     if o.dispatch_correct:
         return True
-    if probe.get("tool_eligibility") == "either_acceptable" and o.tool_called == "zim_query":
+    if (
+        probe.get("tool_eligibility") == "either_acceptable"
+        and o.tool_called == "zim_query"
+        and not _ZIM_QUERY_FALLBACK_CLASSES.isdisjoint(
+            probe.get("operational_classes") or ()
+        )
+    ):
         return True
     return False
 ```
@@ -42,7 +55,7 @@ No other file changes. The `Outcome` already carries `tool_called`; `probe_meta`
 
 ## Probe audit
 
-Confirm the `either_acceptable` assignment is appropriate before relying on it. Verified in brainstorming: all `zim_get-summary` (20), `-structure` (21), `-toc` (21), and `-main-page` (20) probes are `either_acceptable`; 309 probes carry the flag overall, 203 are `zim_query_preferred`. The relaxation accepts only `zim_query` as the alternative (not any tool), so it cannot mask a dispatch to a wrong tool.
+The audit is why the relaxation is **class-scoped, not flag-scoped**. `either_acceptable` is tagged across the whole F2 surface (309 probes): the four prose sub-modes (`summary` 20, `structure` 21, `toc` 21, `main-page` 20) *and* the operational classes (`binary` 20, `batch` 20, `browse-page/walk` 20+20, `metadata` 20, `health` 20, `links-outbound/related` 22+22). For the operational classes a `zim_query` search does not fulfil the request, so accepting it there would be wrong (and would mask a regression). The relaxation therefore keys on membership in `_ZIM_QUERY_FALLBACK_CLASSES` (the four prose sub-modes) **and** `either_acceptable` **and** `tool_called == "zim_query"` — accepting only `zim_query`, only for prose probes. Verified: with this scope, the four prose classes lift to ≥70% while every operational class's accuracy is byte-identical before vs after (no inflation).
 
 ## Verification
 

--- a/docs/superpowers/plans/2026-06-09-dispatch-eval-either-acceptable.md
+++ b/docs/superpowers/plans/2026-06-09-dispatch-eval-either-acceptable.md
@@ -1,0 +1,203 @@
+# Dispatch-eval honours `either_acceptable` (#199) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `analyze.py` honour the probe set's existing `tool_eligibility == "either_acceptable"` flag so a `zim_query` dispatch counts as correct for those probes, lifting the measured `zim_get-summary` / `-structure` / `-main-page` accuracy above the ≥70% floor without changing any production/dispatch code.
+
+**Architecture:** A pure helper `_effective_dispatch_correct(outcome, probe)` in `tests/dispatch_eval/analyze.py`, applied inside `aggregate_cell` everywhere `o.dispatch_correct` currently drives scoring (overall rate, composite, per-class). The runner is untouched; the policy lives in analysis, so it re-scores the committed run and any fresh run with one definition.
+
+**Tech Stack:** Python 3.12, pytest. No model needed for the code change or its unit tests.
+
+**Spec:** [docs/specs/2026-06-09-v2.5-dispatch-eval-either-acceptable-design.md](../../specs/2026-06-09-v2.5-dispatch-eval-either-acceptable-design.md)
+
+---
+
+## Task 1: `analyze.py` honours `either_acceptable`
+
+**Files:**
+
+- Modify: `tests/dispatch_eval/analyze.py` (add helper above `aggregate_cell` line 332; use it in the loop lines 339-385)
+- Test: `tests/dispatch_eval/test_analyze.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/dispatch_eval/test_analyze.py` (it already imports `aggregate_cell`, `Outcome`, `_make_probe_meta`; add a small local builder for outcomes with an explicit `tool_called` and `dispatch_correct=False`):
+
+```python
+def _miss_outcomes(n, *, tool_called, probe_id_prefix="p"):
+    return [
+        Outcome(
+            probe_id=f"{probe_id_prefix}-{i}",
+            rep=0,
+            tool_called=tool_called,
+            parameters={},
+            dispatch_correct=False,
+            parameter_validity="load_bearing_match",
+            spurious_route=False,
+            spurious_route_kind=None,
+            resolved_entry_path=None,
+            cell_variant="rc1",
+            cell_mode="advanced",
+            cell_model="qwen3-8b-q4",
+        )
+        for i in range(n)
+    ]
+
+
+def test_either_acceptable_zim_query_counts_correct():
+    outcomes = _miss_outcomes(10, tool_called="zim_query")
+    probe_meta = _make_probe_meta(
+        10, classes=["zim_get-summary"], tool_eligibility="either_acceptable"
+    )
+    s = aggregate_cell(outcomes, probe_meta)
+    # zim_query on an either_acceptable probe is relaxed to correct
+    assert s.per_class["zim_get-summary"] == (10, 10)
+    assert s.dispatch_correct == 10
+    assert s.composite_correct == 10  # parameter_validity != "fail"
+
+
+def test_either_acceptable_wrong_tool_still_misses():
+    outcomes = _miss_outcomes(10, tool_called="zim_metadata")
+    probe_meta = _make_probe_meta(
+        10, classes=["zim_get-main-page"], tool_eligibility="either_acceptable"
+    )
+    s = aggregate_cell(outcomes, probe_meta)
+    # a dispatch to a third tool is NOT relaxed
+    assert s.per_class["zim_get-main-page"] == (10, 0)
+    assert s.dispatch_correct == 0
+
+
+def test_non_either_acceptable_zim_query_unchanged():
+    outcomes = _miss_outcomes(10, tool_called="zim_query")
+    probe_meta = _make_probe_meta(10, classes=["X"], tool_eligibility="any")
+    s = aggregate_cell(outcomes, probe_meta)
+    # strict scoring stands when the probe is not either_acceptable
+    assert s.per_class["X"] == (10, 0)
+    assert s.dispatch_correct == 0
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/dispatch_eval/test_analyze.py -k "either_acceptable or non_either" -v --no-cov`
+Expected: FAIL — `test_either_acceptable_zim_query_counts_correct` sees `(10, 0)` / `dispatch_correct == 0` (no relaxation yet); the other two already pass.
+
+- [ ] **Step 3: Add the helper**
+
+In `tests/dispatch_eval/analyze.py`, add directly above `def aggregate_cell` (line 332):
+
+```python
+def _effective_dispatch_correct(o: "Outcome", probe: Dict[str, Any]) -> bool:
+    """``dispatch_correct``, relaxed to honour the probe's ``tool_eligibility``.
+
+    A probe tagged ``either_acceptable`` declares that BOTH its
+    ``expected_tool`` and ``zim_query`` (the documented natural-language
+    entry path) are correct outcomes, so a ``zim_query`` dispatch counts
+    as correct. A dispatch to any other tool still misses.
+    """
+    if o.dispatch_correct:
+        return True
+    if (
+        probe.get("tool_eligibility") == "either_acceptable"
+        and o.tool_called == "zim_query"
+    ):
+        return True
+    return False
+```
+
+- [ ] **Step 4: Apply it in `aggregate_cell`**
+
+In the per-outcome loop (lines 339-385), move the `probe` fetch above the counters and replace the three `o.dispatch_correct` uses with the effective value. The loop body becomes:
+
+```python
+    for o in outcomes:
+        if not summary.variant:
+            summary.variant = o.cell_variant
+            summary.mode = o.cell_mode
+            summary.model = o.cell_model
+            summary.family = _family_of(o.cell_model) or "primary"
+        summary.n += 1
+
+        probe = probe_meta.get(o.probe_id, {})
+        eff = _effective_dispatch_correct(o, probe)
+        if eff:
+            summary.dispatch_correct += 1
+        if o.parameter_validity == "load_bearing_match":
+            summary.load_bearing_match += 1
+        if eff and o.parameter_validity != "fail":
+            summary.composite_correct += 1
+
+        # Per-class accounting (F1/F2)
+        classes = probe.get("operational_classes", []) or []
+        for cls in classes:
+            per_class_n[cls] += 1
+            if eff:
+                per_class_correct[cls] += 1
+
+        # Criterion C — zim_query_preferred subset
+        if probe.get("tool_eligibility") == "zim_query_preferred":
+            summary.zqp_n += 1
+            if o.spurious_route:
+                summary.zqp_spurious_route += 1
+                if o.spurious_route_kind == "answer_degrading":
+                    summary.zqp_spurious_answer_degrading += 1
+                elif o.spurious_route_kind == "answer_preserving":
+                    summary.zqp_spurious_answer_preserving += 1
+
+            # Criterion C3 — Z4 subset of zim_query_preferred
+            if "Z4" in classes:
+                summary.z4_zqp_n += 1
+                if o.spurious_route and o.spurious_route_kind == "answer_degrading":
+                    summary.z4_zqp_answer_degrading += 1
+```
+
+(Delete the now-duplicated `probe = probe_meta.get(...)` that previously sat above the per-class block.)
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `uv run pytest tests/dispatch_eval/test_analyze.py -v --no-cov`
+Expected: PASS (all — the 3 new tests plus every existing test; existing tests use `tool_eligibility` `"any"`/`"zim_query_preferred"`, so `_effective_dispatch_correct` returns the unrelaxed `o.dispatch_correct` for them).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/dispatch_eval/analyze.py tests/dispatch_eval/test_analyze.py
+git commit -m "feat(dispatch-eval): analyze.py honours either_acceptable in scoring (#199)"
+```
+
+---
+
+## Task 2: Verify the floor is cleared on the committed run
+
+This is the authoritative, deterministic proof — re-score the real 2026-05-27 model outputs with the patched analyzer.
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Re-analyse the committed rc1 run**
+
+Run:
+
+```bash
+uv run python tests/dispatch_eval/analyze.py --sweep-mode \
+  --runs tests/dispatch_eval/runs/rc1__advanced__qwen3-8b-q4__2026-05-27T03-31-27Z.jsonl
+```
+
+Capture the per-class accuracy for `zim_get-summary`, `zim_get-structure`, `zim_get-main-page`.
+Expected: each ≥ 70% (projected ~100% / ~100% / ~90% from the issue's dispatch data). No class regresses (the relaxation is monotonic).
+
+- [ ] **Step 2: Record the before/after numbers**
+
+If `analyze.py`'s sweep output does not already print per-class accuracy in a readable form, capture the three weak-class figures (and a couple of strong classes to show no regression) into the PR description. No code change; this is evidence-gathering.
+
+- [ ] **Step 3 (optional, opportunistic): model-verified spot-check**
+
+If the live endpoint throughput allows (the node's cold first call needs a high timeout to warm the llama.cpp tool-prefix cache), run a fresh sweep over the three weak classes and analyse it the same way:
+
+```bash
+OZM_VLLM_BASE_URL=https://chat.owl-atlas.ts.net/v1 \
+OZM_OWL_ATLAS_API_KEY=<key> OZM_DISPATCH_TIMEOUT_S=240 \
+uv run python tests/dispatch_eval/runner.py --variant rc1 --mode advanced \
+  --model qwen3-8b-q4 --reps 3 --probes <weak-class-subset>.jsonl --output <out>.jsonl
+uv run python tests/dispatch_eval/analyze.py --sweep-mode --runs <out>.jsonl
+```
+
+Expected: the three weak classes clear ≥70% on live data too. This is confirmation, not a gate — the committed-run re-analysis is the proof. Do NOT commit the API key or the fresh run output unless it is intended as a committed artifact.

--- a/tests/dispatch_eval/analyze.py
+++ b/tests/dispatch_eval/analyze.py
@@ -1,4 +1,4 @@
-"""Gate 0b non-inferiority analyzer.
+r"""Gate 0b non-inferiority analyzer.
 
 Reads per-cell outcome JSONL files (produced by ``tests/dispatch_eval/runner.py``)
 and emits the criterion verdicts per the spec's tiered decision rule.
@@ -148,6 +148,8 @@ _MODEL_FAMILY = {
 
 @dataclass
 class Outcome:
+    """One dispatcher outcome row loaded from a JSONL run file."""
+
     probe_id: str
     rep: int
     tool_called: Optional[str]
@@ -164,6 +166,7 @@ class Outcome:
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> "Outcome":
+        """Construct an Outcome from a raw JSONL row dict."""
         return cls(
             probe_id=d.get("probe_id", ""),
             rep=int(d.get("rep", 0)),
@@ -329,6 +332,24 @@ class CellSummary:
     z4_zqp_answer_degrading: int = 0
 
 
+def _effective_dispatch_correct(o: "Outcome", probe: Dict[str, Any]) -> bool:
+    """``dispatch_correct``, relaxed to honour the probe's ``tool_eligibility``.
+
+    A probe tagged ``either_acceptable`` declares that BOTH its
+    ``expected_tool`` and ``zim_query`` (the documented natural-language
+    entry path) are correct outcomes, so a ``zim_query`` dispatch counts
+    as correct. A dispatch to any other tool still misses.
+    """
+    if o.dispatch_correct:
+        return True
+    if (
+        probe.get("tool_eligibility") == "either_acceptable"
+        and o.tool_called == "zim_query"
+    ):
+        return True
+    return False
+
+
 def aggregate_cell(
     outcomes: Iterable[Outcome], probe_meta: Dict[str, Dict[str, Any]]
 ) -> CellSummary:
@@ -343,19 +364,21 @@ def aggregate_cell(
             summary.model = o.cell_model
             summary.family = _family_of(o.cell_model) or "primary"
         summary.n += 1
-        if o.dispatch_correct:
+
+        probe = probe_meta.get(o.probe_id, {})
+        eff = _effective_dispatch_correct(o, probe)
+        if eff:
             summary.dispatch_correct += 1
         if o.parameter_validity == "load_bearing_match":
             summary.load_bearing_match += 1
-        if o.dispatch_correct and o.parameter_validity != "fail":
+        if eff and o.parameter_validity != "fail":
             summary.composite_correct += 1
 
         # Per-class accounting (F1/F2)
-        probe = probe_meta.get(o.probe_id, {})
         classes = probe.get("operational_classes", []) or []
         for cls in classes:
             per_class_n[cls] += 1
-            if o.dispatch_correct:
+            if eff:
                 per_class_correct[cls] += 1
 
         # Criterion C — zim_query_preferred subset
@@ -388,8 +411,7 @@ def aggregate_cell(
 def split_outcomes_by_cell(
     outcomes: Iterable[Outcome],
 ) -> Dict[Tuple[str, str, str], List[Outcome]]:
-    """Group outcomes by (variant, mode, model) so each cell is summarized
-    independently."""
+    """Group outcomes by (variant, mode, model) so each cell is summarized independently."""
     out: Dict[Tuple[str, str, str], List[Outcome]] = defaultdict(list)
     for o in outcomes:
         out[(o.cell_variant, o.cell_mode, o.cell_model)].append(o)
@@ -425,8 +447,7 @@ def criterion_a_b_d(
 
 
 def criterion_c1(phase_f_advanced_primary: CellSummary) -> Dict[str, Any]:
-    """C1: answer-degrading spurious-routing rate over the
-    zim_query_preferred denominator. Ceiling: 5%.
+    """C1: answer-degrading spurious-routing rate over the zim_query_preferred denominator. Ceiling 5%.
 
     Vacuous when no zim_query_preferred probes ran (events=0): pass=True with
     rate=None — no events means no measured harm, can't block on it.
@@ -451,6 +472,7 @@ def criterion_c1(phase_f_advanced_primary: CellSummary) -> Dict[str, Any]:
 
 def criterion_c2(phase_f_advanced_primary: CellSummary) -> Dict[str, Any]:
     """C2: conditional on misrouting, fraction whose resolved entry differs.
+
     Underpowered below 10 events (returns rate=None, pass=None — hand-audit
     required, gate authors record verdict).
     """
@@ -469,6 +491,7 @@ def criterion_c2(phase_f_advanced_primary: CellSummary) -> Dict[str, Any]:
 
 def criterion_c3(phase_f_advanced_primary: CellSummary) -> Dict[str, Any]:
     """C3: Z4 zim_query_preferred answer-degrading rate. Ceiling: 5%.
+
     Underpowered below 20 events (returns rate=None, pass=None).
     """
     events = phase_f_advanced_primary.z4_zqp_n
@@ -672,11 +695,8 @@ def apply_disagreement_rule(
                 if fam == "primary":
                     # Any primary A/B/D failure blocks — including A/B; D
                     # is the load-bearing one but A/B are also tracked.
-                    if crit_name == "D":
-                        blocking = True
-                    elif crit_name in ("A", "B"):
-                        # A/B failures on primary are also blocking — they
-                        # imply Criterion D is at risk.
+                    # A/B failures imply Criterion D is at risk.
+                    if (crit_name == "D") or (crit_name in ("A", "B")):
                         blocking = True
                 else:
                     family_failures[f"{fam}_blocking_failures"].append(
@@ -737,7 +757,7 @@ def _build_gate_decision(
     # Identify the PRIMARY phase-f advanced cell for C1/C2/C3 + F1/F2
     primary_phase_f: Optional[CellSummary] = None
     primary_b13: Optional[CellSummary] = None
-    for key, summary in cells.items():
+    for _key, summary in cells.items():
         if summary.family == "primary" and summary.mode == "advanced":
             if summary.variant == "phase-f":
                 primary_phase_f = summary
@@ -926,7 +946,7 @@ def _sweep_report(
             per_class.setdefault(cls, {"n": 0, "correct": 0})
             per_class[cls]["n"] += n
             per_class[cls]["correct"] += correct
-    for cls, stats in per_class.items():
+    for _cls, stats in per_class.items():
         stats["rate"] = stats["correct"] / stats["n"] if stats["n"] else 0.0
 
     report: Dict[str, Any] = {
@@ -1053,6 +1073,7 @@ def _expand_globs(patterns: Optional[str]) -> List[str]:
 
 
 def main(argv: Optional[List[str]] = None) -> int:
+    """Entry point for the Gate 0b non-inferiority analyzer CLI."""
     parser = _build_arg_parser()
     args = parser.parse_args(argv)
 

--- a/tests/dispatch_eval/analyze.py
+++ b/tests/dispatch_eval/analyze.py
@@ -332,19 +332,44 @@ class CellSummary:
     z4_zqp_answer_degrading: int = 0
 
 
-def _effective_dispatch_correct(o: "Outcome", probe: Dict[str, Any]) -> bool:
-    """``dispatch_correct``, relaxed to honour the probe's ``tool_eligibility``.
+# Operation classes where ``zim_query`` (the natural-language entry path)
+# genuinely fulfils the request, so a ``zim_query`` dispatch is an acceptable
+# outcome (#199). These are the prose content-retrieval sub-modes: "summarize
+# X", "outline of X", "table of contents of X", "show the main page". The
+# relaxation is scoped to these classes ON PURPOSE — most other F2 probes are
+# ALSO tagged ``either_acceptable`` (binary fetch, batch fetch, namespace walk,
+# metadata, health, link listing), but for those a ``zim_query`` *search* does
+# NOT fulfil the request, so it must keep counting as a miss; otherwise a real
+# routing regression toward ``zim_query`` on those classes would be masked.
+_ZIM_QUERY_FALLBACK_CLASSES = frozenset(
+    {
+        "zim_get-summary",
+        "zim_get-structure",
+        "zim_get-toc",
+        "zim_get-main-page",
+    }
+)
 
-    A probe tagged ``either_acceptable`` declares that BOTH its
-    ``expected_tool`` and ``zim_query`` (the documented natural-language
-    entry path) are correct outcomes, so a ``zim_query`` dispatch counts
-    as correct. A dispatch to any other tool still misses.
+
+def _effective_dispatch_correct(o: "Outcome", probe: Dict[str, Any]) -> bool:
+    """``dispatch_correct``, relaxed for the prose sub-mode classes (#199).
+
+    A probe in one of the ``_ZIM_QUERY_FALLBACK_CLASSES`` (a natural-language
+    "summarize / outline / TOC / main-page" request) tagged
+    ``either_acceptable`` is acceptably answered by either its ``expected_tool``
+    OR ``zim_query`` (the documented natural-language entry path), so a
+    ``zim_query`` dispatch counts as correct. A dispatch to any other tool — or
+    a ``zim_query`` dispatch on a non-prose either_acceptable probe (binary /
+    batch / browse / metadata / health) — still misses.
     """
     if o.dispatch_correct:
         return True
     if (
         probe.get("tool_eligibility") == "either_acceptable"
         and o.tool_called == "zim_query"
+        and not _ZIM_QUERY_FALLBACK_CLASSES.isdisjoint(
+            probe.get("operational_classes") or ()
+        )
     ):
         return True
     return False

--- a/tests/dispatch_eval/test_analyze.py
+++ b/tests/dispatch_eval/test_analyze.py
@@ -222,7 +222,7 @@ def test_criterion_c1_ceiling_5pp_enforced() -> None:
                 parameters={"mode": "title"},
                 dispatch_correct=False,
                 parameter_validity="schema_only",
-                spurious_route=True if i < 6 else False,
+                spurious_route=i < 6,
                 spurious_route_kind="answer_degrading" if i < 6 else None,
                 resolved_entry_path=None,
                 cell_variant="phase-f",
@@ -245,7 +245,7 @@ def test_criterion_c1_ceiling_5pp_enforced() -> None:
                 parameters={"mode": "title"},
                 dispatch_correct=False,
                 parameter_validity="schema_only",
-                spurious_route=True if i < 4 else False,
+                spurious_route=i < 4,
                 spurious_route_kind="answer_degrading" if i < 4 else None,
                 resolved_entry_path=None,
                 cell_variant="phase-f",
@@ -746,6 +746,61 @@ def test_disagreement_rule_primary_d_failure_blocks() -> None:
         },
     )
     assert gate_passed is False
+
+
+def _miss_outcomes(n, *, tool_called, probe_id_prefix="p"):
+    return [
+        Outcome(
+            probe_id=f"{probe_id_prefix}-{i}",
+            rep=0,
+            tool_called=tool_called,
+            parameters={},
+            dispatch_correct=False,
+            parameter_validity="load_bearing_match",
+            spurious_route=False,
+            spurious_route_kind=None,
+            resolved_entry_path=None,
+            cell_variant="rc1",
+            cell_mode="advanced",
+            cell_model="qwen3-8b-q4",
+        )
+        for i in range(n)
+    ]
+
+
+def test_either_acceptable_zim_query_counts_correct():
+    """zim_query dispatch on an either_acceptable probe is relaxed to correct."""
+    outcomes = _miss_outcomes(10, tool_called="zim_query")
+    probe_meta = _make_probe_meta(
+        10, classes=["zim_get-summary"], tool_eligibility="either_acceptable"
+    )
+    s = aggregate_cell(outcomes, probe_meta)
+    # zim_query on an either_acceptable probe is relaxed to correct
+    assert s.per_class["zim_get-summary"] == (10, 10)
+    assert s.dispatch_correct == 10
+    assert s.composite_correct == 10  # parameter_validity != "fail"
+
+
+def test_either_acceptable_wrong_tool_still_misses():
+    """A dispatch to a third tool on an either_acceptable probe still misses."""
+    outcomes = _miss_outcomes(10, tool_called="zim_metadata")
+    probe_meta = _make_probe_meta(
+        10, classes=["zim_get-main-page"], tool_eligibility="either_acceptable"
+    )
+    s = aggregate_cell(outcomes, probe_meta)
+    # a dispatch to a third tool is NOT relaxed
+    assert s.per_class["zim_get-main-page"] == (10, 0)
+    assert s.dispatch_correct == 0
+
+
+def test_non_either_acceptable_zim_query_unchanged():
+    """Strict scoring stands when the probe is not either_acceptable."""
+    outcomes = _miss_outcomes(10, tool_called="zim_query")
+    probe_meta = _make_probe_meta(10, classes=["X"], tool_eligibility="any")
+    s = aggregate_cell(outcomes, probe_meta)
+    # strict scoring stands when the probe is not either_acceptable
+    assert s.per_class["X"] == (10, 0)
+    assert s.dispatch_correct == 0
 
 
 def test_disagreement_rule_observational_secondary_does_not_block() -> None:

--- a/tests/dispatch_eval/test_analyze.py
+++ b/tests/dispatch_eval/test_analyze.py
@@ -803,6 +803,39 @@ def test_non_either_acceptable_zim_query_unchanged():
     assert s.dispatch_correct == 0
 
 
+def test_either_acceptable_non_prose_class_not_relaxed():
+    """A zim_query dispatch on a non-prose either_acceptable probe still misses.
+
+    binary/batch/browse/metadata/health requests are tagged either_acceptable
+    too, but zim_query does not fulfil them — relaxing them would mask a real
+    routing regression toward zim_query, so they must keep counting as misses.
+    """
+    outcomes = _miss_outcomes(10, tool_called="zim_query")
+    probe_meta = _make_probe_meta(
+        10, classes=["zim_get-binary"], tool_eligibility="either_acceptable"
+    )
+    s = aggregate_cell(outcomes, probe_meta)
+    assert s.per_class["zim_get-binary"] == (10, 0)
+    assert s.dispatch_correct == 0
+
+
+def test_relaxed_outcome_credits_co_tagged_classes():
+    """A relaxed prose probe credits every class it carries (mixed F1+F2).
+
+    The f2x probes carry both a hardened F1 tag (e.g. Z4) and a prose F2 class
+    (zim_get-summary); one relaxed zim_query outcome credits both.
+    """
+    outcomes = _miss_outcomes(8, tool_called="zim_query")
+    probe_meta = _make_probe_meta(
+        8,
+        classes=["Z4", "zim_get-summary"],
+        tool_eligibility="either_acceptable",
+    )
+    s = aggregate_cell(outcomes, probe_meta)
+    assert s.per_class["zim_get-summary"] == (8, 8)
+    assert s.per_class["Z4"] == (8, 8)
+
+
 def test_disagreement_rule_observational_secondary_does_not_block() -> None:
     """Secondary unavailable + primary pass → gate passes."""
     criteria = {


### PR DESCRIPTION
## Summary

Resolves #199 (the low `zim_get-summary`/`-structure`/`-main-page` dispatch accuracy) as the **measurement artifact** it is. When the model answers "give me a summary of X" by dispatching `zim_query` — the documented natural-language entry path that returns a working answer — the scorer counted it as a miss. The probe set already tags those probes `tool_eligibility: "either_acceptable"`, but `analyze.py` only honoured `zim_query_preferred`.

`analyze.py`'s `aggregate_cell` now uses `_effective_dispatch_correct(o, probe)`: a `zim_query` dispatch counts as correct **only** for the prose content sub-modes `_ZIM_QUERY_FALLBACK_CLASSES = {summary, structure, toc, main-page}` when the probe is `either_acceptable`. **No production/dispatch code changes; no `*_description.md` changes** → the D14b prototype-parity guard does not fire.

### Scoped on purpose
`either_acceptable` is tagged across the *whole* F2 surface, but `zim_query` (a search) does **not** fulfil `zim_get-binary` ("fetch the image at I/Einstein.jpg"), `zim_get-batch`, `zim_browse-walk`, `zim_metadata`, or `zim_health`. So the relaxation is keyed on the four prose classes — accepting `zim_query` there keeps a real routing regression toward `zim_query` on the operational classes **visible**. A dispatch to a third tool (e.g. `main-page → zim_metadata`) still misses.

## Verification (model-verified, both ways)

| Class | Committed rc1 (2026-05-27) strict→relaxed | Fresh sweep (today, qwen3-8b-q4) strict→relaxed |
|---|---|---|
| zim_get-summary | 20.0% → **100%** | 10.0% → **100%** |
| zim_get-structure | 53.3% → **100%** | 47.6% → **100%** |
| zim_get-toc | 85.7% → **100%** | — |
| zim_get-main-page | 76.0% → **90%** | 65.0% → **85%** |

All four prose classes clear the **≥70% floor**. Operational classes are **byte-identical** before/after (binary 100%, batch 84%, browse 95%, metadata 100%, health 95%) — no inflation. The fresh sweep ran via the live endpoint over the 61 weak-class probes (×2 reps, `error_count: 0`).

- **Spec:** `docs/specs/2026-06-09-v2.5-dispatch-eval-either-acceptable-design.md`
- **Plan:** `docs/superpowers/plans/2026-06-09-dispatch-eval-either-acceptable.md`

## Test plan

- [x] 5 TDD tests (`--dispatch-eval`): relaxed-correct; wrong-tool-still-miss; non-eligible-unchanged; **non-prose either_acceptable NOT relaxed**; mixed F1+F2 credits both classes.
- [x] `uv run pytest -q --no-cov --dispatch-eval` → **3085 passed**; `uv run pytest -q --no-cov` (CI default) green.
- [x] `make lint` clean.
- [x] Two-stage review (spec + quality) — quality review caught an over-broad initial relaxation (all `either_acceptable`); corrected to the prose-class scope here.

## Note
`.pre-commit-config.yaml` gains a `name-tests-test` exclude for the non-test support modules in `tests/dispatch_eval/` — necessary to commit any edit to `analyze.py` (the hook otherwise rejects non-`test_` modules; `--no-verify` is not used). `path A` (description tuning) is deferred — unnecessary since the floor is cleared without touching production behaviour.