### PR TITLE
fix: invalidate caches when ZIM files change at runtime (#307)

### DIFF
--- a/openzim_mcp/bundle.py
+++ b/openzim_mcp/bundle.py
@@ -54,9 +54,12 @@ def archive_stat_token(validated_path: Any) -> str:
     the invalidation guarantee for that key.
 
     ``validated_path`` is typed loosely so callers don't have to import
-    ``pathlib.Path``; any path-like with ``.stat()`` works.
+    ``pathlib.Path``; a ``Path`` or a plain ``str`` path both work (a bare
+    ``str`` has no ``.stat()``, so it is coerced to ``Path`` first).
     """
     try:
+        if isinstance(validated_path, str):
+            validated_path = Path(validated_path)
         st = validated_path.stat()
         return f"{st.st_mtime_ns}:{st.st_size}"
     except OSError:

--- a/openzim_mcp/zim/archive.py
+++ b/openzim_mcp/zim/archive.py
@@ -358,43 +358,64 @@ class ZimOperations(
             )
         logger.info("ZimOperations initialized")
 
-    def _zim_dir_signature(self) -> str:
+    def _glob_zim_paths(self) -> List[Tuple[Path, List[Path]]]:
+        """Walk each allowed directory once for ``*.zim`` candidates.
+
+        Single source of the ``glob("**/*.zim")`` traversal shared by the
+        listing scan and its cache signature, so ``list_zim_files_data``
+        walks the tree at most once per call (previously the signature and
+        the scan each globbed independently — a redundant walk on every
+        cache miss). Returns ``(directory, [candidate_paths])`` pairs; the
+        raw candidates (before symlink/allowed-root filtering, which happens
+        in :meth:`_scan_zim_files`) also drive the signature, so adding,
+        removing, or renaming any ``.zim`` — even a to-be-rejected symlink —
+        changes the signature and rebuilds the listing.
+        """
+        grouped: List[Tuple[Path, List[Path]]] = []
+        for directory_str in self.config.allowed_directories:
+            directory = Path(directory_str)
+            # Resilience: a directory that can't be walked is skipped so the
+            # signature and the scan degrade together rather than raising.
+            try:
+                grouped.append((directory, list(directory.glob("**/*.zim"))))
+            except Exception as e:
+                logger.debug("ZIM glob failed for %s: %s", directory_str, e)
+        return grouped
+
+    def _zim_dir_signature(self, grouped: List[Tuple[Path, List[Path]]]) -> str:
         """Content-free fingerprint of which ``.zim`` files currently exist.
 
         Folded into the ``list_zim_files_data`` cache key so that adding,
         removing, or renaming a ``.zim`` file in an allowed directory at
         runtime invalidates the cached listing instead of serving the prior
         snapshot until the TTL expires or the server restarts (issue #307).
+        Built from the shared :meth:`_glob_zim_paths` walk, so it adds no
+        traversal of its own.
 
-        Mirrors the ``glob("**/*.zim")`` discovery in :meth:`_scan_zim_files`
-        but does not ``stat`` each file, so it stays cheaper than a full
-        rescan: an unchanged directory yields a stable signature and the
-        listing is still served from cache. An in-place same-name
-        replacement (identical path, new bytes) is intentionally not
-        reflected here — that archive's *content* caches invalidate via
-        their own ``archive_stat_token`` and the listing's stale size/mtime
-        is bounded by the cache TTL.
+        A path-set fingerprint (rather than a directory ``mtime``) is used
+        deliberately: it is robust to coarse-resolution filesystem
+        timestamps and detects nested-subdirectory changes, at the cost of
+        one ``readdir`` per call. An in-place same-name replacement
+        (identical path, new bytes) is intentionally not reflected here —
+        that archive's *content* caches invalidate via their own
+        ``archive_stat_token`` and the listing's stale size/mtime is bounded
+        by the cache TTL.
         """
-        paths: List[str] = []
-        for directory_str in self.config.allowed_directories:
-            # Match _scan_zim_files' resilience: a directory that can't be
-            # walked is skipped (and the scan that follows skips it too), so
-            # the signature degrades consistently with the listing rather
-            # than raising.
-            try:
-                paths.extend(str(p) for p in Path(directory_str).glob("**/*.zim"))
-            except Exception as e:
-                logger.debug(
-                    "Directory signature glob failed for %s: %s", directory_str, e
-                )
-        blob = "\n".join(sorted(paths)).encode("utf-8", "surrogatepass")
+        paths = sorted(str(p) for _dir, files in grouped for p in files)
+        blob = "\n".join(paths).encode("utf-8", "surrogatepass")
         # Not a security digest — just a stable fingerprint of the directory
         # contents for cache invalidation; usedforsecurity=False documents
         # that and silences the weak-hash warning (bandit B324).
         return hashlib.sha1(blob, usedforsecurity=False).hexdigest()[:16]
 
-    def _scan_zim_files(self) -> List[Dict[str, Any]]:  # NOSONAR(python:S3776)
-        """Scan all allowed directories for ZIM files (uncached)."""
+    def _scan_zim_files(  # NOSONAR(python:S3776)
+        self, grouped: List[Tuple[Path, List[Path]]]
+    ) -> List[Dict[str, Any]]:
+        """Build the structured listing from the shared glob walk (uncached).
+
+        Takes the ``(directory, candidate_paths)`` pairs from
+        :meth:`_glob_zim_paths` so the tree is not re-globbed here.
+        """
         logger.info(
             f"Searching for ZIM files in {len(self.config.allowed_directories)} "
             "directories:"
@@ -403,8 +424,7 @@ class ZimOperations(
             logger.info(f"  - {dir_path}")
 
         all_zim_files: List[Dict[str, Any]] = []
-        for directory_str in self.config.allowed_directories:
-            directory = Path(directory_str)
+        for directory, zim_files_in_dir in grouped:
             logger.debug(f"Scanning directory: {directory}")
             try:
                 # ``Path.glob`` follows symlinks by default, which would let a
@@ -415,7 +435,6 @@ class ZimOperations(
                 # in a watched directory is a misconfiguration, not a fatal
                 # error).
                 allowed_root = directory.resolve()
-                zim_files_in_dir = list(directory.glob("**/*.zim"))
                 logger.debug(f"Found {len(zim_files_in_dir)} ZIM files in {directory}")
 
                 for file_path in zim_files_in_dir:
@@ -484,14 +503,16 @@ class ZimOperations(
         # listing instead of serving the prior snapshot until the TTL
         # expires or the server restarts (issue #307). An unchanged
         # directory yields a stable signature, so repeat calls still hit
-        # the cache rather than rescanning.
-        cache_key = f"zim_files_list_data_v2b:{self._zim_dir_signature()}"
+        # the cache rather than rescanning. The tree is globbed once here
+        # and reused for both the signature and (on a miss) the scan.
+        grouped = self._glob_zim_paths()
+        cache_key = f"zim_files_list_data_v2b:{self._zim_dir_signature(grouped)}"
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug("Returning cached ZIM files list data")
             all_zim_files: List[Dict[str, Any]] = cached_result
         else:
-            all_zim_files = self._scan_zim_files()
+            all_zim_files = self._scan_zim_files(grouped)
             self.cache.set(cache_key, all_zim_files)
             logger.info(f"Listed {len(all_zim_files)} ZIM files")
 

--- a/openzim_mcp/zim/archive.py
+++ b/openzim_mcp/zim/archive.py
@@ -19,6 +19,7 @@ Layout:
   the class here.
 """
 
+import hashlib
 import logging
 import re
 from contextlib import contextmanager, suppress
@@ -357,6 +358,41 @@ class ZimOperations(
             )
         logger.info("ZimOperations initialized")
 
+    def _zim_dir_signature(self) -> str:
+        """Content-free fingerprint of which ``.zim`` files currently exist.
+
+        Folded into the ``list_zim_files_data`` cache key so that adding,
+        removing, or renaming a ``.zim`` file in an allowed directory at
+        runtime invalidates the cached listing instead of serving the prior
+        snapshot until the TTL expires or the server restarts (issue #307).
+
+        Mirrors the ``glob("**/*.zim")`` discovery in :meth:`_scan_zim_files`
+        but does not ``stat`` each file, so it stays cheaper than a full
+        rescan: an unchanged directory yields a stable signature and the
+        listing is still served from cache. An in-place same-name
+        replacement (identical path, new bytes) is intentionally not
+        reflected here — that archive's *content* caches invalidate via
+        their own ``archive_stat_token`` and the listing's stale size/mtime
+        is bounded by the cache TTL.
+        """
+        paths: List[str] = []
+        for directory_str in self.config.allowed_directories:
+            # Match _scan_zim_files' resilience: a directory that can't be
+            # walked is skipped (and the scan that follows skips it too), so
+            # the signature degrades consistently with the listing rather
+            # than raising.
+            try:
+                paths.extend(str(p) for p in Path(directory_str).glob("**/*.zim"))
+            except Exception as e:
+                logger.debug(
+                    "Directory signature glob failed for %s: %s", directory_str, e
+                )
+        blob = "\n".join(sorted(paths)).encode("utf-8", "surrogatepass")
+        # Not a security digest — just a stable fingerprint of the directory
+        # contents for cache invalidation; usedforsecurity=False documents
+        # that and silences the weak-hash warning (bandit B324).
+        return hashlib.sha1(blob, usedforsecurity=False).hexdigest()[:16]
+
     def _scan_zim_files(self) -> List[Dict[str, Any]]:  # NOSONAR(python:S3776)
         """Scan all allowed directories for ZIM files (uncached)."""
         logger.info(
@@ -442,7 +478,14 @@ class ZimOperations(
         # the per-file dict shape (name/path/directory/size/size_bytes/
         # modified) is unchanged; the v2b rename happens one layer up in
         # ``list_zim_files_summary_data`` (files→results, count→total).
-        cache_key = "zim_files_list_data_v2b"
+        #
+        # The directory signature is folded into the key so that adding,
+        # removing, or renaming a ``.zim`` file at runtime invalidates the
+        # listing instead of serving the prior snapshot until the TTL
+        # expires or the server restarts (issue #307). An unchanged
+        # directory yields a stable signature, so repeat calls still hit
+        # the cache rather than rescanning.
+        cache_key = f"zim_files_list_data_v2b:{self._zim_dir_signature()}"
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug("Returning cached ZIM files list data")
@@ -545,7 +588,16 @@ class ZimOperations(
         # don't collide on shared cache backends. Bumped to v2c when the
         # shape gained uuid / is_multipart / has_*_index / counter_breakdown
         # so pre-upgrade cached responses (old shape) don't leak through.
-        cache_key = f"metadata_data:v2c:{validated_path}"
+        #
+        # The stat token (mtime_ns:size) makes an in-place archive
+        # replacement at the same path a cache miss instead of stale
+        # metadata (archive_stat_token contract).
+        from openzim_mcp.bundle import archive_stat_token
+
+        cache_key = (
+            f"metadata_data:v2c:{validated_path}:"
+            f"{archive_stat_token(validated_path)}"
+        )
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug(f"Returning cached metadata dict for: {validated_path}")
@@ -957,8 +1009,14 @@ class ZimOperations(
         # Validate and resolve file path
         validated_path = self._validate_zim_path(zim_file_path)
 
-        # Check cache
-        cache_key = f"main_page:{validated_path}:compact={compact}"
+        # Check cache. The stat token (mtime_ns:size) invalidates the entry
+        # when the archive is replaced in place (archive_stat_token contract).
+        from openzim_mcp.bundle import archive_stat_token
+
+        cache_key = (
+            f"main_page:{validated_path}:"
+            f"{archive_stat_token(validated_path)}:compact={compact}"
+        )
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug(f"Returning cached main page for: {validated_path}")
@@ -1114,7 +1172,14 @@ class ZimOperations(
 
         # Cache key distinct from the legacy text cache so old persisted
         # entries (which hold strings) don't collide with the new dict shape.
-        cache_key = f"main_page_data:{validated_path}:compact={compact}"
+        # The stat token (mtime_ns:size) invalidates the entry when the
+        # archive is replaced in place (archive_stat_token contract).
+        from openzim_mcp.bundle import archive_stat_token
+
+        cache_key = (
+            f"main_page_data:{validated_path}:"
+            f"{archive_stat_token(validated_path)}:compact={compact}"
+        )
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug(f"Returning cached main page dict for: {validated_path}")

--- a/openzim_mcp/zim/content.py
+++ b/openzim_mcp/zim/content.py
@@ -402,10 +402,14 @@ class _ContentMixin:
         validated_path = self._validate_zim_path(zim_file_path)
 
         # Cheap response cache check: a hit avoids opening the archive
-        # entirely, which is the whole point of caching here.
+        # entirely, which is the whole point of caching here. The stat token
+        # (mtime_ns:size) invalidates the entry when the archive is replaced
+        # in place (archive_stat_token contract).
+        from openzim_mcp.bundle import archive_stat_token
+
         cache_key = (
-            f"entry:{validated_path}:{entry_path}:"
-            f"{max_content_length}:{content_offset}:compact={compact}"
+            f"entry:{validated_path}:{archive_stat_token(validated_path)}:"
+            f"{entry_path}:{max_content_length}:{content_offset}:compact={compact}"
         )
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
@@ -457,10 +461,14 @@ class _ContentMixin:
         # already-cached entries without re-rendering. ``get_zim_entry``
         # checks before opening the archive; this check covers the case
         # where the archive is already open (batch call) and a different
-        # entry within the same ZIM file was previously cached.
+        # entry within the same ZIM file was previously cached. Key must
+        # match get_zim_entry's exactly (same stat token) so the two checks
+        # share one cache entry (archive_stat_token contract).
+        from openzim_mcp.bundle import archive_stat_token
+
         cache_key = (
-            f"entry:{validated_path}:{entry_path}:"
-            f"{max_content_length}:{content_offset}:compact={compact}"
+            f"entry:{validated_path}:{archive_stat_token(validated_path)}:"
+            f"{entry_path}:{max_content_length}:{content_offset}:compact={compact}"
         )
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
@@ -524,9 +532,13 @@ class _ContentMixin:
 
         # Cache key distinct from the legacy string cache so old persisted
         # entries (text payloads) don't collide with the new dict shape.
+        # The stat token (mtime_ns:size) invalidates the entry when the
+        # archive is replaced in place (archive_stat_token contract).
+        from openzim_mcp.bundle import archive_stat_token
+
         cache_key = (
-            f"entry_data:{validated_path}:{entry_path}:"
-            f"{max_content_length}:{content_offset}:compact={compact}"
+            f"entry_data:{validated_path}:{archive_stat_token(validated_path)}:"
+            f"{entry_path}:{max_content_length}:{content_offset}:compact={compact}"
         )
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -198,7 +198,15 @@ class _NamespaceMixin:
 
         # Cache key bumped to v2b (Phase B) so v1.x cached responses (old
         # shape: entry_count key) don't leak through after the rename to ``total``.
-        cache_key = f"namespaces_data:v2b:{validated_path}"
+        # The stat token (mtime_ns:size) invalidates the listing when the
+        # archive is replaced in place (archive_stat_token contract, which
+        # names namespace listings explicitly).
+        from openzim_mcp.bundle import archive_stat_token
+
+        cache_key = (
+            f"namespaces_data:v2b:{validated_path}:"
+            f"{archive_stat_token(validated_path)}"
+        )
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug(f"Returning cached namespaces dict for: {validated_path}")
@@ -736,8 +744,13 @@ class _NamespaceMixin:
         # cursor ``s.o`` is therefore a row offset again; ``total`` stays the
         # authoritative ``entry_count``. The bump stops pre-fix cached pages —
         # with the old entry-id-offset cursor — from leaking through.
+        # The stat token (mtime_ns:size) invalidates the page when the
+        # archive is replaced in place (archive_stat_token contract).
+        from openzim_mcp.bundle import archive_stat_token
+
         cache_key = (
-            f"browse_ns_data:v2d:{validated_path}:{namespace}:"
+            f"browse_ns_data:v2d:{validated_path}:"
+            f"{archive_stat_token(validated_path)}:{namespace}:"
             f"{limit}:{offset}:assets={include_assets}"
         )
         cached_result = self.cache.get(cache_key)

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -470,8 +470,15 @@ class _SearchMixin:
             )
 
         # Cache key bumped to v2b (Phase B) so v1.x cached responses (old shape)
-        # don't leak through after the upgrade.
-        cache_key = f"search_v2b:{validated_path}:{query}:{limit}:{offset}"
+        # don't leak through after the upgrade. The stat token (mtime_ns:size)
+        # invalidates results when the archive is replaced in place
+        # (archive_stat_token contract).
+        from openzim_mcp.bundle import archive_stat_token
+
+        cache_key = (
+            f"search_v2b:{validated_path}:"
+            f"{archive_stat_token(validated_path)}:{query}:{limit}:{offset}"
+        )
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug(f"Returning cached search dict for query: {query}")
@@ -1219,8 +1226,13 @@ class _SearchMixin:
         # with the same matched query but different display forms must
         # render different text; a stale cache would echo the wrong
         # casing back to the second caller.
+        # The stat token (mtime_ns:size) invalidates results when the archive
+        # is replaced in place (archive_stat_token contract).
+        from openzim_mcp.bundle import archive_stat_token
+
         cache_key = (
-            f"search_filtered:{validated_path}:{query}:{namespace}:"
+            f"search_filtered:{validated_path}:"
+            f"{archive_stat_token(validated_path)}:{query}:{namespace}:"
             f"{content_type}:{limit}:{offset}:dq={display_query or ''}"
         )
         cached_result = self.cache.get(cache_key)
@@ -1353,8 +1365,13 @@ class _SearchMixin:
         # Cache key bumped to v2b (Phase B) so v1.x cached responses (markdown
         # strings under the legacy ``search_filtered:`` prefix) don't leak
         # through after the upgrade — different prefix, different cache slot.
+        # The stat token (mtime_ns:size) invalidates results when the archive
+        # is replaced in place (archive_stat_token contract).
+        from openzim_mcp.bundle import archive_stat_token
+
         cache_key = (
-            f"search_filtered_v2b:{validated_path}:{query}:{namespace}:"
+            f"search_filtered_v2b:{validated_path}:"
+            f"{archive_stat_token(validated_path)}:{query}:{namespace}:"
             f"{content_type}:{limit}:{offset}"
         )
         cached_result = self.cache.get(cache_key)
@@ -1930,7 +1947,14 @@ class _SearchMixin:
 
         # Cache key bumped to v2b (Phase B) so v1.x cached responses (old
         # shape: suggestions/count keys) don't leak through after the upgrade.
-        cache_key = f"suggestions_data:v2b:{validated_path}:{partial_query}:{limit}"
+        # The stat token (mtime_ns:size) invalidates suggestions when the
+        # archive is replaced in place (archive_stat_token contract).
+        from openzim_mcp.bundle import archive_stat_token
+
+        cache_key = (
+            f"suggestions_data:v2b:{validated_path}:"
+            f"{archive_stat_token(validated_path)}:{partial_query}:{limit}"
+        )
         cached_result = self.cache.get(cache_key)
         if cached_result is not None:
             logger.debug(f"Returning cached suggestions dict for: {partial_query}")

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -158,7 +158,10 @@ def test_filtered_search_does_not_cache_zero_result_response(
 
     validated_path = zim_operations.path_validator.validate_path(str(zim_file))
     validated_path = zim_operations.path_validator.validate_zim_file(validated_path)
-    cache_key = f"search_filtered:{validated_path}:warmup:C:None:10:0"
+    from openzim_mcp.bundle import archive_stat_token
+
+    tok = archive_stat_token(validated_path)
+    cache_key = f"search_filtered:{validated_path}:{tok}:warmup:C:None:10:0"
     assert (
         zim_operations.cache.get(cache_key) is None
     ), "filtered zero-result response should not be cached"
@@ -189,6 +192,9 @@ def test_get_search_suggestions_does_not_cache_on_error(
 
     validated_path = zim_operations.path_validator.validate_path(str(zim_file))
     validated_path = zim_operations.path_validator.validate_zim_file(validated_path)
+    from openzim_mcp.bundle import archive_stat_token
+
+    tok = archive_stat_token(validated_path)
     # The legacy ``suggestions:`` key was retired in favour of the
     # dict-shaped ``suggestions_data:v2b:`` cache. Neither key should hold a
     # sentinel response when generation raised.
@@ -196,7 +202,9 @@ def test_get_search_suggestions_does_not_cache_on_error(
         zim_operations.cache.get(f"suggestions:{validated_path}:warmup:10") is None
     ), "legacy suggestion cache key should not hold an errored response"
     assert (
-        zim_operations.cache.get(f"suggestions_data:v2b:{validated_path}:warmup:10")
+        zim_operations.cache.get(
+            f"suggestions_data:v2b:{validated_path}:{tok}:warmup:10"
+        )
         is None
     ), "errored suggestion response should not be cached"
 

--- a/tests/test_cache_invalidation_on_file_changes.py
+++ b/tests/test_cache_invalidation_on_file_changes.py
@@ -1,0 +1,232 @@
+"""Cache must reflect runtime ZIM file changes (issue #307).
+
+Two distinct staleness classes are covered here:
+
+1. **Directory listing** — ``list_zim_files_data`` caches the result of
+   scanning the allowed directories. When a ``.zim`` file is added or removed
+   at runtime (the common Kubernetes / shared-volume case from issue #307),
+   the cached listing must reflect the change rather than serving the prior
+   snapshot until the TTL expires or the server restarts.
+
+2. **Per-file content caches** — anything derived from a single archive's
+   contents (metadata, namespace listings, main page, search, suggestions)
+   must invalidate when that archive is replaced in place at the same path
+   (an atomic same-name swap, e.g. a stable ``wikipedia.zim`` symlink that is
+   re-pointed). The codebase's :func:`openzim_mcp.bundle.archive_stat_token`
+   contract requires these keys to embed an ``<mtime_ns>:<size>`` token; this
+   module pins that requirement for the caches that previously omitted it.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from openzim_mcp.bundle import archive_stat_token as _stat
+from openzim_mcp.cache import OpenZimMcpCache
+from openzim_mcp.config import OpenZimMcpConfig
+from openzim_mcp.content_processor import ContentProcessor
+from openzim_mcp.security import PathValidator
+from openzim_mcp.zim_operations import ZimOperations
+
+
+@pytest.fixture
+def zim_operations(
+    test_config: OpenZimMcpConfig,
+    path_validator: PathValidator,
+    openzim_mcp_cache: OpenZimMcpCache,
+    content_processor: ContentProcessor,
+) -> ZimOperations:
+    """A ZimOperations wired to the shared in-memory cache fixture."""
+    return ZimOperations(
+        test_config, path_validator, openzim_mcp_cache, content_processor
+    )
+
+
+class TestDirectoryListingFreshness:
+    """``list_zim_files_data`` must track add/remove without a restart."""
+
+    def test_added_file_is_visible_without_restart(
+        self, zim_operations: ZimOperations, temp_dir: Path
+    ):
+        """A ``.zim`` added after the first scan must appear on the next call."""
+        (temp_dir / "alpha.zim").write_text("alpha")
+
+        first = zim_operations.list_zim_files_data()
+        assert {f["name"] for f in first} == {"alpha.zim"}
+
+        # New archive dropped into the allowed dir while the server runs.
+        (temp_dir / "beta.zim").write_text("beta")
+
+        second = zim_operations.list_zim_files_data()
+        assert {f["name"] for f in second} == {"alpha.zim", "beta.zim"}, (
+            "Newly added .zim must be listed without waiting for the cache "
+            "TTL or a server restart (issue #307)."
+        )
+
+    def test_removed_file_disappears_without_restart(
+        self, zim_operations: ZimOperations, temp_dir: Path
+    ):
+        """A ``.zim`` removed after the first scan must drop off the next call."""
+        (temp_dir / "alpha.zim").write_text("alpha")
+        (temp_dir / "beta.zim").write_text("beta")
+
+        first = zim_operations.list_zim_files_data()
+        assert {f["name"] for f in first} == {"alpha.zim", "beta.zim"}
+
+        (temp_dir / "beta.zim").unlink()
+
+        second = zim_operations.list_zim_files_data()
+        assert {f["name"] for f in second} == {"alpha.zim"}, (
+            "Removed .zim must disappear from the listing without waiting for "
+            "the cache TTL or a server restart (issue #307)."
+        )
+
+    def test_unchanged_directory_still_serves_from_cache(
+        self, zim_operations: ZimOperations, temp_dir: Path
+    ):
+        """When nothing changes, the listing must still be cache-served.
+
+        The fix must not turn every call into a full rescan: a repeat call
+        against an unchanged directory should hit the cache (one stored entry,
+        a recorded hit).
+        """
+        (temp_dir / "alpha.zim").write_text("alpha")
+
+        zim_operations.list_zim_files_data()
+        hits_before = zim_operations.cache.stats()["hits"]
+        zim_operations.list_zim_files_data()
+        hits_after = zim_operations.cache.stats()["hits"]
+
+        assert (
+            hits_after > hits_before
+        ), "An unchanged directory must be served from cache, not rescanned."
+
+
+# Per-cache contract: each content-derived cache key must embed the
+# ``archive_stat_token`` so an in-place same-path archive replacement (a
+# monthly refresh behind a stable filename) is seen as a miss rather than
+# served stale. Each case names the buggy *path-only* key the cache used
+# before the fix and the *token-bearing* key it must use after. Poisoning
+# both and asserting the method returns the token-keyed value pins the
+# contract without opening a real archive (the cache hit short-circuits
+# before libzim is ever touched).
+#
+# Each entry: (id, call(zim_operations, path), old_key(vp), new_key(vp, token)).
+_CONTENT_CACHE_CASES = [
+    (
+        "metadata_data",
+        lambda zo, p: zo.get_zim_metadata_data(p),
+        lambda vp: f"metadata_data:v2c:{vp}",
+        lambda vp, tok: f"metadata_data:v2c:{vp}:{tok}",
+    ),
+    (
+        "namespaces_data",
+        lambda zo, p: zo.list_namespaces_data(p),
+        lambda vp: f"namespaces_data:v2b:{vp}",
+        lambda vp, tok: f"namespaces_data:v2b:{vp}:{tok}",
+    ),
+    (
+        "main_page",
+        lambda zo, p: zo.get_main_page(p, compact=False),
+        lambda vp: f"main_page:{vp}:compact=False",
+        lambda vp, tok: f"main_page:{vp}:{tok}:compact=False",
+    ),
+    (
+        "main_page_data",
+        lambda zo, p: zo.get_main_page_data(p, compact=False),
+        lambda vp: f"main_page_data:{vp}:compact=False",
+        lambda vp, tok: f"main_page_data:{vp}:{tok}:compact=False",
+    ),
+    (
+        "browse_ns_data",
+        lambda zo, p: zo.browse_namespace_data(p, "A", 50, 0),
+        lambda vp: f"browse_ns_data:v2d:{vp}:A:50:0:assets=False",
+        lambda vp, tok: f"browse_ns_data:v2d:{vp}:{tok}:A:50:0:assets=False",
+    ),
+    (
+        # An explicit limit is passed so the key is not affected by the
+        # ``limit is None -> default_search_limit`` resolution these methods do.
+        "search_v2b",
+        lambda zo, p: zo.search_zim_file_data(p, "test", 5, 0),
+        lambda vp: f"search_v2b:{vp}:test:5:0",
+        lambda vp, tok: f"search_v2b:{vp}:{tok}:test:5:0",
+    ),
+    (
+        "search_filtered",
+        lambda zo, p: zo.search_with_filters(p, "test", limit=5),
+        lambda vp: f"search_filtered:{vp}:test:None:None:5:0:dq=",
+        lambda vp, tok: f"search_filtered:{vp}:{tok}:test:None:None:5:0:dq=",
+    ),
+    (
+        "search_filtered_v2b",
+        lambda zo, p: zo.search_with_filters_data(p, "test", limit=5),
+        lambda vp: f"search_filtered_v2b:{vp}:test:None:None:5:0",
+        lambda vp, tok: f"search_filtered_v2b:{vp}:{tok}:test:None:None:5:0",
+    ),
+    (
+        "suggestions_data",
+        lambda zo, p: zo.get_search_suggestions_data(p, "te", 10),
+        lambda vp: f"suggestions_data:v2b:{vp}:te:10",
+        lambda vp, tok: f"suggestions_data:v2b:{vp}:{tok}:te:10",
+    ),
+    (
+        # Entry content/response caches: an explicit max_content_length keeps
+        # the key clear of the ``None -> default`` resolution.
+        "entry",
+        lambda zo, p: zo.get_zim_entry(p, "A/Test", 1000, 0),
+        lambda vp: f"entry:{vp}:A/Test:1000:0:compact=False",
+        lambda vp, tok: f"entry:{vp}:{tok}:A/Test:1000:0:compact=False",
+    ),
+    (
+        "entry_data",
+        lambda zo, p: zo.get_zim_entry_data(p, "A/Test", 1000, 0),
+        lambda vp: f"entry_data:{vp}:A/Test:1000:0:compact=False",
+        lambda vp, tok: f"entry_data:{vp}:{tok}:A/Test:1000:0:compact=False",
+    ),
+]
+
+
+class TestContentCacheReplacementInvalidation:
+    """Content-derived caches must key by ``archive_stat_token`` (in-place swap)."""
+
+    @pytest.mark.parametrize(
+        "case_id, call, old_key, new_key",
+        _CONTENT_CACHE_CASES,
+        ids=[c[0] for c in _CONTENT_CACHE_CASES],
+    )
+    def test_reads_stat_token_keyed_entry_not_path_only(
+        self,
+        zim_operations: ZimOperations,
+        temp_dir: Path,
+        case_id: str,
+        call,
+        old_key,
+        new_key,
+    ):
+        """The method must serve the token-keyed value, ignoring the path-only one.
+
+        A path-only key survives an in-place archive replacement and serves
+        stale data forever (until TTL/restart); embedding the stat token makes
+        the replaced archive a cache miss. See
+        :func:`openzim_mcp.bundle.archive_stat_token`.
+        """
+        zim_file = temp_dir / "archive.zim"
+        zim_file.write_bytes(b"v1 content")
+        validated = zim_operations._validate_zim_path(str(zim_file))
+        token = _stat(validated)
+
+        stale = f"STALE::{case_id}"
+        fresh = f"FRESH::{case_id}"
+        # The pre-fix code reads the path-only key; the fixed code must read
+        # the token-bearing key. Both are populated so neither path opens a
+        # real archive — the assertion is purely about *which key* is read.
+        zim_operations.cache.set(old_key(validated), stale)
+        zim_operations.cache.set(new_key(validated, token), fresh)
+
+        result = call(zim_operations, str(zim_file))
+
+        assert result == fresh, (
+            f"{case_id}: cache key must embed archive_stat_token so an "
+            f"in-place archive replacement invalidates it; got the path-only "
+            f"(stale-prone) entry instead."
+        )

--- a/tests/test_cache_invalidation_on_file_changes.py
+++ b/tests/test_cache_invalidation_on_file_changes.py
@@ -194,7 +194,7 @@ class TestContentCacheReplacementInvalidation:
         _CONTENT_CACHE_CASES,
         ids=[c[0] for c in _CONTENT_CACHE_CASES],
     )
-    def test_reads_stat_token_keyed_entry_not_path_only(
+    def test_stat_token_key_invalidates_on_in_place_replacement(
         self,
         zim_operations: ZimOperations,
         temp_dir: Path,
@@ -203,30 +203,52 @@ class TestContentCacheReplacementInvalidation:
         old_key,
         new_key,
     ):
-        """The method must serve the token-keyed value, ignoring the path-only one.
+        """End-to-end: a real same-path replacement must serve fresh data.
 
-        A path-only key survives an in-place archive replacement and serves
-        stale data forever (until TTL/restart); embedding the stat token makes
-        the replaced archive a cache miss. See
-        :func:`openzim_mcp.bundle.archive_stat_token`.
+        Two phases, both hermetic (cache hits short-circuit before any real
+        archive is opened):
+
+        1. **Reads the token key** — with both the path-only key and the
+           token-bearing key populated, the method must return the
+           token-keyed value. A path-only key would survive a replacement and
+           serve stale data forever (until TTL/restart).
+        2. **Invalidates on a real change** — after actually rewriting the
+           file at the same path (new size/mtime → new stat token → new key),
+           the method must route to the *new* token's entry, not the now-stale
+           v1 one. This exercises the real invalidation, not just the key
+           shape. See :func:`openzim_mcp.bundle.archive_stat_token`.
         """
         zim_file = temp_dir / "archive.zim"
         zim_file.write_bytes(b"v1 content")
         validated = zim_operations._validate_zim_path(str(zim_file))
         token = _stat(validated)
 
+        # Phase 1: with both keys populated, the method must read the
+        # token-bearing key (never opening a real archive).
         stale = f"STALE::{case_id}"
         fresh = f"FRESH::{case_id}"
-        # The pre-fix code reads the path-only key; the fixed code must read
-        # the token-bearing key. Both are populated so neither path opens a
-        # real archive — the assertion is purely about *which key* is read.
         zim_operations.cache.set(old_key(validated), stale)
         zim_operations.cache.set(new_key(validated, token), fresh)
 
         result = call(zim_operations, str(zim_file))
-
         assert result == fresh, (
             f"{case_id}: cache key must embed archive_stat_token so an "
             f"in-place archive replacement invalidates it; got the path-only "
             f"(stale-prone) entry instead."
+        )
+
+        # Phase 2: replace the archive in place. Growing the file guarantees
+        # the stat token changes regardless of mtime resolution, so the v1
+        # entry ('fresh') is now stale and the method must serve the entry
+        # keyed by the *new* token.
+        zim_file.write_bytes(b"v2 content, deliberately longer than v1")
+        token2 = _stat(validated)
+        assert token2 != token, "premise: a same-path rewrite must change the token"
+        fresh2 = f"FRESH2::{case_id}"
+        zim_operations.cache.set(new_key(validated, token2), fresh2)
+
+        result2 = call(zim_operations, str(zim_file))
+        assert result2 == fresh2, (
+            f"{case_id}: an in-place archive replacement must invalidate the "
+            f"cached entry (route to the new stat-token key), not serve v1."
         )

--- a/tests/test_metadata_tools.py
+++ b/tests/test_metadata_tools.py
@@ -232,8 +232,11 @@ class TestGetZimMetadataDataMeta:
         validated = zim_ops.path_validator.validate_path(str(zim_file))
         validated = zim_ops.path_validator.validate_zim_file(validated)
         # Key bumped to v2c when the metadata shape gained identity/index/
-        # counter fields (see get_zim_metadata_data).
-        cache_key = f"metadata_data:v2c:{validated}"
+        # counter fields (see get_zim_metadata_data); the stat token makes an
+        # in-place archive replacement a cache miss (archive_stat_token).
+        from openzim_mcp.bundle import archive_stat_token
+
+        cache_key = f"metadata_data:v2c:{validated}:{archive_stat_token(validated)}"
         seeded = {
             "title": "Test",
             "language": "eng",

--- a/tests/test_zim_operations.py
+++ b/tests/test_zim_operations.py
@@ -1502,9 +1502,14 @@ class TestZimOperations:
         # Get the validated path that would be used in cache keys
         validated_path = zim_operations.path_validator.validate_path(str(zim_file))
         validated_path = zim_operations.path_validator.validate_zim_file(validated_path)
+        # Content-derived caches embed the stat token so an in-place archive
+        # replacement is a miss rather than stale data (archive_stat_token).
+        from openzim_mcp.bundle import archive_stat_token
+
+        stat_token = archive_stat_token(validated_path)
 
         # Test get_zim_entry cache hit (lines 283-284)
-        cache_key = f"entry:{validated_path}:A/Test:1000:0:compact=False"
+        cache_key = f"entry:{validated_path}:{stat_token}:A/Test:1000:0:compact=False"
         zim_operations.cache.set(cache_key, "cached entry content")
 
         result = zim_operations.get_zim_entry(str(zim_file), "A/Test", 1000)
@@ -1514,7 +1519,7 @@ class TestZimOperations:
         # Phase B #12 fix: the cache now stores POST-ATTACH payloads
         # (with ``_meta`` already attached), and cache hits return them
         # verbatim. Seed accordingly.
-        cache_key = f"namespaces_data:v2b:{validated_path}"
+        cache_key = f"namespaces_data:v2b:{validated_path}:{stat_token}"
         cached_ns = {"cached": "namespaces", "_meta": {"chars": 1}}
         zim_operations.cache.set(cache_key, cached_ns)
 
@@ -1525,7 +1530,9 @@ class TestZimOperations:
         # Test browse_namespace_data cache hit. Same contract — cache
         # stores the post-attach payload. Key bumped v2b -> v2c when
         # new-scheme C browse began filtering _zim_static infra assets.
-        cache_key = f"browse_ns_data:v2d:{validated_path}:A:50:0:assets=False"
+        cache_key = (
+            f"browse_ns_data:v2d:{validated_path}:{stat_token}:A:50:0:assets=False"
+        )
         cached_browse = {"cached": "browse", "_meta": {"chars": 1}}
         zim_operations.cache.set(cache_key, cached_browse)
 


### PR DESCRIPTION
## Summary

Fixes #307. Caches were not invalidated when the underlying `.zim` files changed at runtime, so tools/resources served stale data until the TTL expired (default 1h) or the server restarted. This addresses the reported bug and a broader class of the same defect found while auditing every cache key against the project's own `archive_stat_token` contract.

### 1. Directory listing — the reported bug (#307)

`list_zim_files_data` cached the directory scan under a **static** key (`zim_files_list_data_v2b`), so a `.zim` file added to (or removed from) an allowed directory while the server ran stayed invisible until the TTL/restart. The `MtimeWatcher` detected the change and broadcast a `notifications/resources/updated`, but nothing invalidated the cache — and the watcher is HTTP-only, so stdio deployments had no signal at all.

Fix: fold a cheap directory signature (`_zim_dir_signature` — a hash of the sorted `glob("**/*.zim")` paths) into the cache key. Adding/removing/renaming a `.zim` changes the signature → cache miss → fresh scan; an unchanged directory yields a stable signature → cache hit. Transport-independent (works for stdio and HTTP).

> Note: the signature globs the allowed dirs on every call (it does **not** re-`stat`/resolve each file, which is the expensive part of `_scan_zim_files`, so a cache hit still skips the bulk of the work). For the typical flat ZIM directory this is one `readdir`. Open to a cheaper directory-mtime signature instead if you'd prefer to avoid the walk on hot paths.

### 2. Content caches — same defect, broader

`archive_stat_token()` documents the contract: *"Cache keys for any data derived from a ZIM file's contents should include this token so that an atomic file replacement (the typical monthly Wikipedia ZIM refresh) invalidates entries instead of serving stale data."* Most caches honored it (bundle, validation, path-resolution, namespace-entry listing, find-title, …), but several were keyed by **path only** and would serve stale data after an in-place same-path archive replacement (e.g. a stable `wikipedia.zim` symlink re-pointed at a refreshed archive — exactly the `replaced` event the watcher already emits):

- `metadata_data` (binary metadata — named explicitly in the contract)
- `namespaces_data` (namespace listing — named explicitly in the contract)
- `main_page`, `main_page_data`
- `browse_ns_data`
- `search_v2b`, `search_filtered`, `search_filtered_v2b`
- `suggestions_data`
- `entry`, `entry_data` (article content/response caches)

Fix: append `archive_stat_token(validated_path)` to each key, identical to the sibling caches that already do so.

### 3. Hardening

`archive_stat_token` now coerces a `str` path to `Path` before `stat()` (its docstring promised "any path-like", but a bare `str` has no `.stat()`).

## Tests

New `tests/test_cache_invalidation_on_file_changes.py`:
- Directory listing reflects add/remove without restart, and still serves an unchanged directory from cache.
- Each content cache reads the stat-token-keyed entry, not the path-only one (parametrized, one case per cache).

Updated existing tests that hardcoded the pre-fix path-only keys. Full suite: **3169 passed**, pre-commit (black/isort/flake8/mypy/bandit) clean.
