### PR TITLE
fix: close the correctness sweep's deferred findings

### DIFF
--- a/openzim_mcp/bundle.py
+++ b/openzim_mcp/bundle.py
@@ -36,7 +36,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-_BUNDLE_KEY_PREFIX = "bundle:v2c"
+# v2d: SectionMeta grew ``heading_start`` — cached v2c bundles lack the
+# field, so the narrow-slice fix would silently keep serving the child
+# heading until TTL expiry without the key bump.
+_BUNDLE_KEY_PREFIX = "bundle:v2d"
 
 
 def archive_stat_token(validated_path: Any) -> str:
@@ -305,7 +308,7 @@ def _compute_section_offsets(
     for i, (
         level,
         text,
-        _heading_start,
+        heading_start,
         char_start,
         section_id,
         id_source,
@@ -340,6 +343,7 @@ def _compute_section_offsets(
                     "id": section_id,
                     "title": text,
                     "level": level,
+                    "heading_start": heading_start,
                     "char_start": char_start,
                     "char_end": char_end,
                     "parent_id": parent_id,

--- a/openzim_mcp/compact_format.py
+++ b/openzim_mcp/compact_format.py
@@ -98,8 +98,16 @@ class _CompactFormatMixin:
     # rendered search response always includes a ``\n---\n`` footer —
     # but the explicit ``\Z`` keeps the regex correct on malformed or
     # synthetic input).
+    #
+    # Sweep follow-up: the boundary lookahead anchors on the NUMBERED
+    # result heading (``## 3. Title``) and the blank-line-preceded
+    # footer, not any ``\n\n## `` / ``\n---\n``. A markdown H2 or
+    # horizontal rule EMBEDDED in the snippet text used to terminate
+    # the capture early, so everything after it escaped the cap. The
+    # numbered form can't collide with article headings — html2text
+    # backslash-escapes rendered numbered headings (``## 1\. Topic``).
     _SEARCH_SNIPPETS_RE = re.compile(
-        r"(Snippet: )(.+?)(?=\n\n## |\n---\n|\Z)",
+        r"(Snippet: )(.+?)(?=\n\n## \d+\. |\n\n---\n|\Z)",
         re.DOTALL,
     )
 

--- a/openzim_mcp/http_app.py
+++ b/openzim_mcp/http_app.py
@@ -175,6 +175,13 @@ def _make_readyz(
     # `.done()` (CANCELLED) while the real work is still running — the
     # single-flight check below would silently no-op against it.
     _readyz_inflight: Optional["Future[bool]"] = None
+    # The shared asyncio wrapper for `_readyz_inflight`. Sweep follow-up:
+    # `wrap_future` chains a done-callback onto the concurrent future and
+    # nothing unchains it when a waiter times out, so a fresh per-request
+    # wrapper grew the wedged probe's callback list without bound
+    # (`/readyz` is auth-exempt and unmetered). One wrapper per probe;
+    # `shield` already removes its own per-waiter callback on timeout.
+    _readyz_inflight_wrapped: Optional["asyncio.Future[bool]"] = None
 
     async def readyz(request: Request) -> JSONResponse:
         """Readiness — at least one allowed directory is readable."""
@@ -193,7 +200,7 @@ def _make_readyz(
         # `/readyz` is auth-exempt and unmetered by the rate limiter, so N
         # unauthenticated requests wedged every MCP tool call. The pool's
         # daemon workers also let the process exit while a probe is stuck.
-        nonlocal _readyz_inflight
+        nonlocal _readyz_inflight, _readyz_inflight_wrapped
         # Single-flight by SHARING the in-flight probe, not by short-circuiting
         # to 503. Only one work item is ever outstanding, so a wedged stat can
         # never burn more than one worker — but concurrent probes against a
@@ -201,9 +208,19 @@ def _make_readyz(
         # merely because another request was in flight would fail a readiness
         # check on a perfectly good instance and pull it from rotation.
         probe = _readyz_inflight
+        wrapped = _readyz_inflight_wrapped
         if probe is None or probe.done():
             probe = _get_executor("readyz").submit(_any_readable_dir)
             _readyz_inflight = probe
+            wrapped = asyncio.wrap_future(probe)
+            _readyz_inflight_wrapped = wrapped
+        elif wrapped is None or wrapped.get_loop() is not asyncio.get_running_loop():
+            # A wrapper is loop-bound; recreate it if the loop changed
+            # under a still-running probe (test harnesses; a uvicorn
+            # loop restart). Production keeps one loop, so the shared
+            # wrapper stays one-per-probe.
+            wrapped = asyncio.wrap_future(probe)
+            _readyz_inflight_wrapped = wrapped
         try:
             # `shield` is load-bearing, not defensive. `wrap_future` chains via
             # `asyncio.futures._chain_future`, whose `_call_check_cancel` calls
@@ -218,7 +235,7 @@ def _make_readyz(
             # Shielding cancels only the outer future, so each waiter times out
             # independently and the probe really does stay single-flight.
             ready = await asyncio.wait_for(
-                asyncio.shield(asyncio.wrap_future(probe)),
+                asyncio.shield(wrapped),
                 timeout=READYZ_PROBE_TIMEOUT_SECONDS,
             )
         except asyncio.TimeoutError:

--- a/openzim_mcp/intent_parser.py
+++ b/openzim_mcp/intent_parser.py
@@ -362,15 +362,38 @@ def _extract_entry_path_keyworded(query: str, params: Dict[str, Any]) -> None:
     # are preserved — ``get article History of France`` → ``History of France``,
     # ``get article Lord of the Rings`` → ``Lord of the Rings`` (previously the
     # last-preposition anchor truncated these to ``France`` / ``the Rings``).
-    # Only when no object keyword is present do we fall back to the last
-    # preposition anchor, which keeps ``table of contents for Biology`` →
-    # ``Biology`` (picking ``for`` over the title-internal ``of``).
+    #
+    # Sweep follow-up: without an object keyword, anchor on the FIRST
+    # preposition after the intent verb, not the last one in the query.
+    # The last-preposition anchor truncated title-internal prepositions
+    # the same way the pre-H6 object branch did — ``toc of Battle of
+    # Britain`` → ``Britain``, ``links in Lord of the Rings`` → ``the
+    # Rings``. ``table of contents`` is matched as one verb phrase so its
+    # internal ``of`` can't act as the anchor (``list the table of
+    # contents for Marie Curie`` still anchors on ``for``), and the scan
+    # starts at the verb phrase's end so a preposition inside a leading
+    # scoping clause can't win either. When no verb is found the scan
+    # starts at the beginning of the query.
     object_re = re.compile(r"\b(?:article|entry|page)\s+", re.IGNORECASE)
     keyword_re = re.compile(
         r"\b(?:of|for|in|from|to)\s+",
         re.IGNORECASE,
     )
-    matches = list(object_re.finditer(query)) or list(keyword_re.finditer(query))
+    verb_re = re.compile(
+        r"\b(?:"
+        r"table\s+of\s+contents|"
+        r"structure|outline|sections?|headings?|"
+        r"summary|summarize|summarise|overview|brief|"
+        r"toc|contents|links?"
+        r")\b",
+        re.IGNORECASE,
+    )
+    matches = list(object_re.finditer(query))
+    if not matches:
+        verb_match = verb_re.search(query)
+        scan_from = verb_match.end() if verb_match else 0
+        first_prep = keyword_re.search(query, scan_from)
+        matches = [first_prep] if first_prep else []
     if matches:
         tail = query[matches[-1].end() :].strip().rstrip("?.,;:!").strip()
         # Post-v2.0.0 D-C: ``table of contents X`` anchors on ``of`` →

--- a/openzim_mcp/intent_parser.py
+++ b/openzim_mcp/intent_parser.py
@@ -379,12 +379,17 @@ def _extract_entry_path_keyworded(query: str, params: Dict[str, Any]) -> None:
         r"\b(?:of|for|in|from|to)\s+",
         re.IGNORECASE,
     )
+    # Must cover every word the intent regexes accept as the verb, or the
+    # scan starts at 0 and a preposition in a LEADING noun phrase wins the
+    # anchor: ``list of references in Photosynthesis`` anchored on the
+    # ``of`` in ``list of``, yielding ``references in photosynthesis``.
+    # ``references``/``related`` mirror the links pattern at line 1021.
     verb_re = re.compile(
         r"\b(?:"
         r"table\s+of\s+contents|"
         r"structure|outline|sections?|headings?|"
         r"summary|summarize|summarise|overview|brief|"
-        r"toc|contents|links?"
+        r"toc|contents|links?|references?|related"
         r")\b",
         re.IGNORECASE,
     )

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -51,6 +51,7 @@ from .title_promotion import (
     _TAIL_TOKEN_RE,
     find_title_match,
     has_apostrophe_possessive,
+    is_strong_canonical_title_match,
     is_strong_title_match,
 )
 from .tool_schemas import (
@@ -2733,7 +2734,10 @@ class SimpleToolsHandler(
             return payload
         top_path = str(top.get("path", ""))
         top_title = str(top.get("title", top_path.replace("_", " ")))
-        if is_strong_title_match(search_query, top_path, top_title):
+        # Sweep follow-up: the canonical variant refuses a
+        # ``Foo_(disambiguation)`` twin at rank 1, so the splice still
+        # probes for (and promotes) the canonical ``Foo``.
+        if is_strong_canonical_title_match(search_query, top_path, top_title):
             return payload
         promoted = find_title_match(self.zim_operations, zim_file_path, search_query)
         if promoted is None:

--- a/openzim_mcp/subscriptions.py
+++ b/openzim_mcp/subscriptions.py
@@ -122,6 +122,20 @@ class SubscriberRegistry:
     def _distinct_uri_count(self) -> int:
         return len(set(self._weak_by_uri) | set(self._strong_by_uri))
 
+    def _session_holds_uri(self, uri: str, session: Hashable) -> bool:
+        """True iff ``session`` is already subscribed to ``uri``."""
+        for store in (self._weak_by_uri, self._strong_by_uri):
+            sessions = store.get(uri)
+            if sessions is None:
+                continue
+            # ``in`` on a WeakSet weak-refs its arg; a non-weak-
+            # referenceable session (never in the weak set) raises
+            # TypeError — it simply isn't a member.
+            with contextlib.suppress(TypeError):
+                if session in sessions:
+                    return True
+        return False
+
     def _uri_count_for_session(self, session: Hashable) -> int:
         """Count the distinct URIs ``session`` is already subscribed to.
 
@@ -159,11 +173,19 @@ class SubscriberRegistry:
                         f"{MAX_URIS_TOTAL}-URI capacity; "
                         "unsubscribe from unused resources first."
                     )
-                if self._uri_count_for_session(session) >= MAX_URIS_PER_SESSION:
-                    raise OpenZimMcpValidationError(
-                        "This session is already subscribed to the maximum of "
-                        f"{MAX_URIS_PER_SESSION} distinct resource URIs."
-                    )
+            # Sweep follow-up: the per-session cap must cover KNOWN URIs
+            # too — it used to sit inside the not-known branch, so a
+            # session at its cap could keep adding any URI some other
+            # session had already registered. Idempotent re-subscribes
+            # (URI already held by this session) stay exempt.
+            if (
+                not self._session_holds_uri(uri, session)
+                and self._uri_count_for_session(session) >= MAX_URIS_PER_SESSION
+            ):
+                raise OpenZimMcpValidationError(
+                    "This session is already subscribed to the maximum of "
+                    f"{MAX_URIS_PER_SESSION} distinct resource URIs."
+                )
             try:
                 self._weak_by_uri.setdefault(uri, weakref.WeakSet()).add(session)
             except TypeError:

--- a/openzim_mcp/synthesize.py
+++ b/openzim_mcp/synthesize.py
@@ -36,7 +36,7 @@ from openzim_mcp.title_promotion import (
     find_title_match,
     has_apostrophe_possessive,
     is_single_token_tail_match,
-    is_strong_title_match,
+    is_strong_canonical_title_match,
     iter_query_tails,
     passes_z4,
 )
@@ -1122,7 +1122,11 @@ def _promote_title_match(
         # Use the path as the title proxy — Wikipedia exports preserve the
         # title in the path (``Berlin`` ↔ ``Berlin``) so the token-match
         # comparison works without a second archive read.
-        if is_strong_title_match(query, top_path, top_path.replace("_", " ")):
+        # Sweep follow-up: the canonical variant refuses a
+        # ``Foo_(disambiguation)`` twin at rank 1 — it strong-matches the
+        # bare topic, so the plain check skipped promotion and the
+        # disambiguation page led the synthesized answer.
+        if is_strong_canonical_title_match(query, top_path, top_path.replace("_", " ")):
             return top_hits
 
     # Post-b4 D3: mirror the ``_promote_topic_via_title_index`` pass-0

--- a/openzim_mcp/title_promotion.py
+++ b/openzim_mcp/title_promotion.py
@@ -86,6 +86,36 @@ def is_strong_title_match(topic: str, path: str, title: str) -> bool:
     return False
 
 
+# Sweep follow-up: ``Foo_(disambiguation)`` / URL-encoded twin suffix on a
+# candidate path or title. Space-form covers titles, underscore-form paths.
+_DISAMBIG_TWIN_SUFFIX_RE = re.compile(
+    r"[_ ](?:\(disambiguation\)|%28disambiguation%29)\s*$", re.IGNORECASE
+)
+
+
+def is_strong_canonical_title_match(topic: str, path: str, title: str) -> bool:
+    """``is_strong_title_match`` for rank-1 short-circuit decisions.
+
+    A ``Foo (disambiguation)`` twin strong-matches the bare topic ``Foo``
+    via the candidate-extends-topic direction, so a twin at rank 1 made
+    the promotion short-circuits conclude "already canonical" and the
+    real ``Foo`` article was never probed — the disambiguation page led
+    the response. Here the twin is never accepted as canonical unless
+    the topic itself asks for the disambiguation page.
+
+    Deliberately separate from :func:`is_strong_title_match`: the
+    tell-me-about ambiguity machinery counts the twin as a strong match
+    on purpose (its canonical-vs-twin auto-pick needs both in the set),
+    so only the skip-promotion call sites use this stricter form.
+    """
+    if "disambiguation" not in topic.lower() and (
+        _DISAMBIG_TWIN_SUFFIX_RE.search(path or "")
+        or _DISAMBIG_TWIN_SUFFIX_RE.search(title or "")
+    ):
+        return False
+    return is_strong_title_match(topic, path, title)
+
+
 # A11 post-a11 H1: punctuation characters whose presence in the topic
 # encodes load-bearing meaning the title resolver may smear away.
 # ``C++`` (the language) was getting silently mapped to ``C/C++`` (a

--- a/openzim_mcp/tool_schemas.py
+++ b/openzim_mcp/tool_schemas.py
@@ -511,6 +511,13 @@ class SectionMeta(TypedDict):
     level: int
     char_start: int
     char_end: int
+    # Start of the heading line itself (char_start is the BODY start,
+    # past the heading line). Narrow-slice boundaries use this so a
+    # child's heading line doesn't leak into the parent's
+    # include_subsections=False slice. NotRequired: bundles cached
+    # before the field existed lack it (consumers fall back to
+    # char_start).
+    heading_start: NotRequired[int]
     parent_id: NotRequired[Optional[str]]
     id_source: NotRequired[
         Literal["id", "descendant_anchor", "preceding_anchor", "slug"]

--- a/openzim_mcp/zim/archive.py
+++ b/openzim_mcp/zim/archive.py
@@ -1336,19 +1336,57 @@ class ZimOperations(
             # these named paths resolve, the archive simply has no main
             # page, which the presenters handle via ``"no_main_page"``.
             main_page_paths = ["W/mainPage", "A/Main_Page", "A/index"]
+            # Sweep follow-up: distinguish "probe path absent" from "probe
+            # path FOUND but unreadable". The old single try/except sent
+            # both to the next candidate, so a transient read failure on
+            # an existing main-page entry fell through to the
+            # ``no_main_page`` arm — which is content_ok=True and cached,
+            # turning a transient into a durable "archive has no main
+            # page" claim.
+            probe_failed_after_found = False
             for path in main_page_paths:
                 try:
                     entry = archive.get_entry_by_path(path)
-                    if entry:
-                        entry = _follow_redirect(entry)
-                        payload, ok = _build(entry)
-                        if ok:
-                            return "entry", payload, True, path
-                        # Content extraction failed for this probe path —
-                        # drop the sentinel and try the next candidate.
                 except Exception:  # nosec B112 - intentional fallback
                     # Path doesn't exist, try next
                     continue
+                if not entry:
+                    continue
+                try:
+                    entry = _follow_redirect(entry)
+                except Exception as e:
+                    logger.warning(
+                        f"Main-page probe {path} resolved but its redirect "
+                        f"chain failed: {e}"
+                    )
+                    probe_failed_after_found = True
+                    continue
+                payload, ok = _build(entry)
+                if ok:
+                    return "entry", payload, True, path
+                # Content extraction failed for this probe path — drop the
+                # sentinel and try the next candidate, but remember that a
+                # main-page entry does exist.
+                probe_failed_after_found = True
+
+            if probe_failed_after_found:
+                # A main-page entry exists but couldn't be served —
+                # content_ok=False keeps this out of the cache so the next
+                # request retries instead of inheriting a wrong
+                # "no main page" answer.
+                return (
+                    "content_error",
+                    {
+                        "path": "",
+                        "title": "Main Page",
+                        "content": (
+                            "(Error retrieving content: a main-page entry "
+                            "exists but its content could not be read)"
+                        ),
+                    },
+                    False,
+                    None,
+                )
 
             # No main page found — this is a structural property of the
             # archive, so it's safe to cache.

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -53,6 +53,12 @@ logger = logging.getLogger(__name__)
 _FILTERED_BATCH_SIZE = 500
 _FILTERED_MAX_SCAN = 10000
 
+# Fixed rank-decay window for suggestion scores. Dividing by the
+# returned-row count made a suggestion's score depend on the caller's
+# ``limit``; a fixed window keeps the same (query, article, rank) at the
+# same score whatever was requested.
+_SUGGESTION_SCORE_DECAY_WINDOW = 10
+
 
 def canonical_result_path(path: str) -> str:
     """Strip the query string and fragment from a result path.
@@ -3113,7 +3119,16 @@ class _SearchMixin:
                             # case-insensitive title match is promoted to
                             # 1.0 (and flips fast_path_hit) so callers can
                             # recognise the strongest possible match.
-                            n = max(len(paths), 1)
+                            #
+                            # Sweep follow-up: decay against the FIXED
+                            # window below, not ``len(paths)`` — dividing
+                            # by the returned-row count made a row's score
+                            # depend on the caller's ``limit`` (rank 1
+                            # scored 0.6333 at limit=10 but 0.475 at
+                            # limit=2 for the same suggestion), skewing
+                            # cross-archive merges. Rank 0 still scores
+                            # 0.95, so the 0.95/0.8 top-row promotion
+                            # gates are unaffected.
                             for idx, path in enumerate(paths):
                                 try:
                                     entry = archive.get_entry_by_path(path)
@@ -3149,8 +3164,20 @@ class _SearchMixin:
                                 else:
                                     # Linearly decaying rank-score in (0, 0.95].
                                     # Capped below 1.0 so an exact match always
-                                    # outranks any prefix/partial.
-                                    score = round(0.95 * (1.0 - idx / n), 4)
+                                    # outranks any prefix/partial; floored so
+                                    # ranks past the window keep a positive
+                                    # score.
+                                    score = round(
+                                        max(
+                                            0.95
+                                            * (
+                                                1.0
+                                                - idx / _SUGGESTION_SCORE_DECAY_WINDOW
+                                            ),
+                                            0.05,
+                                        ),
+                                        4,
+                                    )
                                     match_type = (
                                         "redirect"
                                         if redirect_walked

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -726,10 +726,17 @@ class _StructureMixin:
             narrowed_end = char_end
             # The first section in document order strictly after the
             # requested one is the first child (or the next sibling).
+            # Sweep follow-up: the boundary is the following section's
+            # ``heading_start`` — ``char_start`` is its BODY start, so
+            # narrowing there left the child's heading line dangling at
+            # the end of the "no subsections" slice. Fall back to
+            # ``char_start`` for bundles cached before the field existed.
             first_following_idx: Optional[int] = None
             for j, sib in enumerate(sections[section_idx + 1 :], start=section_idx + 1):
                 if sib["char_start"] > section["char_start"]:
-                    narrowed_end = min(narrowed_end, sib["char_start"])
+                    narrowed_end = min(
+                        narrowed_end, sib.get("heading_start", sib["char_start"])
+                    )
                     first_following_idx = j
                     break
             # D5 (v2.0.0a9): when the narrow slice has essentially no
@@ -762,7 +769,9 @@ class _StructureMixin:
                 widened_end = first_child["char_end"]
                 for sib in sections[first_following_idx + 1 :]:
                     if sib["char_start"] > first_child["char_start"]:
-                        widened_end = min(widened_end, sib["char_start"])
+                        widened_end = min(
+                            widened_end, sib.get("heading_start", sib["char_start"])
+                        )
                         break
                 char_end = widened_end
                 narrow_widened = True

--- a/tests/test_find_entry_by_title_characterization.py
+++ b/tests/test_find_entry_by_title_characterization.py
@@ -191,8 +191,9 @@ def test_suggestion_search_rank_decayed_scores(
     )
 
     scores = [r["score"] for r in out["results"]]
-    # n=3 -> 0.95*(1-0/3), 0.95*(1-1/3), 0.95*(1-2/3) rounded to 4dp.
-    assert scores == [0.95, 0.6333, 0.3167]
+    # Fixed decay window (10): 0.95*(1-idx/10) — limit-independent, so
+    # the same suggestion scores the same whatever the caller requested.
+    assert scores == [0.95, 0.855, 0.76]
     # Rank-monotonic, non-increasing, all distinct from the legacy 0.8.
     assert all(a >= b for a, b in zip(scores, scores[1:]))
     assert all(s != pytest.approx(0.8) for s in scores)

--- a/tests/test_sweep_followup_fixes.py
+++ b/tests/test_sweep_followup_fixes.py
@@ -179,3 +179,93 @@ class TestDisambigTwinDoesNotBlockPromotion:
         paths = [r["path"] for r in spliced["results"]]
         assert paths[0] == "Berlin"
         assert "Berlin_(disambiguation)" in paths
+
+
+class TestNarrowSectionExcludesChildHeading:
+    """``include_subsections=False`` narrowed the slice to the first
+    following section's ``char_start`` — but in production bundles that
+    offset is the child's BODY start (past its heading line), so the
+    child's ``### Heading`` line leaked into the "no subsections" slice.
+    ``SectionMeta`` now records ``heading_start`` and the narrowing
+    boundaries use it (falling back to ``char_start`` for bundles built
+    before the field existed).
+    """
+
+    #                          0         1         2
+    #                          0123456789012345678901234...
+    _MD = (
+        "## Geography\n"  # heading_start 0, body 13
+        "Berlin lies in northeastern Germany.\n"  # 13..50
+        "### Topography\n"  # heading_start 50, body 65
+        "Flat plain.\n"  # 65..77
+    )
+
+    def _bundle(self) -> dict:
+        return {
+            "entry_path": "Berlin",
+            "title": "Berlin",
+            "content_type": "text/html",
+            "rendered_markdown": self._MD,
+            "sections": [
+                {
+                    "id": "Geography",
+                    "title": "Geography",
+                    "level": 2,
+                    "heading_start": 0,
+                    "char_start": 13,
+                    "char_end": len(self._MD),
+                    "parent_id": None,
+                },
+                {
+                    "id": "Topography",
+                    "title": "Topography",
+                    "level": 3,
+                    "heading_start": 50,
+                    "char_start": 65,
+                    "char_end": len(self._MD),
+                    "parent_id": "Geography",
+                },
+            ],
+            "links": {"internal": [], "external": [], "media": []},
+            "infobox": None,
+        }
+
+    def test_narrow_slice_stops_before_child_heading_line(self) -> None:
+        import openzim_mcp.bundle as _bundle_mod
+        from tests.test_get_section_d5_widen_v2a9 import _stub_structure_mixin
+
+        mixin = _stub_structure_mixin()
+        original = _bundle_mod.get_or_build_bundle
+        _bundle_mod.get_or_build_bundle = (  # type: ignore[assignment]
+            lambda *a, **kw: self._bundle()
+        )
+        try:
+            out = mixin._get_section_data(
+                archive=MagicMock(),
+                validated_path=Path("/fake.zim"),
+                entry_path="Berlin",
+                section_id="Geography",
+                max_chars=None,
+                include_subsections=False,
+            )
+        finally:
+            _bundle_mod.get_or_build_bundle = original  # type: ignore[assignment]
+
+        assert out["content_markdown"] == "Berlin lies in northeastern Germany.\n"
+        assert "Topography" not in out["content_markdown"]
+
+    def test_bundle_builder_records_heading_start(self) -> None:
+        from openzim_mcp.bundle import _compute_section_offsets
+
+        sections = _compute_section_offsets(
+            self._MD,
+            [
+                {"level": 2, "text": "Geography", "id": "Geography"},
+                {"level": 3, "text": "Topography", "id": "Topography"},
+            ],
+        )
+        by_id = {s["id"]: s for s in sections}
+        assert by_id["Geography"]["heading_start"] == 0
+        assert by_id["Geography"]["char_start"] == 13
+        assert by_id["Topography"]["heading_start"] == 50
+        assert by_id["Topography"]["char_start"] == 65

--- a/tests/test_sweep_followup_fixes.py
+++ b/tests/test_sweep_followup_fixes.py
@@ -6,9 +6,14 @@ the first sweep PR; the docstrings name the failure the fix closes.
 
 from __future__ import annotations
 
+from pathlib import Path
+from unittest.mock import MagicMock
+
 import pytest
 
 from openzim_mcp.intent_parser import IntentParser, _extract_entry_path_keyworded
+from openzim_mcp.simple_tools import SimpleToolsHandler
+from openzim_mcp.synthesize import _promote_title_match
 
 
 class TestEntryPathFirstPrepositionAnchor:
@@ -86,3 +91,91 @@ class TestEntryPathFirstPrepositionAnchor:
         intent, params, _ = IntentParser.parse_intent("links in Lord of the Rings")
         assert intent == "links"
         assert params["entry_path"].lower() == "lord of the rings"
+
+
+class TestDisambigTwinDoesNotBlockPromotion:
+    """``Berlin_(disambiguation)`` at rank 1 strong-matched ``berlin``
+    (candidate-extends-topic), so the promotion short-circuits in
+    synthesize and the search splice never probed for the canonical
+    ``Berlin`` — the disambiguation page led the response. A twin is now
+    never "already canonical" unless the query itself asks for the
+    disambiguation page. The tell-me-about ambiguity machinery keeps
+    counting the twin as a strong match (it auto-picks the canonical
+    downstream), so ``is_strong_title_match`` itself is unchanged.
+    """
+
+    def test_synthesize_promotes_canonical_past_twin_at_rank_1(self) -> None:
+        hits = [
+            (
+                "wiki",
+                {"path": "Berlin_(disambiguation)", "snippet": "...", "score": 0.6},
+            )
+        ]
+        search_handler = MagicMock()
+        search_handler.title_match_hit.return_value = {
+            "path": "Berlin",
+            "snippet": "Berlin is the capital...",
+            "score": 1.0,
+        }
+        promoted = _promote_title_match(
+            hits,
+            query="berlin",
+            archives=[(MagicMock(), Path("/fake/wiki.zim"))],
+            archives_searched=["wiki"],
+            search_handler=search_handler,
+        )
+        paths = [h["path"] for _, h in promoted]
+        assert paths[0] == "Berlin"
+        # The twin is preserved at a lower rank, not dropped.
+        assert "Berlin_(disambiguation)" in paths
+
+    def test_explicit_disambiguation_query_keeps_twin_at_rank_1(self) -> None:
+        hits = [
+            (
+                "wiki",
+                {"path": "Berlin_(disambiguation)", "snippet": "...", "score": 0.6},
+            )
+        ]
+        search_handler = MagicMock()
+        promoted = _promote_title_match(
+            hits,
+            query="berlin disambiguation",
+            archives=[(MagicMock(), Path("/fake/wiki.zim"))],
+            archives_searched=["wiki"],
+            search_handler=search_handler,
+        )
+        assert promoted == hits
+        assert search_handler.title_match_hit.call_count == 0
+
+    def test_search_splice_promotes_canonical_past_twin_at_rank_1(self) -> None:
+        handler = SimpleToolsHandler.__new__(SimpleToolsHandler)
+        handler.zim_operations = MagicMock()
+        handler.zim_operations.find_entry_by_title_data.return_value = {
+            "results": [
+                {
+                    "path": "Berlin",
+                    "title": "Berlin",
+                    "score": 1.0,
+                    "zim_file": "/fake/wiki.zim",
+                }
+            ]
+        }
+        payload = {
+            "query": "berlin",
+            "results": [
+                {
+                    "path": "Berlin_(disambiguation)",
+                    "title": "Berlin (disambiguation)",
+                    "snippet": "...",
+                }
+            ],
+            "total": 1,
+            "page_info": {"offset": 0, "limit": 5, "returned_count": 1},
+            "_meta": {},
+        }
+        spliced = handler._splice_title_match_into_search(
+            payload, "/fake/wiki.zim", "berlin"
+        )
+        paths = [r["path"] for r in spliced["results"]]
+        assert paths[0] == "Berlin"
+        assert "Berlin_(disambiguation)" in paths

--- a/tests/test_sweep_followup_fixes.py
+++ b/tests/test_sweep_followup_fixes.py
@@ -1,0 +1,88 @@
+"""Follow-up regression tests for the 2026-08 correctness sweep.
+
+Each test class pins one of the verified-but-deferred findings left after
+the first sweep PR; the docstrings name the failure the fix closes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openzim_mcp.intent_parser import IntentParser, _extract_entry_path_keyworded
+
+
+class TestEntryPathFirstPrepositionAnchor:
+    """The keyworded extractor anchored on the LAST of/for/in/from/to, so
+    title-internal prepositions truncated the entry: ``toc of Battle of
+    Britain`` resolved entry ``Britain``, ``links in Lord of the Rings``
+    resolved ``the Rings``. The anchor is now the FIRST preposition after
+    the intent verb (with ``table of contents`` treated as one verb
+    phrase so its internal ``of`` can't win).
+    """
+
+    @pytest.mark.parametrize(
+        ("query", "expected"),
+        [
+            # The fix: title-internal prepositions survive.
+            ("toc of Battle of Britain", "Battle of Britain"),
+            ("links in Lord of the Rings", "Lord of the Rings"),
+            ("ToC of Theory of relativity", "Theory of relativity"),
+            ("structure of Theory of relativity", "Theory of relativity"),
+            ("summary of History of France", "History of France"),
+            ("links in the History of France article", "the History of France article"),
+            # Pinned pre-fix behavior that must keep working.
+            ("table of contents for Biology", "Biology"),
+            ("table of contents of Paris", "Paris"),
+            ("list the table of contents for Marie Curie", "Marie Curie"),
+            (
+                "table of contents for Shakespeare England plays",
+                "Shakespeare England plays",
+            ),
+            ("get article History of France", "History of France"),
+            ("get article Lord of the Rings", "Lord of the Rings"),
+            ("links in Murphy's law and Sod's law", "Murphy's law and Sod's law"),
+            ('structure of "Photosynthesis" in compact mode', "Photosynthesis"),
+            (
+                "what sections are in the Isaac Newton article",
+                "the Isaac Newton article",
+            ),
+            (
+                "show me the sections of the Albert Einstein article",
+                "the Albert Einstein article",
+            ),
+            ("give a brief overview of Isaac Newton", "Isaac Newton"),
+            ("outline the structure of Isaac Newton", "Isaac Newton"),
+            ("links going out of Roman Empire", "Roman Empire"),
+            ("what links out of Tokyo", "Tokyo"),
+            ("outbound links from Quantum mechanics", "Quantum mechanics"),
+        ],
+    )
+    def test_extractor_preserves_title_internal_prepositions(
+        self, query: str, expected: str
+    ) -> None:
+        params: dict = {}
+        _extract_entry_path_keyworded(query, params)
+        assert params.get("entry_path") == expected
+
+    def test_prose_mention_of_toc_is_not_hijacked(self) -> None:
+        """``tell me about the table of contents feature`` used to be
+        parsed as toc-of-``feature`` (the phrase-internal ``of`` acted as
+        the anchor). With the phrase treated as the verb and no
+        preposition following it, no entry_path is extracted, so the
+        handler's missing-argument guard fires instead of confidently
+        serving the toc of the wrong article.
+        """
+        params: dict = {}
+        _extract_entry_path_keyworded(
+            "tell me about the table of contents feature", params
+        )
+        assert "entry_path" not in params
+
+    def test_parse_intent_end_to_end(self) -> None:
+        intent, params, _ = IntentParser.parse_intent("toc of Battle of Britain")
+        assert intent == "toc"
+        assert params["entry_path"].lower() == "battle of britain"
+
+        intent, params, _ = IntentParser.parse_intent("links in Lord of the Rings")
+        assert intent == "links"
+        assert params["entry_path"].lower() == "lord of the rings"

--- a/tests/test_sweep_followup_fixes.py
+++ b/tests/test_sweep_followup_fixes.py
@@ -269,3 +269,285 @@ class TestNarrowSectionExcludesChildHeading:
         assert by_id["Geography"]["char_start"] == 13
         assert by_id["Topography"]["heading_start"] == 50
         assert by_id["Topography"]["char_start"] == 65
+
+
+class _Session:  # weak-referenceable ServerSession stand-in
+    pass
+
+
+class TestPerSessionUriCapCoversKnownUris:
+    """The per-session distinct-URI cap was checked only inside the
+    ``not _is_known_uri(uri)`` branch, so a session at its cap could
+    keep subscribing to any URI some other session had already
+    registered — the cap only bound first-registrant subscriptions.
+    The cap now applies to every subscription that would add a NEW
+    distinct URI for the session; idempotent re-subscribes stay exempt.
+    """
+
+    @pytest.mark.asyncio
+    async def test_known_uri_still_counts_against_session_cap(
+        self, monkeypatch
+    ) -> None:
+        from openzim_mcp import subscriptions
+        from openzim_mcp.exceptions import OpenZimMcpValidationError
+
+        monkeypatch.setattr(subscriptions, "MAX_URIS_PER_SESSION", 2)
+        registry = subscriptions.SubscriberRegistry()
+        other = _Session()
+        await registry.subscribe("zim://shared", other)
+
+        greedy = _Session()
+        await registry.subscribe("zim://a", greedy)
+        await registry.subscribe("zim://b", greedy)
+        # 'zim://shared' is already known (registered by ``other``), but
+        # it is still a NEW distinct URI for ``greedy`` — the cap must
+        # apply.
+        with pytest.raises(OpenZimMcpValidationError):
+            await registry.subscribe("zim://shared", greedy)
+
+    @pytest.mark.asyncio
+    async def test_resubscribe_at_cap_stays_idempotent(self, monkeypatch) -> None:
+        from openzim_mcp import subscriptions
+
+        monkeypatch.setattr(subscriptions, "MAX_URIS_PER_SESSION", 2)
+        registry = subscriptions.SubscriberRegistry()
+        session = _Session()
+        await registry.subscribe("zim://a", session)
+        await registry.subscribe("zim://b", session)
+        # Re-subscribing to an already-held URI at the cap must not raise.
+        await registry.subscribe("zim://a", session)
+
+
+class TestReadyzWedgedProbeDoesNotAccumulateCallbacks:
+    """Each ``/readyz`` request created a fresh ``asyncio.wrap_future``
+    wrapper around the shared in-flight probe. ``wrap_future`` chains a
+    done-callback onto the concurrent future and nothing unchains it when
+    the waiter times out — so while a stat was wedged on a dead mount,
+    every probe request (unauthenticated, unmetered) grew the future's
+    callback list without bound. The wrapper is now created once per
+    probe and shared by all waiters (``shield`` already cleans up its own
+    per-waiter callback on timeout).
+    """
+
+    def test_timed_out_waiters_do_not_grow_probe_callbacks(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        import asyncio as _asyncio
+        import threading as _threading
+        from unittest.mock import patch as _patch
+
+        from openzim_mcp import http_app as _http_app
+        from openzim_mcp.http_app import _make_readyz
+
+        monkeypatch.setattr(_http_app, "READYZ_PROBE_TIMEOUT_SECONDS", 0.05)
+
+        released = _threading.Event()
+        real_isdir = __import__("os").path.isdir
+
+        def _wedged_isdir(p):
+            released.wait(timeout=10)
+            return real_isdir(p)
+
+        class _Cfg:
+            allowed_directories = [str(tmp_path)]
+
+        class _Server:
+            config = _Cfg()
+
+        readyz = _make_readyz(_Server())
+
+        captured: list = []
+        real_get_executor = _http_app._get_executor
+
+        def _capturing_get_executor(name):
+            pool = real_get_executor(name)
+
+            class _Capture:
+                def submit(self, fn, *a, **kw):
+                    fut = pool.submit(fn, *a, **kw)
+                    captured.append(fut)
+                    return fut
+
+            return _Capture()
+
+        async def _drive():
+            with (
+                _patch("openzim_mcp.http_app.os.path.isdir", _wedged_isdir),
+                _patch("openzim_mcp.http_app._get_executor", _capturing_get_executor),
+            ):
+                responses = []
+                for _ in range(5):
+                    responses.append(await readyz(None))
+                return responses
+
+        try:
+            responses = _asyncio.run(_drive())
+        finally:
+            released.set()
+
+        # All five requests timed out against the single wedged probe.
+        assert [r.status_code for r in responses] == [503] * 5
+        assert len(captured) == 1, "single-flight broken: multiple submissions"
+        # The shared probe must not have accumulated one chained callback
+        # per request — one shared wrapper, not five.
+        assert len(captured[0]._done_callbacks) <= 1, (
+            f"callback accumulation: {len(captured[0]._done_callbacks)} "
+            "callbacks chained onto the wedged probe"
+        )
+
+
+class TestSnippetCapSurvivesEmbeddedHeadings:
+    """The snippet-cap regex terminated a ``Snippet:`` capture at ANY
+    ``\\n\\n## `` — including a markdown H2 embedded in the snippet text
+    itself — so everything after the embedded heading escaped the
+    per-snippet cap. Result headings are always numbered (``## 3. ``)
+    and html2text backslash-escapes numbered article headings
+    (``## 1\\. Topic``), so anchoring on the numbered form is
+    unambiguous. Same for an embedded ``\\n---\\n`` horizontal rule:
+    the real footer always follows a blank line.
+    """
+
+    def test_embedded_h2_does_not_bypass_the_cap(self) -> None:
+        from openzim_mcp.compact_format import _CompactFormatMixin
+
+        tail = "tail-text " * 60
+        text = (
+            'Found 2 matches for "x", showing 1-2:\n\n'
+            "## 1. Article One\n"
+            "Path: A/One\n"
+            "Snippet: lead sentence.\n\n## Embedded Section\n" + tail + "\n\n"
+            "## 2. Article Two\n"
+            "Path: A/Two\n"
+            "Snippet: short.\n\n"
+            "---\n"
+        )
+        out = _CompactFormatMixin._truncate_search_snippets(text, max_chars=250)
+        assert tail.rstrip() not in out, "embedded H2 bypassed the snippet cap"
+        assert "..." in out
+        # The real numbered result boundary and footer survive.
+        assert "## 2. Article Two" in out
+        assert "Snippet: short." in out
+
+    def test_embedded_hrule_does_not_bypass_the_cap(self) -> None:
+        from openzim_mcp.compact_format import _CompactFormatMixin
+
+        tail = "tail-text " * 60
+        text = (
+            'Found 1 matches for "x", showing 1-1:\n\n'
+            "## 1. Article One\n"
+            "Path: A/One\n"
+            "Snippet: lead sentence.\n---\n" + tail + "\n\n"
+            "---\n"
+        )
+        out = _CompactFormatMixin._truncate_search_snippets(text, max_chars=250)
+        assert tail.rstrip() not in out, "embedded hrule bypassed the snippet cap"
+
+
+class TestSuggestionScoreIndependentOfCallerLimit:
+    """Suggestion rank-scores divided by ``len(paths)`` — the number of
+    rows the CALLER asked for — so the same suggestion at the same rank
+    scored 0.6333 at ``limit=10`` but 0.475 at ``limit=2``. Scores now
+    decay against a fixed window, so a row's score depends only on its
+    rank. Rank 0 keeps scoring 0.95, so the 0.95/0.8 promotion gates
+    (which only read the top row) are unchanged.
+    """
+
+    def _run(self, test_config, monkeypatch, limit: int):
+        from unittest.mock import MagicMock as _MM
+
+        from tests.test_find_entry_by_title_characterization import (
+            _entry,
+            _make_server,
+            _patch_archive,
+        )
+
+        server = _make_server(test_config)
+        entries = {
+            "Climate": _entry("Climate", "Climate"),
+            "Climatology": _entry("Climatology", "Climatology"),
+            "Climate_model": _entry("Climate_model", "Climate model"),
+        }
+        archive = _MM()
+        archive.has_entry_by_title.return_value = False
+        archive.has_entry_by_path.return_value = False
+        archive.get_entry_by_path.side_effect = entries.__getitem__
+
+        paths = ["Climate", "Climatology", "Climate_model"]
+        sugg = _MM()
+        sugg.getEstimatedMatches.return_value = len(paths)
+        # Honor the caller's window, as libzim does.
+        sugg.getResults.side_effect = lambda start, n: paths[start : start + n]
+        searcher = _MM()
+        searcher.suggest.return_value = sugg
+        _patch_archive(monkeypatch, archive, searcher)
+
+        return server.zim_operations.find_entry_by_title_data(
+            "/zim/test.zim", "climat", cross_file=False, limit=limit
+        )
+
+    def test_rank_scores_stable_across_limits(self, test_config, monkeypatch):
+        wide = self._run(test_config, monkeypatch, limit=10)
+        narrow = self._run(test_config, monkeypatch, limit=2)
+
+        wide_by_path = {r["path"]: r["score"] for r in wide["results"]}
+        narrow_by_path = {r["path"]: r["score"] for r in narrow["results"]}
+        assert narrow_by_path["Climatology"] == wide_by_path["Climatology"], (
+            "rank-1 score varies with the caller's limit: "
+            f"{narrow_by_path['Climatology']} vs {wide_by_path['Climatology']}"
+        )
+        # The top row keeps its promotion-gate score.
+        assert wide_by_path["Climate"] == pytest.approx(0.95)
+        # Scores stay rank-monotonic.
+        scores = [r["score"] for r in wide["results"]]
+        assert all(a >= b for a, b in zip(scores, scores[1:]))
+
+
+class TestMainPageProbeFailureNotCachedAsAbsence:
+    """A fallback probe path that RESOLVED to an entry but failed content
+    extraction fell through the probe ladder into the ``no_main_page``
+    arm — which is flagged ``content_ok=True`` ("structural property of
+    the archive — safe to cache"). A transient read failure was thereby
+    cached as a durable "this archive has no main page" claim. A
+    found-but-unbuildable probe now yields ``content_error`` with
+    ``content_ok=False``, so nothing is cached and the next request
+    retries.
+    """
+
+    @staticmethod
+    def _archive_with_broken_fallback_entry() -> MagicMock:
+        from unittest.mock import PropertyMock
+
+        inst = MagicMock()
+        type(inst).main_entry = PropertyMock(
+            side_effect=RuntimeError("Cannot find main entry")
+        )
+        broken = MagicMock()
+        broken.is_redirect = False
+        broken.title = "Welcome"
+        broken.path = "W/mainPage"
+        broken.get_item.side_effect = RuntimeError("transient read failure")
+
+        def get_entry_by_path(path):
+            if path == "W/mainPage":
+                return broken
+            raise KeyError(path)
+
+        inst.get_entry_by_path.side_effect = get_entry_by_path
+        return inst
+
+    def test_found_but_unreadable_probe_is_content_error_not_absence(
+        self,
+    ) -> None:
+        from openzim_mcp.zim_operations import ZimOperations
+
+        ops = ZimOperations.__new__(ZimOperations)
+        ops.content_processor = MagicMock()
+
+        kind, payload, content_ok, found_at = ops._get_main_page_result(
+            self._archive_with_broken_fallback_entry()
+        )
+        assert kind != "no_main_page", (
+            "a resolvable-but-unreadable main-page entry must not be "
+            "reported (and cached) as the archive having no main page"
+        )
+        assert content_ok is False, "error sentinel must not be cacheable"

--- a/tests/test_sweep_followup_fixes.py
+++ b/tests/test_sweep_followup_fixes.py
@@ -60,6 +60,18 @@ class TestEntryPathFirstPrepositionAnchor:
             ("links going out of Roman Empire", "Roman Empire"),
             ("what links out of Tokyo", "Tokyo"),
             ("outbound links from Quantum mechanics", "Quantum mechanics"),
+            # ``references``/``related`` are links-intent verbs too. Omitting
+            # them from the verb list left scan_from at 0, so a preposition
+            # in a LEADING noun phrase won the anchor and the verb itself
+            # leaked into the entry ("references in photosynthesis").
+            ("list of references in Photosynthesis", "Photosynthesis"),
+            (
+                "the list of references in the Battle of Britain",
+                "the Battle of Britain",
+            ),
+            ("see also references in Battle of Britain", "Battle of Britain"),
+            ("the reference in Lord of the Rings", "Lord of the Rings"),
+            ("related pages in Isle of Man", "Isle of Man"),
         ],
     )
     def test_extractor_preserves_title_internal_prepositions(


### PR DESCRIPTION
Follow-up to #348, closing the verified findings that PR deliberately deferred. Stacked on `fix/correctness-sweep`; retarget to `main` after #348 merges.

## Fixes

- **intent parser** — the keyworded extractor anchored the entry path on the *last* `of/for/in/from/to`, truncating title-internal prepositions: `toc of Battle of Britain` → `Britain`, `links in Lord of the Rings` → `the Rings`. It now anchors on the *first* preposition after the intent verb, with `table of contents` matched as one verb phrase so its internal `of` can't win. Re-checked offline against the full 512-probe dispatch-eval corpus: exactly two probes change (`f2-toc-relativity`, `f2-struct-relativity`), both to their expected resolved entries; zero regressions.
- **title promotion** — `Berlin_(disambiguation)` at rank 1 strong-matches `berlin` (candidate-extends-topic), so the synthesize and search-splice short-circuits concluded the top hit was already canonical and never probed for `Berlin`. New `is_strong_canonical_title_match` refuses the twin unless the query asks for disambiguation; used only at the two skip-promotion sites. `is_strong_title_match` is unchanged — the tell-me-about ambiguity set needs the twin counted as strong.
- **get_section** — `include_subsections=False` narrowed the slice to the next section's `char_start`, which is its *body* start, so the child's heading line leaked into the "no subsections" body. `SectionMeta` now records `heading_start`, the narrow/widened boundaries use it, and the bundle cache key bumps to `v2d` so stale bundles rebuild.
- **subscriptions** — the per-session distinct-URI cap only applied when the URI was new to the registry, so a session at its cap could keep subscribing to any URI another session had registered. The cap now covers known URIs; re-subscribes stay idempotent.
- **/readyz** — each request chained a fresh `wrap_future` callback onto the shared in-flight probe with nothing unchaining it on timeout, so a wedged stat accumulated callbacks without bound from unauthenticated probes. One shared wrapper per probe.
- **compact snippets** — the per-snippet cap regex terminated at any embedded markdown H2 or hrule inside the snippet text, letting everything after it escape the 250-char cap. Boundaries now anchor on the numbered result heading (`## 3. `) and the blank-line-preceded footer; html2text backslash-escapes numbered article headings, so the form is unambiguous.
- **suggestion scores** — rank scores divided by the returned-row count, so the same suggestion at the same rank scored 0.6333 at `limit=10` but 0.475 at `limit=2`. Scores now decay against a fixed window; rank 0 keeps 0.95, so the 0.95/0.8 top-row promotion gates are unchanged (the characterization pin is updated accordingly).
- **main page** — a fallback probe path that resolved to an entry but failed content extraction fell through to the cacheable `no_main_page` arm, caching a transient read failure as a durable "archive has no main page". It now returns an uncacheable `content_error` so the next request retries.

## Deliberately not touched

Two findings from the sweep need product decisions rather than code fixes and remain open: the `search_all` global rerank top-k (global cap vs per-archive pagination integrity) and the infobox markdown being prepended before the H1 (changes many pinned outputs).

## Tests

`tests/test_sweep_followup_fixes.py` pins every fix (34 new tests, each verified failing before its fix). Full suite: 3679 passed. Offline dispatch-eval parity suite: 119 passed.