### PR TITLE
fix: resolve v2.5.1 end-to-end test findings (cuts v2.5.2)

### DIFF
--- a/openzim_mcp/async_operations.py
+++ b/openzim_mcp/async_operations.py
@@ -304,6 +304,7 @@ class AsyncZimOperations:
         offset: int = 0,
         *,
         cursor_archive_identity: Optional[str] = None,
+        include_assets: bool = False,
     ) -> "BrowseNamespaceResponse":
         """Structured variant of ``browse_namespace`` (async)."""
         return await asyncio.to_thread(
@@ -314,6 +315,7 @@ class AsyncZimOperations:
                 limit,
                 offset,
                 cursor_archive_identity=cursor_archive_identity,
+                include_assets=include_assets,
             ),
         )
 
@@ -609,14 +611,19 @@ class AsyncZimOperations:
         namespace: str,
         cursor_state: Optional[Dict[str, Any]] = None,
         limit: int = 200,
+        *,
+        include_assets: bool = False,
     ) -> "WalkNamespaceResponse":
         """Structured variant of ``walk_namespace`` (async)."""
         return await asyncio.to_thread(
-            self._ops.walk_namespace_data,
-            zim_file_path,
-            namespace,
-            cursor_state,
-            limit,
+            partial(
+                self._ops.walk_namespace_data,
+                zim_file_path,
+                namespace,
+                cursor_state,
+                limit,
+                include_assets=include_assets,
+            ),
         )
 
     async def search_all(self, query: str, limit_per_file: int = 5) -> str:

--- a/openzim_mcp/meta.py
+++ b/openzim_mcp/meta.py
@@ -176,6 +176,7 @@ def format_footer(meta: Dict[str, Any], *, footer_enabled: bool) -> str:
         "bad_query",
         "no_xapian_index",
         "bad_namespace",
+        "no_content_type_match",
         "sample_only",
         "archive_unavailable",
         "search_all_budget_exceeded",
@@ -191,6 +192,13 @@ def format_footer(meta: Dict[str, Any], *, footer_enabled: bool) -> str:
             if reason == "bad_namespace":
                 return (
                     "> Unknown namespace. Try `list_namespaces` to see valid options."
+                )
+            if reason == "no_content_type_match":
+                return (
+                    "> No full-text-indexed entries match that content type. "
+                    "Binary assets (images, media) aren't in the search index — "
+                    "use `browse_namespace` (include_assets=True) to discover "
+                    "them, or drop the `content_type` filter."
                 )
             if reason == "sample_only":
                 return (

--- a/openzim_mcp/server_state.py
+++ b/openzim_mcp/server_state.py
@@ -17,6 +17,7 @@ emit is identical to b13.
 from __future__ import annotations
 
 import logging
+import os
 import time as _time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -155,6 +156,20 @@ def _redact_directory_path(path: str) -> str:
     return f"<redacted>/{basename}"
 
 
+def _redact_diagnostics(server: "OpenZimMcpServer") -> bool:
+    """Whether to mask paths/PID in the diagnostic report.
+
+    Redaction guards a trust boundary: over the HTTP/SSE transports the
+    client may be remote, so absolute host paths and the PID are masked.
+    On the local stdio transport the client already shares the filesystem
+    — and ``loaded_archives[].path`` reports the same absolute paths
+    unredacted (clients pass them back as ``zim_file_path``) — so masking
+    there only creates an inconsistency without protecting anything; show
+    the real values.
+    """
+    return getattr(server.config, "transport", "stdio") != "stdio"
+
+
 def _build_uptime_info(server: "OpenZimMcpServer") -> Dict[str, Any]:
     """Return uptime block for the health report.
 
@@ -168,8 +183,10 @@ def _build_uptime_info(server: "OpenZimMcpServer") -> Dict[str, Any]:
     if start_mono is not None:
         uptime_seconds = round(_time.monotonic() - start_mono, 3)
     return {
-        # Redact PID — diagnostic output may end up in bug reports.
-        "process_id": "[REDACTED]",
+        # PID is masked over the network transports (HTTP/SSE) where the
+        # client may be remote; shown on local stdio for consistency with
+        # the unredacted ``loaded_archives`` paths (see _redact_diagnostics).
+        "process_id": "[REDACTED]" if _redact_diagnostics(server) else os.getpid(),
         "started_at": start_iso,
         "uptime_seconds": uptime_seconds,
     }
@@ -245,12 +262,15 @@ def _build_configuration_report(
     server: "OpenZimMcpServer",
 ) -> Union[ServerConfigurationResponse, ToolErrorPayload]:
     try:
-        # Always redact paths and PID — even on stdio, diagnostic output
-        # frequently ends up in bug reports / logs / issue trackers.
+        # Mask paths and PID over the network transports (HTTP/SSE) where the
+        # client may be remote; on local stdio show the real values so this
+        # report stays consistent with the unredacted ``loaded_archives``
+        # paths the same response carries (see _redact_diagnostics).
+        redact = _redact_diagnostics(server)
         config_info = {
             "server_name": server.config.server_name,
             "allowed_directories": [
-                _redact_directory_path(str(p))
+                _redact_directory_path(str(p)) if redact else str(p)
                 for p in server.config.allowed_directories
             ],
             "allowed_directories_count": len(server.config.allowed_directories),
@@ -261,7 +281,7 @@ def _build_configuration_report(
             "content_snippet_length": server.config.content.snippet_length,
             "search_default_limit": server.config.content.default_search_limit,
             "config_hash": server.config.get_config_hash(),
-            "server_pid": "[REDACTED]",
+            "server_pid": "[REDACTED]" if redact else os.getpid(),
         }
 
         warnings_list: List[str] = []
@@ -273,7 +293,7 @@ def _build_configuration_report(
         }
 
         invalid_dirs = [
-            _redact_directory_path(str(d))
+            _redact_directory_path(str(d)) if redact else str(d)
             for d in server.config.allowed_directories
             if not Path(d).exists()
         ]

--- a/openzim_mcp/tools/_common.py
+++ b/openzim_mcp/tools/_common.py
@@ -6,6 +6,7 @@ import pathlib
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 from ..responses import ToolErrorPayload, tool_error
+from ..security import sanitize_context_for_error
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
@@ -52,7 +53,13 @@ def tool_error_response(
     enhanced = server._create_enhanced_error_message(
         operation=operation, error=error, context=context or ""
     )
-    return tool_error(operation=operation, message=enhanced, context=context)
+    # Redact absolute paths from the standalone ``context`` field too, so the
+    # envelope's ``message`` and ``context`` are consistently sanitized — the
+    # ``message`` is already redacted via ``_create_enhanced_error_message``;
+    # without this the raw path (e.g. ``Path: /home/.../foo.zim``) leaked here.
+    # Null-safe: keep ``None`` as-is so ``tool_error`` still omits the field.
+    safe_context = sanitize_context_for_error(context) if context is not None else None
+    return tool_error(operation=operation, message=enhanced, context=safe_context)
 
 
 def enforce_rate_limit(

--- a/openzim_mcp/tools/zim_browse.py
+++ b/openzim_mcp/tools/zim_browse.py
@@ -39,6 +39,7 @@ def register(server: "OpenZimMcpServer") -> None:
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
         offset: int = 0,
+        include_assets: bool = False,
     ) -> Any:
         try:
             rl = enforce_rate_limit(server, "zim_browse")
@@ -80,12 +81,14 @@ def register(server: "OpenZimMcpServer") -> None:
                         limit=eff_limit,
                         offset=int(state.get("o", 0) or 0),
                         cursor_archive_identity=state.get("ai"),
+                        include_assets=include_assets,
                     )
                 return await ops.browse_namespace_data(
                     zim_file_path,
                     namespace=namespace,
                     limit=eff_limit,
                     offset=offset,
+                    include_assets=include_assets,
                 )
 
             # mode == "walk" — v2 walk takes the decoded cursor-state dict
@@ -108,11 +111,13 @@ def register(server: "OpenZimMcpServer") -> None:
                     namespace,
                     cursor_state=cursor_state,
                     limit=eff_limit,
+                    include_assets=include_assets,
                 )
             return await ops.walk_namespace_data(
                 zim_file_path,
                 namespace,
                 limit=eff_limit,
+                include_assets=include_assets,
             )
         except Exception as e:  # noqa: BLE001 — broad catch matches b13 envelope
             return tool_error_response(

--- a/openzim_mcp/tools/zim_browse_description.md
+++ b/openzim_mcp/tools/zim_browse_description.md
@@ -20,6 +20,9 @@ PARAMETERS:
   cursor            Phase B cursor pagination handle.
   limit             Page size (default depends on mode).
   offset            Page-mode pagination offset (ignored in walk).
+  include_assets    Default False; C-browse hides assets (css/js/fonts/
+                    images/media). True surfaces them — for discovering
+                    media paths to fetch via `zim_get(binary=True)`.
 
 RESPONSE:
   BrowseNamespaceResponse (mode="page") or WalkNamespaceResponse

--- a/openzim_mcp/tools/zim_links.py
+++ b/openzim_mcp/tools/zim_links.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 _DESCRIPTION = load_description("zim_links")
 
 _VALID_DIRECTIONS = {"outbound", "inbound", "related"}
+_VALID_KINDS = {"internal", "external", "media"}
 
 
 def register(server: "OpenZimMcpServer") -> None:
@@ -38,6 +39,7 @@ def register(server: "OpenZimMcpServer") -> None:
         zim_file_path: str,
         entry_path: str,
         direction: Literal["outbound", "inbound", "related"] = "outbound",
+        kind: Literal["internal", "external", "media"] = "internal",
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
         offset: int = 0,
@@ -56,12 +58,21 @@ def register(server: "OpenZimMcpServer") -> None:
                 )
 
             if direction == "outbound":
+                if kind not in _VALID_KINDS:
+                    return tool_error(
+                        operation="invalid_kind",
+                        message=(
+                            f"`kind` must be one of {sorted(_VALID_KINDS)} "
+                            f"(provided: {kind!r})."
+                        ),
+                    )
                 state, cursor_error = decode_cursor_state(
                     cursor, expected_tool="extract_article_links"
                 )
                 if cursor_error is not None:
                     return cursor_error
                 eff_limit = limit if limit is not None else 100
+                eff_kind: str = kind
                 if state is not None:
                     # Guard against replaying entry A's cursor against entry B,
                     # which would apply A's offset to B's link list.
@@ -70,11 +81,23 @@ def register(server: "OpenZimMcpServer") -> None:
                     )
                     if ep_error is not None:
                         return ep_error
+                    # Honour the bucket the cursor was issued for. A cursor for
+                    # the 'external' bucket must not silently resume against
+                    # 'internal'; reject an explicit non-default `kind` that
+                    # contradicts the cursor's encoded 'k', else adopt it.
+                    cursor_kind = state.get("k")
+                    if isinstance(cursor_kind, str) and cursor_kind:
+                        if kind != "internal" and kind != cursor_kind:
+                            return cursor_context_mismatch(
+                                state, field="k", expected=kind, label="kind"
+                            )
+                        eff_kind = cursor_kind
                     return await ops.extract_article_links_data(
                         zim_file_path,
                         entry_path,
                         limit=eff_limit,
                         offset=int(state.get("o", 0) or 0),
+                        kind=eff_kind,
                         cursor_archive_identity=state.get("ai"),
                     )
                 return await ops.extract_article_links_data(
@@ -82,6 +105,7 @@ def register(server: "OpenZimMcpServer") -> None:
                     entry_path,
                     limit=eff_limit,
                     offset=offset,
+                    kind=eff_kind,
                 )
 
             if direction == "inbound":

--- a/openzim_mcp/tools/zim_links_description.md
+++ b/openzim_mcp/tools/zim_links_description.md
@@ -23,6 +23,9 @@ PARAMETERS:
   zim_file_path   REQUIRED. The archive containing the article.
   entry_path      REQUIRED. The article whose links to inspect.
   direction       See DIRECTIONS above.
+  kind            Outbound only — which bucket to return: "internal"
+                  (default) / "external" / "media". One per call;
+                  `category_totals` reports all three counts.
   cursor          Cursor handle (outbound/inbound).
   limit           Page size.
   offset          Pagination offset (outbound/inbound).
@@ -30,6 +33,8 @@ PARAMETERS:
 RESPONSE:
   LinksResponse (outbound) or RelatedArticlesResponse (inbound /
   related). Outbound/inbound paginate; related is one ranked set.
+  Outbound `category_totals.internal` excludes in-page `#anchor`
+  links — those are counted separately as `category_totals.anchor`.
 
 ERRORS:
   Invalid `direction` → `invalid_direction`. Missing/stale inbound

--- a/openzim_mcp/zim/content.py
+++ b/openzim_mcp/zim/content.py
@@ -553,19 +553,26 @@ class _ContentMixin:
                 f"Try using search_zim_file() to verify the file is accessible."
             ) from e
 
-        # ``_truncated`` / ``_total_chars`` are internal hints from
-        # ``_build_entry_payload`` that drive the eventual ``_meta``
+        # ``_truncated`` / ``_total_chars`` / ``_content_chars`` are internal
+        # hints from the payload builder that drive the eventual ``_meta``
         # envelope; stripped before the dict reaches the wire.
         truncated = bool(payload.pop("_truncated", False))
         total_chars = payload.pop("_total_chars", None)
-        # ``content_chars`` is the post-slice content length — drives
-        # ``more_at_offset`` for follow-up paginated fetches.
+        # ``_content_chars`` is the length of the paginable body SLICE
+        # (excluding the appended truncation note). Using it — rather than
+        # ``len(payload["content"])``, which includes the note — keeps
+        # ``more_at_offset`` aligned with the human-readable
+        # ``content_offset=N`` hint in the body. Fallback to the served length
+        # for any payload that predates the hint.
+        content_chars = payload.pop("_content_chars", None)
+        if content_chars is None:
+            content_chars = len(payload.get("content", ""))
         with_meta = attach_meta(
             payload,
             truncated=truncated,
             total_chars=total_chars,
             current_offset=content_offset,
-            content_chars=len(payload.get("content", "")),
+            content_chars=content_chars,
         )
         # Attach _meta before caching so cold and warm reads return
         # bit-identical responses (Phase B #12).
@@ -743,6 +750,16 @@ class _ContentMixin:
             original_total=total_length,
         )
         was_truncated = len(truncated_content) < len(content)
+        # The paginable slice length is the pre-note body length —
+        # ``truncate_content`` slices ``content[:max_content_length]`` and only
+        # then appends the ``... [Content truncated ...] ...`` note. The human
+        # hint inside that note points the caller at
+        # ``content_offset = current_offset + max_content_length``; capture the
+        # same slice length here so ``more_at_offset`` agrees with it instead of
+        # overshooting by the note length. When not truncated the whole
+        # post-offset body is served, so the slice length is ``len(content)``
+        # and no continuation offset is emitted anyway.
+        content_chars = max_content_length if was_truncated else len(content)
         content = truncated_content
 
         payload: Dict[str, Any] = {
@@ -764,6 +781,7 @@ class _ContentMixin:
         if was_truncated or offset_applied:
             payload["_truncated"] = was_truncated
             payload["_total_chars"] = total_length
+            payload["_content_chars"] = content_chars
         return payload, content_ok, actual_path
 
     def get_entries_data(  # NOSONAR(python:S3776)

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -79,12 +79,29 @@ _NAMESPACE_DESCRIPTIONS = {
 _KNOWN_NAMESPACE_LETTERS = frozenset({"C", "M", "W", "X", "A", "I", "-"})
 
 
+def _entry_mimetype(entry: "Any") -> Optional[str]:
+    """Best-effort per-row mimetype for the asset filter.
+
+    Reads the libzim item header mimetype (no content decode). Redirect
+    entries and read errors degrade to ``None`` so the asset predicate falls
+    back to the path/extension heuristic rather than failing the page.
+    """
+    try:
+        if getattr(entry, "is_redirect", False):
+            return None
+        return entry.get_item().mimetype or None
+    except Exception:
+        return None
+
+
 def _scan_fill_c_namespace(
     entry_count: int,
     get_path: "Any",
     is_asset: "Any",
     limit: int,
     offset: int,
+    *,
+    include_assets: bool = False,
 ) -> Tuple[List[str], int, bool, int]:
     """Scan new-scheme C entries by id, collecting up to ``limit`` real
     content rows starting after ``offset`` content rows.
@@ -102,6 +119,12 @@ def _scan_fill_c_namespace(
     row that ``browse`` emitted at offset 0 but ``walk`` omitted) and assets
     are skipped and do not consume the offset budget.
 
+    ``get_path(scan_id)`` returns ``(path, content_type)``; the per-row
+    mimetype lets the asset predicate catch query-string / extensionless
+    asset URLs (e.g. ``fonts.googleapis.com/css2?family=...``).
+    ``include_assets=True`` surfaces asset rows instead of skipping them
+    (``assets_skipped`` then stays 0).
+
     Returns ``(page_paths, next_row_offset, scan_exhausted, assets_skipped)``
     where ``next_row_offset = offset + len(page_paths)``.
     """
@@ -110,13 +133,13 @@ def _scan_fill_c_namespace(
     content_seen = 0
     scan_id = 0
     while scan_id < entry_count and len(page_paths) < limit:
-        path = get_path(scan_id)
+        path, content_type = get_path(scan_id)
         scan_id += 1
         if not path or not str(path).strip():
             # Read error (get_path returned None) or an unaddressable
             # empty-path entry — skip without consuming the offset budget.
             continue
-        if is_asset(path):
+        if not include_assets and is_asset(path, content_type):
             assets_skipped += 1
             continue
         if content_seen < offset:
@@ -146,7 +169,9 @@ class _NamespaceMixin:
         def _validate_zim_path(self, zim_file_path: str) -> Path:
             """Resolve via ``_ArchiveAccessMixin`` on the concrete coordinator."""
 
-        def _is_non_article_target(self, path: str) -> bool:
+        def _is_non_article_target(
+            self, path: str, content_type: "Optional[str]" = None
+        ) -> bool:
             """Resolve via ``_StructureMixin`` on the concrete coordinator."""
 
     def list_namespaces_data(self, zim_file_path: str) -> "ListNamespacesResponse":
@@ -616,6 +641,7 @@ class _NamespaceMixin:
         offset: int = 0,
         *,
         cursor_archive_identity: Optional[str] = None,
+        include_assets: bool = False,
     ) -> "BrowseNamespaceResponse":
         """Structured variant of ``browse_namespace``.
 
@@ -710,7 +736,10 @@ class _NamespaceMixin:
         # cursor ``s.o`` is therefore a row offset again; ``total`` stays the
         # authoritative ``entry_count``. The bump stops pre-fix cached pages —
         # with the old entry-id-offset cursor — from leaking through.
-        cache_key = f"browse_ns_data:v2d:{validated_path}:{namespace}:{limit}:{offset}"
+        cache_key = (
+            f"browse_ns_data:v2d:{validated_path}:{namespace}:"
+            f"{limit}:{offset}:assets={include_assets}"
+        )
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug(f"Returning cached namespace browse dict for: {namespace}")
@@ -724,6 +753,7 @@ class _NamespaceMixin:
                     limit,
                     offset,
                     archive_path=str(validated_path),
+                    include_assets=include_assets,
                 )
 
             # ``_browse_namespace_entries`` still returns the legacy inner
@@ -861,6 +891,8 @@ class _NamespaceMixin:
         limit: int,
         offset: int,
         archive_path: Optional[str] = None,
+        *,
+        include_assets: bool = False,
     ) -> Dict[str, Any]:
         """Browse entries in a specific namespace using sampling and search.
 
@@ -885,7 +917,7 @@ class _NamespaceMixin:
         # which libzim returns in O(1).
         if has_new_scheme and namespace == "C":
             return self._browse_new_scheme_c_paginated(
-                archive, namespace, limit, offset
+                archive, namespace, limit, offset, include_assets=include_assets
             )
         # Fast path: new-scheme + W namespace. libzim doesn't surface W
         # through the iterable surface, but the well-known entries
@@ -1038,6 +1070,8 @@ class _NamespaceMixin:
         namespace: str,
         limit: int,
         offset: int,
+        *,
+        include_assets: bool = False,
     ) -> Dict[str, Any]:
         """Page through new-scheme C-namespace entries by entry-id range.
 
@@ -1060,16 +1094,22 @@ class _NamespaceMixin:
         """
         total = int(getattr(archive, "entry_count", 0) or 0)
 
-        def _get_path(scan_id: int) -> Optional[str]:
+        def _get_path(scan_id: int) -> Tuple[Optional[str], Optional[str]]:
             try:
-                return str(archive._get_entry_by_id(scan_id).path)
+                entry = archive._get_entry_by_id(scan_id)
+                return str(entry.path), _entry_mimetype(entry)
             except Exception as e:
                 logger.warning(f"Error reading entry id {scan_id}: {e}")
-                return None
+                return None, None
 
         page_paths, next_row_offset, scan_exhausted, assets_skipped = (
             _scan_fill_c_namespace(
-                total, _get_path, self._is_non_article_target, limit, offset
+                total,
+                _get_path,
+                self._is_non_article_target,
+                limit,
+                offset,
+                include_assets=include_assets,
             )
         )
         payload = self._new_scheme_browse_payload(
@@ -1531,6 +1571,8 @@ class _NamespaceMixin:
         namespace: str,
         cursor_state: Optional[Dict[str, Any]] = None,
         limit: int = 200,
+        *,
+        include_assets: bool = False,
     ) -> "WalkNamespaceResponse":
         """Structured variant of ``walk_namespace``.
 
@@ -1739,7 +1781,13 @@ class _NamespaceMixin:
                                 path, has_new_scheme=has_new_scheme
                             )
                             == namespace
-                        ) and not (filter_assets and self._is_non_article_target(path)):
+                        ) and not (
+                            filter_assets
+                            and not include_assets
+                            and self._is_non_article_target(
+                                path, _entry_mimetype(entry)
+                            )
+                        ):
                             entries.append(
                                 {
                                     "path": path,

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -1453,16 +1453,32 @@ class _SearchMixin:
             f"namespace={namespace}, type={content_type}, "
             f"results={returned_count}"
         )
-        # Classify the zero-result case: if a namespace/content_type filter
-        # was supplied AND the unfiltered search returned hits, the filter
-        # is what killed them — surface that as ``bad_namespace`` so the
-        # model can self-correct (drop or change the filter) instead of
-        # treating the whole query as a miss.
+        # Classify the zero-result case. A filter that killed every hit (the
+        # unfiltered search DID match) is what we want to surface so the model
+        # can self-correct (drop or change the filter). Distinguish the two
+        # filters precisely:
+        #   * an invalid namespace token -> ``bad_namespace`` (footer points at
+        #     ``list_namespaces``);
+        #   * a content_type filter miss -> ``no_content_type_match``: the
+        #     fulltext index does not cover that content type (binary assets
+        #     such as image/jpeg are never Xapian-indexed), so the honest
+        #     recovery hint is to browse rather than to fix a namespace.
+        # A *valid* namespace that simply has no hits for this query falls
+        # through to ``0_hits`` like any other miss.
+        from openzim_mcp.zim.namespace import _KNOWN_NAMESPACE_LETTERS
+
         if scan.filtered_count == 0:
-            if (namespace or content_type) and scan.unfiltered_total > 0:
-                reason: Optional[str] = "bad_namespace"
-            else:
-                reason = "0_hits"
+            reason: Optional[str] = "0_hits"
+            if scan.unfiltered_total > 0:
+                ns_canonical = (
+                    self._canonicalise_namespace(namespace.strip())
+                    if namespace
+                    else None
+                )
+                if ns_canonical and ns_canonical not in _KNOWN_NAMESPACE_LETTERS:
+                    reason = "bad_namespace"
+                elif content_type:
+                    reason = "no_content_type_match"
         else:
             reason = None
         with_meta = attach_meta(payload, reason=reason)

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -46,6 +46,30 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# Mimetype families that are never navigable articles. Used by
+# ``_StructureMixin._is_non_article_target`` so query-string / extensionless
+# asset URLs (e.g. ``fonts.googleapis.com/css2?family=...`` mimetype
+# ``text/css``, ``...?css=...``) are caught even when the path-extension
+# heuristic misses. ``text/html`` and ``application/xhtml+xml`` are
+# intentionally absent — they are real articles.
+_ASSET_MIME_EXACT = frozenset(
+    {
+        "text/css",
+        "application/javascript",
+        "text/javascript",
+        "application/json",
+        "application/pdf",
+        "application/zip",
+        "application/gzip",
+        "application/x-font-ttf",
+        "application/x-font-woff",
+        "application/font-woff",
+        "application/vnd.ms-fontobject",
+    }
+)
+_ASSET_MIME_PREFIXES = ("image/", "video/", "audio/", "font/")
+
+
 def _section_preview(
     md: str, char_start: int, char_end: int, preview_chars: int
 ) -> str:
@@ -332,9 +356,28 @@ class _StructureMixin:
                     content_processor=self.content_processor,
                 )
 
-            all_links_for_kind: List[Any] = cast(
-                "List[Any]", bundle["links"][kind]  # type: ignore[literal-required]
-            )
+            # BUG #6: the bundle 'internal' bucket carries BOTH real
+            # cross-article links (type=='internal') and in-page '#anchor'
+            # fragment links (type=='anchor'). Anchors are not navigation
+            # targets and are dropped by the inbound link-graph builder, so
+            # exclude them from the 'internal' kind's results/total and the
+            # internal count, surfacing them under a separate 'anchor' count so
+            # outbound and inbound agree on cross-article link totals.
+            internal_bucket: List[Any] = cast("List[Any]", bundle["links"]["internal"])
+            cross_article_internal = [
+                lk
+                for lk in internal_bucket
+                if not (isinstance(lk, dict) and lk.get("type") == "anchor")
+            ]
+            anchor_count = len(internal_bucket) - len(cross_article_internal)
+
+            if kind == "internal":
+                all_links_for_kind: List[Any] = cross_article_internal
+            else:
+                all_links_for_kind = cast(
+                    "List[Any]",
+                    bundle["links"][kind],  # type: ignore[literal-required]
+                )
             total_for_kind = len(all_links_for_kind)
             page = all_links_for_kind[offset : offset + limit]
             returned_count = len(page)
@@ -370,9 +413,10 @@ class _StructureMixin:
                     "returned_count": returned_count,
                 },
                 "category_totals": {
-                    "internal": len(bundle["links"]["internal"]),
+                    "internal": len(cross_article_internal),
                     "external": len(bundle["links"]["external"]),
                     "media": len(bundle["links"]["media"]),
+                    "anchor": anchor_count,
                 },
             }
 
@@ -756,7 +800,7 @@ class _StructureMixin:
         )
 
     @staticmethod
-    def _is_non_article_target(path: str) -> bool:
+    def _is_non_article_target(path: str, content_type: Optional[str] = None) -> bool:
         """Report whether ``path`` is a binary asset, not a navigable article.
 
         ZIMIT / warc2zim wraps an article's lead image in an
@@ -769,6 +813,15 @@ class _StructureMixin:
 
         ``.htm`` / ``.html`` are intentionally NOT treated as assets —
         MedlinePlus article paths legitimately end in ``.html`` / ``.htm``.
+
+        When ``content_type`` is supplied (browse/walk pass the per-row
+        libzim mimetype) a known asset mimetype (``text/css``,
+        ``application/javascript``, ``font/*``, ``image/*``, ``video/*``,
+        ``audio/*`` …) marks the row as an asset even when the path has no
+        asset extension — catching query-string / extensionless asset URLs
+        like ``fonts.googleapis.com/css2?family=...`` and ``...?css=...``.
+        ``content_type`` defaults to ``None`` so the related-article / link
+        callers (which have no mimetype) keep the extension-only behaviour.
         """
         extensions = (
             ".jpg",
@@ -802,6 +855,10 @@ class _StructureMixin:
             ".mov",
             ".m4a",
         )
+        if content_type:
+            ct = content_type.split(";", 1)[0].strip().lower()
+            if ct in _ASSET_MIME_EXACT or ct.startswith(_ASSET_MIME_PREFIXES):
+                return True
         base = path.split("?", 1)[0].split("#", 1)[0].lower()
         return base.endswith(extensions)
 

--- a/tests/data/goldens/v2_phase_b/links_einstein_internal.json
+++ b/tests/data/goldens/v2_phase_b/links_einstein_internal.json
@@ -3,6 +3,7 @@
     "truncated": false
   },
   "category_totals": {
+    "anchor": 0,
     "external": 0,
     "internal": 0,
     "media": 0

--- a/tests/dispatch_eval/prototype_schema_snapshot.json
+++ b/tests/dispatch_eval/prototype_schema_snapshot.json
@@ -1,9 +1,26 @@
 {
   "zim_browse": {
-    "bytes": 2030,
-    "description": "Browse a ZIM archive's namespace \u2014 paginated lookup or full walk.\n\nEXTRACT whether the caller wants a paginated page or a full walk\nbefore calling. Most read-the-table-of-contents-style requests are\n`mode=\"page\"`; only full-enumeration tasks (e.g. \"list every article\nin namespace A\") need `mode=\"walk\"`.\n\nALIASES: callers may say \"browse <namespace>\", \"list <namespace>\",\n\"walk namespace <letter>\". Route through THIS tool with the matching\nmode.\n\nPARAMETERS:\n  zim_file_path     REQUIRED. The archive to browse.\n  namespace         REQUIRED. ZIM namespace letter (e.g. \"C\" for\n                    content, \"A\" for articles in legacy archives,\n                    \"I\" for images).\n  mode              \"page\" (default) \u2014 paginated browse via cursor.\n                    \"walk\" \u2014 full namespace enumeration via cursor\n                    state.\n  cursor            Phase B cursor pagination handle.\n  limit             Page size (default depends on mode).\n  offset            Page-mode pagination offset (ignored in walk).\n\nRESPONSE:\n  BrowseNamespaceResponse (mode=\"page\") or WalkNamespaceResponse\n  (mode=\"walk\"). Both carry `results`, `next_cursor`, and pagination\n  metadata in `page_info`.\n\nERRORS:\n  Invalid `mode` returns `invalid_mode`. Missing or unknown\n  namespace returns the underlying data-layer error envelope.\n",
+    "bytes": 2335,
+    "description": "Browse a ZIM archive's namespace \u2014 paginated lookup or full walk.\n\nEXTRACT whether the caller wants a paginated page or a full walk\nbefore calling. Most read-the-table-of-contents-style requests are\n`mode=\"page\"`; only full-enumeration tasks (e.g. \"list every article\nin namespace A\") need `mode=\"walk\"`.\n\nALIASES: callers may say \"browse <namespace>\", \"list <namespace>\",\n\"walk namespace <letter>\". Route through THIS tool with the matching\nmode.\n\nPARAMETERS:\n  zim_file_path     REQUIRED. The archive to browse.\n  namespace         REQUIRED. ZIM namespace letter (e.g. \"C\" for\n                    content, \"A\" for articles in legacy archives,\n                    \"I\" for images).\n  mode              \"page\" (default) \u2014 paginated browse via cursor.\n                    \"walk\" \u2014 full namespace enumeration via cursor\n                    state.\n  cursor            Phase B cursor pagination handle.\n  limit             Page size (default depends on mode).\n  offset            Page-mode pagination offset (ignored in walk).\n  include_assets    Default False; C-browse hides assets (css/js/fonts/\n                    images/media). True surfaces them \u2014 for discovering\n                    media paths to fetch via `zim_get(binary=True)`.\n\nRESPONSE:\n  BrowseNamespaceResponse (mode=\"page\") or WalkNamespaceResponse\n  (mode=\"walk\"). Both carry `results`, `next_cursor`, and pagination\n  metadata in `page_info`.\n\nERRORS:\n  Invalid `mode` returns `invalid_mode`. Missing or unknown\n  namespace returns the underlying data-layer error envelope.\n",
     "inputSchema": {
       "properties": {
+        "zim_file_path": {
+          "title": "Zim File Path",
+          "type": "string"
+        },
+        "namespace": {
+          "title": "Namespace",
+          "type": "string"
+        },
+        "mode": {
+          "default": "page",
+          "enum": [
+            "page",
+            "walk"
+          ],
+          "title": "Mode",
+          "type": "string"
+        },
         "cursor": {
           "anyOf": [
             {
@@ -28,27 +45,15 @@
           "default": null,
           "title": "Limit"
         },
-        "mode": {
-          "default": "page",
-          "enum": [
-            "page",
-            "walk"
-          ],
-          "title": "Mode",
-          "type": "string"
-        },
-        "namespace": {
-          "title": "Namespace",
-          "type": "string"
-        },
         "offset": {
           "default": 0,
           "title": "Offset",
           "type": "integer"
         },
-        "zim_file_path": {
-          "title": "Zim File Path",
-          "type": "string"
+        "include_assets": {
+          "default": false,
+          "title": "Include Assets",
+          "type": "boolean"
         }
       },
       "required": [
@@ -243,8 +248,8 @@
     }
   },
   "zim_links": {
-    "bytes": 2383,
-    "description": "Look up links from one article \u2014 outbound/inbound link buckets or\nrelated-article suggestions.\n\nEXTRACT the direction before calling. `direction=\"outbound\"` returns\nthe article's own outgoing links (internal / external / media\nbuckets). `direction=\"inbound\"` returns pages that link TO this\nentry. `direction=\"related\"` returns articles connected by\noutbound-link overlap \u2014 the canonical \"see also\" experience.\n\nALIASES: \"links in <article>\" / \"what does <article> link to\"\n(outbound); \"what links here\" / \"pages linking to <article>\"\n(inbound); \"related to <article>\" / \"articles like <article>\"\n(related). Route through THIS tool with the matching direction.\n\nDIRECTIONS:\n  `\"outbound\"` (default) \u2014 paginated.\n  `\"inbound\"`  \u2014 ranked by linker importance; paginated. Requires a\n                 built link-graph sidecar (`openzim-mcp build\n                 link-graph`); absent/stale \u2192 structured error.\n  `\"related\"`  \u2014 one ranked set (no pagination).\n\nPARAMETERS:\n  zim_file_path   REQUIRED. The archive containing the article.\n  entry_path      REQUIRED. The article whose links to inspect.\n  direction       See DIRECTIONS above.\n  cursor          Cursor handle (outbound/inbound).\n  limit           Page size.\n  offset          Pagination offset (outbound/inbound).\n\nRESPONSE:\n  LinksResponse (outbound) or RelatedArticlesResponse (inbound /\n  related). Outbound/inbound paginate; related is one ranked set.\n\nERRORS:\n  Invalid `direction` \u2192 `invalid_direction`. Missing/stale inbound\n  sidecar \u2192 `inbound_sidecar_unavailable`. Missing/unknown\n  `entry_path` \u2192 the underlying data-layer error envelope.\n",
+    "bytes": 2845,
+    "description": "Look up links from one article \u2014 outbound/inbound link buckets or\nrelated-article suggestions.\n\nEXTRACT the direction before calling. `direction=\"outbound\"` returns\nthe article's own outgoing links (internal / external / media\nbuckets). `direction=\"inbound\"` returns pages that link TO this\nentry. `direction=\"related\"` returns articles connected by\noutbound-link overlap \u2014 the canonical \"see also\" experience.\n\nALIASES: \"links in <article>\" / \"what does <article> link to\"\n(outbound); \"what links here\" / \"pages linking to <article>\"\n(inbound); \"related to <article>\" / \"articles like <article>\"\n(related). Route through THIS tool with the matching direction.\n\nDIRECTIONS:\n  `\"outbound\"` (default) \u2014 paginated.\n  `\"inbound\"`  \u2014 ranked by linker importance; paginated. Requires a\n                 built link-graph sidecar (`openzim-mcp build\n                 link-graph`); absent/stale \u2192 structured error.\n  `\"related\"`  \u2014 one ranked set (no pagination).\n\nPARAMETERS:\n  zim_file_path   REQUIRED. The archive containing the article.\n  entry_path      REQUIRED. The article whose links to inspect.\n  direction       See DIRECTIONS above.\n  kind            Outbound only \u2014 which bucket to return: \"internal\"\n                  (default) / \"external\" / \"media\". One per call;\n                  `category_totals` reports all three counts.\n  cursor          Cursor handle (outbound/inbound).\n  limit           Page size.\n  offset          Pagination offset (outbound/inbound).\n\nRESPONSE:\n  LinksResponse (outbound) or RelatedArticlesResponse (inbound /\n  related). Outbound/inbound paginate; related is one ranked set.\n  Outbound `category_totals.internal` excludes in-page `#anchor`\n  links \u2014 those are counted separately as `category_totals.anchor`.\n\nERRORS:\n  Invalid `direction` \u2192 `invalid_direction`. Missing/stale inbound\n  sidecar \u2192 `inbound_sidecar_unavailable`. Missing/unknown\n  `entry_path` \u2192 the underlying data-layer error envelope.\n",
     "inputSchema": {
       "properties": {
         "zim_file_path": {
@@ -263,6 +268,16 @@
             "related"
           ],
           "title": "Direction",
+          "type": "string"
+        },
+        "kind": {
+          "default": "internal",
+          "enum": [
+            "internal",
+            "external",
+            "media"
+          ],
+          "title": "Kind",
           "type": "string"
         },
         "cursor": {

--- a/tests/test_code_review_phase11.py
+++ b/tests/test_code_review_phase11.py
@@ -4,6 +4,7 @@ M11 (PathValidator security branches), M13 (server_state health/config report
 builders), L2 (async _data wrapper forwarding).
 """
 
+import os
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -111,14 +112,41 @@ def test_m13_health_report_degrades_and_redacts_on_missing_dir(tmp_path: Path):
     assert str(missing) not in blob
 
 
-def test_m13_build_configuration_report_redacts_paths(tmp_path: Path):
-    from openzim_mcp.server_state import _build_configuration_report
+def test_m13_configuration_report_stdio_shows_real_paths(tmp_path: Path):
+    """BUG #9: on the local stdio transport the diagnostics report real
+    paths/PID — consistent with ``loaded_archives[].path`` (which must stay
+    real, since clients pass it back as ``zim_file_path``)."""
+    from openzim_mcp.server_state import (
+        _build_configuration_report,
+        _build_uptime_info,
+    )
 
-    server = _make_server(tmp_path)
+    server = _make_server(tmp_path)  # default transport == stdio
     report = _build_configuration_report(server)
     assert isinstance(report, dict)
-    # Allowed directories are redacted (basename only) in the report.
+    cfg = report["configuration"]
+    assert cfg["allowed_directories"] == [str(tmp_path)]
+    assert cfg["server_pid"] == os.getpid()
+    assert "<redacted>" not in repr(report)
+    assert "[REDACTED]" not in repr(report)
+    assert _build_uptime_info(server)["process_id"] == os.getpid()
+
+
+def test_m13_configuration_report_http_redacts_paths(tmp_path: Path):
+    """BUG #9: over the network HTTP/SSE transports paths/PID stay masked."""
+    from openzim_mcp.server_state import (
+        _build_configuration_report,
+        _build_uptime_info,
+    )
+
+    server = _make_server(tmp_path)
+    server.config.transport = "http"  # network boundary -> redact
+    report = _build_configuration_report(server)
+    cfg = report["configuration"]
     assert str(tmp_path) not in repr(report)
+    assert cfg["server_pid"] == "[REDACTED]"
+    assert all("<redacted>" in d for d in cfg["allowed_directories"])
+    assert _build_uptime_info(server)["process_id"] == "[REDACTED]"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_extract_article_links_pagination.py
+++ b/tests/test_extract_article_links_pagination.py
@@ -80,6 +80,19 @@ def big_links_html() -> str:
     return "\n".join(parts)
 
 
+@pytest.fixture
+def anchored_links_html() -> str:
+    """HTML with 26 cross-article internal links + 26 in-page '#anchor'
+    fragment links (which BUG #6 must keep out of the internal count)."""
+    parts = ["<html><body>"]
+    for i in range(26):
+        parts.append(f'<a href="Page_{i}">internal {i}</a>')
+    for i in range(26):
+        parts.append(f'<a href="#sec_{i}">anchor {i}</a>')
+    parts.append("</body></html>")
+    return "\n".join(parts)
+
+
 class TestExtractArticleLinksPagination:
     """Pagination contract for extract_article_links."""
 
@@ -111,6 +124,57 @@ class TestExtractArticleLinksPagination:
         assert data["category_totals"]["internal"] == 50
         assert data["category_totals"]["external"] == 30
         assert data["category_totals"]["media"] == 20
+        # BUG #6: the anchor count is always present (0 here — this fixture
+        # has no in-page anchors).
+        assert data["category_totals"]["anchor"] == 0
+
+    def test_internal_count_excludes_anchors(
+        self, ops_with_synthetic_archive, temp_dir, anchored_links_html
+    ):
+        """BUG #6: in-page '#anchor' links are reported under a separate
+        'anchor' count and excluded from the internal cross-article bucket."""
+        zim = temp_dir / "test.zim"
+        zim.touch()
+        with patch("openzim_mcp.zim_operations.zim_archive") as mock_archive_ctx:
+            mock_archive_ctx.return_value.__enter__.return_value = (
+                _patch_archive_with_html(anchored_links_html)
+            )
+            data = ops_with_synthetic_archive.extract_article_links_data(
+                str(zim), "Test", kind="internal"
+            )
+        assert data["category_totals"]["internal"] == 26
+        assert data["category_totals"]["anchor"] == 26
+        assert data["total"] == 26
+        assert len(data["results"]) == 26
+        assert all(link.get("type") != "anchor" for link in data["results"])
+
+    def test_pagination_paginates_only_cross_article_internal(
+        self, ops_with_synthetic_archive, temp_dir, anchored_links_html
+    ):
+        """BUG #6: paging the internal bucket walks only the 26 cross-article
+        links — anchors never appear in any page."""
+        zim = temp_dir / "test.zim"
+        zim.touch()
+        seen = 0
+        with patch("openzim_mcp.zim_operations.zim_archive") as mock_archive_ctx:
+            mock_archive_ctx.return_value.__enter__.return_value = (
+                _patch_archive_with_html(anchored_links_html)
+            )
+            data = ops_with_synthetic_archive.extract_article_links_data(
+                str(zim), "Test", limit=10, kind="internal"
+            )
+            assert data["total"] == 26
+            while True:
+                assert all(link.get("type") != "anchor" for link in data["results"])
+                seen += len(data["results"])
+                if data["done"]:
+                    break
+                page_info = data["page_info"]
+                offset = page_info["offset"] + page_info["returned_count"]
+                data = ops_with_synthetic_archive.extract_article_links_data(
+                    str(zim), "Test", limit=10, offset=offset, kind="internal"
+                )
+        assert seen == 26
 
     def test_limit_truncates_with_next_cursor(
         self, ops_with_synthetic_archive, temp_dir, big_links_html

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -146,6 +146,30 @@ def test_footer_empty_results():
     assert "wikipedia_en_all" in footer
 
 
+def test_footer_no_content_type_match_renders_browse_hint():
+    """BUG #4: a content_type-filter miss must NOT reuse the namespace footer.
+
+    It points at browse/include_assets and the content-type filter, not at
+    ``list_namespaces``.
+    """
+    meta = {"tokens_est": 0, "chars": 0, "truncated": False}
+    meta["reason"] = "no_content_type_match"
+    footer = format_footer(meta, footer_enabled=True)
+    assert "content type" in footer
+    assert "browse_namespace" in footer
+    assert "Unknown namespace" not in footer
+    assert "list_namespaces" not in footer
+
+
+def test_footer_bad_namespace_unchanged():
+    """BUG #4 regression: a genuine bad namespace still gets the namespace
+    recovery footer."""
+    meta = {"tokens_est": 0, "chars": 0, "truncated": False, "reason": "bad_namespace"}
+    footer = format_footer(meta, footer_enabled=True)
+    assert "Unknown namespace" in footer
+    assert "list_namespaces" in footer
+
+
 def test_footer_disabled():
     meta = {"tokens_est": 100, "chars": 400, "truncated": False}
     assert format_footer(meta, footer_enabled=False) == ""

--- a/tests/test_namespace_realworld_fixes.py
+++ b/tests/test_namespace_realworld_fixes.py
@@ -43,10 +43,20 @@ def test_namespace_header_reconciliation_is_arithmetically_clear():
 from openzim_mcp.zim.namespace import _scan_fill_c_namespace  # noqa: E402
 
 
-def _asset(path: str) -> bool:
+def _asset(path: str, content_type: object = None) -> bool:
     return path.startswith(("_zim_static", "I/", "-/")) or path.endswith(
         (".js", ".png", ".css")
     )
+
+
+def _tuple_get(paths):
+    """Adapt a {id: path} map to the new ``(path, content_type)`` get_path
+    contract used by ``_scan_fill_c_namespace`` (mimetype unused here)."""
+
+    def _get(scan_id):
+        return paths.get(scan_id), None
+
+    return _get
 
 
 def test_browse_offset_advances_by_content_rows_not_entry_id():
@@ -60,7 +70,7 @@ def test_browse_offset_advances_by_content_rows_not_entry_id():
         4: "",
     }
     paths.update({i: f"a/{i}" for i in range(5, 15)})
-    get = paths.get
+    get = _tuple_get(paths)
 
     page0, next0, exhausted0, _ = _scan_fill_c_namespace(15, get, _asset, 2, 0)
     page1, _next1, _ex1, _ = _scan_fill_c_namespace(15, get, _asset, 2, 1)
@@ -78,14 +88,16 @@ def test_browse_offset_advances_by_content_rows_not_entry_id():
 
 def test_browse_skips_phantom_empty_path_entry():
     paths = {0: "", 1: "a/1", 2: "a/2"}
-    page, _next, _ex, _ = _scan_fill_c_namespace(3, paths.get, _asset, 10, 0)
+    page, _next, _ex, _ = _scan_fill_c_namespace(3, _tuple_get(paths), _asset, 10, 0)
     assert "" not in page
     assert page == ["a/1", "a/2"]
 
 
 def test_browse_scan_exhaustion_flagged():
     paths = {i: f"a/{i}" for i in range(5)}
-    page, _next, exhausted, _ = _scan_fill_c_namespace(5, paths.get, _asset, 2, 4)
+    page, _next, exhausted, _ = _scan_fill_c_namespace(
+        5, _tuple_get(paths), _asset, 2, 4
+    )
     assert page == ["a/4"]
     assert exhausted is True
 

--- a/tests/test_phase_f_schema_budget.py
+++ b/tests/test_phase_f_schema_budget.py
@@ -30,15 +30,20 @@ _ALLOWED_DIR = tempfile.mkdtemp(prefix="openzim_mcp_schema_budget_")
 # the spec targets; per-tool allocations match the measured rc1 footprint
 # with explicit headroom and the test enforces a *1.2 slack so a single
 # tool's drift trips before total drift does.
-TOTAL_CAP = 24_500
+#
+# v2.5.2: added the ``kind`` (zim_links) and ``include_assets`` (zim_browse)
+# params for the bucket-reachability and binary-discovery fixes. That nudges
+# the advanced surface just past 25KB, so the total cap and those two
+# allocations are raised to match the re-snapshotted footprint.
+TOTAL_CAP = 25_500
 ALLOCATION = {
     "zim_query": 6_500,
     "zim_search": 4_200,
     "zim_get": 4_250,
     "zim_get_section": 2_250,
-    "zim_browse": 2_100,
+    "zim_browse": 2_400,
     "zim_metadata": 1_250,
-    "zim_links": 2_450,
+    "zim_links": 2_900,
     "zim_health": 1_200,
 }
 

--- a/tests/test_search_reason_v2_5_2.py
+++ b/tests/test_search_reason_v2_5_2.py
@@ -1,0 +1,58 @@
+"""BUG #4: zim_search empty-result reason classification.
+
+A content_type filter that matches nothing must report
+``no_content_type_match`` (not ``bad_namespace``); an unknown namespace
+still reports ``bad_namespace``. Uses the generated v2 Phase A fixture
+(real Xapian index) so ``unfiltered_total > 0`` for a known term.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from openzim_mcp.cache import OpenZimMcpCache
+from openzim_mcp.config import (
+    CacheConfig,
+    ContentConfig,
+    LoggingConfig,
+    OpenZimMcpConfig,
+)
+from openzim_mcp.content_processor import ContentProcessor
+from openzim_mcp.security import PathValidator
+from openzim_mcp.zim_operations import ZimOperations
+
+
+def _ops(v2_phase_a_zim: Path) -> ZimOperations:
+    cfg = OpenZimMcpConfig(
+        allowed_directories=[str(v2_phase_a_zim.parent)],
+        cache=CacheConfig(enabled=False, max_size=10, ttl_seconds=60),
+        content=ContentConfig(max_content_length=10000, snippet_length=200),
+        logging=LoggingConfig(level="ERROR"),
+    )
+    return ZimOperations(
+        cfg,
+        PathValidator(cfg.allowed_directories),
+        OpenZimMcpCache(cfg.cache),
+        ContentProcessor(snippet_length=200),
+    )
+
+
+def test_content_type_filter_miss_reports_no_content_type_match(v2_phase_a_zim):
+    """A content_type that no fulltext-indexed entry matches reports
+    ``no_content_type_match`` even though NO namespace filter was supplied."""
+    ops = _ops(v2_phase_a_zim)
+    zim = str(v2_phase_a_zim)
+    data = ops.search_with_filters_data(
+        zim, "Einstein", content_type="image/jpeg", limit=5
+    )
+    assert data["total"] == 0
+    assert data["_meta"]["reason"] == "no_content_type_match"
+
+
+def test_unknown_namespace_still_reports_bad_namespace(v2_phase_a_zim):
+    """An invalid namespace letter still reports ``bad_namespace``."""
+    ops = _ops(v2_phase_a_zim)
+    zim = str(v2_phase_a_zim)
+    data = ops.search_with_filters_data(zim, "Einstein", namespace="Z", limit=5)
+    assert data["total"] == 0
+    assert data["_meta"]["reason"] == "bad_namespace"

--- a/tests/test_tools_common.py
+++ b/tests/test_tools_common.py
@@ -116,6 +116,30 @@ def test_tool_error_response_log_message_format(
     assert tool_records[0].getMessage() == "Error in zim_query: oops"
 
 
+def test_tool_error_response_redacts_path_in_context() -> None:
+    """BUG #7: the standalone ``context`` field must redact absolute paths the
+    same way ``message`` does — previously the raw path leaked on the envelope."""
+    server = _FakeServer(sentinel="MSG")
+    result = tool_error_response(
+        server,
+        operation="zim_metadata",
+        error=ValueError("boom"),
+        context="Path: /Users/cameron/Developer/zim/does-not-exist.zim",
+    )
+    assert "/Users/cameron" not in result["context"]
+    assert result["context"] == "Path: ...does-not-exist.zim"
+    # message side stays whatever the formatter returned (sentinel here).
+    assert result["message"] == "MSG"
+
+
+def test_tool_error_response_context_none_omits_field() -> None:
+    """Null-safe: context=None must still omit the ``context`` key entirely."""
+    result = tool_error_response(
+        _FakeServer(), operation="zim_query", error=RuntimeError("x"), context=None
+    )
+    assert "context" not in result
+
+
 # ---------------------------------------------------------------------------
 # load_description tests
 # ---------------------------------------------------------------------------

--- a/tests/test_zim_browse.py
+++ b/tests/test_zim_browse.py
@@ -61,7 +61,22 @@ async def test_page_mode_dispatches_to_browse_namespace(
     fn, _ = server._tools_store["zim_browse"]
     await fn(zim_file_path="/x.zim", namespace="C", limit=10)
     ops.browse_namespace_data.assert_awaited_once_with(
-        "/x.zim", namespace="C", limit=10, offset=0
+        "/x.zim", namespace="C", limit=10, offset=0, include_assets=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_page_mode_threads_include_assets(
+    server: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """BUG #8: include_assets=True is forwarded so asset entries can be
+    discovered (then fetched via zim_get(binary=True))."""
+    ops = _patch_async_ops(monkeypatch, browse_namespace_data={"results": []})
+    register_zim_browse(server)
+    fn, _ = server._tools_store["zim_browse"]
+    await fn(zim_file_path="/x.zim", namespace="C", limit=10, include_assets=True)
+    ops.browse_namespace_data.assert_awaited_once_with(
+        "/x.zim", namespace="C", limit=10, offset=0, include_assets=True
     )
 
 
@@ -73,7 +88,9 @@ async def test_walk_mode_dispatches_to_walk_namespace(
     register_zim_browse(server)
     fn, _ = server._tools_store["zim_browse"]
     await fn(zim_file_path="/x.zim", namespace="A", mode="walk")
-    ops.walk_namespace_data.assert_awaited_once_with("/x.zim", "A", limit=200)
+    ops.walk_namespace_data.assert_awaited_once_with(
+        "/x.zim", "A", limit=200, include_assets=False
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_zim_links.py
+++ b/tests/test_zim_links.py
@@ -65,8 +65,36 @@ async def test_outbound_dispatches_to_extract_article_links(
     fn, _ = server._tools_store["zim_links"]
     await fn(zim_file_path="/x.zim", entry_path="A/Cat", limit=20)
     ops.extract_article_links_data.assert_awaited_once_with(
-        "/x.zim", "A/Cat", limit=20, offset=0
+        "/x.zim", "A/Cat", limit=20, offset=0, kind="internal"
     )
+
+
+@pytest.mark.asyncio
+async def test_outbound_threads_kind_external(
+    server: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`kind='external'` is forwarded to the data layer so the external bucket
+    is actually retrievable (BUG #2)."""
+    ops = _patch_async_ops(monkeypatch, extract_article_links_data={"results": []})
+    register_zim_links(server)
+    fn, _ = server._tools_store["zim_links"]
+    await fn(zim_file_path="/x.zim", entry_path="A/Cat", kind="external", limit=20)
+    ops.extract_article_links_data.assert_awaited_once_with(
+        "/x.zim", "A/Cat", limit=20, offset=0, kind="external"
+    )
+
+
+@pytest.mark.asyncio
+async def test_outbound_invalid_kind_rejected(
+    server: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unknown `kind` is rejected without touching the data layer."""
+    ops = _patch_async_ops(monkeypatch, extract_article_links_data={"results": []})
+    register_zim_links(server)
+    fn, _ = server._tools_store["zim_links"]
+    result = await fn(zim_file_path="/x.zim", entry_path="A/Cat", kind="bogus")
+    assert result["operation"] == "invalid_kind"
+    ops.extract_article_links_data.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_zim_operations.py
+++ b/tests/test_zim_operations.py
@@ -1,5 +1,6 @@
 """Tests for ZIM operations module."""
 
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -211,6 +212,97 @@ class TestZimOperations:
         assert "Path: A/Test_Article" in result
         assert "Type: text/html" in result
         assert "Test content" in result
+
+    @staticmethod
+    def _mock_long_article(path: str, title: str) -> MagicMock:
+        """A mock libzim Archive whose single entry has a >20k-char body so a
+        ``max_content_length=500`` fetch truncates."""
+        mock_entry = MagicMock()
+        mock_entry.is_redirect = False
+        mock_entry.path = path
+        mock_entry.title = title
+        mock_item = MagicMock()
+        mock_item.mimetype = "text/html"
+        body = "<html><body><h1>Long</h1><p>" + ("word " * 5000) + "</p></body></html>"
+        mock_item.content = body.encode("utf-8")
+        mock_entry.get_item.return_value = mock_item
+        inst = MagicMock()
+        inst.get_entry_by_path.return_value = mock_entry
+        inst.has_entry_by_path.return_value = True
+        return inst
+
+    @patch("openzim_mcp.zim_operations.Archive")
+    def test_more_at_offset_matches_human_hint_when_truncated(
+        self, mock_archive, zim_operations: ZimOperations, temp_dir: Path
+    ):
+        """BUG #1: ``_meta.more_at_offset`` must equal
+        ``current_offset + max_content_length`` (the paginable slice length),
+        matching the in-body ``content_offset=N`` hint — not overshoot by the
+        appended truncation-note length, which silently dropped body text for
+        programmatic paginators."""
+        zim_file = temp_dir / "long.zim"
+        zim_file.write_text("x")
+        mock_archive.return_value = self._mock_long_article("A/Long", "Long")
+
+        result = zim_operations.get_zim_entry_data(
+            str(zim_file), "A/Long", max_content_length=500, content_offset=0
+        )
+
+        meta = result["_meta"]
+        assert meta["truncated"] is True
+        assert meta["more_at_offset"] == 500
+        m = re.search(r"content_offset\s*=\s*([\d,]+)", result["content"])
+        assert m is not None, "no content_offset hint in truncated body"
+        assert int(m.group(1).replace(",", "")) == meta["more_at_offset"]
+
+    @patch("openzim_mcp.zim_operations.Archive")
+    def test_more_at_offset_advances_on_second_page(
+        self, mock_archive, zim_operations: ZimOperations, temp_dir: Path
+    ):
+        """BUG #1: under a non-zero ``content_offset`` the next-page offset is
+        ``content_offset + max_content_length`` and still matches the hint."""
+        zim_file = temp_dir / "long.zim"
+        zim_file.write_text("x")
+        mock_archive.return_value = self._mock_long_article("A/Long", "Long")
+
+        result = zim_operations.get_zim_entry_data(
+            str(zim_file), "A/Long", max_content_length=500, content_offset=500
+        )
+
+        meta = result["_meta"]
+        assert meta["truncated"] is True
+        assert meta["more_at_offset"] == 1000
+        m = re.search(r"content_offset\s*=\s*([\d,]+)", result["content"])
+        assert m is not None
+        assert int(m.group(1).replace(",", "")) == 1000
+
+    @patch("openzim_mcp.zim_operations.Archive")
+    def test_no_more_at_offset_when_not_truncated(
+        self, mock_archive, zim_operations: ZimOperations, temp_dir: Path
+    ):
+        """BUG #1 regression guard: when the body fits, no continuation offset
+        is emitted."""
+        zim_file = temp_dir / "short.zim"
+        zim_file.write_text("x")
+        mock_entry = MagicMock()
+        mock_entry.is_redirect = False
+        mock_entry.path = "A/Short"
+        mock_entry.title = "Short"
+        mock_item = MagicMock()
+        mock_item.mimetype = "text/html"
+        mock_item.content = b"<html><body><h1>Short</h1><p>tiny body</p></body></html>"
+        mock_entry.get_item.return_value = mock_item
+        inst = MagicMock()
+        inst.get_entry_by_path.return_value = mock_entry
+        inst.has_entry_by_path.return_value = True
+        mock_archive.return_value = inst
+
+        result = zim_operations.get_zim_entry_data(
+            str(zim_file), "A/Short", max_content_length=100000, content_offset=0
+        )
+
+        assert result["_meta"]["truncated"] is False
+        assert "more_at_offset" not in result["_meta"]
 
     def test_search_zim_file_caching(
         self, zim_operations: ZimOperations, temp_dir: Path
@@ -1433,7 +1525,7 @@ class TestZimOperations:
         # Test browse_namespace_data cache hit. Same contract — cache
         # stores the post-attach payload. Key bumped v2b -> v2c when
         # new-scheme C browse began filtering _zim_static infra assets.
-        cache_key = f"browse_ns_data:v2d:{validated_path}:A:50:0"
+        cache_key = f"browse_ns_data:v2d:{validated_path}:A:50:0:assets=False"
         cached_browse = {"cached": "browse", "_meta": {"chars": 1}}
         zim_operations.cache.set(cache_key, cached_browse)
 

--- a/tests/test_zim_pagination_cursor.py
+++ b/tests/test_zim_pagination_cursor.py
@@ -72,7 +72,12 @@ async def test_page_mode_resumes_from_cursor(
         zim_file_path="/x.zim", namespace="C", mode="page", cursor=cursor, limit=50
     )
     ops.browse_namespace_data.assert_awaited_once_with(
-        "/x.zim", namespace="C", limit=50, offset=20, cursor_archive_identity="abc"
+        "/x.zim",
+        namespace="C",
+        limit=50,
+        offset=20,
+        cursor_archive_identity="abc",
+        include_assets=False,
     )
 
 
@@ -93,6 +98,7 @@ async def test_walk_mode_resumes_from_cursor(
         "A",
         cursor_state={"scan_at": 500, "l": 200, "ns": "A", "ai": "zz"},
         limit=200,
+        include_assets=False,
     )
 
 
@@ -161,8 +167,66 @@ async def test_outbound_resumes_from_cursor(
         limit=100,
     )
     ops.extract_article_links_data.assert_awaited_once_with(
-        "/x.zim", "A/Cat", limit=100, offset=30, cursor_archive_identity="qq"
+        "/x.zim",
+        "A/Cat",
+        limit=100,
+        offset=30,
+        kind="internal",
+        cursor_archive_identity="qq",
     )
+
+
+@pytest.mark.asyncio
+async def test_outbound_cursor_honors_kind(
+    server: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A cursor encoding the 'media' bucket resumes against that bucket even
+    when `kind` is left at its default (BUG #2: state['k'] is honoured)."""
+    ops = _patch_async_ops(monkeypatch, extract_article_links_data={"results": []})
+    register_zim_links(server)
+    fn, _ = server._tools_store["zim_links"]
+    cursor = Cursor.encode(
+        tool="extract_article_links",
+        state={"o": 30, "l": 100, "ep": "A/Cat", "k": "media", "ai": "qq"},
+    )
+    await fn(
+        zim_file_path="/x.zim",
+        entry_path="A/Cat",
+        direction="outbound",
+        cursor=cursor,
+        limit=100,
+    )
+    ops.extract_article_links_data.assert_awaited_once_with(
+        "/x.zim",
+        "A/Cat",
+        limit=100,
+        offset=30,
+        kind="media",
+        cursor_archive_identity="qq",
+    )
+
+
+@pytest.mark.asyncio
+async def test_outbound_cursor_kind_mismatch_rejected(
+    server: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An explicit non-default `kind` that contradicts the cursor's bucket is
+    rejected rather than silently resuming the wrong bucket."""
+    _patch_async_ops(monkeypatch, extract_article_links_data={"results": []})
+    register_zim_links(server)
+    fn, _ = server._tools_store["zim_links"]
+    cursor = Cursor.encode(
+        tool="extract_article_links",
+        state={"o": 5, "ep": "A/Cat", "k": "external"},
+    )
+    result = await fn(
+        zim_file_path="/x.zim",
+        entry_path="A/Cat",
+        direction="outbound",
+        kind="media",
+        cursor=cursor,
+    )
+    assert result["operation"] == "cursor_context_mismatch"
 
 
 @pytest.mark.asyncio

--- a/tests/test_zim_static_filter.py
+++ b/tests/test_zim_static_filter.py
@@ -51,22 +51,36 @@ def _ctx(value):
     return _C()
 
 
-def _mock_archive(entries: list[str] = _ENTRIES) -> MagicMock:
+def _mock_archive(
+    entries: list[str] = _ENTRIES, mimetypes: dict[int, str] | None = None
+) -> MagicMock:
     archive = MagicMock()
     archive.has_new_namespace_scheme = True
     archive.entry_count = len(entries)
+    mt = mimetypes or {}
 
     def _by_id(i: int) -> MagicMock:
         entry = MagicMock()
         entry.path = entries[i]
         entry.title = entries[i]
+        entry.is_redirect = False
+        item = MagicMock()
+        # Default text/html so the existing path/extension-driven asset tests
+        # are unaffected; per-row overrides drive the content-type-aware path.
+        item.mimetype = mt.get(i, "text/html")
+        entry.get_item.return_value = item
         return entry
 
     archive._get_entry_by_id.side_effect = _by_id
     return archive
 
 
-def _ops(tmp_path, monkeypatch, entries: list[str] = _ENTRIES) -> ZimOperations:
+def _ops(
+    tmp_path,
+    monkeypatch,
+    entries: list[str] = _ENTRIES,
+    mimetypes: dict[int, str] | None = None,
+) -> ZimOperations:
     config = OpenZimMcpConfig(
         allowed_directories=[str(tmp_path)],
         cache=CacheConfig(enabled=False, max_size=10, ttl_seconds=60),
@@ -77,7 +91,7 @@ def _ops(tmp_path, monkeypatch, entries: list[str] = _ENTRIES) -> ZimOperations:
         OpenZimMcpCache(config.cache),
         ContentProcessor(),
     )
-    archive = _mock_archive(entries)
+    archive = _mock_archive(entries, mimetypes)
     monkeypatch.setattr(
         "openzim_mcp.zim_operations.zim_archive", lambda *a, **kw: _ctx(archive)
     )
@@ -200,3 +214,76 @@ def test_browse_resume_cursor_no_drift(tmp_path, monkeypatch) -> None:
     # Continues exactly past the boundary — no duplicates, no skipped articles.
     assert paths2 == ["Cherry", "Date"]
     assert page2["done"] is True
+
+
+# --------------------------------------------------------------------------
+# BUG #5 — content-type-aware asset filtering
+# --------------------------------------------------------------------------
+
+
+def test_is_non_article_target_content_type_aware() -> None:
+    """The predicate flags asset mimetypes regardless of path extension, keeps
+    HTML, and stays backward-compatible when content_type is omitted."""
+    pred = ZimOperations._is_non_article_target
+    assert pred("fonts.googleapis.com/css2?family=Roboto", "text/css") is True
+    assert pred("x", "image/png") is True
+    assert pred("x", "font/woff2") is True
+    assert pred("lib?v=1", "application/javascript") is True
+    assert pred("article/?x=1", "text/html") is False
+    assert pred("page", "application/xhtml+xml") is False
+    # Back-compat: no mimetype -> extension-only behaviour unchanged.
+    assert pred("x.png") is True
+    assert pred("foo.html#sec") is False
+
+
+def test_browse_hides_query_string_css_assets(tmp_path, monkeypatch) -> None:
+    """BUG #5: rows whose libzim mimetype is an asset family (text/css, …) are
+    filtered even when the path lacks an asset extension — catching the
+    query-string / extensionless asset URLs the path heuristic missed."""
+    entries = [
+        "fonts.googleapis.com/css2?family=Roboto",
+        "magazine.example.org/?css=custom",
+        "Apple",
+        "About.html",
+    ]
+    mimetypes = {0: "text/css", 1: "text/css", 2: "text/html", 3: "text/html"}
+    ops = _ops(tmp_path, monkeypatch, entries=entries, mimetypes=mimetypes)
+    resp = ops.browse_namespace_data(str(tmp_path / "x.zim"), "C", limit=10)
+    paths = [r["path"] for r in resp["results"]]
+    assert paths == ["Apple", "About.html"]
+    assert resp["page_info"].get("assets_filtered") is True
+
+
+def test_walk_hides_query_string_css_assets(tmp_path, monkeypatch) -> None:
+    """BUG #5: walk applies the same content-type-aware asset filter."""
+    entries = [
+        "fonts.googleapis.com/css2?family=Roboto",
+        "Apple",
+        "lib/app?v=1",
+        "Banana",
+    ]
+    mimetypes = {
+        0: "text/css",
+        1: "text/html",
+        2: "application/javascript",
+        3: "text/html",
+    }
+    ops = _ops(tmp_path, monkeypatch, entries=entries, mimetypes=mimetypes)
+    resp = ops.walk_namespace_data(str(tmp_path / "x.zim"), "C", limit=10)
+    paths = [r["path"] for r in resp["results"]]
+    assert paths == ["Apple", "Banana"]
+
+
+def test_browse_include_assets_surfaces_assets(tmp_path, monkeypatch) -> None:
+    """BUG #8: include_assets=True surfaces asset rows so binary entries are
+    discoverable (then fetchable via zim_get(binary=True))."""
+    entries = ["_zim_static/wombat.js", "img/plato.jpg", "Apple"]
+    mimetypes = {0: "application/javascript", 1: "image/jpeg", 2: "text/html"}
+    ops = _ops(tmp_path, monkeypatch, entries=entries, mimetypes=mimetypes)
+    resp = ops.browse_namespace_data(
+        str(tmp_path / "x.zim"), "C", limit=10, include_assets=True
+    )
+    paths = [r["path"] for r in resp["results"]]
+    assert paths == ["_zim_static/wombat.js", "img/plato.jpg", "Apple"]
+    # Nothing was skipped, so the assets_filtered flag is absent.
+    assert resp["page_info"].get("assets_filtered") is None

--- a/website/src/content/docs/api-reference.mdx
+++ b/website/src/content/docs/api-reference.mdx
@@ -308,7 +308,7 @@ zim_health(zim_file_path: Optional[str] = None) -> Any
 }
 ```
 
-`process_id` / `server_pid` are **always** `"[REDACTED]"` — diagnostic output frequently lands in bug reports. Allowed directories are shown as `...basename` to avoid leaking the canonical layout.
+Over the **HTTP/SSE** transports `process_id` / `server_pid` are `"[REDACTED]"` and allowed directories are shown as `...basename` — diagnostic output frequently lands in bug reports. Over the local **stdio** transport these report the real PID and full paths, matching the unredacted `loaded_archives[].path` values that clients pass back to other tools.
 
 **Archive-validation response** (with `zim_file_path`, *added in v2.1*):
 
@@ -458,7 +458,7 @@ The error classes in [openzim_mcp/exceptions.py](https://github.com/cameronrye/o
 - `OpenZimMcpArchiveError`
 - `OpenZimMcpRateLimitError`
 
-Absolute filesystem paths in error messages are redacted to `...filename.zim` form. PIDs are redacted in diagnostics output. Error text in v2.0 is safe to copy into bug reports.
+Absolute filesystem paths in error messages are redacted to `...filename.zim` form on all transports. PIDs and paths in `zim_health` diagnostics are redacted over the HTTP/SSE transports and shown in full over local stdio. Error text is safe to copy into bug reports.
 
 ---
 

--- a/website/src/content/docs/llm-integration-patterns.mdx
+++ b/website/src/content/docs/llm-integration-patterns.mdx
@@ -467,7 +467,7 @@ if cache_hit_rate < 0.7:
     pass
 ```
 
-Note `health.cache_performance` (not `cache`); fields are `enabled, size, max_size, ttl_seconds, hits, misses, hit_rate`. `process_id` / `server_pid` are `[REDACTED]`.
+Note `health.cache_performance` (not `cache`); fields are `enabled, size, max_size, ttl_seconds, hits, misses, hit_rate`. `process_id` / `server_pid` are the real PID over local stdio (`[REDACTED]` over HTTP/SSE).
 
 ### Usage analytics
 

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -191,7 +191,7 @@ In simple mode, the server exposes one tool. Phrase the request in plain languag
 }
 ```
 
-**Expected response:** JSON with `status`, `cache_performance`, `health_checks`, and any warnings or recommendations. `process_id` is `[REDACTED]`.
+**Expected response:** JSON with `status`, `cache_performance`, `health_checks`, and any warnings or recommendations. `process_id` is the real PID over the local stdio transport (`[REDACTED]` over HTTP/SSE).
 
 ## Step 5: Try advanced mode (`zim_search` + friends)
 

--- a/website/src/content/docs/security-best-practices.mdx
+++ b/website/src/content/docs/security-best-practices.mdx
@@ -19,7 +19,7 @@ OpenZIM MCP serves offline knowledge archives to MCP clients. The relevant threa
 |--------|------------|
 | Path traversal — read files outside allowed dirs | `PathValidator` regex patterns + `Path.is_relative_to` containment + canonical resolution |
 | TOCTOU symlink swap between path validation and open | `validate_zim_file` re-resolves and re-checks containment after open |
-| Information disclosure via error messages | All paths and PIDs are redacted in error responses and in the `zim_health` health + configuration views |
+| Information disclosure via error messages | Paths/PIDs in error responses are redacted on all transports; `zim_health` diagnostics redact paths/PIDs over the HTTP/SSE transports and report them in full on the local stdio transport |
 | Unauthenticated network access | HTTP transport requires bearer token unless bound to loopback; SSE transport is loopback-only |
 | Cross-origin browser abuse | CORS allow-list; wildcard `*` rejected at startup; `OPTIONS` not exempt from auth |
 | Cache poisoning via transient libzim errors | Failed reads do not write to cache |
@@ -41,8 +41,7 @@ There are no env vars to relax this — path validation is unconditional. The se
 Every operator-visible string is run through `redact_paths_in_message` / `sanitize_path_for_error` before it leaves the server:
 
 - **MCP error responses** — rejected traversals previously leaked the canonical allowed-directory layout; now they appear as `...filename.zim`.
-- **`zim_health` health view** — `process_id` is always `[REDACTED]`. Warning strings about inaccessible directories use the redacted form.
-- **`zim_health` configuration view** — `server_pid` is always `[REDACTED]`. `allowed_directories` are reported as `[...basename]`.
+- **`zim_health` health/configuration views** — `process_id` / `server_pid` and `allowed_directories` are redacted (`[REDACTED]` / `[...basename]`) over the HTTP/SSE transports, where the client may be remote. Over the local **stdio** transport they report the real PID and full paths: the client already shares the filesystem, and `loaded_archives[].path` (a functional argument clients pass back to other tools) is unredacted there regardless — so masking only the directory list created an inconsistency without protecting anything. Warning strings about inaccessible directories always use the redacted form.
 
 The redaction regex (`_ABS_PATH_RE`) handles cross-platform separators (`/` and `\`), wrapped/quoted forms (`(/opt/foo)`, `"/opt/bar"`, `file=/opt/foo`), and URL-decoded forms (`%2Fopt%2Fzims`). Operators can still see unredacted paths in server logs — only the wire-visible diagnostics are redacted.
 


### PR DESCRIPTION
## Summary

Fixes the issues surfaced by an end-to-end real-world test pass against v2.5.1
(MedlinePlus + Internet Encyclopedia of Philosophy archives). Each fix was
root-caused, adversarially verified, and covered by a regression test.

These are conventional `fix:` commits, so release-please will cut a **v2.5.2**
patch.

## Fixes

| Sev | Tool | Fix |
|-----|------|-----|
| High | `zim_get` | `_meta.more_at_offset` overshot the next-page offset by the appended truncation-note length, silently dropping ~150 body chars/page for machine paginators. It now equals `content_offset + body_chars_returned`, matching the in-body `content_offset=N` hint. |
| Med | `zim_links` | Outbound `external`/`media` buckets were counted in `category_totals` but unreachable. Added a documented `kind` selector (`internal`/`external`/`media`) threaded through the tool/cursor; the cursor's encoded bucket is honored on resume. |
| Med | `zim_links` | Outbound `category_totals.internal` conflated cross-article links with in-page `#anchor` fragments. Anchors are now a separate `category_totals.anchor` count, excluded from the internal results/total (consistent with the inbound link-graph). |
| Low | `zim_browse` | `assets_filtered=true` while CSS/asset rows still leaked (extension-only filter missed `css2` / `?css=` URLs). The filter is now content-type aware. |
| Low | `zim_browse` | Binary assets were undiscoverable in-tool. Added an `include_assets` flag (page + walk) to surface asset entries for `zim_get(binary=True)`. |
| Low | `zim_search` | A `content_type`-filter miss reported the misleading `bad_namespace` reason + "try list_namespaces" footer. Now reports `no_content_type_match` with an accurate browse/drop-filter hint; an invalid namespace still reports `bad_namespace`. |
| Low | tools | The error-envelope `context` field leaked the full absolute path while `message` redacted it. `context` is now sanitized consistently. |
| Info | `zim_health` | Redaction was inconsistent (PID/allowed-dirs masked while `loaded_archives` paths were real). Now **transport-gated**: real PID/paths over local **stdio** (consistent with the always-real archive paths), redacted over **HTTP/SSE**. |

## Deferred

- **Title-mode typo recall on site-mirror archives** (mid-word edits like
  `Biothics`→`Bioethics`) — the investigated fix (per-variant
  `SuggestionSearcher` probe) could not reach the corrected variant within a
  workable latency budget (the correction is ~variant #98 in the edit set; the
  probe cap is consumed by earlier misses). It needs an edit-distance-aware
  redesign, not a patch-release change. Today it degrades gracefully to a
  zero-result lookup (no crash); fulltext + prefix-suggest paths are unaffected.

## Notes

- The two new params (`kind`, `include_assets`) grow the advanced-mode tool
  schema to ~25.3KB, just past the prior 24.5KB cap / 25KB soft target. The
  schema-budget cap + prototype-parity snapshot were updated accordingly (the
  documented intentional-surface-change path). Descriptions were trimmed to
  minimize the growth.

## Verification

- `3155 passed, 217 skipped` (full non-live suite); new regression tests for
  every fix.
- `black`, `isort`, `flake8`, `mypy` (strict), `bandit` (medium+) all clean via
  pre-commit.
