### PR TITLE
fix(deps): bump postcss to 8.5.25 to clear CVE-2026-69153

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -5560,9 +5560,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
Closes Dependabot alert #60.

## Why

[GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) / CVE-2026-69153 (medium): an attacker-controlled `sourceMappingURL` lets PostCSS read arbitrary `.map` files when `from` is unset. It is an **incomplete fix** of the earlier GHSA-6g55-p6wh-862q.

Affected `<= 8.5.22`; the lockfile had exactly 8.5.22. It reaches us transitively via `astro` → `vite`, which pins `postcss ^8.5.17`, so a lockfile bump is sufficient — no `package.json` change and no `overrides` entry needed.

This is `website/` build tooling only. It does not touch the published Python package.

## Why the lockfile was hand-edited

`npm update postcss --package-lock-only` produced a **3 insertion / 105 deletion** diff: this repo's lockfile was written by a newer npm than the one available here (local 11.8.0), and re-resolving strips the `libc` discriminators from every optional platform binary:

```diff
       "cpu": [ "arm64" ],
-      "libc": [ "glibc" ],
       "license": "MIT",
```

Those fields are how npm picks the musl vs glibc binary, so dropping them is a real regression to smuggle into a security patch. Instead I edited the three postcss fields directly, taking `resolved` and `integrity` from the registry.

Verified this is safe: postcss 8.5.22 and 8.5.25 declare **identical** `dependencies` (`nanoid ^3.3.16`, `picocolors ^1.1.1`, `source-map-js ^1.2.1`), `engines`, and `license` — so nothing else in the tree moves. The diff is 3 lines.

## Verification

- `npm ci` installs cleanly and resolves `postcss@8.5.25`; the lockfile is byte-stable afterwards
- `npm run build` — 16 pages, clean
- `npm audit` no longer reports postcss. The one remaining advisory is `fast-uri`, which #337 fixes.