### PR TITLE
docs(roadmap): v2.5.0a2 shipped (v2.3.0), v2.5.0a3 landed

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # openzim-mcp Roadmap
 
-**Status:** Latest release **v2.2.1** (2026-06-05) — PyPI `2.2.1` and `ghcr.io/cameronrye/openzim-mcp:2.2.1` / `:latest`, GitHub Release with assets. v2.0.0 GA shipped 2026-05-27 (as `:2.0.0`); the v2.0.x/v2.1.x line was kept current via beta-sweep fixes plus the v2.1.0 native-libzim reader features. **v2.2.0 shipped the first v2.5 roadmap item — `#17` archive-type presets (the v2.5.0a1 milestone)** — validated against the live superuser (sotoki v3.0.2) archive in the v2.2.0 reprobe; v2.2.1 was a Docker stdio-default fix.
+**Status:** Latest release **v2.3.0** (2026-06-08) — PyPI `2.3.0` and `ghcr.io/cameronrye/openzim-mcp:2.3.0` / `:latest`, GitHub Release with assets. v2.0.0 GA shipped 2026-05-27 (as `:2.0.0`); the v2.0.x/v2.1.x line was kept current via beta-sweep fixes plus the v2.1.0 native-libzim reader features. **v2.2.0 shipped the first v2.5 roadmap item — `#17` archive-type presets (the v2.5.0a1 milestone)** — validated against the live superuser (sotoki v3.0.2) archive in the v2.2.0 reprobe; v2.2.1 was a Docker stdio-default fix. **v2.3.0 shipped `#16` — the inbound link-graph sidecar (the v2.5.0a2 milestone).** The v2.5.0a3 items (`#199` dispatch-eval scoping, `#18` `zim_get_section` raw-text) and the `#16` sidecar-v2 follow-ups (`builder_version` meta + per-edge `anchor_text`, finer `build` CLI errors) landed on `main` (PRs #277/#279/#280/#281) and will ship in the next cut.
 
 This document tracks open work past v2.0.0. Everything here is **additive**: opt-in extras, optional sidecars, or dispatch tuning. None of it changes the v2 tool surface or response contract.
 
@@ -88,13 +88,15 @@ Open commitments referenced from production code (`openzim_mcp/tools/`) and test
 
 **Target.** Description tuning and/or probe-set relaxation on the dispatch path so phrases like "give me a summary of X" or "show the table of contents for X" route to the right sub-mode. Captured at GitHub issue `#199`.
 
-**Status as of 2026-05-27.** Tracked for v2.5. Not a regression — there is always a working fallback through the default entry path.
+**Status — ✅ IMPLEMENTED (PR #281).** Resolved as a measurement artifact, not a dispatch defect: the `zim_query` answer to a prose "summarize / outline / TOC / main-page" request is a working outcome, and the probe set already tags those probes `either_acceptable`. `analyze.py` now counts a `zim_query` dispatch as correct for the four prose sub-mode classes (scoped so a `zim_query` regression on operational classes stays visible). Model-verified: `zim_get-summary`/`-structure`/`-toc`/`-main-page` clear ≥70% on both the committed rc1 run and a fresh qwen3-8b-q4 sweep; operational classes unchanged. Description tuning (path A) was unnecessary and is not done. See [the design spec](specs/2026-06-09-v2.5-dispatch-eval-either-acceptable-design.md).
 
 #### `#18` — `zim_get_section` true raw-text path
 
 **Current state.** [`openzim_mcp/tools/zim_get_section.py`](../openzim_mcp/tools/zim_get_section.py) accepts `compact: bool` for surface uniformity with `zim_query` / `zim_get`, but at v2.0 the parameter is a no-op: section bodies always ship in the bundle's compact rendering so the slice shape matches `zim_get(view="full")` output on the same article.
 
 **Target.** Wire a true raw-text path so `compact=False` returns the unrendered section body, matching the rendering contract the other tools already honour. Schema-additive — no caller has to opt in.
+
+**Status — ✅ IMPLEMENTED (PR #277).** `compact` is threaded through the bundle pipeline with a render-mode-keyed cache; `compact=False` returns full tables instead of `[Table N: …]` placeholders. Default `True` preserves all existing behaviour; no `*_description.md` change. See [the design spec](specs/2026-06-08-v2.5-zim-get-section-raw-text-design.md).
 
 #### `zim_get` `compact` default revisit
 
@@ -104,7 +106,7 @@ Open commitments referenced from production code (`openzim_mcp/tools/`) and test
 
 #### `zim_links` `"inbound"` direction enum promotion — ✅ **IMPLEMENTED with `#16`**
 
-`"inbound"` is now present in the `direction` enum. Schema-additive; no caller had to change. Ships on `feat/inbound-link-graph` alongside `#16`.
+`"inbound"` is now present in the `direction` enum. Schema-additive; no caller had to change. Shipped in **v2.3.0** alongside `#16` (PR #274).
 
 ---
 
@@ -113,8 +115,8 @@ Open commitments referenced from production code (`openzim_mcp/tools/`) and test
 | Milestone | Items | Status / Tag |
 | --- | --- | --- |
 | **v2.5.0a1** | `#17` archive-type presets ([spec](specs/2026-06-04-v2.5-archive-type-presets-design.md) — snippet + summary seams, detect all 4 types, behavior for Wikipedia/Stack Exchange) | ✅ **Shipped in v2.2.0** (reprobe-validated; a2 follow-ons noted above) |
-| **v2.5.0a2** | `#16` link-graph sidecar + `build` CLI + `zim_links` `"inbound"` enum promotion ([spec](specs/2026-06-08-v2.5-link-graph-design.md)) | _Implemented on `feat/inbound-link-graph` (pending merge)_ |
-| **v2.5.0a3** | `#199` `zim_query` sub-mode dispatch + `#18` `zim_get_section` raw-text path | _TBD_ |
+| **v2.5.0a2** | `#16` link-graph sidecar + `build` CLI + `zim_links` `"inbound"` enum promotion ([spec](specs/2026-06-08-v2.5-link-graph-design.md)) | ✅ **Shipped in v2.3.0** (PR #274); sidecar **v2** follow-ups — `builder_version` + per-edge `anchor_text` ([spec](specs/2026-06-09-v2.5-linkgraph-sidecar-v2-design.md)) + finer `build` CLI errors — landed on `main` (PRs #279, #280) |
+| **v2.5.0a3** | `#199` dispatch-eval `either_acceptable` scoping + `#18` `zim_get_section` raw-text path | ✅ **Landed on `main`** (PRs #277, #281); ships in the next cut |
 | **v2.5.0a4** | sub-D-3 if triggered + `zim_get` `compact` default revisit (telemetry-driven) | sub-D-3 → **close-by-default 2026-07-19** unless a field trigger fires (see status above); compact revisit _TBD_ |
 | **v2.5.0a5** | sub-D-4 if triggered | **close-by-default 2026-07-19** unless triggers fire (see status above) |
 | **v2.5.0** | Final after all triggered items ship (closed sub-Ds annotated in CHANGELOG) | _TBD_ |


### PR DESCRIPTION
## Summary

Roadmap housekeeping after the v2.5.0a3 batch landed:

- Header status → **v2.3.0** (was the stale v2.2.1), noting v2.3.0 shipped `#16` (link-graph, v2.5.0a2) and that the a3 items landed on `main`.
- **`#199`** marked ✅ implemented (PR #281) — resolved as a measurement artifact via `analyze.py` `either_acceptable` scoping; model-verified.
- **`#18`** marked ✅ implemented (PR #277) — `compact=False` raw-text path.
- Milestone table: **v2.5.0a2** → "Shipped in v2.3.0" + sidecar-v2 follow-ups (PRs #279/#280); **v2.5.0a3** → "Landed on main" (PRs #277/#281).
- `zim_links` `"inbound"` enum note → shipped in v2.3.0.

Docs-only.

## Test plan

- [x] markdownlint clean (pre-commit).