### PR TITLE
ci: assert a locked dependency set in the release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,9 +125,14 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
+      # ``--locked`` asserts uv.lock is already in sync with pyproject.toml
+      # rather than silently re-resolving. A release must build from the exact
+      # dependency set that CI audited; the release-please ``sync-uv-lock`` job
+      # keeps the lockfile current, so a mismatch here means something is wrong
+      # and failing loudly is the point.
       - name: Install dependencies
         run: |
-          uv sync
+          uv sync --locked
 
       - name: Run tests
         run: |
@@ -172,7 +177,7 @@ jobs:
       # + libzim) before running, which build_mcpb.py needs to spawn the server
       # and capture live tool schemas.
       - name: Build .mcpb bundle
-        run: uv run python scripts/build_mcpb.py --output dist-mcpb
+        run: uv run --locked python scripts/build_mcpb.py --output dist-mcpb
 
       - name: Upload .mcpb bundle
         uses: actions/upload-artifact@v7

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -57,5 +57,12 @@ sonar.issue.ignore.multicriteria.t8.resourceKey=openzim_mcp/http_app.py
 # ``--no-build``. The exposure the rule targets is separately bounded: uv.lock
 # pins every third-party dependency to an exact version and hash, and the
 # companion S8544 finding is genuinely fixed via ``--locked``.
+#
+# NOTE: this project is scanned by SonarCloud Automatic Analysis (there is no
+# scanner step in any workflow), and Automatic Analysis does not apply the
+# ignore rules in this file — verified on PR #323, where the entry below left
+# both findings reported. The two occurrences are therefore marked Accepted in
+# SonarCloud directly. The entry is kept so the suppression travels with the
+# repo if a scanner-based analysis is ever added.
 sonar.issue.ignore.multicriteria.t9.ruleKey=githubactions:S8541
 sonar.issue.ignore.multicriteria.t9.resourceKey=.github/workflows/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -29,7 +29,7 @@ sonar.exclusions=htmlcov/**,dist/**,.venv/**,docs/**
 # * python:S7503 (async without await): test fixtures and mock callbacks
 #   must match async SDK signatures (MCP message handlers, asyncio
 #   watchers); the `async` keyword is contractual, not behavioural.
-sonar.issue.ignore.multicriteria=t1,t2,t3,t5,t6,t7,t8
+sonar.issue.ignore.multicriteria=t1,t2,t3,t5,t6,t7,t8,t9
 sonar.issue.ignore.multicriteria.t1.ruleKey=python:S5443
 sonar.issue.ignore.multicriteria.t1.resourceKey=tests/**
 sonar.issue.ignore.multicriteria.t2.ruleKey=python:S5332
@@ -47,3 +47,15 @@ sonar.issue.ignore.multicriteria.t7.resourceKey=tests/**
 # when the body has no awaits.
 sonar.issue.ignore.multicriteria.t8.ruleKey=python:S7503
 sonar.issue.ignore.multicriteria.t8.resourceKey=openzim_mcp/http_app.py
+# githubactions:S8541 wants ``--no-build`` on every uv invocation so a
+# dependency's setup script cannot execute during install. It is unsatisfiable
+# here: openzim-mcp installs itself into the workflow venv as an editable root
+# project, which has no wheel, so ``uv sync --no-build`` fails outright with
+# "can't be installed because it is marked as --no-build but has no binary
+# distribution". uv offers only a deny-list (``--no-build-package``), not an
+# allow-list, so the root project cannot be exempted from a blanket
+# ``--no-build``. The exposure the rule targets is separately bounded: uv.lock
+# pins every third-party dependency to an exact version and hash, and the
+# companion S8544 finding is genuinely fixed via ``--locked``.
+sonar.issue.ignore.multicriteria.t9.ruleKey=githubactions:S8541
+sonar.issue.ignore.multicriteria.t9.resourceKey=.github/workflows/**


### PR DESCRIPTION
## Why

SonarCloud fails the quality gate on **any PR that touches `release.yml`**, pushing `new_security_rating` to 3. This is currently blocking #319 (the github-actions group bump), which only changes `uses:` pins but gets the whole file rescanned:

| Rule | Line | Finding |
| --- | --- | --- |
| `githubactions:S8544` | 130, 175 | Using dependencies without locking resolved versions |
| `githubactions:S8541` | 130, 175 | Omitting `--no-build` can lead to execution of setup scripts |

## S8544 — fixed, and it was a real gap

Neither uv invocation asserted that `uv.lock` was in sync with `pyproject.toml`, so a release build could silently re-resolve to a dependency set that no CI run had ever audited. `--locked` closes that:

- `uv sync` → `uv sync --locked` (test job)
- `uv run python scripts/build_mcpb.py` → `uv run --locked python ...` (build job)

The release-please `sync-uv-lock` job already keeps the lockfile current on release PRs, so a mismatch here means something is genuinely wrong — failing the release loudly is the intended behaviour, not a regression.

Both verified locally against the current lockfile:

```
$ uv sync --locked
Resolved 111 packages / Checked 94 packages    EXIT=0
$ uv run --locked python -c "print('locked run OK')"
locked run OK                                  EXIT=0
```

## S8541 — unsatisfiable, so suppressed with reasoning

This one cannot be fixed the way the rule asks. The workflow installs `openzim-mcp` into the venv as an **editable root project, which has no wheel**, so a blanket `--no-build` fails outright:

```
error: Distribution `openzim-mcp==2.5.3 @ editable+.` can't be installed
because it is marked as `--no-build` but has no binary distribution
```

uv exposes only a deny-list (`--no-build-package`), not an allow-list, so the root project can't be exempted from a blanket `--no-build`.

The exposure the rule targets is separately bounded: `uv.lock` pins every third-party dependency to an exact version **and hash**, and the companion S8544 finding is genuinely fixed above. So this is suppressed for `.github/workflows/**` via `sonar.issue.ignore.multicriteria`, following the existing convention in `sonar-project.properties` where each suppression carries its justification inline — rather than leaving a permanently red gate that trains people to ignore it.

## Unblocks

#319 — which should go green on SonarCloud once this lands and it rebases.