### PR TITLE
feat(dist): publish to Smithery + MCP Registry via a reproducible .mcpb pipeline

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -194,13 +194,31 @@ jobs:
           MANIFEST_VERSION=$(jq -r '."."' .release-please-manifest.json)
           echo "manifest version: $MANIFEST_VERSION"
 
-          if [ "$TAG_VERSION" = "$PYPROJECT_VERSION" ] && [ "$TAG_VERSION" = "$MANIFEST_VERSION" ]; then
+          # The distribution artifacts are auto-bumped by release-please's json
+          # updaters (release-please-config.json extra-files). Assert they moved,
+          # so a mis-pathed updater fails loudly here with a clear message rather
+          # than as an opaque pytest failure in release.yml's gating test job.
+          MCPB_VERSION=$(jq -r '.version' packaging/mcpb/manifest.json)
+          SERVERJSON_VERSION=$(jq -r '.version' server.json)
+          SERVERJSON_PKG_VERSION=$(jq -r '.packages[0].version' server.json)
+          echo "packaging/mcpb/manifest.json version: $MCPB_VERSION"
+          echo "server.json version: $SERVERJSON_VERSION"
+          echo "server.json packages[0].version: $SERVERJSON_PKG_VERSION"
+
+          if [ "$TAG_VERSION" = "$PYPROJECT_VERSION" ] && \
+             [ "$TAG_VERSION" = "$MANIFEST_VERSION" ] && \
+             [ "$TAG_VERSION" = "$MCPB_VERSION" ] && \
+             [ "$TAG_VERSION" = "$SERVERJSON_VERSION" ] && \
+             [ "$TAG_VERSION" = "$SERVERJSON_PKG_VERSION" ]; then
             echo "✅ All versions are synchronized!"
           else
             echo "❌ Version mismatch detected!"
             echo "Tag: $TAG_VERSION"
             echo "pyproject.toml: $PYPROJECT_VERSION"
-            echo "manifest: $MANIFEST_VERSION"
+            echo "release-please manifest: $MANIFEST_VERSION"
+            echo "packaging/mcpb/manifest.json: $MCPB_VERSION"
+            echo "server.json: $SERVERJSON_VERSION"
+            echo "server.json packages[0]: $SERVERJSON_PKG_VERSION"
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,23 @@ jobs:
           name: dist
           path: dist/
 
+      # The .mcpb bundle (Smithery listing + Claude Desktop one-click extension)
+      # is built into a SEPARATE directory/artifact, never dist/. The
+      # publish-pypi job uploads everything in the `dist` artifact to PyPI, and a
+      # .mcpb is not a valid distribution — keeping it out of `dist` avoids a
+      # failed/garbage PyPI upload. create-release merges it back in for the
+      # GitHub release only. `uv run` syncs the project venv (installs openzim_mcp
+      # + libzim) before running, which build_mcpb.py needs to spawn the server
+      # and capture live tool schemas.
+      - name: Build .mcpb bundle
+        run: uv run python scripts/build_mcpb.py --output dist-mcpb
+
+      - name: Upload .mcpb bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: mcpb
+          path: dist-mcpb/
+
   publish-pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
@@ -218,6 +235,15 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: dist
+          path: dist/
+
+      # Merge the .mcpb bundle (+ its .sha256) into dist/ so the existing
+      # dist/* upload paths below attach it to the GitHub release. This artifact
+      # is intentionally kept out of the PyPI publish (see the build job).
+      - name: Download .mcpb bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: mcpb
           path: dist/
 
       - name: Determine tag name

--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ openzim-mcp --help
 
 Download ZIM files from the [Kiwix Library](https://library.kiwix.org/) into a directory of your choice before running the server.
 
+### Smithery & one-click install
+
+OpenZIM MCP is listed on the [Smithery registry](https://smithery.ai/servers/rye/openzim-mcp). Add it to your MCP client with the Smithery CLI:
+
+```bash
+npx @smithery/cli mcp add rye/openzim-mcp --client claude
+```
+
+For a one-click **Claude Desktop extension**, download the `openzim-mcp-<version>.mcpb` asset from the [latest release](https://github.com/cameronrye/openzim-mcp/releases/latest) and double-click it. The bundle launches `uvx openzim-mcp` (so the host needs [uv](https://docs.astral.sh/uv/)) and prompts for your ZIM directory. Maintainer runbook: [docs/distribution.md](docs/distribution.md).
+
+<!-- mcp-name: io.github.cameronrye/openzim-mcp -->
+
 ## Quick start
 
 Run the server in Simple mode (default — exposes one natural-language tool, `zim_query`):

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ OpenZIM MCP is listed on the [Smithery registry](https://smithery.ai/servers/rye
 npx @smithery/cli mcp add rye/openzim-mcp --client claude
 ```
 
-For a one-click **Claude Desktop extension**, download the `openzim-mcp-<version>.mcpb` asset from the [latest release](https://github.com/cameronrye/openzim-mcp/releases/latest) and double-click it. The bundle launches `uvx openzim-mcp` (so the host needs [uv](https://docs.astral.sh/uv/)) and prompts for your ZIM directory. Maintainer runbook: [docs/distribution.md](docs/distribution.md).
+For a one-click **Claude Desktop extension**, download the `openzim-mcp-<version>.mcpb` asset (and its `.sha256`) from the [latest release](https://github.com/cameronrye/openzim-mcp/releases/latest) and double-click it. The bundle launches the version-pinned `uvx openzim-mcp@<version>` (so the host needs [uv](https://docs.astral.sh/uv/)) and prompts for your ZIM directory. Maintainer runbook: [docs/distribution.md](docs/distribution.md).
 
 <!-- mcp-name: io.github.cameronrye/openzim-mcp -->
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -39,30 +39,50 @@ keeps both artifacts in lockstep with the package version and tool surface.
 
 ---
 
-## 0. On every release (keep versions in lockstep)
+## 0. Version lockstep (automated)
 
-`tests/test_mcpb_distribution.py` fails if these drift from `pyproject.toml`:
+release-please bumps these in the release PR automatically, via the `json`
+updaters in [`release-please-config.json`](../release-please-config.json)
+`extra-files`:
 
-1. `packaging/mcpb/manifest.json` → `version` and the `openzim-mcp@<v>` launch arg.
-2. `server.json` → top-level `version` and `packages[0].version`.
+- `packaging/mcpb/manifest.json` → `version`
+- `server.json` → `version` and `packages[0].version`
 
-Bump both when the package version changes. (Optional follow-up: add them to the
-release-please `extra-files` so the bump is automatic — intentionally not wired
-yet to keep the release workflow unchanged.)
+The MCPB launch arg is deliberately **not** in that list: it is the composite
+string `openzim-mcp@<v>`, which a `json` updater would clobber to a bare version.
+The static template therefore ships an unpinned `openzim-mcp`, and
+[`scripts/build_mcpb.py`](../scripts/build_mcpb.py) stamps the exact
+`openzim-mcp@<version>` into the shipped bundle at build time.
+
+`tests/test_mcpb_distribution.py` still asserts the static `version` fields equal
+`pyproject.toml`, and the release-please `validate-release` job re-checks them at
+tag time — so a missed/mis-pathed bump fails loudly before anything publishes.
 
 ---
 
 ## 1. Build the `.mcpb` bundle
 
+The release workflow ([`.github/workflows/release.yml`](../.github/workflows/release.yml))
+builds this automatically and attaches `openzim-mcp-<version>.mcpb` (plus a
+`.sha256`) to every GitHub release, so the README's one-click download is always
+populated. The bundle is built into a separate directory — never `dist/` — so it
+is excluded from the PyPI upload and attached to the GitHub release only.
+
+To build it by hand (e.g. to publish/refresh the Smithery listing between
+releases):
+
 ```bash
-uv run python scripts/build_mcpb.py        # -> dist/openzim-mcp-<version>.mcpb
+uv run python scripts/build_mcpb.py        # -> dist/openzim-mcp-<version>.mcpb (+ .sha256)
 ```
 
 The script reads the version from `pyproject.toml`, spawns the server in
 advanced mode over stdio to capture the live tool schemas, injects them into the
-manifest, and plain-zips the bundle. It fails loudly if the advanced surface is
-not exactly the expected tool count (a tool-registration regression must break
-the build, not ship a short manifest).
+manifest, and plain-zips the bundle with pinned entry timestamps (rebuilding the
+same commit is byte-identical). It fails loudly if the advanced surface is not
+exactly the expected tool count (a tool-registration regression must break the
+build, not ship a short manifest). The build host must be macOS/Linux — the
+stdio handshake uses `select()` on a pipe — but the produced bundle is
+cross-platform.
 
 ---
 
@@ -121,7 +141,12 @@ server's tool definitions).
 
 ## Recommended sequence
 
-1. Land this change (manifest, `server.json`, build script, README marker, guard test).
-2. Build + publish/update the Smithery `.mcpb` (§1–§2) — does **not** depend on a release.
+1. Land this change (manifest, `server.json`, build script, README marker, guard
+   test, release-please auto-bump, and the `.mcpb` release-asset wiring).
+2. Publish/update the Smithery `.mcpb` (§1–§2) — does **not** depend on a release.
+   (Already published as `rye/openzim-mcp`; re-publish when the tool surface or
+   manifest metadata changes.)
 3. On the next PyPI release (README marker now live), publish `server.json` to
-   the official registry (§3); aggregators follow automatically.
+   the official registry (§3); aggregators follow automatically. From then on the
+   release workflow keeps the manifests version-locked and attaches the `.mcpb`
+   (with its `.sha256`) to each GitHub release for you.

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1,0 +1,127 @@
+# Distribution runbook
+
+How `openzim-mcp` gets discovered and installed beyond PyPI. The package is
+already on PyPI (`uv tool install openzim-mcp`) and shipped as a multi-arch
+Docker image; this is the maintainer playbook for the **MCP registries**.
+
+Two listings, two artifacts, one source of truth (the PyPI release):
+
+| Channel | Artifact | Model |
+| --- | --- | --- |
+| **Official MCP Registry** (`registry.modelcontextprotocol.io`) | [`server.json`](../server.json) | Points clients at the PyPI package, run via `uvx`. Aggregators (PulseMCP, mcp.so, …) ingest from here — highest-leverage. |
+| **Smithery** (`smithery.ai/servers/rye/openzim-mcp`) | `.mcpb` bundle | A local stdio server distributed as an MCPB bundle clients download and run locally. |
+
+Both expose the **advanced 8-tool surface** (`OPENZIM_MCP_TOOL_MODE=advanced`).
+A guard test, [`tests/test_mcpb_distribution.py`](../tests/test_mcpb_distribution.py),
+keeps both artifacts in lockstep with the package version and tool surface.
+
+---
+
+## Why these specific choices
+
+- **Local bundle, not hosted.** openzim-mcp needs each user's own local `.zim`
+  files. A Smithery-hosted (or any shared-URL) instance runs on stateless cloud
+  and can't reach a user's disk, so the only workable Smithery model is a
+  **local stdio** server — an MCPB (`.mcpb`) bundle.
+- **uvx launcher, not a vendored env.** The native `libzim` dependency makes a
+  self-contained bundle platform-locked and would blow the registry's 25 MB cap.
+  The bundle instead launches `uvx openzim-mcp@<version>`, so `uvx` resolves the
+  platform-correct `libzim` wheel from PyPI at run time. Trade-off: the host
+  needs [`uv`](https://docs.astral.sh/uv/). (Smithery's bundle publisher rejects
+  `server.type: "uv"`, so the manifest uses `server.type: "python"` with
+  `command: "uvx"`.)
+- **Plain zip, not `mcpb pack`.** A `.mcpb` is just a zip with `manifest.json`
+  at its root. The MCPB manifest schema only allows `{name, description}` per
+  tool, so `mcpb pack`/`mcpb validate` strip the `inputSchema`/`outputSchema`
+  keys — exactly the schemas Smithery and Glama score listings on.
+  [`scripts/build_mcpb.py`](../scripts/build_mcpb.py) injects the live tool
+  schemas and plain-zips to preserve them.
+
+---
+
+## 0. On every release (keep versions in lockstep)
+
+`tests/test_mcpb_distribution.py` fails if these drift from `pyproject.toml`:
+
+1. `packaging/mcpb/manifest.json` → `version` and the `openzim-mcp@<v>` launch arg.
+2. `server.json` → top-level `version` and `packages[0].version`.
+
+Bump both when the package version changes. (Optional follow-up: add them to the
+release-please `extra-files` so the bump is automatic — intentionally not wired
+yet to keep the release workflow unchanged.)
+
+---
+
+## 1. Build the `.mcpb` bundle
+
+```bash
+uv run python scripts/build_mcpb.py        # -> dist/openzim-mcp-<version>.mcpb
+```
+
+The script reads the version from `pyproject.toml`, spawns the server in
+advanced mode over stdio to capture the live tool schemas, injects them into the
+manifest, and plain-zips the bundle. It fails loudly if the advanced surface is
+not exactly the expected tool count (a tool-registration regression must break
+the build, not ship a short manifest).
+
+---
+
+## 2. Smithery — publish / update the listing
+
+One-time auth (already done on this machine): `npx @smithery/cli auth login`,
+and the `rye` namespace must exist (`npx @smithery/cli namespace list`).
+
+```bash
+npx @smithery/cli mcp publish dist/openzim-mcp-<version>.mcpb -n rye/openzim-mcp
+# Do NOT pass --config-schema for a bundle (URL-only; hard-errors). The config
+# schema is derived from manifest.json's user_config.allowed_directories.
+# If publish pauses for OAuth:
+npx @smithery/cli mcp publish --resume -n rye/openzim-mcp
+```
+
+Verify: `curl https://registry.smithery.ai/servers/rye/openzim-mcp` — the
+`connections[0]` should show `runtime: python`, the `configSchema`, and the
+listing page enumerates the 8 tools.
+
+---
+
+## 3. Official MCP Registry — `server.json`
+
+**Hard ordering constraint:** the registry validates the *live* PyPI package's
+README for an ownership marker — `<!-- mcp-name: io.github.cameronrye/openzim-mcp -->`
+in `README.md` (which becomes the PyPI description via `readme = "README.md"`).
+That marker must be present **in a published PyPI version** before you publish to
+the registry, and `server.json`'s `packages[0].version` must equal that version.
+The marker was added in this change, so the **first registry publish must target
+the first release that ships it** (i.e. the next release, not a version already
+on PyPI without the marker).
+
+```bash
+# Install the publisher CLI
+brew install mcp-publisher
+# or download from github.com/modelcontextprotocol/registry/releases/latest
+
+mcp-publisher validate            # checks ./server.json against the schema
+mcp-publisher login github        # device-code OAuth as cameronrye;
+                                  # authorizes the io.github.cameronrye/* namespace
+mcp-publisher publish             # defaults to ./server.json
+mcp-publisher status
+
+# Confirm:
+curl "https://registry.modelcontextprotocol.io/v0/servers?search=openzim-mcp"
+```
+
+Downstream (no action needed): **PulseMCP** and **mcp.so** ingest from the
+official registry (up to ~1 week latency). **Glama** auto-indexes the public
+GitHub repo; claim it at glama.ai and tighten tool descriptions to raise its
+score (it weights tool-definition quality heavily — the schemas live in the
+server's tool definitions).
+
+---
+
+## Recommended sequence
+
+1. Land this change (manifest, `server.json`, build script, README marker, guard test).
+2. Build + publish/update the Smithery `.mcpb` (§1–§2) — does **not** depend on a release.
+3. On the next PyPI release (README marker now live), publish `server.json` to
+   the official registry (§3); aggregators follow automatically.

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "openzim-mcp",
   "display_name": "OpenZIM MCP",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "ZIM MCP server that gives AI models offline access to ZIM knowledge archives (Wikipedia, Wiktionary, Stack Exchange, and the Kiwix library).",
   "long_description": "OpenZIM MCP is a secure, high-performance Model Context Protocol server that gives AI models structured, offline access to ZIM-format knowledge archives. It provides namespace-aware browsing, structure-aware retrieval (sections, tables of contents, related articles), full-text search with suggestions across one or more archives, and link-graph extraction. Point it at a local directory of .zim files (download archives from the Kiwix library) and it exposes the advanced 8-tool surface: zim_query, zim_search, zim_get, zim_get_section, zim_browse, zim_metadata, zim_links, and zim_health.",
   "author": {
@@ -35,7 +35,7 @@
     "mcp_config": {
       "command": "uvx",
       "args": [
-        "openzim-mcp@2.4.4",
+        "openzim-mcp",
         "${user_config.allowed_directories}"
       ],
       "env": {

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -1,0 +1,65 @@
+{
+  "manifest_version": "0.3",
+  "name": "openzim-mcp",
+  "display_name": "OpenZIM MCP",
+  "version": "2.4.4",
+  "description": "ZIM MCP server that gives AI models offline access to ZIM knowledge archives (Wikipedia, Wiktionary, Stack Exchange, and the Kiwix library).",
+  "long_description": "OpenZIM MCP is a secure, high-performance Model Context Protocol server that gives AI models structured, offline access to ZIM-format knowledge archives. It provides namespace-aware browsing, structure-aware retrieval (sections, tables of contents, related articles), full-text search with suggestions across one or more archives, and link-graph extraction. Point it at a local directory of .zim files (download archives from the Kiwix library) and it exposes the advanced 8-tool surface: zim_query, zim_search, zim_get, zim_get_section, zim_browse, zim_metadata, zim_links, and zim_health.",
+  "author": {
+    "name": "Cameron Rye",
+    "email": "c@meron.io",
+    "url": "https://github.com/cameronrye"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cameronrye/openzim-mcp"
+  },
+  "homepage": "https://github.com/cameronrye/openzim-mcp",
+  "documentation": "https://cameronrye.github.io/openzim-mcp/docs/",
+  "support": "https://github.com/cameronrye/openzim-mcp/issues",
+  "license": "MIT",
+  "keywords": [
+    "zim",
+    "openzim",
+    "mcp",
+    "wikipedia",
+    "kiwix",
+    "offline",
+    "knowledge-base",
+    "search"
+  ],
+  "tools": [],
+  "server": {
+    "type": "python",
+    "entry_point": "server/main.py",
+    "mcp_config": {
+      "command": "uvx",
+      "args": [
+        "openzim-mcp@2.4.4",
+        "${user_config.allowed_directories}"
+      ],
+      "env": {
+        "OPENZIM_MCP_TOOL_MODE": "advanced"
+      }
+    }
+  },
+  "user_config": {
+    "allowed_directories": {
+      "type": "directory",
+      "title": "ZIM directory",
+      "description": "Directory (or directories) containing your .zim archive files. Download archives from the Kiwix library (https://library.kiwix.org/).",
+      "required": true,
+      "multiple": true
+    }
+  },
+  "compatibility": {
+    "platforms": [
+      "darwin",
+      "win32",
+      "linux"
+    ],
+    "runtimes": {
+      "python": ">=3.12 <4"
+    }
+  }
+}

--- a/packaging/mcpb/server/main.py
+++ b/packaging/mcpb/server/main.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Entry-point shim for the OpenZIM MCP MCPB bundle.
+
+The bundle launches the server with ``uvx openzim-mcp@<version>`` (see
+``server.mcp_config.command`` in ``manifest.json``), which resolves the
+published PyPI package and its native ``libzim`` wheel for the host's platform
+at run time. This avoids vendoring a platform-specific virtualenv (which would
+be locked to one OS/arch and blow the registry's bundle-size limit).
+
+This file exists to satisfy the MCPB manifest's required ``entry_point`` and as
+a direct fallback: if invoked with the ``openzim_mcp`` package already
+importable, it delegates to the package's CLI.
+"""
+
+from openzim_mcp.main import main
+
+if __name__ == "__main__":
+    main()

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -70,6 +70,21 @@
           "type": "generic",
           "path": "website/public/llms.txt",
           "glob": false
+        },
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.packages[0].version"
+        },
+        {
+          "type": "json",
+          "path": "packaging/mcpb/manifest.json",
+          "jsonpath": "$.version"
         }
       ],
       "bump-minor-pre-major": true,

--- a/scripts/build_mcpb.py
+++ b/scripts/build_mcpb.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Build the OpenZIM MCP MCPB (``.mcpb``) bundle for Smithery / Claude Desktop.
+
+A ``.mcpb`` is a zip with ``manifest.json`` at its root (the format formerly
+called ``.dxt``). This script assembles a *self-describing* bundle:
+
+  1. Reads the single-source version from ``pyproject.toml`` and stamps it into
+     the manifest (both the top-level ``version`` and the ``uvx openzim-mcp@<v>``
+     launch argument), so the bundle can never drift from the released package.
+  2. Captures the **live** tool schemas — it spawns the server in ``advanced``
+     mode over stdio, calls ``tools/list``, and writes each tool's
+     ``name``/``description``/``inputSchema``/``outputSchema`` into the
+     manifest's ``tools`` array. These are the schemas Smithery and Glama score
+     listings on.
+  3. Packs a **plain zip** — deliberately NOT ``mcpb pack``. The MCPB manifest
+     schema only allows ``{name, description}`` per tool, so ``mcpb pack``/
+     ``mcpb validate`` strip the ``inputSchema``/``outputSchema`` keys. A
+     ``.mcpb`` is just a zip, so plain-zipping preserves the rich schemas.
+
+The bundle is a uvx *launcher* (``command: uvx``, ``args: openzim-mcp@<v> ...``)
+rather than a vendored environment: ``uvx`` resolves the platform-correct native
+``libzim`` wheel from PyPI at run time, keeping one cross-platform bundle far
+under the registry's 25 MB cap. The trade-off is that the host needs ``uv``.
+
+Usage:
+    uv run python scripts/build_mcpb.py [--output DIR]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess  # nosec B404 - spawns this project's own server, fixed argv
+import sys
+import tempfile
+import tomllib
+import zipfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+MANIFEST_TEMPLATE = REPO / "packaging" / "mcpb" / "manifest.json"
+BUNDLE_SRC = REPO / "packaging" / "mcpb"
+PYPI_NAME = "openzim-mcp"
+
+# The advanced surface registers exactly these tools (see
+# ``openzim_mcp/tools/__init__.py``). The bundle ships ``advanced`` mode, so a
+# correct build must capture all of them. ``tests/test_mcpb_distribution.py``
+# pins this against the live server, so adding/removing a tool fails CI here.
+EXPECTED_TOOL_COUNT = 8
+
+# Variable substitution the host (Claude Desktop / Smithery) performs at launch.
+HANDSHAKE_TIMEOUT_S = 120
+
+
+def package_version() -> str:
+    """Single source of truth: ``[project].version`` in pyproject.toml."""
+    with (REPO / "pyproject.toml").open("rb") as fh:
+        return tomllib.load(fh)["project"]["version"]
+
+
+def capture_tools(timeout_s: int = HANDSHAKE_TIMEOUT_S) -> list[dict]:
+    """Spawn the server in advanced mode and return its live ``tools/list``.
+
+    Returns each tool verbatim from the MCP SDK (``name``, ``description``,
+    ``inputSchema``, and ``outputSchema`` when present) so the manifest carries
+    the exact JSON Schemas Smithery scores.
+    """
+    with tempfile.TemporaryDirectory(prefix="openzim_mcp_build_") as zim_dir:
+        env = {
+            **os.environ,
+            "OPENZIM_MCP_TOOL_MODE": "advanced",
+            "LOG_LEVEL": "error",
+        }
+        proc = subprocess.Popen(  # nosec B603 - sys.executable + fixed module
+            [sys.executable, "-m", "openzim_mcp", zim_dir],
+            cwd=REPO,
+            env=env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        try:
+            tools = _handshake_list_tools(proc, timeout_s)
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+    if len(tools) != EXPECTED_TOOL_COUNT:
+        names = sorted(t.get("name", "?") for t in tools)
+        raise SystemExit(
+            f"build_mcpb: expected {EXPECTED_TOOL_COUNT} tools in advanced mode, "
+            f"captured {len(tools)}: {names}. A tool registration regression must "
+            f"break the build, not ship a short/wrong manifest."
+        )
+    return tools
+
+
+def _handshake_list_tools(proc: subprocess.Popen, timeout_s: int) -> list[dict]:
+    """Minimal MCP stdio handshake: initialize -> initialized -> tools/list."""
+    import select
+
+    def send(obj: dict) -> None:
+        assert proc.stdin is not None
+        proc.stdin.write(json.dumps(obj) + "\n")
+        proc.stdin.flush()
+
+    def read_id(target_id: int) -> dict:
+        assert proc.stdout is not None
+        deadline = _monotonic() + timeout_s
+        while True:
+            remaining = deadline - _monotonic()
+            if remaining <= 0:
+                raise SystemExit(f"build_mcpb: timed out waiting for id={target_id}")
+            ready, _, _ = select.select([proc.stdout], [], [], remaining)
+            if not ready:
+                continue
+            line = proc.stdout.readline()
+            if not line:
+                err = proc.stderr.read() if proc.stderr else ""
+                raise SystemExit(
+                    f"build_mcpb: server exited before id={target_id}\n{err[-2000:]}"
+                )
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                continue  # skip any non-JSON log noise on stdout
+            if msg.get("id") == target_id:
+                return msg
+
+    send(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "build_mcpb", "version": "0"},
+            },
+        }
+    )
+    read_id(1)
+    send({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+    send({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+    resp = read_id(2)
+    return resp.get("result", {}).get("tools", [])
+
+
+def _monotonic() -> float:
+    import time
+
+    return time.monotonic()
+
+
+def build_manifest(version: str, tools: list[dict]) -> dict:
+    """Stamp the version + launch arg and inject the captured tool schemas."""
+    manifest = json.loads(MANIFEST_TEMPLATE.read_text(encoding="utf-8"))
+    manifest["version"] = version
+    manifest["server"]["mcp_config"]["args"] = [
+        f"{PYPI_NAME}@{version}",
+        "${user_config.allowed_directories}",
+    ]
+    manifest["tools"] = tools
+    return manifest
+
+
+def pack(manifest: dict, output: Path) -> Path:
+    """Write a plain zip with manifest.json at the root + the server shim.
+
+    Plain zip (not ``mcpb pack``) preserves the ``inputSchema``/``outputSchema``
+    keys in ``tools`` that ``mcpb validate`` would reject.
+    """
+    output.parent.mkdir(parents=True, exist_ok=True)
+    if output.exists():
+        output.unlink()
+    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("manifest.json", json.dumps(manifest, indent=2) + "\n")
+        for path in sorted((BUNDLE_SRC / "server").rglob("*")):
+            if path.is_file():
+                zf.write(path, str(path.relative_to(BUNDLE_SRC)))
+    return output
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build the OpenZIM MCP .mcpb bundle")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=REPO / "dist",
+        help="Output directory for the .mcpb (default: ./dist)",
+    )
+    args = parser.parse_args()
+
+    version = package_version()
+    print(f"build_mcpb: version {version} (from pyproject.toml)")
+    print("build_mcpb: capturing live tool schemas (advanced mode)...")
+    tools = capture_tools()
+    print(f"build_mcpb: captured {len(tools)} tools: {[t['name'] for t in tools]}")
+
+    manifest = build_manifest(version, tools)
+    output = args.output / f"{PYPI_NAME}-{version}.mcpb"
+    pack(manifest, output)
+    size_kb = output.stat().st_size / 1024
+    print(f"build_mcpb: wrote {output} ({size_kb:.1f} KB)")
+    print(
+        f"build_mcpb: publish with -> smithery mcp publish {output} -n rye/openzim-mcp"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_mcpb.py
+++ b/scripts/build_mcpb.py
@@ -29,6 +29,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import subprocess  # nosec B404 - spawns this project's own server, fixed argv
@@ -49,7 +50,7 @@ PYPI_NAME = "openzim-mcp"
 # pins this against the live server, so adding/removing a tool fails CI here.
 EXPECTED_TOOL_COUNT = 8
 
-# Variable substitution the host (Claude Desktop / Smithery) performs at launch.
+# Max seconds for the whole tool-capture handshake (initialize + tools/list).
 HANDSHAKE_TIMEOUT_S = 120
 
 
@@ -66,11 +67,25 @@ def capture_tools(timeout_s: int = HANDSHAKE_TIMEOUT_S) -> list[dict]:
     ``inputSchema``, and ``outputSchema`` when present) so the manifest carries
     the exact JSON Schemas Smithery scores.
     """
+    if sys.platform == "win32":
+        # The handshake below waits on the server's stdout via select(), which
+        # on Windows accepts sockets only — not pipe handles — and raises
+        # WinError 10038. Fail fast with a clear message. The *bundle* this
+        # script produces is still cross-platform (it just launches uvx); only
+        # this build host must be POSIX.
+        raise SystemExit(
+            "build_mcpb: build host must be macOS/Linux — the stdio tool-capture "
+            "handshake uses select() on a pipe, which is unsupported on Windows. "
+            "The produced .mcpb bundle is itself cross-platform."
+        )
     with tempfile.TemporaryDirectory(prefix="openzim_mcp_build_") as zim_dir:
         env = {
             **os.environ,
             "OPENZIM_MCP_TOOL_MODE": "advanced",
-            "LOG_LEVEL": "error",
+            # Quiet the server's stderr during capture. The level is read from
+            # OPENZIM_MCP_LOGGING__LEVEL (env_prefix OPENZIM_MCP_, nested
+            # delimiter __); a bare LOG_LEVEL is silently ignored.
+            "OPENZIM_MCP_LOGGING__LEVEL": "ERROR",
         }
         proc = subprocess.Popen(  # nosec B603 - sys.executable + fixed module
             [sys.executable, "-m", "openzim_mcp", zim_dir],
@@ -87,9 +102,12 @@ def capture_tools(timeout_s: int = HANDSHAKE_TIMEOUT_S) -> list[dict]:
         finally:
             proc.terminate()
             try:
-                proc.wait(timeout=10)
+                # communicate() drains stdout/stderr while waiting, so the child
+                # can't wedge on a full pipe during shutdown.
+                proc.communicate(timeout=10)
             except subprocess.TimeoutExpired:
                 proc.kill()
+                proc.communicate()
 
     if len(tools) != EXPECTED_TOOL_COUNT:
         names = sorted(t.get("name", "?") for t in tools)
@@ -105,6 +123,10 @@ def _handshake_list_tools(proc: subprocess.Popen, timeout_s: int) -> list[dict]:
     """Minimal MCP stdio handshake: initialize -> initialized -> tools/list."""
     import select
 
+    # One shared budget for the whole handshake, so initialize + tools/list
+    # together are bounded by HANDSHAKE_TIMEOUT_S (not 2x it).
+    deadline = _monotonic() + timeout_s
+
     def send(obj: dict) -> None:
         assert proc.stdin is not None
         proc.stdin.write(json.dumps(obj) + "\n")
@@ -112,7 +134,6 @@ def _handshake_list_tools(proc: subprocess.Popen, timeout_s: int) -> list[dict]:
 
     def read_id(target_id: int) -> dict:
         assert proc.stdout is not None
-        deadline = _monotonic() + timeout_s
         while True:
             remaining = deadline - _monotonic()
             if remaining <= 0:
@@ -173,20 +194,48 @@ def build_manifest(version: str, tools: list[dict]) -> dict:
     return manifest
 
 
+def _fixed_date_time() -> tuple[int, int, int, int, int, int]:
+    """A constant zip entry timestamp so two builds of one commit match byte-for-byte.
+
+    Honors ``SOURCE_DATE_EPOCH`` when set, else the zip epoch (1980-01-01).
+    Without this, ``writestr`` stamps wall-clock time and ``write`` inherits the
+    file mtime, both of which vary between builds and break hash verification.
+    """
+    epoch = os.environ.get("SOURCE_DATE_EPOCH")
+    if epoch:
+        import time
+
+        return time.gmtime(int(epoch))[:6]  # type: ignore[return-value]
+    return (1980, 1, 1, 0, 0, 0)
+
+
+def _add_entry(zf: zipfile.ZipFile, arcname: str, data: bytes, date_time) -> None:
+    """Add one file with a pinned timestamp + mode, for a reproducible archive."""
+    info = zipfile.ZipInfo(arcname, date_time=date_time)
+    info.compress_type = zipfile.ZIP_DEFLATED
+    info.external_attr = 0o644 << 16  # -rw-r--r--
+    zf.writestr(info, data)
+
+
 def pack(manifest: dict, output: Path) -> Path:
     """Write a plain zip with manifest.json at the root + the server shim.
 
     Plain zip (not ``mcpb pack``) preserves the ``inputSchema``/``outputSchema``
-    keys in ``tools`` that ``mcpb validate`` would reject.
+    keys in ``tools`` that ``mcpb validate`` would reject. Every entry is stamped
+    with a fixed timestamp/mode (see ``_fixed_date_time``) so rebuilding the same
+    commit yields a byte-identical ``.mcpb``.
     """
     output.parent.mkdir(parents=True, exist_ok=True)
     if output.exists():
         output.unlink()
+    date_time = _fixed_date_time()
     with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr("manifest.json", json.dumps(manifest, indent=2) + "\n")
+        manifest_bytes = (json.dumps(manifest, indent=2) + "\n").encode("utf-8")
+        _add_entry(zf, "manifest.json", manifest_bytes, date_time)
         for path in sorted((BUNDLE_SRC / "server").rglob("*")):
             if path.is_file():
-                zf.write(path, str(path.relative_to(BUNDLE_SRC)))
+                arcname = str(path.relative_to(BUNDLE_SRC))
+                _add_entry(zf, arcname, path.read_bytes(), date_time)
     return output
 
 
@@ -210,7 +259,16 @@ def main() -> int:
     output = args.output / f"{PYPI_NAME}-{version}.mcpb"
     pack(manifest, output)
     size_kb = output.stat().st_size / 1024
+
+    # Emit a `shasum -a 256 -c`-compatible sidecar so a release downloader can
+    # verify the asset they fetched matches what CI built.
+    digest = hashlib.sha256(output.read_bytes()).hexdigest()
+    checksum = output.with_name(output.name + ".sha256")
+    checksum.write_text(f"{digest}  {output.name}\n", encoding="utf-8")
+
     print(f"build_mcpb: wrote {output} ({size_kb:.1f} KB)")
+    print(f"build_mcpb: sha256 {digest}")
+    print(f"build_mcpb: wrote {checksum}")
     print(
         f"build_mcpb: publish with -> smithery mcp publish {output} -n rye/openzim-mcp"
     )

--- a/server.json
+++ b/server.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.cameronrye/openzim-mcp",
+  "description": "Offline MCP access to ZIM knowledge archives — Wikipedia, Wiktionary, Stack Exchange, Kiwix.",
+  "version": "2.4.4",
+  "repository": {
+    "url": "https://github.com/cameronrye/openzim-mcp",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "openzim-mcp",
+      "version": "2.4.4",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "valueHint": "zim_directory",
+          "description": "Path to a directory containing your .zim archive files. Repeat for multiple directories. Download archives from the Kiwix library (https://library.kiwix.org/).",
+          "format": "filepath",
+          "isRequired": true,
+          "isRepeated": true
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "OPENZIM_MCP_TOOL_MODE",
+          "description": "Tool surface: 'advanced' (the default here) registers all 8 tools (zim_query, zim_search, zim_get, zim_get_section, zim_browse, zim_metadata, zim_links, zim_health); 'simple' registers only the zim_query natural-language entry point.",
+          "isRequired": false,
+          "isSecret": false,
+          "default": "advanced"
+        }
+      ]
+    }
+  ]
+}

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.cameronrye/openzim-mcp",
   "description": "Offline MCP access to ZIM knowledge archives — Wikipedia, Wiktionary, Stack Exchange, Kiwix.",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "repository": {
     "url": "https://github.com/cameronrye/openzim-mcp",
     "source": "github"
@@ -12,7 +12,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "openzim-mcp",
-      "version": "2.4.4",
+      "version": "2.4.5",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/tests/fixtures/mcp_server_schema_2025-12-11.json
+++ b/tests/fixtures/mcp_server_schema_2025-12-11.json
@@ -1,0 +1,574 @@
+{
+  "$comment": "This file is auto-generated from docs/reference/api/openapi.yaml. Do not edit manually. Run 'make generate-schema' to update.",
+  "$id": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "$ref": "#/definitions/ServerDetail",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Argument": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PositionalArgument"
+        },
+        {
+          "$ref": "#/definitions/NamedArgument"
+        }
+      ],
+      "description": "Warning: Arguments construct command-line parameters that may contain user-provided input. This creates potential command injection risks if clients execute commands in a shell environment. For example, a malicious argument value like ';rm -rf ~/Development' could execute dangerous commands. Clients should prefer non-shell execution methods (e.g., posix_spawn) when possible to eliminate injection risks entirely. Where not possible, clients should obtain consent from users or agents to run the resolved command before execution."
+    },
+    "Icon": {
+      "description": "An optionally-sized icon that can be displayed in a user interface.",
+      "properties": {
+        "mimeType": {
+          "description": "Optional MIME type override if the source MIME type is missing or generic. Must be one of: image/png, image/jpeg, image/jpg, image/svg+xml, image/webp.",
+          "enum": [
+            "image/png",
+            "image/jpeg",
+            "image/jpg",
+            "image/svg+xml",
+            "image/webp"
+          ],
+          "example": "image/png",
+          "type": "string"
+        },
+        "sizes": {
+          "description": "Optional array of strings that specify sizes at which the icon can be used. Each string should be in WxH format (e.g., '48x48', '96x96') or 'any' for scalable formats like SVG. If not provided, the client should assume that the icon can be used at any size.",
+          "examples": [
+            [
+              "48x48",
+              "96x96"
+            ],
+            [
+              "any"
+            ]
+          ],
+          "items": {
+            "pattern": "^(\\d+x\\d+|any)$",
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "src": {
+          "description": "A standard URI pointing to an icon resource. Must be an HTTPS URL. Consumers SHOULD take steps to ensure URLs serving icons are from the same domain as the server or a trusted domain. Consumers SHOULD take appropriate precautions when consuming SVGs as they can contain executable JavaScript.",
+          "example": "https://example.com/icon.png",
+          "format": "uri",
+          "maxLength": 255,
+          "type": "string"
+        },
+        "theme": {
+          "description": "Optional specifier for the theme this icon is designed for. 'light' indicates the icon is designed to be used with a light background, and 'dark' indicates the icon is designed to be used with a dark background. If not provided, the client should assume the icon can be used with any theme.",
+          "enum": [
+            "light",
+            "dark"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "src"
+      ],
+      "type": "object"
+    },
+    "Input": {
+      "properties": {
+        "choices": {
+          "description": "A list of possible values for the input. If provided, the user must select one of these values.",
+          "example": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "default": {
+          "description": "The default value for the input.  This should be a valid value for the input.  If you want to provide input examples or guidance, use the `placeholder` field instead.",
+          "type": "string"
+        },
+        "description": {
+          "description": "A description of the input, which clients can use to provide context to the user.",
+          "type": "string"
+        },
+        "format": {
+          "default": "string",
+          "description": "Specifies the input format. Supported values include `filepath`, which should be interpreted as a file on the user's filesystem.\n\nWhen the input is converted to a string, booleans should be represented by the strings \"true\" and \"false\", and numbers should be represented as decimal values.",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "filepath"
+          ],
+          "type": "string"
+        },
+        "isRequired": {
+          "default": false,
+          "type": "boolean"
+        },
+        "isSecret": {
+          "default": false,
+          "description": "Indicates whether the input is a secret value (e.g., password, token). If true, clients should handle the value securely.",
+          "type": "boolean"
+        },
+        "placeholder": {
+          "description": "A placeholder for the input to be displaying during configuration. This is used to provide examples or guidance about the expected form or content of the input.",
+          "type": "string"
+        },
+        "value": {
+          "description": "The value for the input. If this is not set, the user may be prompted to provide a value. If a value is set, it should not be configurable by end users.\n\nIdentifiers wrapped in `{curly_braces}` will be replaced with the corresponding properties from the input `variables` map. If an identifier in braces is not found in `variables`, or if `variables` is not provided, the `{curly_braces}` substring should remain unchanged.\n",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "InputWithVariables": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Input"
+        },
+        {
+          "properties": {
+            "variables": {
+              "additionalProperties": {
+                "$ref": "#/definitions/Input"
+              },
+              "description": "A map of variable names to their values. Keys in the input `value` that are wrapped in `{curly_braces}` will be replaced with the corresponding variable values.",
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "KeyValueInput": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/InputWithVariables"
+        },
+        {
+          "properties": {
+            "name": {
+              "description": "Name of the header or environment variable.",
+              "example": "SOME_VARIABLE",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "LocalTransport": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/StdioTransport"
+        },
+        {
+          "$ref": "#/definitions/StreamableHttpTransport"
+        },
+        {
+          "$ref": "#/definitions/SseTransport"
+        }
+      ],
+      "description": "Transport protocol configuration for local/package context"
+    },
+    "NamedArgument": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/InputWithVariables"
+        },
+        {
+          "properties": {
+            "isRepeated": {
+              "default": false,
+              "description": "Whether the argument can be repeated multiple times.",
+              "type": "boolean"
+            },
+            "name": {
+              "description": "The flag name, including any leading dashes.",
+              "example": "--port",
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "named"
+              ],
+              "example": "named",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "name"
+          ],
+          "type": "object"
+        }
+      ],
+      "description": "A command-line `--flag={value}`."
+    },
+    "Package": {
+      "properties": {
+        "environmentVariables": {
+          "description": "A mapping of environment variables to be set when running the package.",
+          "items": {
+            "$ref": "#/definitions/KeyValueInput"
+          },
+          "type": "array"
+        },
+        "fileSha256": {
+          "description": "SHA-256 hash of the package file for integrity verification. Required for MCPB packages and optional for other package types. Authors are responsible for generating correct SHA-256 hashes when creating server.json. If present, MCP clients must validate the downloaded file matches the hash before running packages to ensure file integrity.",
+          "example": "fe333e598595000ae021bd27117db32ec69af6987f507ba7a63c90638ff633ce",
+          "pattern": "^[a-f0-9]{64}$",
+          "type": "string"
+        },
+        "identifier": {
+          "description": "Package identifier - either a package name (for registries) or URL (for direct downloads)",
+          "examples": [
+            "@modelcontextprotocol/server-brave-search",
+            "https://github.com/example/releases/download/v1.0.0/package.mcpb"
+          ],
+          "type": "string"
+        },
+        "packageArguments": {
+          "description": "A list of arguments to be passed to the package's binary.",
+          "items": {
+            "$ref": "#/definitions/Argument"
+          },
+          "type": "array"
+        },
+        "registryBaseUrl": {
+          "description": "Base URL of the package registry",
+          "examples": [
+            "https://registry.npmjs.org",
+            "https://pypi.org",
+            "https://docker.io",
+            "https://api.nuget.org/v3/index.json",
+            "https://github.com",
+            "https://gitlab.com"
+          ],
+          "format": "uri",
+          "type": "string"
+        },
+        "registryType": {
+          "description": "Registry type indicating how to download packages (e.g., 'npm', 'pypi', 'oci', 'nuget', 'mcpb')",
+          "examples": [
+            "npm",
+            "pypi",
+            "oci",
+            "nuget",
+            "mcpb"
+          ],
+          "type": "string"
+        },
+        "runtimeArguments": {
+          "description": "A list of arguments to be passed to the package's runtime command (such as docker or npx). The `runtimeHint` field should be provided when `runtimeArguments` are present.",
+          "items": {
+            "$ref": "#/definitions/Argument"
+          },
+          "type": "array"
+        },
+        "runtimeHint": {
+          "description": "A hint to help clients determine the appropriate runtime for the package. This field should be provided when `runtimeArguments` are present.",
+          "examples": [
+            "npx",
+            "uvx",
+            "docker",
+            "dnx"
+          ],
+          "type": "string"
+        },
+        "transport": {
+          "$ref": "#/definitions/LocalTransport",
+          "description": "Transport protocol configuration for the package"
+        },
+        "version": {
+          "description": "Package version. Must be a specific version. Version ranges are rejected (e.g., '^1.2.3', '~1.2.3', '\u003e=1.2.3', '1.x', '1.*').",
+          "example": "1.0.2",
+          "minLength": 1,
+          "not": {
+            "const": "latest"
+          },
+          "type": "string"
+        }
+      },
+      "required": [
+        "registryType",
+        "identifier",
+        "transport"
+      ],
+      "type": "object"
+    },
+    "PositionalArgument": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/InputWithVariables"
+        },
+        {
+          "anyOf": [
+            {
+              "required": [
+                "valueHint"
+              ]
+            },
+            {
+              "required": [
+                "value"
+              ]
+            }
+          ],
+          "properties": {
+            "isRepeated": {
+              "default": false,
+              "description": "Whether the argument can be repeated multiple times in the command line.",
+              "type": "boolean"
+            },
+            "type": {
+              "enum": [
+                "positional"
+              ],
+              "example": "positional",
+              "type": "string"
+            },
+            "valueHint": {
+              "description": "An identifier for the positional argument. It is not part of the command line. It may be used by client configuration as a label identifying the argument. It is also used to identify the value in transport URL variable substitution.",
+              "example": "file_path",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        }
+      ],
+      "description": "A positional input is a value inserted verbatim into the command line."
+    },
+    "RemoteTransport": {
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StreamableHttpTransport"
+            },
+            {
+              "$ref": "#/definitions/SseTransport"
+            }
+          ]
+        },
+        {
+          "properties": {
+            "variables": {
+              "additionalProperties": {
+                "$ref": "#/definitions/Input"
+              },
+              "description": "Configuration variables that can be referenced in URL template {curly_braces}. The key is the variable name, and the value defines the variable properties.",
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      ],
+      "description": "Transport protocol configuration for remote context - extends StreamableHttpTransport or SseTransport with variables"
+    },
+    "Repository": {
+      "description": "Repository metadata for the MCP server source code. Enables users and security experts to inspect the code, improving transparency.",
+      "properties": {
+        "id": {
+          "description": "Repository identifier from the hosting service (e.g., GitHub repo ID). Owned and determined by the source forge. Should remain stable across repository renames and may be used to detect repository resurrection attacks - if a repository is deleted and recreated, the ID should change. For GitHub, use: gh api repos/\u003cowner\u003e/\u003crepo\u003e --jq '.id'",
+          "example": "b94b5f7e-c7c6-d760-2c78-a5e9b8a5b8c9",
+          "type": "string"
+        },
+        "source": {
+          "description": "Repository hosting service identifier. Used by registries to determine validation and API access methods.",
+          "example": "github",
+          "type": "string"
+        },
+        "subfolder": {
+          "description": "Optional relative path from repository root to the server location within a monorepo or nested package structure. Must be a clean relative path.",
+          "example": "src/everything",
+          "type": "string"
+        },
+        "url": {
+          "description": "Repository URL for browsing source code. Should support both web browsing and git clone operations.",
+          "example": "https://github.com/modelcontextprotocol/servers",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "url",
+        "source"
+      ],
+      "type": "object"
+    },
+    "ServerDetail": {
+      "description": "Schema for a static representation of an MCP server. Used in various contexts related to discovery, installation, and configuration.",
+      "properties": {
+        "$schema": {
+          "description": "JSON Schema URI for this server.json format",
+          "example": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+          "format": "uri",
+          "type": "string"
+        },
+        "_meta": {
+          "description": "Extension metadata using reverse DNS namespacing for vendor-specific data",
+          "properties": {
+            "io.modelcontextprotocol.registry/publisher-provided": {
+              "additionalProperties": true,
+              "description": "Publisher-provided metadata for downstream registries",
+              "example": {
+                "buildInfo": {
+                  "commit": "abc123def456",
+                  "pipelineId": "build-789",
+                  "timestamp": "2023-12-01T10:30:00Z"
+                },
+                "tool": "publisher-cli",
+                "version": "1.2.3"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "description": {
+          "description": "Clear human-readable explanation of server functionality. Should focus on capabilities, not implementation details.",
+          "example": "MCP server providing weather data and forecasts via OpenWeatherMap API",
+          "maxLength": 100,
+          "minLength": 1,
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface. Clients that support rendering icons MUST support at least the following MIME types: image/png and image/jpeg (safe, universal compatibility). Clients SHOULD also support: image/svg+xml (scalable but requires security precautions) and image/webp (modern, efficient format).",
+          "items": {
+            "$ref": "#/definitions/Icon"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Server name in reverse-DNS format. Must contain exactly one forward slash separating namespace from server name.",
+          "example": "io.github.user/weather",
+          "maxLength": 200,
+          "minLength": 3,
+          "pattern": "^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$",
+          "type": "string"
+        },
+        "packages": {
+          "items": {
+            "$ref": "#/definitions/Package"
+          },
+          "type": "array"
+        },
+        "remotes": {
+          "items": {
+            "$ref": "#/definitions/RemoteTransport"
+          },
+          "type": "array"
+        },
+        "repository": {
+          "$ref": "#/definitions/Repository",
+          "description": "Optional repository metadata for the MCP server source code. Recommended for transparency and security inspection."
+        },
+        "title": {
+          "description": "Optional human-readable title or display name for the MCP server. MCP subregistries or clients MAY choose to use this for display purposes.",
+          "example": "Weather API",
+          "maxLength": 100,
+          "minLength": 1,
+          "type": "string"
+        },
+        "version": {
+          "description": "Version string for this server. SHOULD follow semantic versioning (e.g., '1.0.2', '2.1.0-alpha'). Equivalent of Implementation.version in MCP specification. Non-semantic versions are allowed but may not sort predictably. Version ranges are rejected (e.g., '^1.2.3', '~1.2.3', '\u003e=1.2.3', '1.x', '1.*').",
+          "example": "1.0.2",
+          "maxLength": 255,
+          "type": "string"
+        },
+        "websiteUrl": {
+          "description": "Optional URL to the server's homepage, documentation, or project website. This provides a central link for users to learn more about the server. Particularly useful when the server has custom installation instructions or setup requirements.",
+          "example": "https://modelcontextprotocol.io/examples",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "description",
+        "version"
+      ],
+      "type": "object"
+    },
+    "SseTransport": {
+      "properties": {
+        "headers": {
+          "description": "HTTP headers to include",
+          "items": {
+            "$ref": "#/definitions/KeyValueInput"
+          },
+          "type": "array"
+        },
+        "type": {
+          "description": "Transport type",
+          "enum": [
+            "sse"
+          ],
+          "example": "sse",
+          "type": "string"
+        },
+        "url": {
+          "description": "Server-Sent Events endpoint URL template. Variables in {curly_braces} are resolved based on context: In Package context, they reference argument valueHints, argument names, or environment variable names from the parent Package. In Remote context, they reference variables from the transport's 'variables' object. After variable substitution, this should produce a valid URI.",
+          "example": "https://mcp-fs.example.com/sse",
+          "pattern": "^https?://[^\\s]+$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "url"
+      ],
+      "type": "object"
+    },
+    "StdioTransport": {
+      "properties": {
+        "type": {
+          "description": "Transport type",
+          "enum": [
+            "stdio"
+          ],
+          "example": "stdio",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "StreamableHttpTransport": {
+      "properties": {
+        "headers": {
+          "description": "HTTP headers to include",
+          "items": {
+            "$ref": "#/definitions/KeyValueInput"
+          },
+          "type": "array"
+        },
+        "type": {
+          "description": "Transport type",
+          "enum": [
+            "streamable-http"
+          ],
+          "example": "streamable-http",
+          "type": "string"
+        },
+        "url": {
+          "description": "URL template for the streamable-http transport. Variables in {curly_braces} are resolved based on context: In Package context, they reference argument valueHints, argument names, or environment variable names from the parent Package. In Remote context, they reference variables from the transport's 'variables' object. After variable substitution, this should produce a valid URI.",
+          "example": "https://api.example.com/mcp",
+          "pattern": "^https?://[^\\s]+$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "url"
+      ],
+      "type": "object"
+    }
+  },
+  "title": "server.json defining a Model Context Protocol (MCP) server"
+}

--- a/tests/test_mcpb_distribution.py
+++ b/tests/test_mcpb_distribution.py
@@ -1,0 +1,182 @@
+"""Distribution guards for the Smithery / MCP-Registry artifacts.
+
+These tests keep the published distribution artifacts honest and in lockstep
+with the package:
+
+  - ``packaging/mcpb/manifest.json`` — the MCPB (``.mcpb``) bundle manifest
+    published to Smithery and shipped as the Claude Desktop one-click extension.
+  - ``server.json`` — the official MCP Registry manifest (PyPI package).
+  - ``scripts/build_mcpb.py`` — the bundle build pipeline.
+  - the ``mcp-name:`` ownership marker in ``README.md`` (the PyPI description).
+
+A tool added to or removed from the advanced surface, or a version bump that
+forgets one of these files, must fail here rather than ship a stale/wrong
+listing. See ``docs/distribution.md``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from openzim_mcp import __version__
+from openzim_mcp.config import OpenZimMcpConfig
+from openzim_mcp.server import OpenZimMcpServer
+
+REPO = Path(__file__).resolve().parent.parent
+SERVER_NAME = "io.github.cameronrye/openzim-mcp"
+PYPI_NAME = "openzim-mcp"
+
+
+def _load_build_mcpb():
+    """Import scripts/build_mcpb.py by path (scripts/ is not a package)."""
+    spec = importlib.util.spec_from_file_location(
+        "build_mcpb", REPO / "scripts" / "build_mcpb.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def manifest() -> dict:
+    return json.loads(
+        (REPO / "packaging" / "mcpb" / "manifest.json").read_text(encoding="utf-8")
+    )
+
+
+@pytest.fixture(scope="module")
+def server_json() -> dict:
+    return json.loads((REPO / "server.json").read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def build_mcpb():
+    return _load_build_mcpb()
+
+
+# --- version lockstep -------------------------------------------------------
+
+
+def test_manifest_version_matches_package(manifest: dict) -> None:
+    assert manifest["version"] == __version__, (
+        "packaging/mcpb/manifest.json version is stale — bump it (and server.json) "
+        "to match pyproject on every release. See docs/distribution.md."
+    )
+
+
+def test_manifest_launch_arg_pins_package_version(manifest: dict) -> None:
+    args = manifest["server"]["mcp_config"]["args"]
+    assert args == [f"{PYPI_NAME}@{__version__}", "${user_config.allowed_directories}"]
+
+
+def test_server_json_versions_match_package(server_json: dict) -> None:
+    assert server_json["version"] == __version__
+    assert server_json["packages"][0]["version"] == __version__
+
+
+# --- MCPB manifest structural invariants ------------------------------------
+
+
+def test_manifest_runtime_and_config(manifest: dict) -> None:
+    server = manifest["server"]
+    assert server["type"] == "python"
+    assert server["entry_point"] == "server/main.py"
+    mcp_config = server["mcp_config"]
+    assert mcp_config["command"] == "uvx"
+    # The bundle ships the advanced 8-tool surface.
+    assert mcp_config["env"]["OPENZIM_MCP_TOOL_MODE"] == "advanced"
+    cfg = manifest["user_config"]["allowed_directories"]
+    assert cfg["type"] == "directory"
+    assert cfg["required"] is True
+    assert cfg["multiple"] is True
+
+
+# --- server.json (MCP Registry) invariants ----------------------------------
+
+
+def test_server_json_pypi_package(server_json: dict) -> None:
+    assert server_json["name"] == SERVER_NAME
+    assert len(server_json["description"]) <= 100  # registry hard limit
+    pkg = server_json["packages"][0]
+    assert pkg["registryType"] == "pypi"
+    assert pkg["identifier"] == PYPI_NAME
+    assert pkg["runtimeHint"] == "uvx"
+    assert pkg["transport"]["type"] == "stdio"
+
+
+def test_server_json_requires_positional_zim_directory(server_json: dict) -> None:
+    args = server_json["packages"][0]["packageArguments"]
+    positional = [a for a in args if a.get("type") == "positional"]
+    assert positional, "server.json must declare a positional ZIM-directory argument"
+    arg = positional[0]
+    assert arg["isRequired"] is True
+    assert arg["format"] == "filepath"
+
+
+# --- ownership marker (PyPI description) ------------------------------------
+
+
+def test_readme_has_ownership_marker_matching_server_json(server_json: dict) -> None:
+    readme = (REPO / "README.md").read_text(encoding="utf-8")
+    match = re.search(r"mcp-name:\s*(\S+)", readme)
+    assert match, (
+        "README.md must carry an `mcp-name: <server-name>` marker so the MCP "
+        "Registry can verify PyPI package ownership."
+    )
+    assert match.group(1) == server_json["name"]
+
+
+# --- build pipeline guards --------------------------------------------------
+
+
+def test_build_script_plain_zips_and_captures_live_schemas() -> None:
+    src = (REPO / "scripts" / "build_mcpb.py").read_text(encoding="utf-8")
+    assert "zipfile.ZipFile" in src, "bundle must be built as a plain zip"
+    assert "tools/list" in src, "build must capture live tool schemas"
+
+
+def test_build_pipeline_preserves_rich_tool_schemas(build_mcpb, tmp_path) -> None:
+    """The packed bundle keeps inputSchema/outputSchema — the keys ``mcpb pack``
+    would strip and the exact schemas Smithery scores. Proven by packing a tool
+    that carries both and reading them back out of the zip."""
+    import zipfile
+
+    fake_tools = [
+        {
+            "name": "zim_query",
+            "description": "d",
+            "inputSchema": {"type": "object", "properties": {"q": {"type": "string"}}},
+            "outputSchema": {"type": "object"},
+        }
+    ]
+    manifest = build_mcpb.build_manifest("9.9.9", fake_tools)
+    out = build_mcpb.pack(manifest, tmp_path / "out.mcpb")
+
+    with zipfile.ZipFile(out) as zf:
+        names = zf.namelist()
+        packed = json.loads(zf.read("manifest.json"))
+    assert "manifest.json" in names and "server/main.py" in names
+    assert packed["version"] == "9.9.9"
+    assert packed["server"]["mcp_config"]["args"][0] == f"{PYPI_NAME}@9.9.9"
+    tool = packed["tools"][0]
+    assert tool["inputSchema"]["properties"]["q"]["type"] == "string"
+    assert tool["outputSchema"] == {"type": "object"}
+
+
+def test_build_expected_count_matches_advanced_surface(build_mcpb, tmp_path) -> None:
+    """The build's expected tool count must equal what advanced mode registers.
+
+    Adding/removing a tool changes the live surface and breaks this test,
+    forcing ``EXPECTED_TOOL_COUNT`` (and the shipped manifest) to be updated.
+    """
+    cfg = OpenZimMcpConfig(allowed_directories=[str(tmp_path)], tool_mode="advanced")
+    server = OpenZimMcpServer(cfg)
+    registered = set(server.mcp._tool_manager._tools)
+    assert len(registered) == build_mcpb.EXPECTED_TOOL_COUNT
+    assert "zim_query" in registered

--- a/tests/test_mcpb_distribution.py
+++ b/tests/test_mcpb_distribution.py
@@ -70,8 +70,18 @@ def test_manifest_version_matches_package(manifest: dict) -> None:
     )
 
 
-def test_manifest_launch_arg_pins_package_version(manifest: dict) -> None:
-    args = manifest["server"]["mcp_config"]["args"]
+def test_built_manifest_launch_arg_pins_package_version(build_mcpb) -> None:
+    """The *shipped* bundle pins ``openzim-mcp@<version>``.
+
+    build_mcpb.py stamps the exact launch arg from pyproject at build time, so
+    we validate the built manifest — the artifact users actually run — not the
+    static template (whose arg is intentionally unpinned; see
+    ``test_manifest_runtime_and_config``). This keeps the composite ``name@ver``
+    string out of the per-release version-lockstep burden (a release-please
+    json updater would clobber it to a bare version).
+    """
+    built = build_mcpb.build_manifest(__version__, [])
+    args = built["server"]["mcp_config"]["args"]
     assert args == [f"{PYPI_NAME}@{__version__}", "${user_config.allowed_directories}"]
 
 
@@ -89,12 +99,30 @@ def test_manifest_runtime_and_config(manifest: dict) -> None:
     assert server["entry_point"] == "server/main.py"
     mcp_config = server["mcp_config"]
     assert mcp_config["command"] == "uvx"
+    # The static template's launch arg is intentionally UNPINNED ("openzim-mcp",
+    # no @version). build_mcpb.py stamps the exact openzim-mcp@<version> at build
+    # time (see test_built_manifest_launch_arg_pins_package_version); keeping the
+    # template unpinned removes it from the per-release version-lockstep burden.
+    assert mcp_config["args"] == [PYPI_NAME, "${user_config.allowed_directories}"]
     # The bundle ships the advanced 8-tool surface.
     assert mcp_config["env"]["OPENZIM_MCP_TOOL_MODE"] == "advanced"
     cfg = manifest["user_config"]["allowed_directories"]
     assert cfg["type"] == "directory"
     assert cfg["required"] is True
     assert cfg["multiple"] is True
+
+
+def test_manifest_static_template_identity(manifest: dict) -> None:
+    """Guard the static-template fields build_manifest does NOT overwrite.
+
+    ``tools`` is injected at build time from the live server, so the committed
+    template must ship empty (a stale hand-edited tools array would otherwise be
+    the fallback if anyone zipped the template directly). ``name`` and
+    ``manifest_version`` pass through build_manifest unchanged.
+    """
+    assert manifest["tools"] == []
+    assert manifest["name"] == PYPI_NAME
+    assert manifest["manifest_version"] == "0.3"
 
 
 # --- server.json (MCP Registry) invariants ----------------------------------
@@ -117,6 +145,22 @@ def test_server_json_requires_positional_zim_directory(server_json: dict) -> Non
     arg = positional[0]
     assert arg["isRequired"] is True
     assert arg["format"] == "filepath"
+
+
+def test_server_json_validates_against_registry_schema(server_json: dict) -> None:
+    """server.json must validate against the exact MCP Registry schema it
+    declares, so a malformed doc (missing required field, disallowed extra key,
+    malformed packageArguments/environmentVariables entry) fails here in CI
+    rather than at ``mcp-publisher`` time after the release is already cut. The
+    schema is vendored (pinned) so the check stays offline and deterministic.
+    """
+    jsonschema = pytest.importorskip("jsonschema")
+    schema_path = REPO / "tests" / "fixtures" / "mcp_server_schema_2025-12-11.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    # The vendored copy must be the schema server.json points at; otherwise the
+    # pin has silently drifted and we'd be validating against the wrong version.
+    assert server_json["$schema"] == schema["$id"]
+    jsonschema.Draft7Validator(schema).validate(server_json)
 
 
 # --- ownership marker (PyPI description) ------------------------------------
@@ -180,3 +224,45 @@ def test_build_expected_count_matches_advanced_surface(build_mcpb, tmp_path) -> 
     registered = set(server.mcp._tool_manager._tools)
     assert len(registered) == build_mcpb.EXPECTED_TOOL_COUNT
     assert "zim_query" in registered
+
+
+def test_capture_tools_rejects_wrong_tool_count(build_mcpb, monkeypatch) -> None:
+    """A handshake regression that yields the wrong number of tools must break
+    the build (SystemExit), never ship a short/wrong manifest. Hermetic: the
+    real server spawn and the stdio handshake are stubbed out, so this covers the
+    count-mismatch guard branch without spawning a subprocess.
+    """
+
+    class _FakeProc:
+        def terminate(self) -> None: ...
+
+        def communicate(self, timeout=None):
+            return ("", "")
+
+        def kill(self) -> None: ...
+
+    monkeypatch.setattr(build_mcpb.subprocess, "Popen", lambda *a, **k: _FakeProc())
+    monkeypatch.setattr(
+        build_mcpb,
+        "_handshake_list_tools",
+        lambda proc, timeout_s: [{"name": f"t{i}"} for i in range(7)],
+    )
+    with pytest.raises(SystemExit):
+        build_mcpb.capture_tools()
+
+
+@pytest.mark.live
+def test_capture_tools_live_matches_advanced_surface(build_mcpb) -> None:
+    """End-to-end: spawn the real server over stdio and capture ``tools/list``.
+
+    Exercises the initialize/initialized/tools/list handshake that the unit
+    tests stub out — the most failure-prone path in build_mcpb.py — and would
+    catch an SDK response-shape regression. Marked ``live`` so it is deselected
+    from the default suite (run via ``make test-live``); the release pipeline
+    also exercises this path when it builds the .mcpb.
+    """
+    tools = build_mcpb.capture_tools()
+    names = {t["name"] for t in tools}
+    assert len(tools) == build_mcpb.EXPECTED_TOOL_COUNT
+    assert "zim_query" in names
+    assert all("inputSchema" in t for t in tools)


### PR DESCRIPTION
ZIM data is per-user and local, so a hosted/shared-URL MCP listing can never reach it. This distributes `openzim-mcp` as a **local-stdio `.mcpb` bundle** (Smithery + Claude Desktop one-click) and lists it on the **official MCP Registry** via `server.json`, with everything kept in lockstep with the PyPI release automatically.

## What's in the pipeline
- **`scripts/build_mcpb.py`** — builds the `.mcpb`: reads the version from `pyproject.toml`, spawns the server in advanced mode over stdio to capture the **live tool schemas**, injects them into the manifest, and plain-zips the bundle (not `mcpb pack`, which strips the `inputSchema`/`outputSchema` keys Smithery and Glama score on).
- **uvx launcher, not a vendored env** — native `libzim` would lock the bundle to one platform and blow the 25 MB registry cap, so the bundle launches the version-pinned `uvx openzim-mcp@<version>` and `uvx` resolves the right wheel per-platform at run time.
- **`server.json`** — the official MCP Registry listing (PyPI package, positional ZIM-directory arg), gated on a new `mcp-name` ownership marker in the README.
- **Guard tests + runbook** in `docs/distribution.md`.

## Finishing work (this also resolves a 22-finding self-review of the branch)
- **`.mcpb` is now a real release asset.** `release.yml` builds the bundle (+ a `.sha256`) and attaches it to every GitHub release, so the README's "download from the latest release" is actually true. It builds into a **separate artifact, never `dist/`**, so it stays out of the PyPI upload (a `.mcpb` is not a valid distribution and would fail the publish step).
- **Version lockstep is automated.** `manifest.json` and `server.json` versions are auto-bumped by release-please `json` updaters and re-checked in the `validate-release` job. The composite launch arg can't be json-updated, so the static template ships an unpinned `openzim-mcp` and the build stamps `openzim-mcp@<version>` (the shipped pin stays test-covered).
- **Build-script hardening:** byte-reproducible zip (pinned entry timestamps — verified identical across rebuilds), the correct `OPENZIM_MCP_LOGGING__LEVEL` env var (a bare `LOG_LEVEL` was silently ignored), fail-fast on Windows build hosts, a single shared handshake deadline, and the sha256 sidecar.
- **Test coverage:** the previously-untested subprocess capture path (a hermetic count-guard test + a `live` end-to-end test) and `server.json` validated against a vendored copy of the `2025-12-11` MCP Registry schema.

## Test plan
- `make check` — green (3134 passed, 217 skipped, 42 deselected; lint + type-check + security pass).
- `make test-live` — the live `capture_tools` end-to-end test passes (8 tools captured with schemas).
- `scripts/build_mcpb.py` run twice → **byte-identical** `.mcpb`; `shasum -c` of the sidecar OK; built manifest pins `openzim-mcp@2.4.5` and carries all 8 tool schemas.
- `server.json` validates against the registry schema; `release-please-config.json` validates against its published config schema (confirms the `json`/`jsonpath` updaters are accepted).

## Notes for the maintainer
- Smithery is already published as `rye/openzim-mcp` (verified live); re-publish when the tool surface changes.
- The official MCP Registry publish (`server.json`) still happens on the **next** PyPI release, once the `mcp-name` marker is live on PyPI — see `docs/distribution.md` §3.