### PR TITLE
feat: advertise project identity and complete archive arguments

### DIFF
--- a/openzim_mcp/server.py
+++ b/openzim_mcp/server.py
@@ -4,6 +4,8 @@ import ipaddress
 import logging
 from typing import Any, Literal, Optional
 
+from mcp.types import Icon
+
 from . import __version__
 from .async_operations import AsyncZimOperations
 from .cache import OpenZimMcpCache
@@ -29,6 +31,13 @@ from .tools import register_phase_f_tools
 from .zim_operations import ZimOperations
 
 logger = logging.getLogger(__name__)
+
+# Identity advertised in ``serverInfo``. The docs site is the project's public
+# face — a client that surfaces a "learn more" link should land users on
+# documentation rather than the raw repository — and the icon is served from
+# the same origin, so both live or die together with the published site.
+PROJECT_WEBSITE_URL = "https://cameronrye.github.io/openzim-mcp/"
+PROJECT_ICON_URL = "https://cameronrye.github.io/openzim-mcp/assets/logo.svg"
 
 # Loopback entries always present in the Host allow-list so localhost-direct
 # access keeps working alongside any proxied hostname. Both the bare host and
@@ -246,7 +255,16 @@ class OpenZimMcpServer:
         # ``instructions`` rides in the initialize response — once per session,
         # not once per tools/list — so cross-tool routing guidance lives there
         # instead of being duplicated across the tool descriptions.
-        fastmcp_kwargs: dict = {"instructions": instructions_for(config.tool_mode)}
+        # ``website_url`` and ``icons`` ride in ``serverInfo``. Without them a
+        # registry listing or client UI has nothing to show beyond a bare name
+        # string. Both are served over https from the published docs site: an
+        # icon fetched over plain http would be blocked as mixed content in any
+        # browser-based client.
+        fastmcp_kwargs: dict = {
+            "instructions": instructions_for(config.tool_mode),
+            "website_url": PROJECT_WEBSITE_URL,
+            "icons": [Icon(src=PROJECT_ICON_URL, mimeType="image/svg+xml")],
+        }
         if config.transport == "http":
             transport_security, host_warning = _build_transport_security(config)
             fastmcp_kwargs["transport_security"] = transport_security

--- a/openzim_mcp/tools/__init__.py
+++ b/openzim_mcp/tools/__init__.py
@@ -48,6 +48,7 @@ def register_phase_f_tools(server: "OpenZimMcpServer") -> None:
         zim_metadata,
         zim_search,
     )
+    from .completions import register_completions
     from .prompts import register_prompts
     from .resource_tools import register_resources
 
@@ -67,3 +68,6 @@ def register_phase_f_tools(server: "OpenZimMcpServer") -> None:
     # shape" only.
     register_resources(server)
     register_prompts(server)
+    # Completions serve the prompt and resource-template arguments registered
+    # just above, so this has to follow them.
+    register_completions(server)

--- a/openzim_mcp/tools/completions.py
+++ b/openzim_mcp/tools/completions.py
@@ -1,0 +1,119 @@
+"""Argument completions for prompts and resource templates.
+
+MCP lets a client ask what a given argument could be, which is how a picker
+offers real choices instead of a free-text box. Every argument this server
+exposes that names an archive was previously untyped: the user had to recall a
+filesystem path or a bare basename and type it correctly, with a failed tool
+call as the only feedback.
+
+Two argument shapes are completable, and they are deliberately *not* the same
+string. A prompt takes ``zim_file_path``, a full path the tools resolve against
+the allowed directories. The ``zim://{name}`` resource template takes ``name``,
+the bare basename without ``.zim`` — offering a path there would build a URI
+that cannot resolve.
+
+Everything else answers empty. A prompt topic is free text, and an entry path
+inside an archive is unbounded — a Wikipedia mirror has millions. Returning
+nothing is the honest answer, and it has to be an *empty list* rather than an
+error: a raising handler surfaces in the client as a failed request rather than
+as "no suggestions".
+"""
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, List, Optional
+
+from mcp.types import Completion
+
+if TYPE_CHECKING:
+    from ..server import OpenZimMcpServer
+
+logger = logging.getLogger(__name__)
+
+# The spec caps one completion response at 100 values. An allowed directory
+# holding a full Kiwix mirror has far more, so the cap is enforced here and the
+# true size reported in ``total`` rather than the list being silently cut.
+MAX_COMPLETION_VALUES = 100
+
+# Prompt arguments that name an archive by path. Keyed by prompt name so a new
+# prompt with an unrelated ``zim_file_path`` argument cannot pick this up by
+# accident.
+_PATH_ARGUMENT_PROMPTS = {"summarize", "explore"}
+_PATH_ARGUMENT = "zim_file_path"
+
+# The resource template whose ``{name}`` segment is an archive basename.
+_ARCHIVE_TEMPLATE_URI = "zim://{name}"
+_ARCHIVE_TEMPLATE_ARGUMENT = "name"
+
+
+def _page(values: List[str]) -> Completion:
+    """Cap ``values`` at the protocol page size, reporting the true total."""
+    total = len(values)
+    page = values[:MAX_COMPLETION_VALUES]
+    return Completion(
+        values=page,
+        total=total,
+        hasMore=total > len(page),
+    )
+
+
+def register_completions(server: "OpenZimMcpServer") -> None:
+    """Register the ``completion/complete`` handler."""
+
+    def _archives() -> List[dict]:
+        """The current archive listing, read fresh on every request.
+
+        Deliberately not cached at registration time: an operator dropping a
+        new archive into an allowed directory is exactly when a user reaches
+        for the picker to find it, and a startup snapshot would be missing it.
+        """
+        try:
+            return server.zim_operations.list_zim_files_data()
+        except Exception:  # noqa: BLE001 - a picker must not break the session
+            logger.warning("completion: archive listing failed", exc_info=True)
+            return []
+
+    def _matching(values: List[str], typed: str) -> List[str]:
+        """Values consistent with what the user has typed so far.
+
+        Case-insensitive, and matched on the basename as well as the whole
+        string so typing ``wikipedia`` still offers
+        ``/srv/zim/wikipedia_en.zim``.
+        """
+        if not typed:
+            return values
+        needle = typed.lower()
+        return [
+            v
+            for v in values
+            if v.lower().startswith(needle) or Path(v).name.lower().startswith(needle)
+        ]
+
+    @server.mcp.completion()
+    async def complete(
+        ref: Any, argument: Any, context: Any = None
+    ) -> Optional[Completion]:
+        """Offer archive choices for the two argument shapes that have them."""
+        name = getattr(argument, "name", None)
+        typed = getattr(argument, "value", "") or ""
+
+        ref_type = getattr(ref, "type", None)
+        if ref_type == "ref/prompt":
+            if getattr(ref, "name", None) not in _PATH_ARGUMENT_PROMPTS:
+                return _page([])
+            if name != _PATH_ARGUMENT:
+                return _page([])
+            paths = [row["path"] for row in _archives()]
+            return _page(_matching(paths, typed))
+
+        if ref_type == "ref/resource":
+            if getattr(ref, "uri", None) != _ARCHIVE_TEMPLATE_URI:
+                return _page([])
+            if name != _ARCHIVE_TEMPLATE_ARGUMENT:
+                return _page([])
+            # ``{name}`` is the basename without the extension — the same form
+            # ``zim_file_overview`` resolves and ``resources/list`` advertises.
+            stems = [Path(row["path"]).stem for row in _archives()]
+            return _page(_matching(stems, typed))
+
+        return _page([])

--- a/tests/test_server_metadata_and_completions.py
+++ b/tests/test_server_metadata_and_completions.py
@@ -1,0 +1,216 @@
+"""Server identity metadata and argument completions.
+
+Two client-facing surfaces that the server had left empty. ``serverInfo``
+carried only a name and version, so a client or registry listing had no icon
+and no link home. And ``completion/complete`` was never registered, so every
+argument a client could have offered a picker for — which archive to summarize,
+which archive a ``zim://{name}`` URI refers to — was a free-text field the user
+had to fill from memory.
+
+Both are asserted through a real client session rather than on the server
+object, because both only matter as what a client receives.
+"""
+
+import json
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any, AsyncIterator
+
+import pytest
+from mcp.types import PromptReference, ResourceTemplateReference
+
+from openzim_mcp.config import OpenZimMcpConfig
+from openzim_mcp.server import OpenZimMcpServer
+
+DOCS_URL = "https://cameronrye.github.io/openzim-mcp/"
+
+
+@asynccontextmanager
+async def _session(tmp_path: Path, **kwargs: Any) -> AsyncIterator[Any]:
+    """A connected client session against a server rooted at ``tmp_path``."""
+    from mcp.shared.memory import create_connected_server_and_client_session
+
+    config = OpenZimMcpConfig(
+        allowed_directories=[str(tmp_path)], tool_mode="advanced", **kwargs
+    )
+    server = OpenZimMcpServer(config)
+    async with create_connected_server_and_client_session(
+        server.mcp._mcp_server
+    ) as session:
+        yield session
+
+
+def _make_zim(tmp_path: Path, name: str) -> Path:
+    """A file that the archive scanner will list.
+
+    The listing walks for ``*.zim`` and reports name/path/size; it does not
+    open the archive, so completions can be exercised without the real corpus.
+    """
+    path = tmp_path / f"{name}.zim"
+    path.write_bytes(b"ZIM\x04not-a-real-archive")
+    return path
+
+
+@pytest.mark.asyncio
+async def test_server_info_carries_website_and_icon(tmp_path: Path) -> None:
+    """``serverInfo`` should identify the project, not just name it.
+
+    A registry listing or client UI has nothing to show without these: the
+    icon and the link home are the only two identity fields the protocol
+    offers beyond a bare name string.
+    """
+    async with _session(tmp_path) as session:
+        result = await session.initialize()
+
+    info = result.serverInfo
+    assert info.websiteUrl == DOCS_URL
+    assert info.icons, "serverInfo advertises no icon"
+    assert all(icon.src.startswith("https://") for icon in info.icons), (
+        "an icon served over plain http would be blocked as mixed content "
+        "in any browser-based client"
+    )
+
+
+@pytest.mark.asyncio
+async def test_completes_zim_file_path_for_prompts(tmp_path: Path) -> None:
+    """The ``summarize`` prompt's archive argument offers the real archives."""
+    _make_zim(tmp_path, "wikipedia_en")
+    _make_zim(tmp_path, "wiktionary_en")
+
+    async with _session(tmp_path) as session:
+        result = await session.complete(
+            ref=PromptReference(type="ref/prompt", name="summarize"),
+            argument={"name": "zim_file_path", "value": ""},
+        )
+
+    values = result.completion.values
+    assert len(values) == 2
+    assert any(v.endswith("wikipedia_en.zim") for v in values)
+    assert any(v.endswith("wiktionary_en.zim") for v in values)
+
+
+@pytest.mark.asyncio
+async def test_completion_filters_by_what_was_typed(tmp_path: Path) -> None:
+    """A completion that ignores the partial value is worse than none.
+
+    The client shows the returned list as-is, so failing to filter offers the
+    user entries that contradict what they have already typed.
+    """
+    _make_zim(tmp_path, "wikipedia_en")
+    _make_zim(tmp_path, "wiktionary_en")
+
+    async with _session(tmp_path) as session:
+        result = await session.complete(
+            ref=PromptReference(type="ref/prompt", name="summarize"),
+            argument={"name": "zim_file_path", "value": "wikip"},
+        )
+
+    values = result.completion.values
+    assert len(values) == 1
+    assert values[0].endswith("wikipedia_en.zim")
+
+
+@pytest.mark.asyncio
+async def test_completes_archive_name_for_the_resource_template(
+    tmp_path: Path,
+) -> None:
+    """``zim://{name}`` completes to bare basenames, not paths.
+
+    The template's ``{name}`` segment is the basename without ``.zim``;
+    offering a full filesystem path there would build a URI that cannot
+    resolve.
+    """
+    _make_zim(tmp_path, "wikipedia_en")
+
+    async with _session(tmp_path) as session:
+        result = await session.complete(
+            ref=ResourceTemplateReference(type="ref/resource", uri="zim://{name}"),
+            argument={"name": "name", "value": ""},
+        )
+
+    assert result.completion.values == ["wikipedia_en"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_completion_targets_return_empty(tmp_path: Path) -> None:
+    """An argument with nothing to offer must answer empty, not fail.
+
+    ``research(topic)`` is free text and the entry path inside an archive is
+    unbounded. A client asking about either should get an empty list, since a
+    handler that raises would surface as a protocol error in the client UI.
+    """
+    _make_zim(tmp_path, "wikipedia_en")
+
+    async with _session(tmp_path) as session:
+        free_text = await session.complete(
+            ref=PromptReference(type="ref/prompt", name="research"),
+            argument={"name": "topic", "value": "photo"},
+        )
+        unknown_prompt = await session.complete(
+            ref=PromptReference(type="ref/prompt", name="does_not_exist"),
+            argument={"name": "zim_file_path", "value": ""},
+        )
+
+    assert free_text.completion.values == []
+    assert unknown_prompt.completion.values == []
+
+
+@pytest.mark.asyncio
+async def test_completion_never_exceeds_the_protocol_page_size(
+    tmp_path: Path,
+) -> None:
+    """The spec caps a completion page at 100 values, and sets ``hasMore``.
+
+    An allowed directory holding a full Kiwix mirror would otherwise return
+    hundreds of entries in one response.
+    """
+    for i in range(120):
+        _make_zim(tmp_path, f"archive_{i:03d}")
+
+    async with _session(tmp_path) as session:
+        result = await session.complete(
+            ref=ResourceTemplateReference(type="ref/resource", uri="zim://{name}"),
+            argument={"name": "name", "value": ""},
+        )
+
+    assert len(result.completion.values) == 100
+    assert result.completion.total == 120
+    assert result.completion.hasMore is True
+
+
+@pytest.mark.asyncio
+async def test_completion_reflects_archives_added_after_startup(
+    tmp_path: Path,
+) -> None:
+    """Completions must read the directory live, not a startup snapshot.
+
+    A cached list would go stale the moment an operator drops in a new
+    archive — exactly when a user reaches for the picker to find it.
+    """
+    _make_zim(tmp_path, "first")
+
+    async with _session(tmp_path) as session:
+        before = await session.complete(
+            ref=ResourceTemplateReference(type="ref/resource", uri="zim://{name}"),
+            argument={"name": "name", "value": ""},
+        )
+        _make_zim(tmp_path, "second")
+        after = await session.complete(
+            ref=ResourceTemplateReference(type="ref/resource", uri="zim://{name}"),
+            argument={"name": "name", "value": ""},
+        )
+
+    assert before.completion.values == ["first"]
+    assert after.completion.values == ["first", "second"]
+
+
+def test_docs_url_matches_the_published_site() -> None:
+    """The advertised website must be the one the project actually publishes."""
+    readme = Path(__file__).parent.parent / "README.md"
+    assert DOCS_URL.rstrip("/") in readme.read_text(encoding="utf-8"), (
+        "serverInfo.websiteUrl should point at the documentation site the "
+        "README links, or clients send users somewhere unmaintained"
+    )
+    assert json.loads(
+        (Path(__file__).parent.parent / "server.json").read_text(encoding="utf-8")
+    )["repository"]["url"].startswith("https://github.com/cameronrye/openzim-mcp")

--- a/website/src/content/docs/resources-prompts-subscriptions.mdx
+++ b/website/src/content/docs/resources-prompts-subscriptions.mdx
@@ -244,6 +244,19 @@ Produces a compact briefing of what the archive is, what it covers, and what typ
 
 If your client supports MCP prompts, prefer them — they save the LLM from having to remember the orchestration. If you're building your own client or your host doesn't surface prompts, the same workflows are easy to call directly with the underlying tools.
 
+### Argument completion
+
+The server answers `completion/complete`, so a client that supports it offers real choices instead of a free-text box for the arguments that name an archive:
+
+| What you're filling in | What you get offered |
+|---|---|
+| `zim_file_path` on `/summarize` or `/explore` | full paths of the archives in your allowed directories |
+| `{name}` in the `zim://{name}` resource URI | bare basenames, without the `.zim` extension |
+
+The two are deliberately different strings — a path in a `zim://{name}` URI would not resolve. Suggestions filter as you type, matching either the whole path or just the filename, so typing `wikipedia` finds `/srv/zim/wikipedia_en.zim`. The listing is read fresh on each request, so an archive you just dropped into a watched directory shows up immediately.
+
+Anything with an unbounded answer returns nothing rather than guessing: a `/research` topic is free text, and an entry path inside an archive can run to millions of rows. Responses are capped at the protocol's 100-value page, with the true count in `total`.
+
 ---
 
 ## Subscriptions


### PR DESCRIPTION
Two client-facing surfaces the server had left empty. Both work on the **1.29 SDK we ship today** — neither needs #362 — so they reach users now rather than waiting on an SDK patch release.

## `serverInfo` identity

It carried a name and a version. A registry listing or client UI had nothing else to show, so the server appeared as a bare string. It now advertises the documentation site and the logo.

Both are https URLs on the published site (verified live, `200 image/svg+xml`). An icon fetched over plain http would be blocked as mixed content in any browser-based client, which the test asserts rather than leaves to review.

## Argument completion

`completion/complete` was never registered, so every argument naming an archive was a free-text field the user filled from memory, with a failed call as the only feedback.

| Argument | Completes to |
|---|---|
| `zim_file_path` on `/summarize`, `/explore` | full archive paths |
| `{name}` in `zim://{name}` | bare basenames, no `.zim` |

The two are deliberately different strings — a path in a `zim://{name}` URI would not resolve, and the test pins that distinction. Matching is prefix-based on the filename as well as the whole path, so `wikipedia` finds `/srv/zim/wikipedia_en.zim`.

Three decisions worth review:

- **Empty, never an error.** A `/research` topic is free text and an entry path can run to millions of rows. Returning `[]` rather than raising matters because a raising handler surfaces in the client as a *failed request* instead of "no suggestions" — a picker must not break the session. The archive listing call is guarded for the same reason.
- **Read live, not snapshotted.** An operator dropping in a new archive is precisely when someone reaches for the picker to find it. A registration-time snapshot would be stale exactly then, so there is a test that adds a file mid-session and expects it offered.
- **Capped at the protocol's 100-value page**, with the true count in `total` and `hasMore` set, so a full Kiwix mirror degrades honestly instead of returning a silently truncated list.

## Verification

- 3711 passed, 217 skipped, 0 failed, with the real ZIM corpus (`ZIM_TEST_DATA_DIR` set).
- 8 new tests, written first and watched fail; all assert through a real client session, since both features only exist as what a client receives.
- black / isort / flake8 / mypy clean.

## Note for #362

`title` and `description` are v2-only constructor arguments and are deliberately **not** included here; they belong with that port. Everything in this PR is era-neutral and will carry across the merge.