### PR TITLE
ci: run the corpus-backed suite on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -291,10 +291,18 @@ jobs:
   test-comprehensive:
     name: Comprehensive Testing
     runs-on: ubuntu-latest
-    # Heaviest job (downloads the ZIM testing suite + full + slow suites);
-    # cap it so a hung ZIM-data fetch can't ride the 6h default either.
+    # Downloads the ZIM testing suite and runs the full + slow suites; cap it
+    # so a hung ZIM-data fetch can't ride GitHub's 6h default.
     timeout-minutes: 45
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Runs on pull requests too. This is the only job that fetches the corpus,
+    # so gating it to main-only meant the ~54 tests that need a real archive
+    # skipped themselves silently on every PR and were first exercised after
+    # merge — the reads, the per-entry resource, the search paths. A PR could
+    # go green having never opened a ZIM file.
+    #
+    # It was gated as "the heaviest job", which measurement does not support:
+    # the corpus is 14MB and the whole job takes ~2.5 minutes, against ~5 for
+    # the Windows matrix entries it runs beside.
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## The problem

`Comprehensive Testing` is the only job that downloads the ZIM testing suite, and it was gated to pushes on `main`:

```yaml
if: github.event_name == 'push' && github.ref == 'refs/heads/main'
```

So it reported `skipping` on every pull request — and the tests that need a real archive then skipped themselves *silently* inside the jobs that did run. Nothing failed, nothing warned; the suite just quietly covered less.

The gap is measurable. A checkout without the corpus skips **271** tests; one with it skips **217**. That is roughly **54 tests** — the resource reads, the per-entry resource, the search paths — first exercised only after merge, on `main`.

This surfaced while verifying #362, where it matters most: a protocol port whose resource-read paths are exactly the corpus-dependent ones, going green on checks that had never opened a ZIM file.

## Why the gate does not hold up

It was justified in a comment as the heaviest job. Measured:

| | |
|---|---|
| Corpus size | 14 MB |
| Job duration on `main` (download + full suite + slow suite) | ~2m21s |
| Windows matrix entries it runs beside | ~5m |

It was not costing runner time. It was costing confidence on every PR.

## Safety

Nothing in the job needs a push context. `permissions` is `contents: read`, and the Codecov upload is already conditional with `fail_ci_if_error: false`, so it degrades quietly on a fork PR with no token.

## Follow-up worth considering separately

This makes the job *run and be visible* on PRs, but it is not in the branch-protection required set, so a failure would not block a merge. Adding it there is a repo-settings change and deliberately not bundled here.