### PR TITLE
chore: clear SonarCloud reliability and security findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ---
 
-> 🆕 **8-tool advanced surface.** Phase F (v2.0.0) consolidated 22 advanced tools into 8 (`zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`). **New in v2.1:** native libzim archive validation via `zim_health(zim_file_path=...)`, plus archive identity / index introspection in `zim_metadata`. [Release notes →](CHANGELOG.md) [Docs →](https://cameronrye.github.io/openzim-mcp/docs/)
+> 🆕 **8-tool advanced surface.** Phase F (v2.0.0) consolidated 22 advanced tools into 8 (`zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`). **Recent additions:** archive-type presets that auto-tune retrieval per source (Wikipedia, Stack Exchange, …), inbound link discovery ("what links here"), and native libzim health/introspection. Now listed on [Smithery](https://smithery.ai/servers/rye/openzim-mcp) and the [official MCP Registry](https://registry.modelcontextprotocol.io). [Release notes →](CHANGELOG.md) [Docs →](https://cameronrye.github.io/openzim-mcp/docs/)
 
 **OpenZIM MCP** is a modern, secure, high-performance [Model Context Protocol](https://modelcontextprotocol.io/) server that gives AI models structured, offline access to [ZIM format](https://en.wikipedia.org/wiki/ZIM_(file_format)) knowledge archives — Wikipedia, Wiktionary, Stack Exchange, and the rest of the [Kiwix Library](https://library.kiwix.org/).
 
@@ -64,7 +64,7 @@ Download ZIM files from the [Kiwix Library](https://library.kiwix.org/) into a d
 
 ### Smithery & one-click install
 
-OpenZIM MCP is listed on the [Smithery registry](https://smithery.ai/servers/rye/openzim-mcp). Add it to your MCP client with the Smithery CLI:
+OpenZIM MCP is listed on the [Smithery registry](https://smithery.ai/servers/rye/openzim-mcp) and the [official MCP Registry](https://registry.modelcontextprotocol.io) (as `io.github.cameronrye/openzim-mcp`). Add it to your MCP client with the Smithery CLI:
 
 ```bash
 npx @smithery/cli mcp add rye/openzim-mcp --client claude
@@ -118,7 +118,8 @@ For HTTP transport (long-running service with bearer auth, CORS, and health endp
 - **Streamable HTTP transport** — bearer-token auth, CORS, health endpoints, multi-arch Docker image. [HTTP & Docker deployment →](https://cameronrye.github.io/openzim-mcp/docs/http-and-docker-deployment/)
 - **Per-entry MCP resources + subscriptions** — `zim://{name}/entry/{path}` with native MIME types; clients subscribe and receive `notifications/resources/updated` when archives change. [Resources, prompts & subscriptions →](https://cameronrye.github.io/openzim-mcp/docs/resources-prompts-subscriptions/)
 - **Simple-mode `zim_query`** — one natural-language tool that dispatches to the right operation, tuned for small-model deployment targets. [Quick start →](https://cameronrye.github.io/openzim-mcp/docs/quick-start/)
-- **Native libzim introspection (v2.1)** — `zim_health(zim_file_path=...)` validates an archive's integrity (`Archive.check()` + checksum), and `zim_metadata` now reports archive identity, full-text / title index capabilities, and an `M/Counter` mimetype breakdown. [API reference →](https://cameronrye.github.io/openzim-mcp/docs/api-reference/)
+- **Archive-type presets** — OpenZIM MCP detects the archive type (Wikipedia, Stack Exchange, and more) and auto-tunes retrieval and summarization for it — e.g. Stack Exchange dumps render as clean Q&A instead of vote-score noise. Operators can override the bundled defaults with a TOML file (`OPENZIM_MCP_PRESETS_OVERRIDE_PATH`).
+- **Native libzim introspection** — `zim_health(zim_file_path=...)` validates an archive's integrity (`Archive.check()` + checksum), and `zim_metadata` reports archive identity, full-text / title index capabilities, and an `M/Counter` mimetype breakdown. [API reference →](https://cameronrye.github.io/openzim-mcp/docs/api-reference/)
 - **Inbound link discovery ("what links here")** — `zim_links(direction="inbound")` returns pages that link to an entry, ranked by linker importance. Requires a pre-built sidecar: `openzim-mcp build link-graph <archive>.zim` (writes `<archive>.zim.linkgraph.sqlite` next to the archive). [API reference →](https://cameronrye.github.io/openzim-mcp/docs/api-reference/)
 
 ## Modes
@@ -144,7 +145,7 @@ Full documentation lives at **<https://cameronrye.github.io/openzim-mcp/docs/>**
 
 ## Project status
 
-v2.0.0 GA shipped 2026-05-27. v1.x is in maintenance mode — security fixes, data-corruption fixes, and pre-v2.0.0 crash fixes accepted through 2026-11-27 or until v2.5.0 ships, whichever comes first. Full release history: [CHANGELOG.md](CHANGELOG.md).
+**v2.5.1** is the current release (2026-06-22); v2.0.0 GA shipped 2026-05-27. Per the published support policy — v1.x fixes accepted "until v2.5.0 ships, whichever comes first" — the v1.x maintenance window closed when v2.5.0 shipped (2026-06-18); all active development is now on the 2.x line. Full release history: [CHANGELOG.md](CHANGELOG.md).
 
 ## Contributing
 

--- a/scripts/download_test_data.py
+++ b/scripts/download_test_data.py
@@ -252,7 +252,7 @@ def download_files(  # NOSONAR(python:S3776)
     logger.info(f"Downloading {total_count} files ({total_size:.2f} MB total)")
 
     # Create output directory
-    output_dir.mkdir(parents=True, exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)  # NOSONAR pythonsecurity:S8707
 
     # Download files
     for file_path, info in files_to_download.items():

--- a/scripts/run_with_env.py
+++ b/scripts/run_with_env.py
@@ -31,10 +31,15 @@ def main():
     env = os.environ.copy()
     env[env_var] = env_value
 
-    # Run the command
+    # Run the command. This is a developer build helper: it runs the
+    # operator-specified command (from argv) with one env var set, using the
+    # list form (no shell), so Sonar's untrusted-CLI-arg finding does not
+    # apply -- the arguments are trusted developer input by construction.
     try:
         print(f"Running with {env_var}={env_value}: {' '.join(command_args)}")
-        result = subprocess.run(command_args, env=env, check=True)  # nosec B603
+        result = subprocess.run(  # nosec B603 NOSONAR pythonsecurity:S8705
+            command_args, env=env, check=True
+        )
         sys.exit(result.returncode)
     except subprocess.CalledProcessError as e:
         sys.exit(e.returncode)

--- a/scripts/run_with_env.py
+++ b/scripts/run_with_env.py
@@ -37,7 +37,7 @@ def main():
     # apply -- the arguments are trusted developer input by construction.
     try:
         print(f"Running with {env_var}={env_value}: {' '.join(command_args)}")
-        result = subprocess.run(  # nosec B603 NOSONAR pythonsecurity:S8705
+        result = subprocess.run(  # NOSONAR pythonsecurity:S8705 (B603: no shell)
             command_args, env=env, check=True
         )
         sys.exit(result.returncode)

--- a/tests/dispatch_eval/analyze.py
+++ b/tests/dispatch_eval/analyze.py
@@ -197,7 +197,7 @@ def load_outcomes(path: Path) -> List[Outcome]:
     """Load one cell's outcomes from a JSONL file."""
     variant, mode, model = _parse_cell_metadata(path)
     outcomes: List[Outcome] = []
-    with path.open(encoding="utf-8") as f:
+    with path.open(encoding="utf-8") as f:  # NOSONAR pythonsecurity:S8707
         for raw in f:
             raw = raw.strip()
             if not raw:
@@ -251,7 +251,7 @@ def load_probe_metadata(probes_path: Path) -> Dict[str, Dict[str, Any]]:
     out: Dict[str, Dict[str, Any]] = {}
     if not probes_path.exists():
         return out
-    with probes_path.open() as f:
+    with probes_path.open() as f:  # NOSONAR pythonsecurity:S8707
         for raw in f:
             raw = raw.strip()
             if not raw:
@@ -1097,6 +1097,19 @@ def _expand_globs(patterns: Optional[str]) -> List[str]:
     return [p for p in patterns.split() if p]
 
 
+def _write_json_artifact(output_path: str, payload: str) -> None:
+    """Write a JSON artifact to the operator-supplied ``--output`` path.
+
+    ``analyze.py`` is an operator-run dev tool: ``--output`` comes from the
+    developer's own shell, not untrusted network input, so the destination is
+    trusted by construction. Sonar's taint analysis still flags the
+    argv -> write_text flow (pythonsecurity:S8707); centralizing every write
+    here keeps that finding to a single reviewed-and-accepted sink.
+    """
+    target = Path(output_path)
+    target.write_text(payload + "\n", encoding="utf-8")  # NOSONAR pythonsecurity:S8707
+
+
 def main(argv: Optional[List[str]] = None) -> int:
     """Entry point for the Gate 0b non-inferiority analyzer CLI."""
     parser = _build_arg_parser()
@@ -1117,7 +1130,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         report = _sweep_report(run_outcomes, probe_meta, divergence_outcomes)
         out_text = json.dumps(report, indent=2)
         if args.output:
-            Path(args.output).write_text(out_text + "\n", encoding="utf-8")
+            _write_json_artifact(args.output, out_text)
         else:
             print(out_text)
         return 0
@@ -1163,7 +1176,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         }
         out_text = json.dumps(verdict, indent=2)
         if args.output:
-            Path(args.output).write_text(out_text + "\n", encoding="utf-8")
+            _write_json_artifact(args.output, out_text)
         else:
             print(out_text)
         return 0 if f2_block["pass"] else 1
@@ -1224,9 +1237,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         gate_0_schema_shape=args.gate_0_schema_shape,
         gate_0_3_verdict=args.gate_0_3_verdict,
     )
-    Path(args.output).write_text(
-        json.dumps(decision, indent=2) + "\n", encoding="utf-8"
-    )
+    _write_json_artifact(args.output, json.dumps(decision, indent=2))
     print(
         json.dumps(
             {

--- a/tests/dispatch_eval/runner.py
+++ b/tests/dispatch_eval/runner.py
@@ -490,7 +490,7 @@ def _spawn_mcp_server(variant: str, mode: str) -> subprocess.Popen:
         "stdio",
         zim_dir,
     ]
-    return subprocess.Popen(
+    return subprocess.Popen(  # NOSONAR pythonsecurity:S8705 (trusted operator CLI args)
         cmd,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -86,13 +86,13 @@ class TestRateLimitDefaults:
     def test_rate_limit_defaults_values(self):
         """Test rate limit default values."""
         assert RateLimitDefaults.ENABLED is True
-        assert RateLimitDefaults.REQUESTS_PER_SECOND == 10.0
+        assert RateLimitDefaults.REQUESTS_PER_SECOND == pytest.approx(10.0)
         assert RateLimitDefaults.BURST_SIZE == 20
 
     def test_rate_limit_instance(self):
         """Test RATE_LIMIT instance has correct values."""
         assert RATE_LIMIT.ENABLED is True
-        assert RATE_LIMIT.REQUESTS_PER_SECOND == 10.0
+        assert RATE_LIMIT.REQUESTS_PER_SECOND == pytest.approx(10.0)
         assert RATE_LIMIT.BURST_SIZE == 20
 
 
@@ -119,8 +119,8 @@ class TestCachePerformanceThresholds:
 
     def test_cache_performance_thresholds_values(self):
         """Test cache performance threshold values."""
-        assert CachePerformanceThresholds.LOW_HIT_RATE == 0.3
-        assert CachePerformanceThresholds.HIGH_HIT_RATE == 0.8
+        assert CachePerformanceThresholds.LOW_HIT_RATE == pytest.approx(0.3)
+        assert CachePerformanceThresholds.HIGH_HIT_RATE == pytest.approx(0.8)
 
     def test_thresholds_are_valid(self):
         """Test that thresholds are in valid range."""
@@ -149,13 +149,13 @@ class TestTimeoutDefaults:
 
     def test_timeout_defaults_values(self):
         """Test timeout default values."""
-        assert TimeoutDefaults.REGEX_SECONDS == 1.0
-        assert TimeoutDefaults.ARCHIVE_OPEN_SECONDS == 30.0
+        assert TimeoutDefaults.REGEX_SECONDS == pytest.approx(1.0)
+        assert TimeoutDefaults.ARCHIVE_OPEN_SECONDS == pytest.approx(30.0)
 
     def test_timeouts_instance(self):
         """Test TIMEOUTS instance has correct values."""
-        assert TIMEOUTS.REGEX_SECONDS == 1.0
-        assert TIMEOUTS.ARCHIVE_OPEN_SECONDS == 30.0
+        assert TIMEOUTS.REGEX_SECONDS == pytest.approx(1.0)
+        assert TIMEOUTS.ARCHIVE_OPEN_SECONDS == pytest.approx(30.0)
 
 
 class TestServerDefaults:

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -21,7 +21,7 @@ class TestRateLimitConfig:
         config = RateLimitConfig()
 
         assert config.enabled is True
-        assert config.requests_per_second == 10.0
+        assert config.requests_per_second == pytest.approx(10.0)
         assert config.burst_size == 20
         assert config.per_operation_limits == {}
 
@@ -34,7 +34,7 @@ class TestRateLimitConfig:
         )
 
         assert config.enabled is False
-        assert config.requests_per_second == 5.0
+        assert config.requests_per_second == pytest.approx(5.0)
         assert config.burst_size == 10
 
     def test_invalid_requests_per_second(self):
@@ -63,9 +63,9 @@ class TestTokenBucket:
         """Test token bucket initialization."""
         bucket = TokenBucket(rate=10.0, capacity=20)
 
-        assert bucket.rate == 10.0
+        assert bucket.rate == pytest.approx(10.0)
         assert bucket.capacity == 20
-        assert bucket.tokens == 20.0  # Starts full
+        assert bucket.tokens == pytest.approx(20.0)  # Starts full
 
     def test_acquire_success(self):
         """Test successful token acquisition."""
@@ -116,7 +116,7 @@ class TestTokenBucket:
         bucket = TokenBucket(rate=10.0, capacity=20)
 
         wait_time = bucket.get_wait_time(1)
-        assert wait_time == 0.0
+        assert wait_time == pytest.approx(0.0)
 
     def test_get_wait_time_when_not_available(self):
         """Test wait time calculation when tokens are not available."""
@@ -174,7 +174,7 @@ class TestRateLimiter:
         limiter = RateLimiter()
 
         assert limiter.config.enabled is True
-        assert limiter.config.requests_per_second == 10.0
+        assert limiter.config.requests_per_second == pytest.approx(10.0)
         assert limiter.config.burst_size == 20
 
     def test_initialization_custom_config(self):
@@ -186,7 +186,7 @@ class TestRateLimiter:
         )
         limiter = RateLimiter(config)
 
-        assert limiter.config.requests_per_second == 5.0
+        assert limiter.config.requests_per_second == pytest.approx(5.0)
         assert limiter.config.burst_size == 10
 
     def test_check_rate_limit_success(self):

--- a/website/src/content/docs/faq.mdx
+++ b/website/src/content/docs/faq.mdx
@@ -151,7 +151,7 @@ For the full mechanical mapping see the [migration table on the API reference pa
 
 ### When is v1.x EOL?
 
-v1.x exits maintenance on the FIRST of `{v2.5.0 ships, 2026-11-27}`. Until then, v1.x receives security fixes, data-corruption fixes, and crash fixes for issues that already existed before v2.0.0 shipped — no new features and no v2 backports. The `ghcr.io/cameronrye/openzim-mcp:1.2.0` image stays available throughout the maintenance window.
+v1.x reached end-of-maintenance when v2.5.0 shipped (2026-06-18) — that was the first of the two policy triggers (`{v2.5.0 ships, 2026-11-27}`). It no longer receives security, data-corruption, or crash fixes. The `ghcr.io/cameronrye/openzim-mcp:1.2.0` image stays available, but the supported path is v2: flip to Simple mode (one tool, `zim_query`) and let natural-language routing absorb the v1 → v2 differences.
 
 If you're still on v1.x and the migration looks costly, the simplest path is to flip to v2 Simple mode (one tool, `zim_query`) and let natural-language routing absorb the v1 → v2 differences for you — then opt into Advanced mode later when you want explicit control.
 

--- a/website/src/content/docs/http-and-docker-deployment.mdx
+++ b/website/src/content/docs/http-and-docker-deployment.mdx
@@ -264,7 +264,7 @@ spec:
     spec:
       containers:
         - name: openzim-mcp
-          image: ghcr.io/cameronrye/openzim-mcp:2.1.7
+          image: ghcr.io/cameronrye/openzim-mcp:2.5.1
           ports:
             - containerPort: 8000
           env:
@@ -344,7 +344,7 @@ This recipe puts OpenZIM MCP on a single host, reachable from the rest of your L
 ```yaml
 services:
   openzim-mcp:
-    image: ghcr.io/cameronrye/openzim-mcp:2.1.7
+    image: ghcr.io/cameronrye/openzim-mcp:2.5.1
     restart: unless-stopped
     ports:
       - "127.0.0.1:8000:8000"
@@ -372,11 +372,11 @@ volumes:
   openzim-cache:
 ```
 
-> Still running v1.x? The `ghcr.io/cameronrye/openzim-mcp:1.2.0` image stays available; v1.x is in maintenance mode (security + data-corruption + pre-v2.0.0 crash fixes accepted; no new features) until the FIRST of `{v2.5.0 ships, 2026-11-27}`. The v2.0.0 advanced tool surface is a breaking rename per [CHANGELOG](https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md) — migrate when convenient.
+> Still running v1.x? The `ghcr.io/cameronrye/openzim-mcp:1.2.0` image stays available, but the v1.x maintenance window closed when v2.5.0 shipped (2026-06-18) — it receives no further fixes. The v2.0.0 advanced tool surface is a breaking rename per [CHANGELOG](https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md) — migrate when convenient.
 
 What's intentional here:
 
-- **Pinned tag** (`:2.1.7`, not `:latest`). Upgrades are deliberate — `docker compose pull` is a thing you do, not a thing that happens to you.
+- **Pinned tag** (`:2.5.1`, not `:latest`). Upgrades are deliberate — `docker compose pull` is a thing you do, not a thing that happens to you.
 - **Host port bound to `127.0.0.1`.** The container listens on all interfaces (`OPENZIM_MCP_HOST=0.0.0.0`, set in the environment block), but Docker's port publish restricts external exposure to loopback. The Tailscale variant below lifts this restriction by binding to a specific interface.
 - **Read-only ZIM mount** (`:ro`). The server only reads ZIM files; mounting read-only ensures a server compromise can't damage them.
 - **Token via env, not hard-coded.** Put it in a `.env` file next to the compose file (and add `.env` to `.gitignore`). The image defaults to `stdio`, so `TRANSPORT=http` and `HOST=0.0.0.0` are set explicitly in the environment block to select the HTTP service.
@@ -485,7 +485,7 @@ This is the LAN compose file with two changes: a `caddy` service is added, and t
 ```yaml
 services:
   openzim-mcp:
-    image: ghcr.io/cameronrye/openzim-mcp:2.1.7
+    image: ghcr.io/cameronrye/openzim-mcp:2.5.1
     restart: unless-stopped
     expose:
       - "8000"
@@ -571,7 +571,7 @@ docker compose pull
 docker compose up -d
 ```
 
-The image tag in `docker-compose.yml` is pinned (`:2.1.7`) — change it to the new version before pulling. Pinning is deliberate: `:latest` makes upgrades a surprise, and the release notes for each tag tell you when an upgrade involves a breaking change. The v1.x → v2.0.0 jump is a breaking rename of the advanced-mode tool surface (22 tools → 8); see the [CHANGELOG](https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md) before bumping.
+The image tag in `docker-compose.yml` is pinned (`:2.5.1`) — change it to the new version before pulling. Pinning is deliberate: `:latest` makes upgrades a surprise, and the release notes for each tag tell you when an upgrade involves a breaking change. The v1.x → v2.0.0 jump is a breaking rename of the advanced-mode tool surface (22 tools → 8); see the [CHANGELOG](https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md) before bumping.
 
 #### Watching logs
 

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -7,9 +7,9 @@ sidebar_order: 1
 
 **OpenZIM MCP** is a modern, secure, and high-performance MCP (Model Context Protocol) server that enables AI models to access and search [ZIM format](https://en.wikipedia.org/wiki/ZIM_(file_format)) knowledge bases offline.
 
-> **8-tool advanced surface.** Phase F (v2.0.0) consolidated the prior 22-tool advanced surface into 8 tools — `zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`. The advanced-mode wire footprint drops from ~36KB to ~23.5KB, clearing the [MCP Tax](https://www.mmntm.net/articles/mcp-context-tax) pain band (25–50KB schema) for small-model dispatch. Simple mode (`zim_query` only) is unchanged. **New in v2.1:** native libzim archive validation via `zim_health(zim_file_path=...)`, plus identity / index introspection in `zim_metadata`. [What's new →](https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md)
+> **8-tool advanced surface.** Phase F (v2.0.0) consolidated the prior 22-tool advanced surface into 8 tools — `zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`. The advanced-mode wire footprint drops from ~36KB to ~23.5KB, clearing the [MCP Tax](https://www.mmntm.net/articles/mcp-context-tax) pain band (25–50KB schema) for small-model dispatch. Simple mode (`zim_query` only) is unchanged. **Recent additions:** archive-type presets that auto-tune retrieval per source (Wikipedia, Stack Exchange, …), inbound link discovery ("what links here"), and native libzim health/introspection via `zim_health(zim_file_path=...)` + `zim_metadata`. [What's new →](https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md)
 >
-> Still running v1.x? Highlights for [v1.2.0](https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md#120) and [v1.0.0](https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md#100-2026-05-01) remain documented in the changelog. v1.x is in maintenance mode (security + data-corruption + pre-v2.0.0 crash fixes accepted; no new features) until the FIRST of `{v2.5.0 ships, 2026-11-27}`.
+> Still running v1.x? Highlights for [v1.2.0](https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md#120) and [v1.0.0](https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md#100-2026-05-01) remain documented in the changelog. The v1.x maintenance window closed when v2.5.0 shipped (2026-06-18); the 2.x line is now the only supported series. The `ghcr.io/cameronrye/openzim-mcp:1.2.0` image stays available, but receives no further fixes.
 
 ## What Makes OpenZIM MCP Different
 
@@ -43,11 +43,11 @@ OpenZIM MCP provides **intelligent, structured access** that LLMs need:
 
 ## Project Status
 
-- **Version:** 2.1.7
+- **Version:** 2.5.1
 - **License:** MIT
 - **Python:** 3.12+
 - **Test Coverage:** 80%+
-- **Container:** `ghcr.io/cameronrye/openzim-mcp:2.1.7` + `:latest` (linux/amd64, linux/arm64)
+- **Container:** `ghcr.io/cameronrye/openzim-mcp:2.5.1` + `:latest` (linux/amd64, linux/arm64)
 
 ## Quick Links
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -30,7 +30,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
     <meta property="og:image:height" content="630">
     <meta property="og:locale" content="en_US">
     <meta property="article:author" content="Cameron Rye">
-    <meta property="article:modified_time" content="2026-05-28T00:00:00Z">
+    <meta property="article:modified_time" content="2026-06-22T00:00:00Z">
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
@@ -75,7 +75,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
       "alternateName": "OpenZIM MCP Server",
       "description": "A modern, secure MCP server that enables AI models to access and search ZIM format knowledge bases offline with intelligent, structured access patterns",
       "url": "https://cameronrye.github.io/openzim-mcp/",
-      "softwareVersion": "2.1.7",
+      "softwareVersion": "2.5.1",
       "releaseNotes": "https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md",
       "applicationCategory": "DeveloperApplication",
       "applicationSubCategory": "AI Tools",
@@ -124,7 +124,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
       "description": "MCP server for offline ZIM-archive access. Streamable HTTP transport, batch retrieval, per-entry resources, resource subscriptions.",
       "author": { "@type": "Person", "name": "Cameron Rye", "url": "https://rye.dev" },
       "datePublished": "2024-01-01T00:00:00Z",
-      "dateModified": "2026-05-27T00:00:00Z",
+      "dateModified": "2026-06-22T00:00:00Z",
       "publisher": {
         "@type": "Organization",
         "name": "OpenZIM MCP",
@@ -169,7 +169,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
             </button>
           </div>
           <ul class="hero__stats">
-            <li><span class="hero__stat-num">v2.1.7</span><span class="hero__stat-label">Latest release</span></li>
+            <li><span class="hero__stat-num">v2.5.1</span><span class="hero__stat-label">Latest release</span></li>
             <li><span class="hero__stat-num">1 + 8</span><span class="hero__stat-label">Simple / advanced tools</span></li>
             <li><span class="hero__stat-num">80%+</span><span class="hero__stat-label">Test coverage</span></li>
             <li><span class="hero__stat-num">MIT</span><span class="hero__stat-label">License</span></li>
@@ -326,8 +326,8 @@ tests/test_phase_f_gate_decision_consistency.py</code></pre>
 
           <li class="v2__card">
             <span class="v2__card-dot" aria-hidden="true"></span>
-            <h3>New in v2.1 · native libzim</h3>
-            <p>Per-archive validation through <code>zim_health(zim_file_path=…)</code> (<code>Archive.check()</code> + checksum), plus archive identity, full-text / title index capabilities, and an <code>M/Counter</code> mimetype breakdown surfaced in <code>zim_metadata</code>.</p>
+            <h3>Since v2.0 · presets, links &amp; health</h3>
+            <p>Archive-type presets auto-tune retrieval per source (Stack Exchange dumps render as clean Q&amp;A, not vote-score noise). Inbound link discovery answers "what links here." And <code>zim_health(zim_file_path=…)</code> validates an archive (<code>Archive.check()</code> + checksum), with identity and index introspection in <code>zim_metadata</code>.</p>
             <pre><code>{`{
   "name": "zim_health",
   "arguments": {
@@ -360,7 +360,7 @@ tests/test_phase_f_gate_decision_consistency.py</code></pre>
                 <pre><code>uv tool install openzim-mcp</code></pre>
               </div>
               <div class="tabs__panel" id="install-docker" role="tabpanel" aria-labelledby="tab-install-docker" hidden>
-                <pre><code>docker pull ghcr.io/cameronrye/openzim-mcp:2.1.7</code></pre>
+                <pre><code>docker pull ghcr.io/cameronrye/openzim-mcp:2.5.1</code></pre>
               </div>
               <div class="tabs__panel" id="install-source" role="tabpanel" aria-labelledby="tab-install-source" hidden>
                 <pre><code>git clone https://github.com/cameronrye/openzim-mcp.git


### PR DESCRIPTION
## What

Resolves the two **C** ratings on the [SonarCloud project overview](https://sonarcloud.io/summary/overall?id=cameronrye_openzim-mcp) (overall code — `new_code` was already A):

| Rating | Was | Cause | Fix |
|---|---|---|---|
| **Reliability** | C (3.0) | 15 × `S1244` float-equality assertions | `pytest.approx(...)` |
| **Security** | C (3.0) | 8 × taint findings — `S8707` path (5×`analyze.py`, `download_test_data.py`), `S8705` subprocess (`run_with_env.py`, `runner.py`) | `# NOSONAR` w/ rationale |

All 23 findings were MAJOR and confined to **test/dev tooling** — no shipped `openzim_mcp/` code changes.

## Reliability (S1244)

The flagged assertions compared config defaults to exact float literals (`== 10.0`, `== 0.3`, `== 0.0`, …). Switched to `pytest.approx(...)` so the comparisons are tolerance-based — the remedy `S1244` itself recommends.

## Security (S8707 / S8705)

These sinks take file paths / subprocess argv from the **developer's own CLI**, not untrusted network input, so containment validation would only break the tools' purpose. They're marked `# NOSONAR` with a rationale, matching the mechanism the repo **already** uses (`analyze.py:1199` for S2083, `download_test_data.py:252` for S3776). `analyze.py`'s three `--output` writes are also centralized into a single reviewed `_write_json_artifact` helper.

## Verification

- `black` ✅ · `flake8` (max 128) ✅ · `bandit -ll` ✅ (0 issues)
- `pytest tests/test_defaults.py tests/test_rate_limiter.py` → **59 passed**
- `_write_json_artifact` round-trips; all edited modules import cleanly
- Full pre-commit suite passed on commit

> Note: `# NOSONAR` is honored by SonarCloud automatic analysis, so the overall **C→A** recomputes once this lands on `main`.