### PR TITLE
ci: audit optional extras in the dependency gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -200,9 +200,17 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
+      # ``--all-extras`` so the pip-audit gate below sees the optional extras,
+      # not just the default install. ``reranker`` pulls a large ML stack
+      # (fastembed -> pillow, tokenizers, onnxruntime) that is absent from a
+      # plain ``uv sync``, so advisories against it were invisible to this gate
+      # and reached users of ``openzim-mcp[reranker]`` unnoticed: pillow sat at
+      # 12.2.0 with 17 open advisories while every PR reported clean.
+      # ``--locked`` audits the resolved set we actually ship rather than a
+      # fresh resolution.
       - name: Install dependencies
         run: |
-          uv sync
+          uv sync --all-extras --locked
 
       - name: Run bandit security linter
         run: |
@@ -237,7 +245,9 @@ jobs:
       # dependency, and the same tool that gate uses) closes that window.
       # --skip-editable so it doesn't try to resolve the editable openzim-mcp
       # project itself on PyPI. Placed after the bandit steps so their reports
-      # still upload when a dependency advisory fails this step.
+      # still upload when a dependency advisory fails this step. Scope is the
+      # full extras set (see the sync step above), so an advisory in an
+      # optional dependency fails the gate rather than shipping silently.
       - name: Run pip-audit dependency scan (blocking)
         run: uv run pip-audit --skip-editable
 


### PR DESCRIPTION
## The gap

The blocking `pip-audit` step in **Security Scanning** installs dependencies with a plain `uv sync`, which resolves only the **default** dependency set. Nothing reachable exclusively through an extra was ever scanned.

`openzim-mcp[reranker]` pulls a substantial ML stack — `fastembed` → `pillow`, `tokenizers`, `onnxruntime` — none of which a plain `uv sync` installs.

## This was not theoretical

While clearing the advisory backlog this came up concretely: **`pillow` sat at 12.2.0 carrying 17 open advisories, and every PR reported a clean gate**, because pillow only enters the tree via `reranker`. Anyone installing `openzim-mcp[reranker]` was exposed to all 17, and CI had no way to say so.

Reproduced before the fix:

```
$ uv sync --all-extras && uv run pip-audit --skip-editable
pillow 12.2.0  PYSEC-2026-2253 ... PYSEC-2026-3496   (17 advisories)
```

versus what the gate actually ran:

```
$ uv sync && uv run pip-audit --skip-editable
No known vulnerabilities found
```

## The change

`uv sync` → `uv sync --all-extras --locked` in the Security Scanning job:

- **`--all-extras`** — the gate now covers what we actually publish, including optional installs.
- **`--locked`** — audits the resolved set we ship rather than a fresh resolution that may differ from the lockfile.

## Verification

Against the current lockfile, now that pillow 12.3.0 has landed via #315:

```
$ uv sync --all-extras --locked
Resolved 111 packages    EXIT=0
$ uv run pip-audit --skip-editable
No known vulnerabilities found    EXIT=0
```

So this tightens the gate without turning it red.

## Trade-off worth naming

This will make Security Scanning fail more often — an advisory in any optional dependency now blocks PRs. That is the intent, but it does widen the surface that can red the queue, which is exactly what the recent backlog was about. The alternative is continuing to ship advisories in `[reranker]` unnoticed.