### PR TITLE
fix(deps): clear website vite + astro security advisories (npm audit → 0)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2126,14 +2126,14 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.3.8",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.3.8.tgz",
-      "integrity": "sha512-xH2UA8Z17IS+JaqSlSkBor7jO6gd7zXTLdmu06nKpfpDDJFbi/7KZEy3NDmWxmier+6XrCZ9Z4aitO8jhC9oiA==",
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.7.tgz",
+      "integrity": "sha512-5vsXx0H52u23Jpshs9tM81D03Tb3Oh2Vt2Zo0bpqjXN+njkAWjFyGjTfmWJLAcrCQd9Q+iWB1eqfhR1sZJEaUA==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",
-        "@astrojs/internal-helpers": "0.9.1",
-        "@astrojs/markdown-remark": "7.1.2",
+        "@astrojs/internal-helpers": "0.10.0",
+        "@astrojs/markdown-remark": "7.2.0",
         "@astrojs/telemetry": "3.3.2",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
@@ -2145,7 +2145,7 @@
         "clsx": "^2.1.1",
         "common-ancestor-path": "^2.0.0",
         "cookie": "^1.1.1",
-        "devalue": "^5.6.3",
+        "devalue": "^5.8.1",
         "diff": "^8.0.3",
         "dset": "^3.1.4",
         "es-module-lexer": "^2.0.0",
@@ -2201,6 +2201,47 @@
       },
       "optionalDependencies": {
         "sharp": "^0.34.0"
+      }
+    },
+    "node_modules/astro/node_modules/@astrojs/internal-helpers": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.0.tgz",
+      "integrity": "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.1.1",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
+      }
+    },
+    "node_modules/astro/node_modules/@astrojs/markdown-remark": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.0.tgz",
+      "integrity": "sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.0",
+        "@astrojs/prism": "4.0.2",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-to-text": "^4.0.2",
+        "mdast-util-definitions": "^6.0.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "remark-smartypants": "^3.0.2",
+        "unified": "^11.0.5",
+        "unist-util-remove-position": "^5.0.0",
+        "unist-util-visit": "^5.1.0",
+        "unist-util-visit-parents": "^6.0.2",
+        "vfile": "^6.0.3"
       }
     },
     "node_modules/axobject-query": {
@@ -6022,9 +6063,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",


### PR DESCRIPTION
## Summary

Clears the website's open security advisories. `npm audit` in `website/` now reports **0 vulnerabilities** (was 1 HIGH + 1 MEDIUM from Dependabot, plus a HIGH in astro that npm audit surfaces but Dependabot hadn't alerted on yet).

| Package | Advisory | Severity | Fix |
| --- | --- | --- | --- |
| `vite` | [Dependabot #29] CVE-2026-53571 — `server.fs.deny` bypass on Windows alternate paths | HIGH | → 7.3.5 |
| `vite` | [Dependabot #30] CVE-2026-53632 — launch-editor NTLMv2 hash disclosure (Windows UNC) | MEDIUM | → 7.3.5 |
| `astro` | GHSA-jrpj-wcv7-9fh9 — XSS via unescaped attribute names in spread props | HIGH | → 6.4.7 |
| `astro` | GHSA-2pvr-wf23-7pc7 — Host-header SSRF in prerendered error-page fetch | HIGH | → 6.4.7 |

`vite` is transitive (via `astro`'s `^7.3.2`); `astro` is a direct dep at `^6.3.8` and 6.4.7 stays in range — so **only `website/package-lock.json` changes**, no `package.json` edit.

The astro XSS/SSRF pair is the higher-impact fix here: it affects the **served site**, whereas the vite issues are Windows dev-server-only. Bundled in since I was already in the lockfile.

## Verification (local — `deploy-website.yml` only builds on push to main, so no PR check covers this)

- `npm ci` → `found 0 vulnerabilities`
- `npx astro check` → 0 errors, 0 warnings
- `npm run build` → 16 pages built, Complete
