### PR TITLE
fix(docker): drop the BuildKit frontend directive from the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
-# syntax=docker/dockerfile:1.6
+# No `# syntax=` directive on purpose. This file uses no BuildKit-only
+# features, so pinning a frontend buys nothing — it only makes every
+# BuildKit-based builder resolve and pull docker/dockerfile:1.6 before the
+# first step runs. Registry builders that mirror or firewall Docker Hub fail
+# there, before any of our layers are even attempted. Keep this file
+# classic-builder clean (verify with `DOCKER_BUILDKIT=0 docker build .`) and
+# do not re-add the directive without adding a feature that needs it.
 
 # ---- builder stage ----
 FROM python:3.13-slim AS builder


### PR DESCRIPTION
## Why

The Glama registry's Dockerfile test is failing and its public API reports `"tools": []`, meaning Glama never got far enough to enumerate the server's tools.

I could not reproduce any defect in the Dockerfile itself — see the verification below — but I did find one gratuitous external dependency worth removing.

`# syntax=docker/dockerfile:1.6` was on line 1, yet this file uses **no BuildKit-only features**. The `COPY --chmod` that once justified the directive was replaced by a builder-stage `chmod` some time ago (the comment explaining that swap is still in the file). What the directive still does is make every BuildKit-based builder resolve and pull `docker/dockerfile:1.6` from Docker Hub *before the first build step runs*. That's a third registry dependency — on top of Docker Hub for `python:3.13-slim` and ghcr.io for `uv` — and builders that mirror or firewall Hub, or that are simply rate-limited, fail there before any of our layers are attempted.

Removing it is strictly a reduction in build-time surface. The replacement comment records why it's absent so it doesn't get re-added reflexively.

## Verification

Run locally against this change:

| Check | Result |
|---|---|
| `DOCKER_BUILDKIT=0 docker build .` (classic builder) | passes |
| `docker build .` (BuildKit) | passes |
| `docker buildx build --platform linux/amd64` | passes |
| MCP `initialize` + `tools/list` over stdio, no volume mounted | returns `zim_query` |
| Same handshake under `--read-only --memory 512m` | returns `zim_query` |
| stdout / stderr separation | stdout is JSON-RPC only; all logs on stderr |

## What this does not yet explain

The Glama admin test page is behind auth, so I have not seen its actual error output. This change removes the most plausible builder-side failure I could identify from the outside, but if Glama is failing for a different reason the error text would pin it down.