### PR TITLE
fix(docker): drop BuildKit-only COPY --chmod so registry builders can build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,14 @@ COPY openzim_mcp ./openzim_mcp
 COPY README.md ./
 RUN uv sync --frozen --no-dev
 
+# Strip write bits here rather than via `COPY --chmod` in the final stage.
+# --chmod is a BuildKit-only flag, and registry builders that use the classic
+# builder (or Kaniko) fail the build outright on it. Doing it in the builder
+# means the plain COPY below carries these modes through, which every builder
+# supports. `a-w` also beats a flat 555: it clears write without granting
+# execute to files that never had it.
+RUN chmod -R a-w /app/.venv /app/openzim_mcp
+
 # ---- final stage ----
 FROM python:3.13-slim
 
@@ -30,12 +38,20 @@ RUN groupadd --gid 10001 appuser \
 
 WORKDIR /app
 
-# Copy the virtualenv and source from builder as read-only (--chmod=555:
-# r-x for owner/group/other, no write bits). uv pre-compiles .pyc during
-# install, so the runtime never needs to write into /app; making the tree
-# read-only at rest keeps the runtime user from mutating its own code.
-COPY --from=builder --chown=appuser:appuser --chmod=555 /app/.venv /app/.venv
-COPY --from=builder --chown=appuser:appuser --chmod=555 /app/openzim_mcp /app/openzim_mcp
+# Copy the virtualenv and source from builder. The write bits were already
+# stripped in the builder stage and COPY preserves source modes, so the tree
+# lands read-only. uv pre-compiles .pyc during install, so the runtime never
+# needs to write into /app; read-only at rest keeps the runtime user from
+# mutating its own code.
+COPY --from=builder --chown=appuser:appuser /app/.venv /app/.venv
+COPY --from=builder --chown=appuser:appuser /app/openzim_mcp /app/openzim_mcp
+
+# COPY re-creates the destination directory itself at the default 0755 owned
+# by appuser, so the builder-stage chmod covers the contents but not these two
+# inodes — without this the runtime user could still add new files alongside
+# the code. Non-recursive on purpose: two inodes, so the layer stays tiny
+# instead of duplicating the whole virtualenv.
+RUN chmod 555 /app/.venv /app/openzim_mcp
 
 ENV PATH="/app/.venv/bin:$PATH"
 


### PR DESCRIPTION
## Problem

The Glama image build fails at the `.venv` copy:

```
Step 12/18 : COPY --from=builder --chown=appuser:appuser --chmod=555 /app/.venv /app/.venv
the --chmod option requires BuildKit.
```

`COPY --chmod` is a BuildKit-only flag. Registry builders that use the classic
builder (or Kaniko) reject it outright, so the build never reaches the final
stage. Our own CI publishes via `docker/build-push-action` (BuildKit), which is
why this never surfaced in-repo.

## Fix

Strip the write bits in the builder stage and let a plain `COPY` carry the
modes through — supported by every builder. `chmod -R a-w` is also more precise
than a flat `555`: it clears write without granting execute to files that never
had it.

`COPY` re-creates the two destination directories at the default 0755 owned by
appuser, so those inodes are chmod'd explicitly in the final stage. That step is
deliberately non-recursive — two inodes, ~1KB of layer, instead of duplicating
the whole virtualenv.

## Verification

| Check | Before | After |
|---|---|---|
| Classic builder (`DOCKER_BUILDKIT=0`) | ❌ `--chmod requires BuildKit` | ✅ builds |
| BuildKit `linux/amd64` | ✅ | ✅ |
| BuildKit `linux/arm64` | ✅ | ✅ |
| `/app/.venv`, `/app/openzim_mcp` modes | `dr-xr-xr-x` | `dr-xr-xr-x` |
| appuser creates file in either dir | denied | denied |
| appuser overwrites `server.py` | denied | denied |
| MCP `initialize` + `tools/list` | ✅ | ✅ |
| Image size | 66,464,952 B | 66,465,825 B (+873 B) |

Read-only-at-rest is unchanged. Handshake verified with no volume mount, with
`--network none`, and with `--read-only`; stdout carries only JSON-RPC in every
case. End-to-end `zim_query` against a mounted ZIM returns real article content
and exits 0.