### PR TITLE
docs: close the remaining drift the envelope audit surfaced

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,15 +119,18 @@ openzim-mcp/
 │   │   ├── namespace.py        # Namespace listing, browse, walk
 │   │   ├── search.py           # Full-text + suggestion search; cursor pagination
 │   │   └── structure.py        # Article structure, links, related articles
-│   └── tools/                  # MCP tool registrations
-│       ├── __init__.py
-│       ├── file_tools.py       # list_zim_files
-│       ├── content_tools.py    # get_zim_entry, get_zim_entries
-│       ├── search_tools.py     # search_zim_file, search_all, find_entry_by_title
-│       ├── navigation_tools.py # browse_namespace, walk_namespace, search_with_filters, get_search_suggestions
-│       ├── structure_tools.py  # get_article_structure, extract_article_links, get_entry_summary, get_table_of_contents, get_binary_entry
-│       ├── metadata_tools.py   # get_zim_metadata, get_main_page, list_namespaces
-│       ├── server_tools.py     # get_server_health, get_server_configuration
+│   └── tools/                  # MCP tool registrations — one module per v2 tool
+│       ├── __init__.py         # register_phase_f_tools(); simple mode stops after zim_query
+│       ├── _common.py          # description loader, rate limit, cursor decode, error envelope
+│       ├── zim_query.py        # zim_query — NL entry point (registered in both tool modes)
+│       ├── zim_search.py       # zim_search — fulltext/title/suggest, cross_file fan-out
+│       ├── zim_get.py          # zim_get — single/batch/binary/main_page; view=full|summary|toc|structure
+│       ├── zim_get_section.py  # zim_get_section — one named section of an article
+│       ├── zim_browse.py       # zim_browse — namespace enumeration, mode=page|walk
+│       ├── zim_metadata.py     # zim_metadata — M-namespace fields + namespace inventory
+│       ├── zim_links.py        # zim_links — direction=outbound|inbound|related
+│       ├── zim_health.py       # zim_health — health+config+archives, or archive validation
+│       ├── *_description.md    # LLM-facing tool descriptions, loaded at import
 │       ├── resource_tools.py   # MCP resources (zim://files, zim://{name}/...)
 │       └── prompts.py          # MCP prompts (/research, /summarize, /explore)
 ├── tests/                      # Test suite (pytest)

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -158,6 +158,14 @@ zim_browse(zim_file_path="wikipedia_en.zim", namespace="C", mode="walk", limit=2
 - Pagination recommended for large result sets
 - Use specific tools in advanced mode for best performance
 
+### Error Handling
+- Failures are RETURNED, not raised: every tool responds with `{"error": true, "operation": "<op>", "message": "<text>"}`
+- `context` is present only when the tool supplies one; some failures merge extra self-correction keys (e.g. `zim_get_section` adds `available_section_ids` and `closest_match`)
+- There is no `status` key and no `hint` key — branch on `result["error"] is True`
+- Since v2.6.0 the `CallToolResult` also carries `isError: true` for these envelopes
+- No tool advertises an `outputSchema`, so nothing arrives in `structuredContent` — parse the JSON text block in `content`
+- Partial failures do not flag the call: a `zim_get(entry_paths=[...])` batch or `zim_search(cross_file=True)` where some rows fail still returns `isError: false` — only the TOP-LEVEL dict is inspected. Per-row outcome is nested and differs per tool: batch rows carry `success` (bool) plus `error` (message string); cross-archive rows carry `error` (bool) plus `error_message` / `error_operation`
+
 ## Configuration
 
 Configuration is via environment variables with the `OPENZIM_MCP_` prefix:

--- a/website/src/content/docs/api-reference.mdx
+++ b/website/src/content/docs/api-reference.mdx
@@ -25,7 +25,7 @@ Tools return one of:
 
 - **JSON payload responses** (most tools) — typed payloads (`SearchResponse`, `ArchiveMetadataResponse`, `ServerHealthResponse`, etc.) serialized as JSON **text** inside a `TextContent` block. All 8 tools are annotated `-> Any`, so FastMCP derives no `outputSchema` and **nothing arrives in `structuredContent`** — parse the text block as JSON.
 - **Markdown-string responses** — `zim_get` (single-entry mode) returns a rendered string with `Title:`, `Path:`, `Type:` lines, then a `## Content` block.
-- **Tool errors** — every tool catches exceptions and returns a structured `ToolErrorPayload` (`{error: true, operation, message, context?}`) rather than raising. There is no `status` key and no `hint` key. Only `error`, `operation`, and `message` are guaranteed; individual failures may merge extra self-correction keys into the same envelope (a `section_not_found` error, for example, also carries `available_section_ids`, `available_section_ids_truncated`, `available_section_ids_total`, and `closest_match`). The envelope arrives as JSON text in the response's `content` — no tool advertises an `outputSchema`, so nothing lands in `structuredContent` — and `openzim_mcp/mcp_envelope.py` recognises it on the way out and sets `isError: true` on the `CallToolResult`. Path entries inside errors are redacted to `...filename.zim` form so the canonical allowed-directory layout is never leaked.
+- **Tool errors** — every tool catches exceptions and returns a structured `ToolErrorPayload` (`{error: true, operation, message, context?}`) rather than raising. The exception is `zim_query` on its default path: handler-side failures there return markdown guidance instead of an envelope, so they carry `isError: false`; only its argument rejections and its `synthesize=True` refusals produce one. There is no `status` key and no `hint` key. Only `error`, `operation`, and `message` are guaranteed; individual failures may merge extra self-correction keys into the same envelope (a `section_not_found` error, for example, also carries `available_section_ids`, `available_section_ids_truncated`, `available_section_ids_total`, and `closest_match`). The envelope arrives as JSON text in the response's `content` — no tool advertises an `outputSchema`, so nothing lands in `structuredContent` — and `openzim_mcp/mcp_envelope.py` recognises it on the way out and sets `isError: true` on the `CallToolResult`. Path entries inside errors are redacted to `...filename.zim` form so the canonical allowed-directory layout is never leaked.
 
 ---
 
@@ -51,6 +51,8 @@ zim_query(
     synthesize: bool = False,
 ) -> Any
 ```
+
+**At runtime** the tool returns a string for ordinary calls (markdown for every intent except `list available ZIM files`, which embeds a JSON array in the string), a `SynthesizeResponse` dict when `synthesize=True`, and a `ToolErrorPayload` dict when it rejects an argument, hits the rate limit, cannot decode a `cursor`, or the synthesize pipeline fails. The `-> Any` annotation is deliberate — it keeps FastMCP from deriving an `outputSchema`.
 
 | Parameter | Type | Default | Notes |
 |-----------|------|---------|-------|
@@ -78,7 +80,7 @@ zim_query(
 - "articles related to Climate_Change"
 - "summary of Quantum_mechanics"
 
-**Returns:** intent-specific output; for searches a markdown list of results, for retrievals a rendered article, for "synthesize" intents a structured `SynthesizeResponse`.
+**Returns:** intent-specific output — a markdown list for searches, a rendered article for retrievals, a `SynthesizeResponse` when `synthesize=True`. On the default (non-synthesize) path, handler-side failures (no archive specified, `zim_file_path` not found, empty / meta-only / chained query) come back as markdown guidance rather than an error envelope, so they carry `isError: false`. The `synthesize=True` path instead refuses bad paths, meta-only queries, and chained queries with a `ToolErrorPayload`, so those do set `isError: true`.
 
 ---
 
@@ -275,7 +277,7 @@ zim_health(zim_file_path: Optional[str] = None) -> Any
 
 | Argument | Behavior |
 |----------|----------|
-| *(omitted)* | Combined server-state report: `{health, configuration, loaded_archives}`. |
+| *(omitted)* | Combined server-state report: `{health, configuration, loaded_archives, _meta}`. |
 | `zim_file_path` | Per-archive integrity/identity check via libzim — runs `Archive.check()` and reports checksum, index capabilities, and identity. Lets a caller tell a valid archive from a corrupt one. |
 
 **Server-state response** (no argument) — shape (abbreviated):
@@ -283,7 +285,7 @@ zim_health(zim_file_path: Optional[str] = None) -> Any
 ```json
 {
   "health": {
-    "timestamp": "2026-05-27T15:30:00.000000",
+    "timestamp": "2026-05-27T15:30:00.000000+00:00",
     "status": "healthy",
     "server_name": "openzim-mcp",
     "uptime_info": { "process_id": "[REDACTED]", "started_at": "..." },
@@ -293,22 +295,27 @@ zim_health(zim_file_path: Optional[str] = None) -> Any
     "warnings": []
   },
   "configuration": {
-    "server_name": "openzim-mcp",
-    "allowed_directories": ["...zim-files"],
-    "cache_enabled": true,
-    "cache_max_size": 100,
-    "tool_mode": "advanced",
-    "transport": "stdio",
-    "config_hash": "<sha256>",
-    "server_pid": "[REDACTED]"
+    "configuration": {
+      "server_name": "openzim-mcp",
+      "allowed_directories": ["...zim-files"],
+      "allowed_directories_count": 1,
+      "cache_enabled": true,
+      "cache_max_size": 100,
+      "config_hash": "<sha256>",
+      "server_pid": "[REDACTED]"
+    },
+    "diagnostics": { "validation_status": "ok", "warnings": [], "recommendations": [] },
+    "timestamp": "2026-05-27T15:30:00.000000+00:00"
   },
   "loaded_archives": [
-    { "name": "wikipedia_en_100_2026-02.zim", "path": "...wikipedia_en_100_2026-02.zim", "size": 124857600, "modified": "2026-02-15T10:30:00" }
+    { "name": "wikipedia_en_100_2026-02.zim", "path": "...wikipedia_en_100_2026-02.zim", "size": "119.07 MB", "size_bytes": 124857600, "modified": "2026-02-15T10:30:00" }
   ]
 }
 ```
 
 Over the **HTTP/SSE** transports `process_id` / `server_pid` are `"[REDACTED]"` and allowed directories are shown as `...basename` — diagnostic output frequently lands in bug reports. Over the local **stdio** transport these report the real PID and full paths, matching the unredacted `loaded_archives[].path` values that clients pass back to other tools.
+
+The three blocks are built independently. If the health or configuration builder raises, that block alone is replaced by a `ToolErrorPayload` — `{"error": true, "operation": "get server health" | "get server configuration", "message": ..., "context": ...}`, the only two `operation` values in the codebase that are not snake_case — and the rest of the response, `loaded_archives` included, is still returned. The top-level dict is not an error envelope, so `isError` stays `false`; check `.health` and `.configuration` for an `error` key before reading their fields. A top-level envelope comes back only two ways — a rate-limit rejection (`operation: "rate_limited"`), or an exception escaping the tool body (`operation: "zim_health"`), which for the no-argument call means only the directory scan behind `loaded_archives`, since the other two builders swallow their own exceptions, and for the `zim_file_path` call below means any validation failure.
 
 **Archive-validation response** (with `zim_file_path`, *added in v2.1*):
 
@@ -439,7 +446,7 @@ When the limit is exceeded the tool returns a `ToolErrorPayload` with `operation
 
 ## Error responses
 
-Every tool wraps exceptions and returns a structured `ToolErrorPayload`, delivered as JSON text in the response's `content` — never in `structuredContent`, since no tool advertises an `outputSchema` — with `isError: true` set on the `CallToolResult`. `error` (always `true`), `operation`, and `message` are always present; `context` is added only when the tool supplies one. One path merges operation-specific self-correction keys: the `section_not_found` envelope returned by `zim_get_section` also carries `available_section_ids` (capped at 50), `available_section_ids_truncated`, and `available_section_ids_total`, plus `closest_match` when a near-miss section ID is found:
+Every tool wraps exceptions and returns a structured `ToolErrorPayload` — except `zim_query`'s default path, which returns markdown guidance for handler-side failures — delivered as JSON text in the response's `content` — never in `structuredContent`, since no tool advertises an `outputSchema` — with `isError: true` set on the `CallToolResult`. `error` (always `true`), `operation`, and `message` are always present; `context` is added only when the tool supplies one. One path merges operation-specific self-correction keys: the `section_not_found` envelope returned by `zim_get_section` also carries `available_section_ids` (capped at 50), `available_section_ids_truncated`, and `available_section_ids_total`, plus `closest_match` when a near-miss section ID is found:
 
 ```json
 {

--- a/website/src/content/docs/architecture-overview.mdx
+++ b/website/src/content/docs/architecture-overview.mdx
@@ -30,8 +30,8 @@ Module map, transports, and the `zim/` package layout.
                       │
 ┌─────────────────────▼────────────────────────────────────────────┐
 │              Tool Surface (advanced=8, simple=1)                 │
-│  tools/{file,content,search,navigation,structure,                │
-│          metadata,server,resource,prompts}_tools.py              │
+│  tools/zim_{query,search,get,get_section,browse,                 │
+│             metadata,links,health}.py, resource_tools, prompts   │
 └─────────────────────┬────────────────────────────────────────────┘
                       │
 ┌─────────────────────▼────────────────────────────────────────────┐
@@ -72,22 +72,22 @@ v2.0.0 collapsed the 22-tool v1 advanced surface into 8 tools. Each consolidated
   │  • mode="fulltext"  (default)│  │  • entry_path=...            │
   │  • mode="title"              │  │  • entry_paths=[...]  batch  │
   │  • mode="suggest"            │  │  • binary=True   binary blob │
-  │  • mode="cross_file"         │  │  • main_page=True            │
-  │  • mode="filtered"           │  │  • view="summary"            │
+  │  • cross_file=True  fan-out  │  │  • main_page=True            │
+  │  • namespace= / content_type=│  │  • view="summary"            │
   │                              │  │  • view="toc"                │
   │                              │  │  • view="structure"          │
   └──────────────────────────────┘  └──────────────────────────────┘
 
   ┌──────────────────────────────┐  ┌──────────────────────────────┐
   │  zim_get_section             │  │  zim_browse                  │
-  │  • section_id=...            │  │  • mode="list"    (default)  │
+  │  • section_id=...            │  │  • mode="page"    (default)  │
   │  • from a TOC node           │  │  • mode="walk"    deep tree  │
   └──────────────────────────────┘  └──────────────────────────────┘
 
   ┌──────────────────────────────┐  ┌──────────────────────────────┐
   │  zim_links                   │  │  zim_metadata                │
-  │  • direction="outgoing"      │  │  • metadata + namespace      │
-  │  • direction="related"       │  │    counts in one payload     │
+  │  • direction="outbound"      │  │  • metadata + namespace      │
+  │  • "inbound" / "related"     │  │    counts in one payload     │
   └──────────────────────────────┘  └──────────────────────────────┘
 
   ┌──────────────────────────────┐
@@ -133,20 +133,22 @@ openzim_mcp/
 │   ├── content.py           # _ContentMixin
 │   ├── structure.py         # _StructureMixin
 │   └── namespace.py         # _NamespaceMixin
-└── tools/                   # MCP tool registration — one file per v2 tool category
-    ├── __init__.py
-    ├── file_tools.py        # underlying file-listing helpers (rolled into zim_health)
-    ├── content_tools.py     # zim_get (single + batch + binary + main_page + views)
-    ├── navigation_tools.py  # zim_browse (list + walk), zim_search filtered/suggest modes
-    ├── search_tools.py      # zim_search (fulltext + title + cross_file modes)
-    ├── metadata_tools.py    # zim_metadata (combined metadata + namespace counts)
-    ├── structure_tools.py   # zim_get views (structure, toc, summary), zim_links, zim_get_section
-    ├── server_tools.py      # zim_health (consolidated health + config + archives)
-    ├── resource_tools.py    # zim:// resources + per-entry template
-    └── prompts.py           # /research, /summarize, /explore
+└── tools/                   # MCP tool registration — one module per v2 tool
+    ├── __init__.py          # register_phase_f_tools() — tool_mode gate; simple stops after zim_query
+    ├── _common.py           # shared wrapper helpers: description loader, rate limit, cursors, errors
+    ├── zim_query.py         # zim_query — NL entry point via SimpleToolsHandler (both tool modes)
+    ├── zim_search.py        # zim_search — mode="fulltext"|"title"|"suggest", plus cross_file fan-out
+    ├── zim_get.py           # zim_get — single/batch/binary/main_page fetch; view=full|summary|toc|structure
+    ├── zim_get_section.py   # zim_get_section — one named section (section_id) of an article
+    ├── zim_browse.py        # zim_browse — namespace enumeration, mode="page"|"walk"
+    ├── zim_metadata.py      # zim_metadata — M-namespace fields + namespace inventory in one payload
+    ├── zim_links.py         # zim_links — direction="outbound"|"inbound"|"related", kind filter
+    ├── zim_health.py        # zim_health — no arg → health+config+archives; path → archive validation
+    ├── resource_tools.py    # zim:// resources + MIME-aware per-entry template (advanced only)
+    └── prompts.py           # /research, /summarize, /explore prompts (advanced only)
 ```
 
-The `tools/` filenames pre-date the v2 consolidation; the *category* organization still holds (search, navigation, content, structure, metadata, server, resources, prompts) but each file now registers one v2 tool that may dispatch to multiple underlying mixin operations based on `mode` / `view`.
+Each `zim_*.py` module exports a single `register(server)` function that declares one v2 tool via `@server.mcp.tool(description=...)`, loads its LLM-facing description from the sibling `_description.md` file at import time, and forwards to `AsyncZimOperations` so blocking ZIM I/O runs under `asyncio.to_thread` — the exception is `zim_query`, which dispatches `SimpleToolsHandler.handle_zim_query` on a worker thread instead. `register_phase_f_tools(server)` registers `zim_query` unconditionally, then returns early when `config.tool_mode == "simple"`; the other seven tools, the `zim://` resources, and the prompts are advanced-mode only.
 
 ## Core components
 
@@ -166,7 +168,7 @@ subscriber_reg    → SubscriberRegistry()  (only when subscriptions_enabled)
 simple_tools_h    → SimpleToolsHandler(zim_operations, async_zim_operations)
 ```
 
-Tool registration is dispatched from `tools/__init__.py:register_all_tools(server)`. In Simple mode, only `zim_query` is registered as a *new* tool — the underlying advanced tools are still wired for routing but aren't surfaced to the MCP client unless `tool_mode='advanced'`.
+Tool registration is dispatched from `tools/__init__.py:register_phase_f_tools(server)`. In Simple mode, only `zim_query` is registered as a *new* tool — the underlying advanced tools are still wired for routing but aren't surfaced to the MCP client unless `tool_mode='advanced'`.
 
 ### HTTP / SSE transport (`http_app.py`)
 
@@ -200,7 +202,7 @@ Polling-based mtime watcher:
 
 Single LRU+TTL cache shared across all tools and the smart-retrieval path-mapping store. Backed by an in-memory `OrderedDict`; optional disk persistence at `~/.cache/openzim-mcp` (off by default).
 
-Cache stats: `enabled, size, max_size, ttl_seconds, hits, misses, hit_rate`. Surfaced inside `zim_health.cache_performance` — there are no separate management tools; restart the server to flush.
+Cache stats: `enabled, size, max_size, ttl_seconds, hits, misses, hit_rate`. Surfaced inside `zim_health` under `.health.cache_performance` — there are no separate management tools; restart the server to flush.
 
 ### Rate limiter (`rate_limiter.py`)
 
@@ -232,7 +234,7 @@ Each mixin uses the same shared services injected into the parent: `config`, `pa
 
 ### Tools package (`tools/`)
 
-One file per category. Every file exports a `register_*_tools(server)` function called from `tools/__init__.py:register_all_tools`. Tools are decorated with `@server.mcp.tool()` (FastMCP) and forward to either `server.async_zim_operations` (for blocking ZIM I/O dispatched via `asyncio.to_thread`) or `server.zim_operations` (for cheap synchronous helpers).
+One module per tool. Every `zim_*.py` exports a `register(server)` function called from `tools/__init__.py:register_phase_f_tools`. Tools are decorated with `@server.mcp.tool()` (FastMCP) and forward to either `server.async_zim_operations` (for blocking ZIM I/O dispatched via `asyncio.to_thread`) or `server.zim_operations` (for cheap synchronous helpers).
 
 ### Smart retrieval fallback
 

--- a/website/src/content/docs/faq.mdx
+++ b/website/src/content/docs/faq.mdx
@@ -284,7 +284,7 @@ Yes. Any valid ZIM file works with OpenZIM MCP. You can create custom ZIM files 
 
 ### What's a good cache hit rate?
 
-Target >70% cache hit rate for good performance. Monitor using `zim_health` (the `.cache_performance` block) and adjust cache size accordingly.
+Target >70% cache hit rate for good performance. Monitor using `zim_health` (the `.health.cache_performance` block) and adjust cache size accordingly.
 
 ### How much memory does it use?
 

--- a/website/src/content/docs/llm-integration-patterns.mdx
+++ b/website/src/content/docs/llm-integration-patterns.mdx
@@ -436,7 +436,7 @@ If your MCP client surfaces the flag, branch on it first: it is one boolean and 
 Two edges worth knowing:
 
 - **`structuredContent` is deliberately unset** on error results. No tool advertises an `outputSchema`, and per the MCP spec `structuredContent` is the counterpart to one, so the envelope always lives in the `content` text block.
-- **Partial failures are not call failures.** A cross-archive `zim_search(cross_file=True)` where one archive is unreadable, or a `zim_get(entry_paths=[...])` batch where some entries fail, still returns `isError: false`. The per-row status is nested and shaped differently per tool, and the server's discriminator only inspects the top-level dict — so nested rows never flag the whole call.
+- **Partial failures are not call failures.** A cross-archive `zim_search(cross_file=True)` where one archive is unreadable, a `zim_get(entry_paths=[...])` batch where some entries fail, and a no-argument `zim_health()` whose `health` or `configuration` block could not be built all still return `isError: false`. The per-row or per-block status is nested and shaped differently per tool, and the server's discriminator only inspects the top-level dict — so nested failures never flag the whole call. For `zim_health` that is deliberate: the two sub-report builders catch their own exceptions and return an envelope in place of their block, so a failed cache-stats read still leaves you the `configuration` and `loaded_archives` blocks that did build. Total failure is still flagged — if the `loaded_archives` scan raises, it reaches the tool boundary and you get an ordinary top-level `operation: "zim_health"` envelope with `isError: true`. The nested envelopes carry `operation: "get server health"` and `operation: "get server configuration"`, the only two non-snake_case `operation` values on the wire.
 
 ### Progressive content loading
 
@@ -478,7 +478,7 @@ if cache_hit_rate < 0.7:
     pass
 ```
 
-Note `health.cache_performance` (not `cache`); fields are `enabled, size, max_size, ttl_seconds, hits, misses, hit_rate`. `process_id` / `server_pid` are the real PID over local stdio (`[REDACTED]` over HTTP/SSE).
+Note `.health.cache_performance` (not `cache`); fields are `enabled, size, max_size, ttl_seconds, hits, misses, hit_rate`. `process_id` / `server_pid` are the real PID over local stdio (`[REDACTED]` over HTTP/SSE).
 
 ### Usage analytics
 

--- a/website/src/content/docs/performance-optimization.mdx
+++ b/website/src/content/docs/performance-optimization.mdx
@@ -37,7 +37,7 @@ export OPENZIM_MCP_CACHE__PERSISTENCE_ENABLED=true    # cache survives restarts
 | Memory-constrained (RPi, small VPS) | `MAX_SIZE=25-50`, `TTL_SECONDS=900-1800` |
 | Volatile content (frequent ZIM swaps) | shorter TTL or rely on subscriptions to invalidate downstream |
 
-Cache stats surface in `zim_health().cache_performance` (`enabled`, `size`, `max_size`, `ttl_seconds`, `hits`, `misses`, `hit_rate`). There are no `warm_cache` / `cache_stats` / `cache_clear` tools — restart to flush.
+Cache stats surface in `zim_health().health.cache_performance` (`enabled`, `size`, `max_size`, `ttl_seconds`, `hits`, `misses`, `hit_rate`). There are no `warm_cache` / `cache_stats` / `cache_clear` tools — restart to flush.
 
 **Persistence path:** defaults to `~/.cache/openzim-mcp` (resolved to absolute). For containerized deployments, mount a volume there or override `OPENZIM_MCP_CACHE__PERSISTENCE_PATH`.
 
@@ -158,7 +158,7 @@ Both endpoints are auth-exempt and CORS-friendly; safe to wire into Kubernetes p
 
 ### Health detail
 
-`zim_health()` returns the full status. Real response shape:
+`zim_health()` returns `{health, configuration, loaded_archives, _meta}`. The `.health` block (abbreviated):
 
 ```json
 {
@@ -211,7 +211,7 @@ For platform-level monitoring prefer `/healthz` (no auth, no JSON body, 200/503)
 
 ### External monitoring
 
-Wire `/healthz` and `/readyz` into your platform's uptime monitor. For Prometheus-style metrics OpenZIM MCP doesn't ship a metrics endpoint — scrape `/healthz` for liveness or compose `zim_health().cache_performance` into your own exporter.
+Wire `/healthz` and `/readyz` into your platform's uptime monitor. For Prometheus-style metrics OpenZIM MCP doesn't ship a metrics endpoint — scrape `/healthz` for liveness or compose `zim_health().health.cache_performance` into your own exporter.
 
 ## Resource patterns
 

--- a/website/src/content/docs/resources-prompts-subscriptions.mdx
+++ b/website/src/content/docs/resources-prompts-subscriptions.mdx
@@ -28,7 +28,9 @@ JSON list of every ZIM file in the allowed directories.
   {
     "name": "wikipedia_en_100_2026-02.zim",
     "path": "/srv/zim/wikipedia_en_100_2026-02.zim",
-    "size": 124857600,
+    "directory": "/srv/zim",
+    "size": "119.07 MB",
+    "size_bytes": 124857600,
     "modified": "2026-02-15T10:30:00"
   }
 ]

--- a/website/src/content/docs/smart-retrieval.mdx
+++ b/website/src/content/docs/smart-retrieval.mdx
@@ -103,6 +103,8 @@ Some failures are *not* candidates for search-based retrieval — searching woul
 
 If you see a redirect-cycle error, the ZIM file's data is broken; smart retrieval cannot fix it.
 
+*Propagate unchanged* describes the retrieval layer, not the wire. For the two redirect failures above, the ladder in [openzim_mcp/zim/content.py](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/zim/content.py) re-raises the `OpenZimMcpArchiveError` instead of retrying the search fallback or writing a path mapping — but the exception never reaches your client as a raise. The tool wrapper's catch-all (`except Exception` → `tool_error_response` in [openzim_mcp/tools/_common.py](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/tools/_common.py)) converts it into the standard error envelope — `{"error": true, "operation": "zim_get", "message": ..., "context": ...}`, delivered with `isError: true` — with the original text (`Redirect cycle detected at ...`) preserved under **Technical Details** inside `message`.
+
 ## Tuning
 
 There are no smart-retrieval-specific knobs. The global cache config governs:

--- a/website/src/content/docs/troubleshooting.mdx
+++ b/website/src/content/docs/troubleshooting.mdx
@@ -11,7 +11,7 @@ Common issues, error messages, and solutions for OpenZIM MCP.
 
 ## Error response shape
 
-Before diving into specific failure modes — v2 changed how errors come back from tools. Every tool catches exceptions and returns a structured `ToolErrorPayload` instead of raising:
+Before diving into specific failure modes — v2 changed how errors come back from tools. Every tool catches exceptions and returns a structured `ToolErrorPayload` instead of raising — except `zim_query`, whose handler-side failures (no archive specified, `zim_file_path` not found, an empty query/topic/search term, and any other exception raised while handling the query) return markdown guidance and still carry `isError: false`:
 
 ```json
 {
@@ -40,7 +40,8 @@ Check for it with `isinstance(result, dict) and result.get("error") is True`. Si
 - `file_not_found` / `entry_not_found` / `section_not_found` / `invalid_max_chars` — data-layer failures surfaced by `zim_get_section`. `section_not_found` is the one envelope that carries extra keys: `available_section_ids`, `available_section_ids_truncated`, `available_section_ids_total`, and `closest_match` when a near match exists.
 - `inbound_sidecar_unavailable` — `zim_links(direction="inbound")` against an archive with no link-graph sidecar
 - the tool's own wire name — `zim_get`, `zim_search`, `zim_query`, `zim_browse`, `zim_links`, `zim_metadata`, `zim_health`, `zim_get_section` — when an unexpected exception escapes the tool body (archive read error, smart-retrieval miss). There is no `get_entry` or `search` operation value: those are internal rate-limiter bucket names, never envelope operations.
-- `zim_query`'s simple-mode dispatch adds `synthesize_pipeline_error`, `synthesize_not_applicable`, `no_archives_available`, `meta_only_guidance`, `chained_intent_rejected`, `topic_required`, `search_terms_required`, `multi_entity_chain_rejected`, and `invalid_path`
+- `get server health` / `get server configuration` — the only two `operation` values that are not snake_case, and the only two that never appear at the top level of a response. The no-argument `zim_health()` builds `.health`, `.configuration` and `.loaded_archives` independently, and each of the first two catches its own exceptions — so a failure inside one replaces that block alone with an envelope while the rest of the response still comes back. The top-level dict stays an ordinary success payload, so `isError` is `false`: test `.health` and `.configuration` for an `error` key rather than assuming the whole call succeeded. This partial case is the only unflagged one — a failure in the `loaded_archives` scan, or anywhere in the `zim_health(zim_file_path=...)` validation branch, surfaces as a normal top-level `operation="zim_health"` envelope with `isError: true`.
+- `zim_query`'s `synthesize=True` path adds `synthesize_pipeline_error`, `synthesize_not_applicable`, `no_archives_available`, `meta_only_guidance`, `chained_intent_rejected`, `topic_required`, `search_terms_required`, `multi_entity_chain_rejected`, and `invalid_path`. These are the only `zim_query` handler failures that produce an envelope at all — on the default path the same conditions come back as markdown guidance with `isError: false`.
 
 The envelope itself is defined in [openzim_mcp/responses.py](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/responses.py) — the `ToolErrorPayload` TypedDict and the `tool_error()` builder every failure path must go through — and the `isError` mapping in [openzim_mcp/mcp_envelope.py](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/mcp_envelope.py). The underlying exception hierarchy in [openzim_mcp/exceptions.py](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/exceptions.py) is what the broad-`except` paths wrap; it shapes the `message` text but not the envelope's keys — `error_code` is never emitted.
 
@@ -439,7 +440,7 @@ When reporting issues, include:
 
 - **Operating system** and version
 - **Python version**: `python --version`
-- **OpenZIM MCP version**: `python -c "import openzim_mcp; print(openzim_mcp.__version__)"` or check `zim_health` → `.configuration.config_hash` and the MCP `serverInfo.version` (reads from `importlib.metadata`; reports openzim-mcp's actual version, not the FastMCP SDK default)
+- **OpenZIM MCP version**: `python -c "import openzim_mcp; print(openzim_mcp.__version__)"` or check `zim_health` → `.configuration.configuration.config_hash` (the outer key is the block, the inner one the report) and the MCP `serverInfo.version` (reads from `importlib.metadata`; reports openzim-mcp's actual version, not the FastMCP SDK default)
 - **ZIM file details**: Size, source, name
 - **Error messages**: Full error text
 - **Configuration**: MCP client config (remove sensitive paths)

--- a/website/src/content/docs/worked-examples.mdx
+++ b/website/src/content/docs/worked-examples.mdx
@@ -23,18 +23,25 @@ Response (truncated):
 
 ```json
 {
-  "status": "healthy",
-  "server_name": "openzim-mcp",
+  "health": {
+    "status": "healthy",
+    "server_name": "openzim-mcp",
+    "cache_performance": { "enabled": true, "size": 0, "max_size": 100, "hit_rate": 0.0 },
+    "configuration": { "allowed_directories": 1, "cache_enabled": true, "config_hash": "a1b2c3d4..." }
+  },
+  "configuration": {
+    "configuration": { "server_name": "openzim-mcp", "allowed_directories": ["...zim-files"], "allowed_directories_count": 1, "cache_enabled": true },
+    "diagnostics": { "validation_status": "ok", "warnings": [], "recommendations": [] }
+  },
   "loaded_archives": [
     {
       "name": "wikipedia_en_100_2025-08.zim",
       "path": "...wikipedia_en_100_2025-08.zim",
       "size": "310.77 MB",
+      "size_bytes": 325866721,
       "modified": "2025-09-11T10:20:50"
     }
-  ],
-  "cache_performance": { "enabled": true, "size": 0, "max_size": 100, "hit_rate": 0.0 },
-  "configuration": { "allowed_directories": 1, "cache_enabled": true }
+  ]
 }
 ```
 


### PR DESCRIPTION
Follow-up to #339, which left seven verified-but-unfixed items. Fixing them exposed a wider instance of the same problem: docs written against a pre-v2 layout that no longer exists.

## `zim_health` nested errors — documented, not changed

`_build_health_report` and `_build_configuration_report` swallow their own exceptions and return an envelope *in place of their block*, so `is_tool_error_envelope` — which only inspects the top-level dict — leaves `isError: false`.

Verified by runtime repro rather than reasoning: forcing `cache.stats()` to raise yields `.health` as a nested envelope with `isError` false and the other two blocks intact; forcing the `loaded_archives` scan to raise yields a normal top-level `operation: "zim_health"` envelope with `isError: true`.

So **total failure is already flagged** and only the partial case is not. Making the discriminator recurse would also flip cross-archive and batch partial failures to `isError: true`, contradicting the rule #339 just documented, and would discard a usable 2-of-3 health report. Documented instead. The two nested `operation` values (`get server health`, `get server configuration`) are the only non-snake_case ones on the wire and are now listed as such.

## The response is nested a level deeper than documented

Six pages read fields off the wrong path:

| Documented | Actual |
|---|---|
| `zim_health().cache_performance` | `.health.cache_performance` |
| `zim_health` → `.configuration.config_hash` | `.configuration.configuration.config_hash` |

Hit `performance-optimization.mdx` (×3), `faq.mdx`, `llm-integration-patterns.mdx`, `architecture-overview.mdx`, `troubleshooting.mdx`. The `api-reference.mdx` and `worked-examples.mdx` payload samples were reshaped to the real structure, including the `size` / `size_bytes` split that `resources-prompts-subscriptions.mdx` asserts is "the same shape" — it wasn't, and now is.

## Phantom modules

`architecture-overview.mdx` and `CONTRIBUTING.md` both list seven `tools/` modules that do not exist (`file_tools.py`, `content_tools.py`, `navigation_tools.py`, `search_tools.py`, `metadata_tools.py`, `structure_tools.py`, `server_tools.py`). The v2 layout is one `zim_*.py` per tool. Replaced with the real listing in all three places they appeared, including the high-level layers diagram.

`register_all_tools` does not exist either — the orchestrator is `register_phase_f_tools` and modules export `register`, not `register_*_tools`. Fixed at both sites, since #339's new paragraph would otherwise have contradicted them 66 lines apart on the same page.

## The 8-tool diagram advertised four invalid parameter values

`mode="list"`, `mode="filtered"`, `mode="cross_file"` (it is a bool parameter, not a mode) and `direction="outgoing"`. `direction="inbound"` was missing entirely. Corrected in-place with box-drawing widths preserved byte-for-byte.

## `zim_query` is not covered by "every tool returns an envelope"

Its default-path handler failures (no archive, path not found, empty query) return **markdown guidance** and ship `isError: false`; only argument rejections and `synthesize=True` refusals produce an envelope. Hedged at the three sites making the blanket claim, and the nine simple-mode `operation` values were re-scoped to the `synthesize=True` path where they actually occur.

## `llms.txt`

Gains an **Error Handling** section. It is the model-facing surface and said nothing about the envelope at all. Placed clear of the version line that release-please rewrites.

## Verification

- `3605 passed / 213 skipped / 0 failed`
- Website builds clean (16 pages); markdownlint and pre-commit pass
- Every JSON sample in the three reshaped files re-parsed
- Box-drawing line widths asserted equal before/after
- Post-sweep: zero hits for the phantom module names, the wrong cache paths, or the invalid mode/direction values

## Known leftovers, deliberately not in scope

`quick-start.mdx:194` lists `status` / `cache_performance` / `health_checks` as bare field names — loose rather than wrong, since it asserts no path.