### PR TITLE
docs: correct the error envelope shape across the docs

### DIFF
--- a/openzim_mcp/tools/zim_get_description.md
+++ b/openzim_mcp/tools/zim_get_description.md
@@ -56,7 +56,7 @@ RESPONSE:
 
 ERRORS:
   Invalid branch combinations return structured
-  `invalid_path_combination` with a hint naming the conflict.
+  `invalid_path_combination`; `message` names the conflict.
   Defense-in-depth: even if a small model flattens the wire-schema
   oneOf and sends an impossible payload, the handler rejects it
   cleanly.

--- a/openzim_mcp/tools/zim_get_section_description.md
+++ b/openzim_mcp/tools/zim_get_section_description.md
@@ -28,5 +28,6 @@ RESPONSE:
   any nested subsections.
 
 ERRORS:
-  Returns a ToolErrorPayload on missing/unknown section_id with a
-  hint listing the available section ids from the article's TOC.
+  Returns a ToolErrorPayload on missing/unknown section_id with an
+  `available_section_ids` key — not a `hint` — listing the available
+  section ids from the article's TOC, plus `closest_match`.

--- a/website/src/content/docs/api-reference.mdx
+++ b/website/src/content/docs/api-reference.mdx
@@ -23,9 +23,9 @@ v2.0.0 collapsed the prior 22-tool advanced surface into 8 consolidated tools. T
 
 Tools return one of:
 
-- **Structured response objects** (most tools) — typed payloads (`SearchResponse`, `EntryBundle`, `MetadataResponse`, etc.) that the MCP transport serializes. Clients should parse the JSON envelope.
+- **JSON payload responses** (most tools) — typed payloads (`SearchResponse`, `ArchiveMetadataResponse`, `ServerHealthResponse`, etc.) serialized as JSON **text** inside a `TextContent` block. All 8 tools are annotated `-> Any`, so FastMCP derives no `outputSchema` and **nothing arrives in `structuredContent`** — parse the text block as JSON.
 - **Markdown-string responses** — `zim_get` (single-entry mode) returns a rendered string with `Title:`, `Path:`, `Type:` lines, then a `## Content` block.
-- **Tool errors** — every tool catches exceptions and returns a structured `ToolErrorPayload` (`{operation, message, hint?}`) rather than raising. Path entries inside errors are redacted to `...filename.zim` form so the canonical allowed-directory layout is never leaked.
+- **Tool errors** — every tool catches exceptions and returns a structured `ToolErrorPayload` (`{error: true, operation, message, context?}`) rather than raising. There is no `status` key and no `hint` key. Only `error`, `operation`, and `message` are guaranteed; individual failures may merge extra self-correction keys into the same envelope (a `section_not_found` error, for example, also carries `available_section_ids`, `available_section_ids_truncated`, `available_section_ids_total`, and `closest_match`). The envelope arrives as JSON text in the response's `content` — no tool advertises an `outputSchema`, so nothing lands in `structuredContent` — and `openzim_mcp/mcp_envelope.py` recognises it on the way out and sets `isError: true` on the `CallToolResult`. Path entries inside errors are redacted to `...filename.zim` form so the canonical allowed-directory layout is never leaked.
 
 ---
 
@@ -49,7 +49,7 @@ zim_query(
     compact: bool = True,
     compact_budget: Optional[Union[str, int]] = None,
     synthesize: bool = False,
-) -> Union[str, SynthesizeResponse, ToolErrorPayload]
+) -> Any
 ```
 
 | Parameter | Type | Default | Notes |
@@ -433,20 +433,19 @@ All tools are subject to a global token-bucket limiter (default 20 work units/s,
 
 Tune via `OPENZIM_MCP_RATE_LIMIT__REQUESTS_PER_SECOND`, `OPENZIM_MCP_RATE_LIMIT__BURST_SIZE`, and `OPENZIM_MCP_RATE_LIMIT__PER_OPERATION_LIMITS`. See [Configuration](/openzim-mcp/docs/configuration/#rate-limiting).
 
-When the limit is exceeded, the tool returns a `ToolErrorPayload` with a `retry_after` hint; it does not raise.
+When the limit is exceeded the tool returns a `ToolErrorPayload` with `operation: "rate_limited"` instead of raising — and since 2.6.0 that envelope reaches the client as a `CallToolResult` with `isError: true` (see `openzim_mcp/mcp_envelope.py`). There is no `retry_after` field. The wait is stated in prose in `message` (`"Rate limit exceeded for operation 'search'. Please wait 1.23 seconds before retrying."`) and repeated in machine-readable form in `context`, which is always present on this error and formatted `operation=<internal op>, cost=<N>, wait_time=<S>s`.
 
 ---
 
 ## Error responses
 
-Every tool wraps exceptions and returns a structured `ToolErrorPayload`:
+Every tool wraps exceptions and returns a structured `ToolErrorPayload`, delivered as JSON text in the response's `content` — never in `structuredContent`, since no tool advertises an `outputSchema` — with `isError: true` set on the `CallToolResult`. `error` (always `true`), `operation`, and `message` are always present; `context` is added only when the tool supplies one. One path merges operation-specific self-correction keys: the `section_not_found` envelope returned by `zim_get_section` also carries `available_section_ids` (capped at 50), `available_section_ids_truncated`, and `available_section_ids_total`, plus `closest_match` when a near-miss section ID is found:
 
 ```json
 {
-  "status": "error",
+  "error": true,
   "operation": "invalid_path_combination",
-  "message": "Set exactly one of: entry_path, entry_paths, binary, main_page",
-  "hint": "Use entry_paths=[...] for batch fetch"
+  "message": "`entry_path` and `entry_paths` are mutually exclusive."
 }
 ```
 

--- a/website/src/content/docs/architecture-overview.mdx
+++ b/website/src/content/docs/architecture-overview.mdx
@@ -122,7 +122,9 @@ openzim_mcp/
 ├── error_messages.py        # markdown error templates
 ├── exceptions.py            # OpenZimMcp* exception hierarchy
 ├── constants.py             # cross-module constants (input limits, thresholds)
-├── types.py                 # shared TypedDicts / Protocols
+├── tool_schemas.py          # per-tool response TypedDicts (tools annotate -> Any, no outputSchema)
+├── responses.py             # tool_error() + ToolErrorPayload: {error, operation, message, context?} + extras
+├── mcp_envelope.py          # EnvelopeAwareFastMCP — returned error envelope -> isError=True
 ├── zim_operations.py        # back-compat shim — re-exports from zim/
 ├── zim/                     # ZIM operations package
 │   ├── __init__.py
@@ -285,7 +287,7 @@ MCP client         FastMCP                Server core         async_zim_operatio
     │◀── result ───────│                        │                          │                       │                  │
 ```
 
-Errors anywhere in the chain are caught by the tool wrapper and returned as a structured `ToolErrorPayload` (`{operation, message, hint?}`) rather than raised. Absolute paths inside error messages are redacted to `...filename.zim` form before the payload is returned.
+Errors anywhere in the chain are returned rather than raised, as a structured `ToolErrorPayload` — `{error: true, operation, message}`, plus `context` when the call site supplies one, plus any self-correction extras merged in (e.g. `zim_get_section` attaches `available_section_ids` and `closest_match` on `operation="section_not_found"`). There is no `status` key and no `hint` key. Both failure paths go through `responses.tool_error`: the tool wrapper's catch-all (`tools/_common.py`) wraps unexpected exceptions, and validation failures build the same envelope in-band at the call site. Because the envelope is *returned*, `EnvelopeAwareFastMCP` (`mcp_envelope.py`) recognises it at `call_tool` and sets `isError` on the `CallToolResult`, with the serialized body byte-identical to the plain dict return. No tool advertises an `outputSchema` — all eight are annotated `-> Any` — so nothing arrives in `structuredContent`; clients parse the JSON text block. Absolute paths inside error messages are redacted to `...filename.zim` form before the payload is returned.
 
 ## Data flow — HTTP transport
 

--- a/website/src/content/docs/configuration.mdx
+++ b/website/src/content/docs/configuration.mdx
@@ -118,7 +118,7 @@ export OPENZIM_MCP_CONTENT__SNIPPET_LENGTH=1000         # default 1000, min 100
 export OPENZIM_MCP_CONTENT__DEFAULT_SEARCH_LIMIT=10     # default 10, range 1-100
 ```
 
-`zim_get(entry_path=...)` requires `max_content_length >= 100` (lower values are rejected with a `ToolErrorPayload`).
+The **config** field `content.max_content_length` must be `>= 100`; a lower value fails pydantic validation and aborts startup as an `OpenZimMcpConfigurationError`, never as a tool response. The separate **per-call** `max_content_length` argument — accepted only by `zim_get` and `zim_query` — is validated independently and only has to be `>= 1`; below that the call returns a `ToolErrorPayload`, `{"error": true, "operation": "invalid_max_content_length", "message": "..."}`, which the server delivers as JSON text with `isError: true`.
 
 ## Logging
 

--- a/website/src/content/docs/llm-integration-patterns.mdx
+++ b/website/src/content/docs/llm-integration-patterns.mdx
@@ -402,7 +402,7 @@ def summarize_topic(topic):
 
 ### Structured tool errors
 
-OpenZIM MCP v2 tools return **structured `ToolErrorPayload` objects**, not exceptions. The payload has `{status: "error", operation, message, hint?}`. Smart retrieval already handles "wrong path" cases automatically — see [Smart retrieval](/openzim-mcp/docs/smart-retrieval/).
+OpenZIM MCP v2 tools return **structured `ToolErrorPayload` objects**, not exceptions. The payload is `{"error": true, "operation": "<op>", "message": "<text>"}`, plus `"context"` when the tool supplied one, plus any operation-specific extra keys — `zim_get_section`, for example, adds `available_section_ids`, `available_section_ids_truncated` and `available_section_ids_total` on an unknown section ID, and `closest_match` when a near-miss heading exists. There is no `status` key and no `hint` key; branch on `result["error"] is True`. No tool advertises an `outputSchema`, so nothing arrives in `structuredContent` — parse the JSON text block in `content`. The server also flags these envelopes with `isError: true` on the `CallToolResult`. Smart retrieval already handles "wrong path" cases automatically — see [Smart retrieval](/openzim-mcp/docs/smart-retrieval/).
 
 ```python
 def robust_content_access(entry_path):
@@ -411,7 +411,7 @@ def robust_content_access(entry_path):
     result = zim_get(zim_file_path=zim_path, entry_path=entry_path)
 
     # When smart retrieval bails, the result is a ToolErrorPayload dict.
-    if isinstance(result, dict) and result.get("status") == "error":
+    if isinstance(result, dict) and result.get("error") is True:
         # Title-mode search is the cheapest "I have a name, give me the path" fallback.
         hit = zim_search(
             query=entry_path.split("/")[-1],
@@ -426,6 +426,17 @@ def robust_content_access(entry_path):
 ```
 
 For programmatic checks, the underlying exception class hierarchy lives in [openzim_mcp/exceptions.py](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/exceptions.py): `OpenZimMcpArchiveError`, `OpenZimMcpValidationError`, `OpenZimMcpRateLimitError`, `OpenZimMcpConfigurationError`. They're caught at the tool boundary; you don't see them on the wire.
+
+### Branching on `isError`
+
+As of v2.6.0 the failure is visible at the protocol level too: `EnvelopeAwareFastMCP.call_tool` ([openzim_mcp/mcp_envelope.py](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/mcp_envelope.py)) recognises a returned envelope and emits a `CallToolResult` with `isError: true`. Tools still signal failure by *returning* the envelope rather than raising — before v2.6.0 that meant every failure, security denials included, travelled the SDK's ordinary success path and reached the client with `isError: false`.
+
+If your MCP client surfaces the flag, branch on it first: it is one boolean and needs no JSON parsing. The body is unchanged — byte-identical to what the plain dict return produced — so parse `content[0].text` only when you need `operation`, `message`, or the extra keys.
+
+Two edges worth knowing:
+
+- **`structuredContent` is deliberately unset** on error results. No tool advertises an `outputSchema`, and per the MCP spec `structuredContent` is the counterpart to one, so the envelope always lives in the `content` text block.
+- **Partial failures are not call failures.** A cross-archive `zim_search(cross_file=True)` where one archive is unreadable, or a `zim_get(entry_paths=[...])` batch where some entries fail, still returns `isError: false`. The per-row status is nested and shaped differently per tool, and the server's discriminator only inspects the top-level dict — so nested rows never flag the whole call.
 
 ### Progressive content loading
 
@@ -488,7 +499,7 @@ popular_articles = track_article_access()
 3. **Use `view="summary"`** for lead-paragraph previews before fetching full bodies.
 4. **Use `zim_get_section`** when you already have a section ID — much cheaper than fetching the whole article.
 5. **Leverage caching** by reusing common queries.
-6. **Handle structured tool errors** with `isinstance(result, dict) and result.get("status") == "error"`.
+6. **Handle structured tool errors** by branching on the MCP `isError` flag when your client exposes it, or on `isinstance(result, dict) and result.get("error") is True` when you only have the parsed payload.
 7. **Monitor performance** via `zim_health` and adjust limits accordingly.
 8. **Use appropriate content limits** (`max_content_length`) for different use cases.
 9. **Use `zim_links(direction="related")`** for content discovery.

--- a/website/src/content/docs/security-best-practices.mdx
+++ b/website/src/content/docs/security-best-practices.mdx
@@ -132,7 +132,7 @@ Token-bucket limiter (`rate_limiter.py`):
 - Per-client buckets with LRU eviction (10k cap) — client identity scopes the limit so one noisy client can't drain the global bucket.
 - `zim_get(entry_paths=[...])` charges per-entry to prevent batch bypass.
 
-When the limit is exceeded, the tool returns a markdown error block (it does not raise).
+When the limit is exceeded, the tool returns the standard error envelope — `{"error": true, "operation": "rate_limited", "message": ..., "context": ...}` — serialized as JSON in the response's text block, and the `CallToolResult` is flagged `isError: true`. It does not raise. Both limiter paths (global and per-operation) always attach `context`, and the retry delay is carried as prose inside `message` ("Please wait 3.42 seconds before retrying") and `context` (`wait_time=3.42s`) — there is no machine-readable `retry_after` field.
 
 ## Prompt hardening
 

--- a/website/src/content/docs/troubleshooting.mdx
+++ b/website/src/content/docs/troubleshooting.mdx
@@ -15,22 +15,34 @@ Before diving into specific failure modes — v2 changed how errors come back fr
 
 ```json
 {
-  "status": "error",
+  "error": true,
   "operation": "invalid_path_combination",
-  "message": "Set exactly one of: entry_path, entry_paths, binary, main_page",
-  "hint": "Use entry_paths=[...] for batch fetch"
+  "message": "Provide one of `entry_path`, `entry_paths`, or `main_page=True`."
 }
 ```
 
-Check for it with `isinstance(result, dict) and result.get("status") == "error"`. Common v2 error `operation` values you'll see in this guide:
+Check for it with `isinstance(result, dict) and result.get("error") is True`. Since v2.6 the server also sets the MCP `isError` flag on these — `EnvelopeAwareFastMCP.call_tool` recognises the envelope on the way out and returns a `CallToolResult` with `isError=True` — so a client that branches on `isError` works too. No tool advertises an `outputSchema`, so nothing arrives in `structuredContent`; the envelope is JSON in the response's text `content` block. Common error `operation` values you'll see in this guide:
 
-- `invalid_path_combination` — `zim_get` got conflicting branch selectors (e.g. `entry_path` + `main_page`)
-- `invalid_mode` — `zim_browse`, `zim_search`, or `zim_links` got an unsupported mode/direction
+- `invalid_path_combination` — `zim_get` got an impossible branch: `entry_path` + `entry_paths`, `entry_paths` + a non-`full` `view`, `entry_paths` + `content_offset`, `binary` + `entry_paths`/`main_page`/a non-`full` `view`, `binary` without `entry_path`, `main_page` + a path or a non-`full` `view`, or no selector at all
+- `invalid_view` — `zim_get` got a `view` outside `{full, summary, toc, structure}`
+- `invalid_mode` — `zim_browse` got a `mode` outside `{page, walk}`, or `zim_search` a `mode` outside `{fulltext, title, suggest}`
+- `invalid_direction` / `invalid_kind` — `zim_links` got a `direction` outside `{outbound, inbound, related}`, or (on `direction="outbound"`) a `kind` outside `{internal, external, media}`. `zim_links` never emits `invalid_mode`.
 - `invalid_section` — `zim_get_section` got an empty/missing `section_id`
 - `invalid_content_offset` — `zim_get` / `zim_query` got a negative `content_offset`
-- specific operation names (`get_entry`, `search`, etc.) for underlying-operation failures (smart retrieval miss, archive read error, rate-limit exhausted)
+- `invalid_limit` — `zim_search` / `zim_query` got a `limit` below 1, or above the cap (50 for `mode="title"` / `mode="suggest"`, 1000 otherwise)
+- `invalid_offset` — `zim_search` / `zim_query` got a negative `offset` (`offset=0` is the valid default)
+- `invalid_max_content_length` — `zim_get` / `zim_query` got a `max_content_length` below 1 (`zim_search` has no such parameter)
+- `invalid_combination` — `zim_search` got mutually exclusive arguments (any `cursor`, a non-zero `offset` outside single-archive fulltext, `cross_file` + `zim_file_path`, `mode="suggest"` + `cross_file`, or `namespace`/`content_type` filters + `cross_file`)
+- `missing_archive` — `zim_search` could not resolve an archive for `mode="suggest"`, `mode="title"`, or single-archive fulltext
+- `invalid_query` — `zim_query` got a query over the 4096-character cap
+- `rate_limited` — the token bucket for the internal operation was exhausted
+- `cursor_decode` / `cursor_mismatch` / `cursor_context_mismatch` / `cursor_unsupported` — a malformed, wrong-tool, wrong-context, or unsupported `cursor`
+- `file_not_found` / `entry_not_found` / `section_not_found` / `invalid_max_chars` — data-layer failures surfaced by `zim_get_section`. `section_not_found` is the one envelope that carries extra keys: `available_section_ids`, `available_section_ids_truncated`, `available_section_ids_total`, and `closest_match` when a near match exists.
+- `inbound_sidecar_unavailable` — `zim_links(direction="inbound")` against an archive with no link-graph sidecar
+- the tool's own wire name — `zim_get`, `zim_search`, `zim_query`, `zim_browse`, `zim_links`, `zim_metadata`, `zim_health`, `zim_get_section` — when an unexpected exception escapes the tool body (archive read error, smart-retrieval miss). There is no `get_entry` or `search` operation value: those are internal rate-limiter bucket names, never envelope operations.
+- `zim_query`'s simple-mode dispatch adds `synthesize_pipeline_error`, `synthesize_not_applicable`, `no_archives_available`, `meta_only_guidance`, `chained_intent_rejected`, `topic_required`, `search_terms_required`, `multi_entity_chain_rejected`, and `invalid_path`
 
-The underlying exception hierarchy in [openzim_mcp/exceptions.py](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/exceptions.py) is the canonical source.
+The envelope itself is defined in [openzim_mcp/responses.py](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/responses.py) — the `ToolErrorPayload` TypedDict and the `tool_error()` builder every failure path must go through — and the `isError` mapping in [openzim_mcp/mcp_envelope.py](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/mcp_envelope.py). The underlying exception hierarchy in [openzim_mcp/exceptions.py](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/exceptions.py) is what the broad-`except` paths wrap; it shapes the `message` text but not the envelope's keys — `error_code` is never emitted.
 
 ## Quick diagnostics
 


### PR DESCRIPTION
## Why

The website documented every tool failure as:

```json
{ "status": "error", "operation": "...", "message": "...", "hint": "..." }
```

`responses.tool_error` has never emitted `status` or `hint`. The real envelope ([responses.py:63-72](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/responses.py)) is:

```json
{ "error": true, "operation": "...", "message": "...", "context": "..." }
```

`context` only when supplied, plus any per-operation extras merged from `extras`.

Every documented client check — `result.get("status") == "error"` in `llm-integration-patterns.mdx` (twice) and `troubleshooting.mdx` — branched on a key that is never present. Those samples do not merely mislead; they **silently classify every failure as a success**.

The phantom `hint` looks traceable to `zim_search_description.md:56`, which describes a real `hint` key — but one set in `_meta` on a *success* payload ([zim_search.py:419](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/tools/zim_search.py)), not on the error envelope.

## Other falsified claims corrected

Each of these was verified against the code, not just reasoned about:

- **`retry_after` does not exist.** `api-reference.mdx:436` promised the rate limiter returns "a `ToolErrorPayload` with a `retry_after` hint". No such key is emitted anywhere. The delay is prose in `message` and `wait_time=<S>s` inside `context`. `security-best-practices.mdx:135` separately claimed a *markdown error block*; it is the JSON envelope with `operation: "rate_limited"`.
- **`zim_get_section`'s self-correction key** is `available_section_ids` (+ `_truncated`, `_total`, and conditional `closest_match`), never a `hint`.
- **The `operation` catalogue was wrong in two ways.** `get_entry` and `search` have zero production hits — they are rate-limiter *bucket* names fed to `enforce_rate_limit`, which emits `rate_limited`. And `invalid_mode` was attributed to `zim_links`, which emits `invalid_direction`/`invalid_kind` and never `invalid_mode`. The list also omitted 26 real values; it is now regenerated from the 43 `operation=` sites.
- **`architecture-overview.mdx:125` mapped `openzim_mcp/types.py`**, which does not exist and never did. Replaced with the three real modules.
- **`configuration.mdx:121` conflated two different limits.** The `>= 100` floor is on the *config* field and fails pydantic validation at startup; the *per-call* `max_content_length` argument only has to be `>= 1` and returns an envelope below that.
- **`api-reference.mdx:52`** still showed `zim_query`'s old `Union[...]` return annotation — the very thing whose removal in #333 dropped the last `outputSchema`.

## Added

`structuredContent` and `isError` were documented nowhere. A new **Branching on `isError`** section covers the 2.6.0 semantics, including the edge that partial failures do not flag the call: a `cross_file` search with one unreadable archive, or a batch `zim_get` with some failed rows, still returns `isError: false`, because the discriminator only inspects the top-level dict.

## Byte-budgeted files

`zim_get_description.md` and `zim_get_section_description.md` ship as `tools/list` descriptions and are bounded by `test_phase_f_prototype_parity` on both wire bytes and edit distance from the frozen snapshot. `zim_get` had **6 bytes** of headroom; the replacement is 2 bytes shorter. `zim_get_section` fits the byte band and lands at 28.8% edit distance against a 30% tolerance.

## Verification

- `3605 passed / 213 skipped / 0 failed`
- `tests/test_phase_f_prototype_parity.py` + `tests/test_phase_f_schema_budget.py`: 11 passed
- Website builds clean (16 pages); pre-commit and markdownlint pass
- Zero residual `status`/`hint` envelope references in `website/src/content/docs/`

## Deliberately not touched

`website/dist/**` (gitignored build output), `tests/dispatch_eval/prototype_schema_snapshot.json` (frozen Gate 0b snapshot — re-snapshotting needs a `gate_0b_decision.json` amendment), and `CHANGELOG.md` (accurate when written).

Health/readiness `status` fields elsewhere in the docs are unrelated to the error envelope and were left alone.