### PR TITLE
ci: guard against BuildKit-only Dockerfile syntax

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,6 +17,29 @@ on:
         type: string
 
 jobs:
+  # Build once with the classic (non-BuildKit) builder. The publish job below
+  # goes through buildx, which is always BuildKit — so BuildKit-only Dockerfile
+  # syntax passes CI here while failing on registry builders that don't use it.
+  # That blind spot shipped a broken image to Glama once already: `COPY --chmod`
+  # is BuildKit-only and died with "the --chmod option requires BuildKit" (#343).
+  # This job is the regression guard, and it is the whole point of not reusing
+  # buildx for it.
+  classic-builder:
+    name: Build without BuildKit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      # No setup-buildx-action on purpose: DOCKER_BUILDKIT=0 selects the
+      # classic builder, which rejects BuildKit-only flags the way a
+      # registry builder such as Kaniko or plain `docker build` would.
+      - name: Build with the classic builder
+        env:
+          DOCKER_BUILDKIT: "0"
+        run: docker build -t openzim-mcp:classic-builder-check .
+
   publish:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Why

#343 fixed a Dockerfile that built fine in CI and failed on Glama. The cause was
structural, not a one-off: the `publish` job builds through `docker/build-push-action`,
which is **always BuildKit**, so BuildKit-only syntax is green in-repo and broken
everywhere else. `COPY --chmod` sat in the Dockerfile for two months before anyone
noticed, because nothing here could see it.

## What

One job that builds with `DOCKER_BUILDKIT=0`. The classic builder rejects
BuildKit-only flags the same way Kaniko or a plain `docker build` on a registry
builder does — which is exactly the environment CI wasn't modelling.

Deliberately **no** `setup-buildx-action` in this job. Reusing buildx would
reintroduce the blind spot it exists to close.

## Cost

The workflow already triggers only on changes to `Dockerfile`, `.dockerignore`,
or itself, so this adds one amd64 build to PRs touching those paths and nothing
elsewhere.

## Verification

`DOCKER_BUILDKIT=0 docker build .` passes against current `main` (post-#343), and
failed against the pre-#343 Dockerfile with `the --chmod option requires BuildKit`
— so the guard both passes now and would have caught the original bug.