### PR TITLE
fix: close the nanoid advisory and both open code-scanning alerts

### DIFF
--- a/openzim_mcp/content_processor.py
+++ b/openzim_mcp/content_processor.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 
 import html2text
 from bs4 import BeautifulSoup, Comment, NavigableString, Tag
+from soupsieve import SelectorSyntaxError
 
 from .constants import (
     DEFAULT_SNIPPET_LENGTH,
@@ -591,7 +592,15 @@ def _heading_visible_text(heading: Tag) -> str:
         try:
             for el in heading.select(selector):
                 unwanted_ids.add(id(el))
-        except Exception:  # pragma: no cover - selector engine quirks
+        except (SelectorSyntaxError, NotImplementedError) as exc:
+            # The only two failures soupsieve raises from ``select``: a
+            # malformed selector, and a pseudo-class the installed engine
+            # does not implement. One unusable selector must not cost the
+            # heading its whole cleanup, but the previous bare ``except
+            # Exception: continue`` also swallowed the diagnostic — a typo
+            # in UNWANTED_HTML_SELECTORS looked exactly like a selector
+            # that legitimately matched nothing.
+            logger.debug("heading cleanup skipped selector %r: %s", selector, exc)
             continue
     if not unwanted_ids:
         return str(heading.get_text()).strip()

--- a/openzim_mcp/ml/reranker.py
+++ b/openzim_mcp/ml/reranker.py
@@ -214,10 +214,24 @@ class BGEReranker:
         result_q: "queue.Queue[tuple[str, Any]]" = queue.Queue(maxsize=1)
 
         def _worker() -> None:
+            # Every exit path has to leave exactly one item in the queue: a
+            # worker that dies without posting strands the caller on the full
+            # timeout for a load that already failed. A raised ``Exception``
+            # is relayed verbatim so the caller re-raises the real cause; the
+            # ``finally`` covers the BaseException exits (a SystemExit from
+            # deep inside the ML stack, an injected KeyboardInterrupt), which
+            # must NOT be re-raised in the caller's thread as though the
+            # caller itself had been interrupted.
+            outcome: "tuple[str, Any]" = (
+                "err",
+                RuntimeError("reranker model load thread terminated abnormally"),
+            )
             try:
-                result_q.put(("ok", _load_model(cfg.model_id, cfg.cache_dir)))
-            except BaseException as exc:  # noqa: BLE001 — relayed to caller
-                result_q.put(("err", exc))
+                outcome = ("ok", _load_model(cfg.model_id, cfg.cache_dir))
+            except Exception as exc:  # noqa: BLE001 — relayed to caller
+                outcome = ("err", exc)
+            finally:
+                result_q.put(outcome)
 
         threading.Thread(
             target=_worker, name="openzim-reranker-load", daemon=True

--- a/tests/test_security_alert_fixes.py
+++ b/tests/test_security_alert_fixes.py
@@ -1,0 +1,137 @@
+"""Regression tests for the code-scanning alert fixes.
+
+Two alerts, two behaviour changes worth pinning:
+
+* CodeQL ``py/catch-base-exception`` — the reranker's model-load worker
+  caught ``BaseException`` purely to guarantee the caller always got a
+  queue item. The guarantee is real; the handler was not the way to get
+  it. It now lives in a ``finally``, so a ``BaseException`` exit still
+  wakes the caller instead of stranding it on the full timeout, and is
+  no longer laundered into the caller's thread as if the caller itself
+  had been interrupted.
+
+* Bandit ``B112`` (try/except/continue) — ``_heading_visible_text``
+  swallowed every exception from ``Tag.select`` with a bare ``continue``,
+  so a typo in ``UNWANTED_HTML_SELECTORS`` was indistinguishable from a
+  selector that legitimately matched nothing.
+"""
+
+import logging
+import threading
+from unittest.mock import patch
+
+import pytest
+from bs4 import BeautifulSoup
+
+from openzim_mcp import content_processor as cp
+
+
+class _WorkerAbort(BaseException):
+    """A BaseException that is not an Exception, like SystemExit."""
+
+
+def _heading(html: str):
+    tag = BeautifulSoup(html, "html.parser").find(["h1", "h2", "h3"])
+    assert tag is not None
+    return tag
+
+
+class TestRerankerWorkerAlwaysReportsBack:
+    """CodeQL py/catch-base-exception — reranker.py ``_worker``."""
+
+    def test_base_exception_in_loader_wakes_caller_instead_of_timing_out(
+        self,
+    ) -> None:
+        """A BaseException must not strand the caller for the whole timeout.
+
+        Before the fix the ``except BaseException`` handler was what put
+        the item on the queue. Removing it naively would mean the worker
+        thread dies silently and the caller blocks until
+        ``first_call_timeout_seconds`` elapses, then reports a misleading
+        TimeoutError for a load that had already failed. The ``finally``
+        keeps the wake-up; a TimeoutError here is the regression.
+        """
+        from openzim_mcp.ml.reranker import BGEReranker, RerankerConfig
+
+        def abort(_model_id, _cache_dir):
+            raise _WorkerAbort("interpreter is going down")
+
+        cfg = RerankerConfig(first_call_timeout_seconds=5.0)
+        with patch("openzim_mcp.ml.reranker._load_model", side_effect=abort):
+            # The worker re-raises after the finally; silence the thread
+            # excepthook so the expected traceback is not printed.
+            with patch.object(threading, "excepthook", lambda _args: None):
+                with pytest.raises(RuntimeError) as excinfo:
+                    BGEReranker._load_with_timeout(cfg)
+
+        assert not isinstance(excinfo.value, TimeoutError), (
+            "caller waited out the full timeout — the worker died without "
+            "posting to the queue"
+        )
+        assert "terminated abnormally" in str(excinfo.value)
+
+    def test_system_exit_is_not_re_raised_in_the_caller_thread(self) -> None:
+        """SystemExit from the ML stack must not become the caller's exit.
+
+        Relaying it verbatim made a worker-thread SystemExit look like the
+        calling process had asked to terminate.
+        """
+        from openzim_mcp.ml.reranker import BGEReranker, RerankerConfig
+
+        def abort(_model_id, _cache_dir):
+            raise SystemExit(3)
+
+        cfg = RerankerConfig(first_call_timeout_seconds=5.0)
+        with patch("openzim_mcp.ml.reranker._load_model", side_effect=abort):
+            with pytest.raises(RuntimeError):
+                BGEReranker._load_with_timeout(cfg)
+
+    def test_ordinary_exception_is_still_relayed_verbatim(self) -> None:
+        """The real cause must survive, not be replaced by the sentinel."""
+        from openzim_mcp.ml.reranker import BGEReranker, RerankerConfig
+
+        cause = OSError("model file is corrupt")
+        cfg = RerankerConfig(first_call_timeout_seconds=5.0)
+        with patch("openzim_mcp.ml.reranker._load_model", side_effect=cause):
+            with pytest.raises(OSError) as excinfo:
+                BGEReranker._load_with_timeout(cfg)
+
+        assert excinfo.value is cause
+
+
+class TestHeadingSelectorFailuresAreVisible:
+    """Bandit B112 — content_processor.py ``_heading_visible_text``."""
+
+    def test_malformed_selector_is_skipped_and_logged(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        heading = _heading('<h2>History<span class="mw-editsection">[edit]</span></h2>')
+
+        with patch.object(cp, "UNWANTED_HTML_SELECTORS", [".a{b", ".mw-editsection"]):
+            with caplog.at_level(logging.DEBUG, logger="openzim_mcp.content_processor"):
+                text = cp._heading_visible_text(heading)
+
+        assert text == "History", "the surviving selector must still be applied"
+        assert any(
+            ".a{b" in record.getMessage() for record in caplog.records
+        ), "the unusable selector was swallowed silently"
+
+    def test_unsupported_pseudo_class_is_skipped_and_logged(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """soupsieve raises NotImplementedError, not SelectorSyntaxError."""
+        heading = _heading('<h2>Etymology<sup class="reference">[1]</sup></h2>')
+
+        with patch.object(
+            cp, "UNWANTED_HTML_SELECTORS", ["div::bogus", "sup.reference"]
+        ):
+            with caplog.at_level(logging.DEBUG, logger="openzim_mcp.content_processor"):
+                text = cp._heading_visible_text(heading)
+
+        assert text == "Etymology"
+        assert any("div::bogus" in record.getMessage() for record in caplog.records)
+
+    def test_valid_selectors_are_unaffected(self) -> None:
+        """The happy path keeps its behaviour: no logging, full strip."""
+        heading = _heading('<h2>History<span class="mw-editsection">[edit]</span></h2>')
+        assert cp._heading_visible_text(heading) == "History"

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -5305,9 +5305,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Closes the three open Security-tab findings: Dependabot alert #63 and both open code-scanning alerts.

## 1. nanoid < 3.3.17 — GHSA-2v37-7h3g-55p8 (high)

A custom generator handed `size` zero loops forever. It reaches the website transitively (`astro` → `vite` → `postcss`), and postcss already declares `nanoid: ^3.3.16`, so the patched release is inside the existing range — only the lockfile pin moves, no `overrides` entry needed. Bumped 3.3.16 → 3.3.18.

Applied by hand rather than with `npm update`: the local npm (11.8.0) additionally stripped the `libc` discriminators from ~35 optional platform packages, which would have quietly cost npm its glibc/musl filtering on Linux. The integrity hash was verified against the registry, and `npm ci` reinstalls cleanly from the edited lockfile.

## 2. CodeQL `py/catch-base-exception` — `openzim_mcp/ml/reranker.py`

The model-load worker caught `BaseException` solely to guarantee the caller always got a queue item. That guarantee is real — without it a failed load strands the caller for the whole first-call timeout and then reports a `TimeoutError` for something that had already failed — but a handler was the wrong way to get it.

Moved to a `finally` with a pre-seeded sentinel outcome. A `BaseException` exit still wakes the caller, but is no longer re-raised in the caller's thread as though the caller itself had been interrupted: a worker-thread `SystemExit` is not the caller's exit. Ordinary exceptions are still relayed verbatim so the real cause surfaces.

## 3. Bandit `B112` (try/except/continue) — `openzim_mcp/content_processor.py`

`_heading_visible_text` swallowed every selector failure with a bare `continue`, so a typo in `UNWANTED_HTML_SELECTORS` looked exactly like a selector that legitimately matched nothing. Narrowed to the only two failures soupsieve raises from `select` — `SelectorSyntaxError` (malformed) and `NotImplementedError` (unimplemented pseudo-class) — and logged at debug. This also makes the call site consistent with the other three `UNWANTED_HTML_SELECTORS` loops, which call `select` unguarded. `soupsieve` is already a declared direct dependency.

The block carried `# pragma: no cover`; it is now actually covered, so the pragma is gone.

## Verification

- Bandit at full severity (same invocation as the SARIF job): **1 finding before → 0 after**, whole package.
- AST scan for `except BaseException` / bare `except:` across `openzim_mcp/`: **0 candidates remain**.
- New `tests/test_security_alert_fixes.py` (6 tests): confirmed **4 fail against the pre-fix sources**, all 6 pass after. The other 2 pin behaviour that must *not* change (verbatim exception relay, happy-path stripping).
- Full suite: **3693 passed, 217 skipped, 42 deselected** (live tests excluded by the default `addopts`, as usual).
- black / isort / flake8 / mypy / pre-commit: clean, exit 0.
- `npm ci` + `npm run build` in `website/`: 16 pages built, `npm audit` reports 0 vulnerabilities.