### PR TITLE
fix(deps): bump mcp and soupsieve to clear blocking pip-audit advisories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "beautifulsoup4>=4.14.3,<5.0",
     "html2text>=2025.4.15,<2027.0",
     "libzim>=3.9.0,<4.0",
-    "mcp[cli]>=1.27.0,<2.0",
+    "mcp[cli]>=1.28.1,<2.0",
     "pydantic>=2.13.3,<3.0",
     "pydantic-settings>=2.14.0,<3.0",
     "tiktoken>=0.7.0,<1.0",
@@ -108,12 +108,19 @@ openzim_mcp = ["data/*.txt", "data/*.toml", "tools/*.md"]
 # -53539 / -53540 (python-multipart < 0.0.31); and CVE-2026-48817 / -48818 /
 # -54282 / -54283 (starlette < 1.3.1). Floors only — mcp sets no upper bound;
 # drop each once mcp's own pins guarantee patched versions.
+#
+# soupsieve is pulled in transitively via beautifulsoup4 (its CSS selector
+# engine). Floor it at 2.8.4 so the pip-audit gate stays clear of
+# PYSEC-2026-3071 / -3072, two advisories against soupsieve 2.8.3. beautifulsoup4
+# sets no upper bound, so this only raises the floor. Drop this constraint once
+# beautifulsoup4's own pin guarantees >= 2.8.4.
 constraint-dependencies = [
     "pyjwt>=2.13.0",
     "pip>=26.1.2",
     "cryptography>=48.0.1",
     "python-multipart>=0.0.31",
     "starlette>=1.3.1",
+    "soupsieve>=2.8.4",
 ]
 
 [tool.black]

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,7 @@ constraints = [
     { name = "pip", specifier = ">=26.1.2" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "python-multipart", specifier = ">=0.0.31" },
+    { name = "soupsieve", specifier = ">=2.8.4" },
     { name = "starlette", specifier = ">=1.3.1" },
 ]
 
@@ -856,7 +857,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.0"
+version = "1.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -874,9 +875,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
 ]
 
 [package.optional-dependencies]
@@ -1222,7 +1223,7 @@ requires-dist = [
     { name = "fastembed", marker = "extra == 'reranker'", specifier = ">=0.4.0,<1.0" },
     { name = "html2text", specifier = ">=2025.4.15,<2027.0" },
     { name = "libzim", specifier = ">=3.9.0,<4.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.27.0,<2.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1,<2.0" },
     { name = "pydantic", specifier = ">=2.13.3,<3.0" },
     { name = "pydantic-settings", specifier = ">=2.14.0,<3.0" },
     { name = "tiktoken", specifier = ">=0.7.0,<1.0" },
@@ -2065,11 +2066,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/38/e12680bbe6b4f8f3d17adcaf38d26850aa756c85cf4a80e79fc12a018fe8/soupsieve-2.9.1.tar.gz", hash = "sha256:c33e6605bbc71dd628b00c632d58ae607c22bade247e52553928f83bbb75b4ba", size = 122261, upload-time = "2026-07-21T16:57:17.452Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/2c/437fe806897c2d6cfdc3ee43a18da8bf8e568530a4ae9bac781541ca9896/soupsieve-2.9.1-py3-none-any.whl", hash = "sha256:4f4477399246b7a0c720a88ca2454b11cd6bb9ae4c9d170140786e916776c14c", size = 37404, upload-time = "2026-07-21T16:57:16.421Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

The blocking `pip-audit` step in **Security Scanning** — a required check — was failing on **every open PR**, because the vulnerable versions sit in `main`'s own lockfile. Nothing could merge regardless of its contents:

```
Found 5 known vulnerabilities in 2 packages
Name      Version ID              Fix Versions
mcp       1.27.0  CVE-2026-52870  1.27.2
mcp       1.27.0  CVE-2026-52869  1.27.2
mcp       1.27.0  CVE-2026-59950  1.28.1
soupsieve 2.8.3   PYSEC-2026-3072 2.8.4
soupsieve 2.8.3   PYSEC-2026-3071 2.8.4
```

## What

- `mcp` 1.27.0 → **1.29.0**, floor raised to `>=1.28.1` (the first release fixing all three CVEs) so a fresh `pip install openzim-mcp` cannot land on a vulnerable version.
- `soupsieve` 2.8.3 → **2.9.1**, floored at `>=2.8.4` in `[tool.uv] constraint-dependencies` — it reaches us transitively via `beautifulsoup4`, so it follows the same pattern as the existing `pyjwt` / `cryptography` / `starlette` floors.

## Verification

The exact CI gate, reproduced locally after a plain `uv sync`:

```
$ uv run pip-audit --skip-editable
No known vulnerabilities found
GATE EXIT=0
```

`make check` (lint, type-check, security, test) exits **0** — 3169 passed, 217 skipped, 0 failed.

## Supersedes

Closes #312 (mcp → 1.28.1) and #311 (soupsieve → 2.8.4); this lands both, at higher versions.

Unblocks #315, #316, #317, #318 and #319 once they rebase. Note #319 has an additional, unrelated SonarCloud failure on `release.yml` that this PR does not address.