### PR TITLE
feat: close the pre-existing follow-ups surfaced by the v3 field sweep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,9 +282,22 @@ jobs:
           echo "::error::openzim-mcp ${VERSION} never appeared on PyPI"
           exit 1
 
+      # Skipped when the registry already serves this version, so a re-dispatch
+      # of an old tag (backfilling the registry) does not re-publish a version
+      # that is already live. The verification step below still runs, so a
+      # skipped publish is proved rather than assumed.
       - name: Publish server.json
         run: |
           set -euo pipefail
+          SERVER_NAME=$(jq -r '.name' server.json)
+          VERSION=$(jq -r '.version' server.json)
+          if curl --proto '=https' --tlsv1.2 -fsS \
+            "https://registry.modelcontextprotocol.io/v0/servers?search=${SERVER_NAME}&version=${VERSION}" \
+            | jq -e --arg n "$SERVER_NAME" --arg v "$VERSION" \
+              'any(.servers[]; .server.name == $n and .server.version == $v)' >/dev/null; then
+            echo "Registry already serves ${SERVER_NAME} ${VERSION} — nothing to publish"
+            exit 0
+          fi
           ./mcp-publisher validate
           ./mcp-publisher login github-oidc
           ./mcp-publisher publish
@@ -364,8 +377,25 @@ jobs:
           if gh release view "$TAG_NAME" --json tagName >/dev/null 2>&1; then
             echo "release_exists=true" >> $GITHUB_OUTPUT
             echo "✅ Release already exists for $TAG_NAME (created by release-please)"
+            # A release that is already PUBLISHED *and* already carries assets is
+            # finished. This run is then a re-dispatch of an old tag — backfilling
+            # the MCP Registry, say — not the tail of a real release. Its assets
+            # rebuild from the same source but are not byte-identical (wheels
+            # embed a build timestamp), so re-uploading them with --clobber would
+            # change published checksums for no reason. A draft, or a published
+            # release with no assets, still needs populating and is untouched by
+            # this branch.
+            is_draft=$(gh release view "$TAG_NAME" --json isDraft --jq .isDraft)
+            asset_count=$(gh release view "$TAG_NAME" --json assets --jq '.assets | length')
+            if [ "$is_draft" = "false" ] && [ "$asset_count" -gt 0 ]; then
+              echo "release_is_complete=true" >> $GITHUB_OUTPUT
+              echo "ℹ️  $TAG_NAME is published with $asset_count assets — leaving them as they are"
+            else
+              echo "release_is_complete=false" >> $GITHUB_OUTPUT
+            fi
           else
             echo "release_exists=false" >> $GITHUB_OUTPUT
+            echo "release_is_complete=false" >> $GITHUB_OUTPUT
             echo "📝 Release does not exist for $TAG_NAME, will create new release"
           fi
 
@@ -420,7 +450,7 @@ jobs:
           " VERSION="$VERSION"
 
       - name: Upload assets to existing release
-        if: steps.check-release.outputs.release_exists == 'true'
+        if: steps.check-release.outputs.release_exists == 'true' && steps.check-release.outputs.release_is_complete != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -56,15 +56,16 @@ jobs:
           results_format: sarif
           publish_results: true
 
+      # Deliberately NOT uploaded to the Security tab. Scorecard reports every
+      # check as its own alert — the first run opened 55, of which 38 were
+      # Pinned-Dependencies and 12 Token-Permissions — which buries the
+      # findings that actually need triage (a CodeQL or Bandit alert) under a
+      # standing list that only clears when the whole supply-chain backlog
+      # does. `publish_results` above already puts the score where the
+      # aggregators read it; the artifact keeps the detail one click away.
       - name: Upload results as an artifact
         uses: actions/upload-artifact@v7
         with:
           name: scorecard-results
           path: results.sarif
-          retention-days: 5
-
-      - name: Upload results to the Security tab
-        uses: github/codeql-action/upload-sarif@v4.37.6
-        with:
-          sarif_file: results.sarif
-          category: scorecard
+          retention-days: 30

--- a/docs/extras-reranker.md
+++ b/docs/extras-reranker.md
@@ -13,12 +13,18 @@ pip install openzim-mcp[reranker]
 ```
 
 Install footprint: roughly 200 MB of Python packages (FastEmbed +
-onnxruntime + tokenizers + huggingface_hub). The cross-encoder model
-itself is downloaded lazily on first use (~1.1 GB for the default
-`BAAI/bge-reranker-base`) and cached in FastEmbed's model cache
+onnxruntime + tokenizers + huggingface_hub). Installing the extra is
+**not** enough on its own: the cross-encoder model (~1.1 GB for the
+default `BAAI/bge-reranker-base`) is never fetched by the server, so a
+second step is required — see
+[Staging the model](#staging-the-model-required).
+
+The model is read from FastEmbed's model cache
 (`$FASTEMBED_CACHE_PATH`, defaulting to `<tempdir>/fastembed_cache`);
-set `OPENZIM_MCP_ML__RERANKER__CACHE_DIR` to pin a persistent location
-for offline deployments.
+set `OPENZIM_MCP_ML__RERANKER__CACHE_DIR` to pin a persistent location.
+Pinning it is strongly recommended: the default cache lives under the
+system temp directory, so a reboot or a temp sweeper discards the
+staged model and rerank goes quiet until you stage it again.
 
 ## Supported platforms
 
@@ -35,20 +41,40 @@ Edge platforms (Alpine, FreeBSD, ARM32) are not part of the supported
 matrix; FastEmbed wheels may not be available there. The base install
 (`pip install openzim-mcp`) is unaffected.
 
-## Pre-staging models for offline deployment
+## Staging the model (required)
 
-By default, the first call after install downloads `BAAI/bge-reranker-base`
-(~1.1 GB) from HuggingFace. Operators running in air-gapped environments
-should pre-stage:
+The server never downloads the model. `ml.reranker.allow_model_download`
+defaults to `false`, so the runtime loads the cross-encoder from the
+local cache only — the MCP `instructions` payload tells callers this
+server reads content from local archives, and an unannounced 1.1 GB
+fetch to huggingface.co on someone's first question contradicts that.
+
+Stage it once, on a machine with network access:
 
 ```bash
 openzim-mcp download-models
 ```
 
-Idempotent — safe to re-run. Without pre-staging, the first MCP query
-that triggers rerank has a 15-second timeout; on timeout the reranker
-falls back to Xapian-only ranking for the rest of the process and logs
-a structured warning.
+Idempotent — safe to re-run; it checks the cache and fetches only what
+is missing. It honours `OPENZIM_MCP_ML__RERANKER__CACHE_DIR`, so run it
+with the same cache directory the server uses.
+
+If the model is not in the cache, the first rerank-eligible query falls
+back to Xapian-only ranking for the rest of the process and logs a
+WARNING naming this command. Search still works; results are simply
+ranked by Xapian alone.
+
+Operators who would rather trade the offline guarantee for convenience
+can opt back into the old behaviour:
+
+```bash
+export OPENZIM_MCP_ML__RERANKER__ALLOW_MODEL_DOWNLOAD=true
+```
+
+With that set, the first rerank-eligible query fetches the model from
+HuggingFace, bounded by `first_call_timeout_seconds` (default 15 s) —
+and the "content is read from local archives" statement in the server's
+instructions no longer tells the whole story for that deployment.
 
 ## Verifying it's active
 
@@ -87,6 +113,8 @@ export OPENZIM_MCP_ML__RERANKER__ENABLED=true
 export OPENZIM_MCP_ML__RERANKER__MIN_QUERY_TOKENS=4
 export OPENZIM_MCP_ML__RERANKER__FINAL_TOP_K=10
 export OPENZIM_MCP_ML__RERANKER__FIRST_CALL_TIMEOUT_SECONDS=15.0
+export OPENZIM_MCP_ML__RERANKER__ALLOW_MODEL_DOWNLOAD=false
+export OPENZIM_MCP_ML__RERANKER__CACHE_DIR=/var/lib/openzim-mcp/models
 ```
 
 (The `__` double-underscore delimits nested config sections.)
@@ -116,8 +144,9 @@ operators running in simple tool mode, who don't have access to the
 advanced-mode `zim_health` tool to read the counter directly. Set the
 logger to WARNING or higher to suppress them.
 
-A model-load failure (timeout, network error) logs a one-line WARNING
-to the configured logger and trips a process-wide kill switch
+A model-load failure (model not staged, timeout, corrupt cache) logs a
+one-line WARNING to the configured logger and trips a process-wide kill
+switch
 (`BGEReranker`'s load-failure latch; mid-inference failures are
 separately kill-switched by the `ml_fallback` decorator) — subsequent
 search calls emit
@@ -126,13 +155,18 @@ None) until the process restarts.
 
 ## Troubleshooting
 
+**"reranker model load failed: ... Model downloads are off by default"**
+The model is not in the local cache. Run `openzim-mcp download-models`
+with the same `CACHE_DIR` the server uses. If you staged it earlier and
+it has vanished, the cache is probably still on its default path under
+the system temp directory — pin `OPENZIM_MCP_ML__RERANKER__CACHE_DIR`.
+
 **"reranker model load failed: timeout"**
-The first-call download exceeded the configured
-`first_call_timeout_seconds` (default 15s — sized for ONNX session
-creation on a warm cache). Run `openzim-mcp download-models` once to
-pre-stage; the next server start will use the cached model. On slower
-hardware or cold-cache fetches, raise the timeout via
-`OPENZIM_MCP_ML__RERANKER__FIRST_CALL_TIMEOUT_SECONDS`.
+Loading exceeded the configured `first_call_timeout_seconds` (default
+15s — sized for ONNX session creation on a warm cache). Raise it via
+`OPENZIM_MCP_ML__RERANKER__FIRST_CALL_TIMEOUT_SECONDS` on slow hardware,
+or — if you enabled `allow_model_download` — stage the model with
+`openzim-mcp download-models` instead of paying the fetch at query time.
 
 **Install fails with "no wheel for fastembed"**
 The platform isn't in the supported matrix (see above). Use the base

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,7 +11,7 @@ v3 is reserved for a future breaking change (libzim major bump or a deeper surfa
 ## Foundational decisions (carried forward)
 
 - **ML accelerators are opt-in via extras.** Default install stays lean.
-- **Offline-first.** Sidecars and models load from disk; build steps are explicit operator commitments.
+- **Offline-first.** Sidecars and models load from disk; acquiring them (sidecar builds, `openzim-mcp download-models`) is an explicit operator commitment. No tool fetches on the caller's behalf.
 - **Markdown for prose, JSON for navigation; no XML in tool responses.**
 - **Backward compat at the data layer.** Sidecars live next to `.zim` files; absence is reported gracefully.
 - **Clean breaks land at major versions only.** v2.5 ships zero wire-format changes.

--- a/openzim_mcp/config.py
+++ b/openzim_mcp/config.py
@@ -255,6 +255,21 @@ class RerankerConfig(BaseModel):
             "~/.cache/openzim-mcp/models/fastembed."
         ),
     )
+    # Defaults to False to keep the shipped MCP `instructions` honest and to
+    # honour the offline-first principle in docs/roadmap.md — not to save
+    # bandwidth. A cold cache used to make the first rerank-eligible query
+    # open connections to huggingface.co and stall for
+    # `first_call_timeout_seconds`, which no caller consented to.
+    allow_model_download: bool = Field(
+        default=False,
+        description=(
+            "Allow the first model load to fetch from HuggingFace. False (the "
+            "default) loads only from the local cache and falls back to "
+            "Xapian-only ranking if the model was never staged. Pre-stage with "
+            "`openzim-mcp download-models`, or set this True to accept ~1.1GB "
+            "of first-call egress."
+        ),
+    )
 
 
 class MLConfig(BaseModel):

--- a/openzim_mcp/content_processor.py
+++ b/openzim_mcp/content_processor.py
@@ -218,14 +218,61 @@ def _fold_with_index_map(text: str) -> Tuple[str, List[int]]:
     return "".join(out), index_map
 
 
+# A query term, plus the trailing ``*`` that marks it as a PREFIX probe.
+# Xapian honours ``*`` only at the END of a term, so that is the only
+# position treated as a wildcard here: ``a*b`` reads as two ordinary terms,
+# exactly as Xapian reads it.
+_QUERY_TERM_RE = re.compile(r"(\w+)(\*?)")
+
+# Shortest prefix term that is allowed to match beyond its own characters.
+# Higher than the 3-char floor literal terms use: a 3-char prefix is too
+# unselective to be informative (``car*`` bolds carbon, cardiac, carry and
+# careful alike). Mirrors ``_RELEVANCE_STEM_MIN_LEN`` in
+# :mod:`openzim_mcp.zim.search`, the existing "shortest prefix that counts
+# as a stem" constant.
+_PREFIX_TERM_MIN_LEN = 4
+
+
+def _split_query_terms_typed(query: str) -> List[Tuple[str, bool]]:
+    """``(term, is_prefix)`` pairs; ``diabet*`` -> ``("diabet", True)``.
+
+    WHY the flag: the ``*`` used to be dropped as punctuation, so a
+    truncated term could only ever be matched whole-word — and ``diabet``
+    is never a whole word, so the very hit Xapian's stemmer found went
+    unhighlighted and could even anchor a different paragraph.
+    """
+    return [
+        (m.group(1), bool(m.group(2))) for m in _QUERY_TERM_RE.finditer(_fold(query))
+    ]
+
+
 def _split_query_terms(query: str) -> list:
     """Split a query string into individual terms; drop punctuation."""
-    return [t for t in re.split(r"\W+", _fold(query)) if t]
+    return [t for t, _ in _split_query_terms_typed(query)]
 
 
-def _word_in(folded_paragraph: str, term: str) -> bool:
-    """Whole-word match of `term` in already-folded paragraph text."""
-    return bool(re.search(rf"\b{re.escape(term)}\b", folded_paragraph))
+def _word_in(folded_paragraph: str, term: str, *, prefix: bool = False) -> bool:
+    """Whole-word match of `term` in already-folded paragraph text.
+
+    With ``prefix=True`` the term only has to open a word (``climat*``
+    matches ``climate``), so paragraph selection agrees with what
+    ``_highlight_terms`` will actually bold.
+    """
+    tail = r"\w*" if prefix else r"\b"
+    return bool(re.search(rf"\b{re.escape(term)}{tail}", folded_paragraph))
+
+
+def _keep_highlightable_terms(query: str) -> List[Tuple[str, bool]]:
+    """Query terms long enough to be worth matching, with their prefix flag.
+
+    Shared by paragraph anchoring and highlighting so the paragraph a
+    snippet starts on is always one the highlighter can mark up.
+    """
+    return [
+        (term, is_prefix)
+        for term, is_prefix in _split_query_terms_typed(query)
+        if len(term) >= (_PREFIX_TERM_MIN_LEN if is_prefix else 3)
+    ]
 
 
 # A complete ``[text](href "title")`` markdown link, matched as ONE unit.
@@ -596,11 +643,22 @@ def _highlight_terms(text: str, query: str, *, max_hits: int) -> str:
     layering ``**…**`` on top of those produces malformed markdown that
     confuses small models more than it helps them.
     """
-    terms = [t for t in _split_query_terms(query) if len(t) >= 3]
-    if not terms:
+    typed = _keep_highlightable_terms(query)
+    if not typed:
         return text
+    # Longest first: alternation is first-match-wins, so a short term must
+    # not shadow a longer alternative sharing its opening characters.
+    typed.sort(key=lambda tp: len(tp[0]), reverse=True)
+    # A prefix term closes on ``\w*`` — the remainder of the word the
+    # stemmer matched; a literal term keeps its closing ``\b``. Both keep
+    # the leading ``\b``: Xapian prefixes anchor at a word start, so
+    # ``diabet*`` must not light up the middle of ``prediabetes``.
+    alts = [
+        re.escape(term) + (r"\w*" if is_prefix else r"\b") for term, is_prefix in typed
+    ]
     # No ``re.IGNORECASE``: both sides are already lowercased by the fold.
-    pattern = re.compile(r"\b(" + "|".join(re.escape(t) for t in terms) + r")\b")
+    # The group is non-capturing — only ``m.start()``/``m.end()`` are read.
+    pattern = re.compile(r"\b(?:" + "|".join(alts) + r")")
     folded, index_map = _fold_with_index_map(text)
 
     # Pre-compute spans where we must not wrap. Overlapping markdown
@@ -1664,7 +1722,8 @@ class ContentProcessor:
             snippet_length if snippet_length is not None else self.snippet_length
         )
 
-        terms = [t for t in _split_query_terms(query) if len(t) >= 3] if query else []
+        typed = _keep_highlightable_terms(query) if query else []
+        terms = [t for t, _ in typed]
 
         # Site furniture (share-widget boilerplate, in-page navigation
         # lists) is neither a useful anchor nor useful fill: on MedlinePlus
@@ -1675,7 +1734,9 @@ class ContentProcessor:
         paragraphs = _drop_boilerplate_paragraphs(
             content.split("\n\n"),
             is_query_hit=(
-                (lambda p: any(_word_in(_fold(p), t) for t in terms)) if terms else None
+                (lambda p: any(_word_in(_fold(p), t, prefix=pfx) for t, pfx in typed))
+                if typed
+                else None
             ),
         )
         start_idx = 0
@@ -1687,7 +1748,7 @@ class ContentProcessor:
                 # Phase A #1 spec promise).
                 whole_word_idx: Optional[int] = None
                 for i, p in enumerate(folded_paragraphs):
-                    if any(_word_in(p, t) for t in terms):
+                    if any(_word_in(p, t, prefix=pfx) for t, pfx in typed):
                         whole_word_idx = i
                         break
                 if whole_word_idx is not None:

--- a/openzim_mcp/error_messages.py
+++ b/openzim_mcp/error_messages.py
@@ -13,6 +13,7 @@ from .exceptions import (
     OpenZimMcpArchiveError,
     OpenZimMcpArchiveNameError,
     OpenZimMcpArchivePathError,
+    OpenZimMcpEntryNotFoundError,
     OpenZimMcpError,
     OpenZimMcpFileNotFoundError,
     OpenZimMcpRateLimitError,
@@ -367,6 +368,14 @@ def get_error_config(
         return _archive_path_config(
             ERROR_CONFIGS[OpenZimMcpArchivePathError], operation, count_archives
         )
+
+    # A typed not-found beats the prose check below it. The type-mapping fall
+    # back at the bottom is by EXACT type, so this subclass would otherwise
+    # reach the client only for as long as its message keeps saying "entry not
+    # found" — one rephrase at a raise site and a missing page would start
+    # rendering "verify the ZIM file is not corrupted".
+    if isinstance(error, OpenZimMcpEntryNotFoundError):
+        return NOT_FOUND_ERROR_CONFIG
 
     # Specific failure modes detectable from the message take priority.
     if "entry not found" in message or "does not exist" in message:

--- a/openzim_mcp/exceptions.py
+++ b/openzim_mcp/exceptions.py
@@ -105,6 +105,23 @@ class OpenZimMcpArchiveError(OpenZimMcpError):
     error_code: str = "OPENZIM_ARCHIVE_ERROR"
 
 
+class OpenZimMcpEntryNotFoundError(OpenZimMcpArchiveError):
+    """Raised when the caller names an entry path the archive does not contain.
+
+    A subclass of :class:`OpenZimMcpArchiveError` so every existing
+    ``except OpenZimMcpArchiveError`` keeps catching it unchanged; the only
+    thing that changes is that callers can now tell "you asked for a page
+    that isn't here" apart from "this archive is corrupt". That is the
+    difference between a caller mistake and a server fault, and therefore
+    between a WARNING and an ERROR — a distinction that must come from the
+    exception TYPE, never from string-matching the message.
+    ``tools/resource_tools.py`` already draws exactly this line at the
+    protocol layer by answering a miss with ``INVALID_PARAMS``.
+    """
+
+    error_code: str = "OPENZIM_ENTRY_NOT_FOUND"
+
+
 class OpenZimMcpConfigurationError(OpenZimMcpError):
     """Raised when configuration is invalid."""
 

--- a/openzim_mcp/instructions.py
+++ b/openzim_mcp/instructions.py
@@ -35,7 +35,7 @@ small-model surface and belongs in its own commit.
 
 ADVANCED_INSTRUCTIONS = """\
 Offline ZIM archives (Wikipedia, Stack Exchange, Wiktionary, …). Retrieval \
-only — these tools never reach the network.
+only — content is read from local archives.
 
 Choosing a tool:
 - zim_query — a natural-language question when you don't have an entry path. \
@@ -59,7 +59,7 @@ a "message" describing how to correct the call.
 
 SIMPLE_INSTRUCTIONS = """\
 Offline ZIM archives (Wikipedia, Stack Exchange, Wiktionary, …). Retrieval \
-only — this tool never reaches the network.
+only — content is read from local archives.
 
 zim_query takes a natural-language question and handles search, entry \
 selection and rendering in one call. Ask it the question directly rather than \

--- a/openzim_mcp/mcp_envelope.py
+++ b/openzim_mcp/mcp_envelope.py
@@ -34,10 +34,16 @@ them to ``-32603 Internal server error`` with no detail, and both put either
 nothing or pydantic's rendered report on the wire. :meth:`get_prompt` makes
 the caller's mistakes ``-32602`` with a message naming the prompt and the
 arguments, and a fault inside a prompt body ``-32603`` naming only the prompt.
+
+:meth:`~EnvelopeAwareMCPServer.call_tool` closes the same gap for *tools*.
+Prompts already rejected an undeclared argument; tools dropped one silently,
+because the SDK's generated argument models inherit pydantic's default
+``extra="ignore"``. See :func:`_unknown_argument_error`.
 """
 
 from __future__ import annotations
 
+import difflib
 import json
 from typing import Any
 
@@ -55,6 +61,8 @@ from mcp_types import (
     TextResourceContents,
 )
 from pydantic import ValidationError
+
+from .responses import tool_error
 
 __all__ = ["EnvelopeAwareMCPServer", "is_tool_error_envelope"]
 
@@ -169,6 +177,88 @@ def error_result(payload: dict) -> CallToolResult:
     return CallToolResult(
         content=[TextContent(type="text", text=_serialize_envelope(payload))],
         is_error=True,
+    )
+
+
+# Keys the MCP spec reserves on the *params* object rather than inside
+# ``arguments`` (``mcp_types.RequestParams.meta``, alias ``_meta``). A
+# conforming client never nests one here, but tolerating exactly this key keeps
+# a lenient client's protocol metadata from reading as the caller's typo.
+# Nothing else is tolerated — ``_limit`` has to stay a rejection, or the silent
+# no-op comes straight back for anything underscore-prefixed.
+_RESERVED_ARGUMENT_KEYS = frozenset({"_meta"})
+
+
+def _unknown_argument_error(
+    tool: Any, name: str, arguments: dict[str, Any]
+) -> dict | None:
+    """The ``unknown_argument`` envelope for argument names ``tool`` does not declare.
+
+    Returns ``None`` when every key is declared, so the caller falls through to
+    the ordinary dispatch.
+
+    The SDK builds one pydantic model per tool and its ``ArgModelBase`` sets
+    only ``arbitrary_types_allowed``, so pydantic's default ``extra="ignore"``
+    made a misspelled parameter a silent no-op: ``zim_search(query=...,
+    limitt=2)`` ran at the default page size and returned ten hits while the
+    caller believed it had asked for two.
+
+    ``extra="forbid"`` would reject it, but as a pydantic ``ValidationError``
+    the SDK stringifies into a bare text block ("1 validation error for
+    zim_searchArguments ... errors.pydantic.dev/...") — the exact leak D04
+    removed from ``zim_browse``. Checking here instead makes the rejection the
+    same ``tool_error`` envelope every other rejected argument gets, which is
+    the contract ``instructions.py`` already advertises.
+
+    The rejection is deliberately runtime-only: publishing
+    ``additionalProperties: false`` costs ~232 bytes across the advanced
+    surface against ~159 bytes of headroom under the hard schema cap, and it
+    would only *hint* — a client that does not validate still sends the stray
+    key, so this check is required either way. Do not re-open that trade
+    without buying the bytes first.
+
+    ``tool.parameters["properties"]`` is the allow-list rather than
+    ``arg_model.model_fields`` because it is alias-correct: ``func_metadata``
+    renames a field that shadows a ``BaseModel`` attribute to ``field_<name>``
+    and keeps the wire name only as the alias.
+    """
+    declared = tool.parameters.get("properties") or {}
+    unknown = sorted(set(arguments) - set(declared) - _RESERVED_ARGUMENT_KEYS)
+    if not unknown:
+        return None
+
+    # Case-folded, mirroring the section-id repair in ``zim/structure.py``:
+    # difflib is case-sensitive and a pure case variant of a short name scores
+    # under the cutoff, so the easiest typo to repair would get no suggestion.
+    folded: dict[str, str] = {}
+    for prop in declared:
+        folded.setdefault(prop.casefold(), prop)
+    closest: dict[str, str] = {}
+    for key in unknown:
+        match = difflib.get_close_matches(key.casefold(), list(folded), n=1, cutoff=0.6)
+        if match:
+            closest[key] = folded[match[0]]
+
+    hint = " ".join(f"Did you mean {v!r} instead of {k!r}?" for k, v in closest.items())
+    accepted = sorted(declared)
+    extras: dict[str, Any] = {
+        "unknown_arguments": unknown,
+        "accepted_arguments": accepted,
+    }
+    if closest:
+        extras["closest_matches"] = closest
+    # ``dict(...)`` widens the ``ToolErrorPayload`` TypedDict to the plain
+    # mapping ``error_result`` takes; the payload itself is unchanged.
+    return dict(
+        tool_error(
+            operation="unknown_argument",
+            message=(
+                f"`{name}` does not accept argument(s): {', '.join(unknown)}. "
+                + (hint + " " if hint else "")
+                + f"Accepted: {', '.join(accepted) or 'none'}."
+            ),
+            extras=extras,
+        )
     )
 
 
@@ -346,6 +436,15 @@ class EnvelopeAwareMCPServer(MCPServer):
     ) -> CallToolResult | InputRequiredResult:
         if context is None:
             context = Context(mcp_server=self, subscriptions=self._subscriptions)
+        # Reject argument names the tool does not declare before dispatching:
+        # pydantic drops them silently, so this is the only place the stray key
+        # is still visible. ``get_tool`` returning ``None`` falls through, so an
+        # unknown *tool* name keeps raising the SDK's ``ToolError`` as before.
+        tool = self._tool_manager.get_tool(name)
+        if tool is not None:
+            rejected = _unknown_argument_error(tool, name, arguments)
+            if rejected is not None:
+                return error_result(rejected)
         # convert_result=False so the raw return value is still inspectable;
         # the success path is then converted by the same
         # ``fn_metadata.convert_result`` the base class would have used, which
@@ -356,7 +455,6 @@ class EnvelopeAwareMCPServer(MCPServer):
         if is_tool_error_envelope(result):
             return error_result(result)
 
-        tool = self._tool_manager.get_tool(name)
         if tool is None:  # pragma: no cover - call_tool raises on unknown names
             return result  # type: ignore[no-any-return]
         converted: CallToolResult | InputRequiredResult = (

--- a/openzim_mcp/ml/reranker.py
+++ b/openzim_mcp/ml/reranker.py
@@ -28,9 +28,18 @@ from openzim_mcp.ml.fallback import ml_fallback
 logger = logging.getLogger(__name__)
 
 
-def _load_model(model_id: str, cache_dir: Optional[Path]) -> Any:
+def _load_model(
+    model_id: str, cache_dir: Optional[Path], *, allow_download: bool = True
+) -> Any:
     """Lazy import + load. Called inside BGEReranker.get(). Kept as a
-    module-level function so tests can mock it cleanly."""
+    module-level function so tests can mock it cleanly.
+
+    ``allow_download`` defaults to True because the only callers that omit
+    it are the ones whose whole job is to populate the cache (the
+    ``openzim-mcp download-models`` CLI and the live-model test fixture).
+    The serving path always passes ``cfg.allow_model_download``, which
+    defaults to False — see RerankerConfig for why.
+    """
     from fastembed.rerank.cross_encoder import (  # type: ignore[import-not-found]
         TextCrossEncoder,
     )
@@ -38,6 +47,11 @@ def _load_model(model_id: str, cache_dir: Optional[Path]) -> Any:
     kwargs: dict[str, Any] = {"model_name": model_id}
     if cache_dir is not None:
         kwargs["cache_dir"] = str(cache_dir)
+    # local_files_only is the portable switch: FastEmbed has accepted it
+    # since 0.4.0, our declared floor. HF_HUB_OFFLINE would have been
+    # simpler but FastEmbed only started honouring it well after 0.4.x, so
+    # it would silently no-op across most of the range pyproject.toml admits.
+    kwargs["local_files_only"] = not allow_download
     return TextCrossEncoder(**kwargs)
 
 
@@ -189,14 +203,34 @@ class BGEReranker:
             try:
                 cls._instance = cls._load_with_timeout(cfg)
             except Exception as exc:  # noqa: BLE001
+                # Two very different situations produce a load failure now,
+                # and an operator cannot act without knowing which: "you
+                # never staged the model" vs "the staged model is broken /
+                # HuggingFace is unreachable". Name the flag in the first
+                # case so the fix is one command away.
+                if cfg.allow_model_download:
+                    remedy = (
+                        "Run `openzim-mcp download-models` to pre-stage the "
+                        "model offline."
+                    )
+                else:
+                    remedy = (
+                        "Model downloads are off by default "
+                        "(ml.reranker.allow_model_download=false), so the "
+                        "model must already be in the local cache. Run "
+                        "`openzim-mcp download-models` on a networked "
+                        "machine to stage it, or set "
+                        "OPENZIM_MCP_ML__RERANKER__ALLOW_MODEL_DOWNLOAD=true "
+                        "to accept first-call egress."
+                    )
                 logger.warning(
                     (
                         "reranker model load failed: %s. "
                         "Falling back to Xapian-only ranking for this "
-                        "process. Run `openzim-mcp download-models` to "
-                        "pre-stage the model offline."
+                        "process. %s"
                     ),
                     exc,
+                    remedy,
                 )
                 cls._load_failed = True
                 return None
@@ -227,7 +261,14 @@ class BGEReranker:
                 RuntimeError("reranker model load thread terminated abnormally"),
             )
             try:
-                outcome = ("ok", _load_model(cfg.model_id, cfg.cache_dir))
+                outcome = (
+                    "ok",
+                    _load_model(
+                        cfg.model_id,
+                        cfg.cache_dir,
+                        allow_download=cfg.allow_model_download,
+                    ),
+                )
             except Exception as exc:  # noqa: BLE001 — relayed to caller
                 outcome = ("err", exc)
             finally:

--- a/openzim_mcp/security.py
+++ b/openzim_mcp/security.py
@@ -567,6 +567,32 @@ def sanitize_control_chars(text: str) -> str:
     return _CONTEXT_CONTROL_CHARS_RE.sub(" ", text)
 
 
+def sanitize_for_log(text: str) -> str:
+    """Collapse control chars AND bound the length of caller-influenced log text.
+
+    ``sanitize_control_chars`` stopped a hostile argument forging extra
+    physical log lines (R2-3); it did nothing about VOLUME. A 1 MB
+    ``entry_path`` still wrote a 1 MB log record while the client-facing
+    envelope was capped — the log was the last unbounded amplifier of an
+    attacker-controlled string.
+
+    Deliberately the SAME ``_CONTEXT_MAX_LENGTH`` as the envelope's
+    ``context`` field and the ``**Technical Details**`` echo
+    (``error_messages._DETAILS_MAX_LENGTH``), so one number bounds every
+    user-influenced string that leaves this process, to the client or to
+    disk. It sits above ``INPUT_LIMITS.FILE_PATH`` (1000), the largest
+    documented argument, so a legal value is never trimmed.
+    """
+    text = sanitize_control_chars(text)
+    if len(text) <= _CONTEXT_MAX_LENGTH:
+        return text
+    kept = text[:_CONTEXT_MAX_LENGTH].rstrip()
+    # Count against what survived, not against the cap: a derived
+    # ``len(text) - _CONTEXT_MAX_LENGTH`` would misreport by however much
+    # ``rstrip`` removed.
+    return f"{kept}... [+{len(text) - len(kept)} chars elided]"
+
+
 def sanitize_context_for_error(context: str) -> str:
     """Sanitize context strings for error messages.
 

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -2920,12 +2920,23 @@ class SimpleToolsHandler(
         # ``returned_count`` counts rendered rows, so it now includes the
         # synthetic one. That makes it unusable as "how far through the ranked
         # stream this page went", which is what a resume point needs — so
-        # record that separately. ``limit`` is deliberately left alone: the
-        # page consumed exactly ``len(results)`` ranked rows, so the
-        # renderer's ``offset + limit`` still lands on the first row this page
-        # did not show.
+        # record that separately. ``limit`` is deliberately left alone; the
+        # renderer resumes at ``offset + source_consumed``.
+        #
+        # ``max``, not a plain assignment: the backend may already have
+        # recorded a LARGER ranked-row count, because ``_collect_distinct_hits``
+        # skips query-string variants inside the window and reports the rows it
+        # walked, not the rows it emitted. Overwriting that with the emitted
+        # count walked the resume point BACKWARDS into rows this page already
+        # showed. The splice itself consumes no extra ranked rows — the
+        # synthetic row comes from the title index — so the emitted count is
+        # only ever the floor. Guarded against a bool (``isinstance(True, int)``
+        # is True) and any non-count value a caller might have put there.
+        backend_consumed = page_info.get("source_consumed")
+        if not isinstance(backend_consumed, int) or isinstance(backend_consumed, bool):
+            backend_consumed = 0
         page_info["returned_count"] = len(spliced)
-        page_info["source_consumed"] = len(results)
+        page_info["source_consumed"] = max(backend_consumed, len(results))
         payload["page_info"] = page_info
         return payload
 

--- a/openzim_mcp/tools/_common.py
+++ b/openzim_mcp/tools/_common.py
@@ -6,13 +6,42 @@ import pathlib
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 from ..constants import MAX_SEARCH_RESULT_LIMIT
+from ..exceptions import (
+    OpenZimMcpEntryNotFoundError,
+    OpenZimMcpFileNotFoundError,
+    OpenZimMcpRateLimitError,
+    OpenZimMcpSecurityError,
+    OpenZimMcpValidationError,
+)
 from ..responses import ToolErrorPayload, tool_error
-from ..security import sanitize_context_for_error, sanitize_control_chars
+from ..security import sanitize_context_for_error, sanitize_for_log
 
 if TYPE_CHECKING:
     from ..server import OpenZimMcpServer
 
 _DESCRIPTIONS_DIR = pathlib.Path(__file__).parent
+
+# A caller mistake is not a server fault. Every family here means "the request
+# was wrong and the same request will always be wrong": the process is healthy
+# and there is no operator action to take. Logging them at ERROR — which this
+# seam did for the whole 8-tool surface — trains an operator to ignore ERROR,
+# which is how a real archive corruption gets missed. Security denials stay at
+# WARNING rather than INFO so they remain visible for intrusion triage at the
+# shipped default LOG_LEVEL. Split on the exception TYPE, never by
+# string-matching the message.
+#
+# ``OpenZimMcpValidationError`` covers its subclasses (cursor mismatch,
+# archive-path, archive-name); ``OpenZimMcpEntryNotFoundError`` is the reason
+# that type exists. Everything absent from this tuple keeps ERROR: a bare
+# ``OpenZimMcpArchiveError`` (corrupt archive, decode failure), the timeout
+# family, configuration errors, and any raw ``Exception`` (a bug).
+_CALLER_FAULT = (
+    OpenZimMcpValidationError,
+    OpenZimMcpSecurityError,
+    OpenZimMcpFileNotFoundError,
+    OpenZimMcpRateLimitError,
+    OpenZimMcpEntryNotFoundError,
+)
 
 
 def load_description(name: str) -> str:
@@ -50,10 +79,14 @@ def tool_error_response(
 
     # Control characters in the exception text (a ``zim_file_path`` with an
     # embedded LF is echoed verbatim by the validator) would otherwise forge
-    # extra physical lines in the ERROR log (R2-3). Paths are deliberately
-    # NOT redacted here: the operator-facing log needs the real one.
-    logging.getLogger(f"openzim_mcp.tools.{operation}").error(
-        "Error in %s: %s", operation, sanitize_control_chars(str(error))
+    # extra physical lines in the log (R2-3), and its LENGTH is caller-chosen
+    # too — a 1 MB ``entry_path`` wrote a 1 MB record while the client-facing
+    # envelope was already bounded. ``sanitize_for_log`` applies both, under
+    # the same cap the envelope uses. Paths are deliberately NOT redacted
+    # here: the operator-facing log needs the real one.
+    level = logging.WARNING if isinstance(error, _CALLER_FAULT) else logging.ERROR
+    logging.getLogger(f"openzim_mcp.tools.{operation}").log(
+        level, "Error in %s: %s", operation, sanitize_for_log(str(error))
     )
     enhanced = server._create_enhanced_error_message(
         operation=operation, error=error, context=context or ""

--- a/openzim_mcp/tools/completions.py
+++ b/openzim_mcp/tools/completions.py
@@ -72,12 +72,20 @@ def register_completions(server: "OpenZimMcpServer") -> None:
         allowed directory (glob + stat) before any cache lookup — run inline
         it would block the event loop, and a hung network mount would wedge
         every session on one completion request.
+
+        Sorted by path because the underlying scan globs the directory and
+        returns it in filesystem order, which differs between filesystems and
+        between two runs on the same one. A picker that reorders itself
+        between keystrokes is unusable, and an unordered list also made
+        ``test_completion_reflects_archives_added_after_startup`` fail on CI
+        runners whose glob happened to return the newer file first.
         """
         try:
-            return await asyncio.to_thread(server.zim_operations.list_zim_files_data)
+            rows = await asyncio.to_thread(server.zim_operations.list_zim_files_data)
         except Exception:  # noqa: BLE001 - a picker must not break the session
             logger.warning("completion: archive listing failed", exc_info=True)
             return []
+        return sorted(rows, key=lambda row: str(row.get("path", "")))
 
     def _matching(values: List[str], typed: str) -> List[str]:
         """Values consistent with what the user has typed so far.

--- a/openzim_mcp/zim/archive.py
+++ b/openzim_mcp/zim/archive.py
@@ -51,6 +51,7 @@ from openzim_mcp.defaults import CONTENT
 from openzim_mcp.exceptions import (
     ArchiveOpenTimeoutError,
     OpenZimMcpArchiveError,
+    OpenZimMcpEntryNotFoundError,
 )
 from openzim_mcp.meta import attach_meta
 from openzim_mcp.preset_data import ArchivePreset, resolve_preset_from_entries
@@ -1710,7 +1711,7 @@ class ZimOperations(
         if actual_path:
             resolved = _follow(archive.get_entry_by_path(actual_path))
             return resolved, resolved.path
-        raise OpenZimMcpArchiveError(
+        raise OpenZimMcpEntryNotFoundError(
             f"Entry not found: '{entry_path}'. "
             f"Try using zim_search() to find available entries."
         ) from None

--- a/openzim_mcp/zim/content.py
+++ b/openzim_mcp/zim/content.py
@@ -32,6 +32,7 @@ import openzim_mcp.zim_operations as _zim_ops_mod
 from openzim_mcp.content_processor import paged_slice_length
 from openzim_mcp.exceptions import (
     OpenZimMcpArchiveError,
+    OpenZimMcpEntryNotFoundError,
     OpenZimMcpValidationError,
 )
 from openzim_mcp.meta import attach_meta
@@ -974,7 +975,7 @@ class _ContentMixin:
                 )
                 return result, content_ok
             # No entry found via search
-            raise OpenZimMcpArchiveError(
+            raise OpenZimMcpEntryNotFoundError(
                 f"Entry not found: '{entry_path}'. "
                 f"The entry path may not exist in this ZIM file. "
                 f"Try using zim_search() to find available entries, "
@@ -1679,7 +1680,7 @@ class _ContentMixin:
                         entry = archive.get_entry_by_path(actual_path)
                         entry_path = actual_path
                     else:
-                        raise OpenZimMcpArchiveError(
+                        raise OpenZimMcpEntryNotFoundError(
                             f"Entry not found: '{entry_path}'. "
                             f"Try using zim_search() to find available entries, "
                             f"or zim_browse() to explore the archive's namespaces."

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -3198,7 +3198,7 @@ class _SearchMixin:
                     entry = self._verify_variant_via_title_index(
                         archive, variant, searcher=title_index
                     )
-            except Exception:
+            except Exception:  # nosec B112 - a variant that raises did not resolve
                 continue
             if entry is None:
                 continue

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -61,6 +61,19 @@ _FILTERED_MAX_SCAN = 10000
 # same score whatever was requested.
 _SUGGESTION_SCORE_DECAY_WINDOW = 10
 
+# How many ranked rows before a page ``_collect_distinct_hits`` re-reads to
+# seed its canonical set. Within-page dedup alone lets a duplicate pair leak
+# whenever it straddles a page boundary; a lookbehind makes the rule
+# "suppress a row whose canonical appeared within the previous K rows",
+# which does not depend on where the boundary falls. Deliberately a module
+# constant rather than a config knob: no caller can reason about it, and the
+# right value is a property of how ZIM writers emit variants, not of the
+# request. Measured on the shipped warc2zim shape (MedlinePlus, 4251 ranked
+# rows over five queries) the gap between two rows sharing a canonical never
+# exceeded 2 — 78 pairs at gap 1, 7 at gap 2 — so 8 is margin at the cost of
+# one extra ``getResults`` of path strings per paged request.
+_CANONICAL_LOOKBEHIND = 8
+
 
 def canonical_result_path(path: str) -> str:
     """Strip the query string and fragment from a result path.
@@ -936,11 +949,24 @@ class _SearchMixin:
         warc2zim stores query-string variants of a page as separate entries
         (``quiz.htm`` and ``quiz.htm?quiz=1``), and Xapian ranks them side
         by side — a MedlinePlus page of 40 carried 19 duplicates. Collapse
-        on the canonical path, as the filtered scanner does. Page-scoped
-        (not scan-scoped) so ``offset`` stays a plain ranked-row offset and
-        a high offset never triggers a scan from zero; the rows actually
-        consumed are reported in ``page_info.source_consumed`` so a client
-        resumes at ``offset + source_consumed``.
+        on the canonical path, as the filtered scanner does. Not scan-scoped
+        (the filtered scanner's answer) so ``offset`` stays a plain ranked-row
+        offset and a high offset never triggers a scan from zero; the rows
+        actually consumed are reported in ``page_info.source_consumed`` so a
+        client resumes at ``offset + source_consumed``.
+
+        Purely page-scoped dedup still leaked whenever a duplicate pair
+        straddled the boundary — the last row of one page and the first row
+        of the next were the same article, because the next page started
+        with an empty set. So the set is seeded from the
+        ``_CANONICAL_LOOKBEHIND`` rows immediately BEFORE the page, making
+        the rule "suppress a row whose canonical appeared within the
+        previous K rows" — independent of where the boundary falls, and
+        stateless (no cursor payload, no contract change). RESIDUAL: this is
+        correct only for duplicate chains whose links are ≤K apart. An
+        archive that ranked a variant hundreds of rows from its canonical
+        would still leak; only the filtered path's scan-from-zero is fully
+        general, and that costs O(offset) per page.
 
         Returns ``(rows, consumed, exhausted)``. ``total_results`` is
         Xapian's ESTIMATE and can exceed the real hit count; when
@@ -954,6 +980,20 @@ class _SearchMixin:
         seen_canonical: set[str] = set()
         consumed = 0
         exhausted = False
+        # Seed the lookbehind window. Clamped at 0 — ``getResults`` takes an
+        # absolute start index, and a negative one reads from the tail of the
+        # stream rather than the head. This fetch is deliberately kept out of
+        # the ``len(batch) < want -> exhausted`` test below: it is short
+        # whenever the window runs off the front, and treating that as the
+        # end of the stream would make every early page claim to be the last.
+        lookbehind_start = max(0, offset - _CANONICAL_LOOKBEHIND)
+        if offset > lookbehind_start:
+            seen_canonical.update(
+                canonical_result_path(entry_id)
+                for entry_id in search.getResults(
+                    lookbehind_start, offset - lookbehind_start
+                )
+            )
         while len(results) < limit and not exhausted:
             want = min(limit - len(results), total_results - offset - consumed)
             if want <= 0:

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -270,13 +270,21 @@ def _query_title_already_on_page(results: List[Dict[str, Any]], query: str) -> b
 # and got bolded as if they were content.
 _QUERY_OPERATOR_WORDS = frozenset({"and", "or", "not", "xor", "near", "adj"})
 
+# Xapian field prefixes libzim actually indexes. ``title:diabetes`` is one
+# term to the searcher, but the snippet builder saw two words and bolded the
+# FIELD NAME wherever "title" appeared in the article body. An allowlist
+# rather than a generic ``^\w+:`` strip, so a prose query like ``3:1 ratio``
+# survives intact.
+_QUERY_FIELD_PREFIXES = frozenset({"title", "path"})
+
 
 def _snippet_query(query: str) -> Optional[str]:
     """``query`` without Boolean-operator words, for snippet selection.
 
     ``(insulin) AND (NOT glucose)`` -> ``insulin glucose``: operator words
-    go, and grouping/quoting punctuation is peeled off the words that stay
-    (inner hyphens as in ``insulin-like`` survive). Returns ``None`` when
+    go, grouping/quoting punctuation is peeled off the words that stay
+    (inner hyphens as in ``insulin-like`` survive), and a known field prefix
+    is dropped (``title:diabetes`` -> ``diabetes``). Returns ``None`` when
     nothing remains, so the caller falls back to the lead paragraph.
 
     A TRAILING ``*`` is deliberately kept: it tells the highlighter to bold
@@ -290,6 +298,9 @@ def _snippet_query(query: str) -> Optional[str]:
         # marker is still seen in ``(climat*)``.
         if bare and word.rstrip("()\"'").endswith("*"):
             bare += "*"
+        head, sep, tail = bare.partition(":")
+        if sep and tail and head.lower() in _QUERY_FIELD_PREFIXES:
+            bare = tail
         # ``rstrip("*")`` on the operator test, or ``and*`` slips past the
         # filter and gets bolded as content.
         if bare and bare.rstrip("*").lower() not in _QUERY_OPERATOR_WORDS:
@@ -4091,7 +4102,12 @@ class _SearchMixin:
             try:
                 entry = archive.get_entry_by_path(entry_id)
                 snippet = self._get_entry_snippet(
-                    entry, query=query, validated_path=validated_path
+                    entry,
+                    # Same normalisation the interactive search rows get —
+                    # this path fed the raw query, so operator words were
+                    # still anchoring and bolding on the synthesize route.
+                    query=_snippet_query(query),
+                    validated_path=validated_path,
                 )
             except Exception as exc:
                 logger.warning(
@@ -4149,7 +4165,14 @@ class _SearchMixin:
         entry = self._follow_redirect_chain(entry)
         try:
             snippet = self._get_entry_snippet(
-                entry, query=title, validated_path=validated_path
+                # Deliberately NOT ``_snippet_query(title)``: this "query" is
+                # an article TITLE, so its words are content, not syntax.
+                # Normalising would turn "Sense and Sensibility" into the
+                # terms "Sense Sensibility" and drop a word the entry is
+                # literally named after.
+                entry,
+                query=title,
+                validated_path=validated_path,
             )
         except Exception as e:
             logger.debug(f"title_match_hit snippet failed for {title!r}: {e}")

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -275,15 +275,24 @@ def _snippet_query(query: str) -> Optional[str]:
     """``query`` without Boolean-operator words, for snippet selection.
 
     ``(insulin) AND (NOT glucose)`` -> ``insulin glucose``: operator words
-    go, and grouping/quoting/wildcard punctuation is peeled off the words
-    that stay (inner hyphens as in ``insulin-like`` survive). Returns
-    ``None`` when nothing remains, so the caller falls back to the lead
-    paragraph.
+    go, and grouping/quoting punctuation is peeled off the words that stay
+    (inner hyphens as in ``insulin-like`` survive). Returns ``None`` when
+    nothing remains, so the caller falls back to the lead paragraph.
+
+    A TRAILING ``*`` is deliberately kept: it tells the highlighter to bold
+    the whole word the stemmer actually matched (``climat*`` -> **climate**)
+    instead of hunting a literal "climat" that never occurs in prose.
     """
     kept = []
     for word in query.split():
         bare = word.strip("()\"'+-*")
-        if bare and bare.lower() not in _QUERY_OPERATOR_WORDS:
+        # ``rstrip`` the closing grouping/quoting characters first, so the
+        # marker is still seen in ``(climat*)``.
+        if bare and word.rstrip("()\"'").endswith("*"):
+            bare += "*"
+        # ``rstrip("*")`` on the operator test, or ``and*`` slips past the
+        # filter and gets bolded as content.
+        if bare and bare.rstrip("*").lower() not in _QUERY_OPERATOR_WORDS:
             kept.append(bare)
     return " ".join(kept) or None
 

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -32,6 +32,7 @@ import openzim_mcp.zim_operations as _zim_ops_mod
 from openzim_mcp.exceptions import (
     OpenZimMcpArchiveError,
     OpenZimMcpCursorMismatchError,
+    OpenZimMcpEntryNotFoundError,
     OpenZimMcpFileNotFoundError,
     OpenZimMcpValidationError,
 )
@@ -205,7 +206,7 @@ class _OutboundLinkBuckets(NamedTuple):
         return self.external
 
 
-def _entry_not_found_error(entry_path: str) -> OpenZimMcpArchiveError:
+def _entry_not_found_error(entry_path: str) -> OpenZimMcpEntryNotFoundError:
     """Typed not-found error for a missing ``entry_path``.
 
     libzim reports a miss as a bare ``KeyError('Cannot find entry')``. Left
@@ -213,12 +214,13 @@ def _entry_not_found_error(entry_path: str) -> OpenZimMcpArchiveError:
     a generic "Operation Failed / KeyError" envelope advising retries and a
     health check; wrapped as a generic archive error it renders as
     "verify the ZIM file is not corrupted". Neither points at the one thing
-    actually wrong — the path. The "Entry not found" phrasing is what
-    ``error_messages.get_error_config`` pattern-matches onto the focused
+    actually wrong — the path. The TYPE is what
+    ``error_messages.get_error_config`` resolves onto the focused
     *Resource Not Found* template, the same envelope ``zim_get`` produces
-    for the identical miss.
+    for the identical miss, and what marks the failure a caller mistake
+    rather than a server fault when the tool seam picks a log level.
     """
-    return OpenZimMcpArchiveError(
+    return OpenZimMcpEntryNotFoundError(
         f"Entry not found: '{entry_path}'. Double-check the spelling and "
         "path (entry paths are case-sensitive), or use "
         "`zim_search(mode='title')` to locate the entry."

--- a/tests/ml/test_reranker_offline_by_default.py
+++ b/tests/ml/test_reranker_offline_by_default.py
@@ -24,6 +24,7 @@ from typing import Any, Iterator, List
 import pytest
 
 from openzim_mcp.config import RerankerConfig
+from openzim_mcp.instructions import ADVANCED_INSTRUCTIONS, SIMPLE_INSTRUCTIONS
 from openzim_mcp.ml.fallback import reset_kill_switches
 from openzim_mcp.ml.reranker import BGEReranker, _load_model
 
@@ -185,3 +186,12 @@ def test_synthesize_rerank_path_makes_no_outbound_connection(
     assert out_passages == passages
     assert out_keys == hit_keys
     assert no_egress == [], f"synthesize path dialled out: {no_egress}"
+
+
+def test_instructions_do_not_promise_absolute_network_isolation() -> None:
+    """The [reranker] extra can still fetch a model when an operator opts
+    in, so the shipped instructions must not claim the tools *never* reach
+    the network. This guard stops the absolute phrasing coming back."""
+    for text in (ADVANCED_INSTRUCTIONS, SIMPLE_INSTRUCTIONS):
+        assert "never reach" not in text
+        assert "never reaches" not in text

--- a/tests/ml/test_reranker_offline_by_default.py
+++ b/tests/ml/test_reranker_offline_by_default.py
@@ -1,0 +1,187 @@
+"""The reranker must not dial out unless an operator asked it to.
+
+The MCP ``instructions`` payload tells callers this server is retrieval
+from local archives, and ``docs/roadmap.md`` states the project is
+offline-first ("models load from disk"). Before ``allow_model_download``
+existed, a cold FastEmbed cache made the *first* rerank-eligible
+``zim_query`` call open connections to huggingface.co and stall for up
+to ``first_call_timeout_seconds`` before falling back to Xapian — a
+1.1 GB fetch that no caller consented to and that the shipped
+instructions denied could happen.
+
+These tests pin the whole contract: the default is offline, the flag
+reaches FastEmbed, the escape hatch (`openzim-mcp download-models`)
+still downloads, and the instructions no longer make the absolute
+never-network claim that this behaviour used to falsify.
+"""
+
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+from typing import Any, Iterator, List
+
+import pytest
+
+from openzim_mcp.config import RerankerConfig
+from openzim_mcp.ml.fallback import reset_kill_switches
+from openzim_mcp.ml.reranker import BGEReranker, _load_model
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> Iterator[None]:
+    BGEReranker.reset_instance()
+    reset_kill_switches()
+    yield
+    BGEReranker.reset_instance()
+    reset_kill_switches()
+
+
+@pytest.fixture
+def no_egress(monkeypatch: pytest.MonkeyPatch) -> List[Any]:
+    """Record and refuse every outbound TCP connect.
+
+    Asserting on a recorded list rather than on wall-clock or on a
+    firewall makes the test deterministic on a developer machine that
+    *does* have a warm cache and *does* have network.
+    """
+    attempts: List[Any] = []
+
+    def _blocked(address: Any, *args: Any, **kwargs: Any) -> Any:
+        attempts.append(address)
+        raise OSError("test guard: no outbound connections allowed")
+
+    monkeypatch.setattr(socket, "create_connection", _blocked)
+    monkeypatch.setattr(
+        socket.socket,
+        "connect",
+        lambda self, address, *a, **k: _blocked(address),
+    )
+    return attempts
+
+
+def test_reranker_config_defaults_to_no_model_download() -> None:
+    """Pin the default itself: this is the whole user-visible contract."""
+    assert RerankerConfig().allow_model_download is False
+
+
+@pytest.mark.requires_reranker
+def test_cold_cache_load_makes_no_outbound_connection(
+    tmp_path: Path, no_egress: List[Any]
+) -> None:
+    """A guaranteed-cold cache under the default config must fail fast to
+    Xapian-only ranking instead of fetching the model from HuggingFace."""
+    cfg = RerankerConfig(cache_dir=tmp_path)
+    assert cfg.allow_model_download is False
+
+    assert BGEReranker.get(cfg) is None, "expected graceful Xapian fallback"
+    assert no_egress == [], f"reranker dialled out: {no_egress}"
+
+
+@pytest.mark.requires_reranker
+def test_load_model_translates_the_flag_for_fastembed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Assert on the kwarg, not on behaviour.
+
+    ``local_files_only`` is the portable switch: FastEmbed has accepted it
+    since 0.4.0, our declared floor, whereas ``HF_HUB_OFFLINE`` is only
+    honoured by later releases inside the same ``>=0.4.0,<1.0`` range and
+    would silently no-op for anyone the lockfile does not pin.
+    """
+    import fastembed.rerank.cross_encoder as ce
+
+    seen: dict[str, Any] = {}
+
+    class _FakeCrossEncoder:
+        def __init__(self, **kwargs: Any) -> None:
+            seen.clear()
+            seen.update(kwargs)
+
+    monkeypatch.setattr(ce, "TextCrossEncoder", _FakeCrossEncoder)
+
+    _load_model("BAAI/bge-reranker-base", None, allow_download=False)
+    assert seen["local_files_only"] is True
+
+    _load_model("BAAI/bge-reranker-base", None, allow_download=True)
+    assert seen["local_files_only"] is False
+
+
+@pytest.mark.requires_reranker
+def test_runtime_load_honours_the_config_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The loader thread must read the operator's config, not a hardcoded
+    default — otherwise the flag exists but changes nothing at runtime."""
+    seen: List[bool] = []
+
+    def _fake_load(model_id: str, cache_dir: Any, *, allow_download: bool) -> Any:
+        seen.append(allow_download)
+        raise RuntimeError("stop before touching fastembed")
+
+    monkeypatch.setattr("openzim_mcp.ml.reranker._load_model", _fake_load)
+
+    BGEReranker.get(RerankerConfig())
+    BGEReranker.reset_instance()
+    BGEReranker.get(RerankerConfig(allow_model_download=True))
+
+    assert seen == [False, True]
+
+
+@pytest.mark.requires_reranker
+def test_download_models_cli_still_downloads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pre-stage command is the escape hatch the fallback message
+    names. If it inherited the offline default it would be inert and the
+    advice would be a dead end."""
+    from openzim_mcp.ml.cli import download as download_cli
+
+    seen: List[bool] = []
+
+    def _fake_load(model_id: str, cache_dir: Any, **kwargs: Any) -> Any:
+        seen.append(bool(kwargs.get("allow_download", True)))
+        return object()
+
+    monkeypatch.setattr("openzim_mcp.ml.reranker._load_model", _fake_load)
+
+    download_cli._stage_reranker(RerankerConfig())
+
+    assert seen == [True]
+
+
+@pytest.mark.requires_reranker
+def test_synthesize_rerank_path_makes_no_outbound_connection(
+    tmp_path: Path, no_egress: List[Any]
+) -> None:
+    """`zim_query(synthesize=True)` is where the egress was first noticed;
+    pin that it inherits the offline default rather than carrying its own."""
+    from openzim_mcp.synthesize import _maybe_rerank_synthesize_passages
+
+    passages: List[Any] = [
+        {
+            "cite_id": "wiki/A/Aspirin",
+            "text_markdown": "Aspirin is a salicylate drug.",
+            "rank": 1,
+            "score": 0.9,
+        },
+        {
+            "cite_id": "wiki/A/Cat",
+            "text_markdown": "The cat is a domestic species.",
+            "rank": 2,
+            "score": 0.4,
+        },
+    ]
+    hit_keys = [("wiki", "A/Aspirin"), ("wiki", "A/Cat")]
+
+    out_passages, out_keys = _maybe_rerank_synthesize_passages(
+        passages,
+        hit_keys,
+        query="what is aspirin used for",
+        top_hits=[],
+        reranker_config=RerankerConfig(cache_dir=tmp_path),
+    )
+
+    assert out_passages == passages
+    assert out_keys == hit_keys
+    assert no_egress == [], f"synthesize path dialled out: {no_egress}"

--- a/tests/ml/test_reranker_unit.py
+++ b/tests/ml/test_reranker_unit.py
@@ -80,7 +80,7 @@ class TestBGEGet:
         """Regression: after a load failure, subsequent get() calls must NOT retry."""
         call_count = 0
 
-        def failing_load(model_id: str, cache_dir: object) -> object:
+        def failing_load(model_id: str, cache_dir: object, **kwargs: object) -> object:
             nonlocal call_count
             call_count += 1
             raise RuntimeError("simulated load failure")

--- a/tests/test_correctness_sweep_fixes.py
+++ b/tests/test_correctness_sweep_fixes.py
@@ -825,7 +825,7 @@ class TestRerankerLifecycleAndPageIntegrity:
 
         release = threading.Event()
 
-        def slow_load(_model_id, _cache_dir):
+        def slow_load(_model_id, _cache_dir, **_kwargs):
             release.wait(timeout=30)
             return MagicMock()
 

--- a/tests/test_d27_cross_page_dedup.py
+++ b/tests/test_d27_cross_page_dedup.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Dict, List
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -208,6 +208,92 @@ class TestCrossPageCanonicalDedup:
                     offset - _CANONICAL_LOOKBEHIND,
                     _CANONICAL_LOOKBEHIND,
                 )
+
+
+class TestSpliceKeepsBackendConsumedCount:
+    """D27c — the canonical splice clobbered ``source_consumed``."""
+
+    @staticmethod
+    def _handler(monkeypatch: Any):
+        import openzim_mcp.simple_tools as st
+
+        monkeypatch.setattr(
+            st,
+            "find_title_match",
+            lambda *a, **k: {"path": "A/Biofuel", "title": "Biofuel"},
+        )
+        monkeypatch.setattr(
+            st, "is_strong_canonical_title_match", lambda *a, **k: False
+        )
+        return st.SimpleToolsHandler(MagicMock())
+
+    @staticmethod
+    def _payload(paths: List[str], limit: int, **page_info: Any) -> Dict[str, Any]:
+        return {
+            "query": "biomass fuel",
+            "results": [
+                {"path": p, "title": p.split("/")[-1], "snippet": "..."} for p in paths
+            ],
+            "total": 70,
+            "done": False,
+            "next_cursor": "opaque",
+            "page_info": {
+                "offset": 0,
+                "limit": limit,
+                "returned_count": len(paths),
+                **page_info,
+            },
+            "_meta": {},
+        }
+
+    def test_splice_keeps_the_backends_larger_consumed_count(
+        self, monkeypatch: Any
+    ) -> None:
+        """The backend deduped two variants inside the window, so it walked
+        5 ranked rows to emit 3. Overwriting that with the emitted-row count
+        rewinds the resume point into rows this page already showed.
+        """
+        handler = self._handler(monkeypatch)
+        payload = self._payload(
+            ["A/Biomass_(energy)", "A/Biomass_briquettes", "A/Aviation_biofuel"],
+            limit=3,
+            source_consumed=5,
+        )
+        out = handler._splice_title_match_into_search(payload, "/x.zim", "biomass fuel")
+
+        assert out["page_info"]["source_consumed"] == 5
+        assert out["page_info"]["returned_count"] == 4
+
+    def test_splice_still_records_consumed_when_the_backend_did_not(
+        self, monkeypatch: Any
+    ) -> None:
+        """No incoming key (the clean-page case): the splice must still say
+        how many ranked rows the page went through, or ``returned_count``
+        — inflated by the synthetic row — becomes the resume point."""
+        handler = self._handler(monkeypatch)
+        payload = self._payload(
+            ["A/Biomass_(energy)", "A/Biomass_briquettes", "A/Aviation_biofuel"],
+            limit=3,
+        )
+        out = handler._splice_title_match_into_search(payload, "/x.zim", "biomass fuel")
+
+        assert out["page_info"]["source_consumed"] == 3
+
+    @pytest.mark.parametrize("bogus", [None, True, "5", -1])
+    def test_splice_ignores_a_non_count_consumed_value(
+        self, monkeypatch: Any, bogus: Any
+    ) -> None:
+        """``max()`` must not be fed a bool, a string or a negative — the
+        emitted-row count is the floor in every one of those cases."""
+        handler = self._handler(monkeypatch)
+        payload = self._payload(
+            ["A/Biomass_(energy)", "A/Biomass_briquettes", "A/Aviation_biofuel"],
+            limit=3,
+            source_consumed=bogus,
+        )
+        out = handler._splice_title_match_into_search(payload, "/x.zim", "biomass fuel")
+
+        assert out["page_info"]["source_consumed"] == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_d27_cross_page_dedup.py
+++ b/tests/test_d27_cross_page_dedup.py
@@ -1,0 +1,273 @@
+"""D27 follow-up: canonical dedup must survive a page boundary.
+
+PR #374 collapsed warc2zim query-string variants (``foo.htm`` and
+``foo.htm?quiz=1``) *within* a page, and taught the renderer to advertise
+``offset + page_info.source_consumed`` so a client resumes where the page
+really stopped. Both are page-scoped, so a duplicate pair that straddles the
+boundary still leaks: the last row of page N and the first row of page N+1
+are the same article, and page N+1 starts with an empty ``seen`` set.
+
+Measured on ``medlineplus.gov_en_all_2025-01.zim`` with a client following
+the documented resume rule to the letter — ``offset += source_consumed``:
+
+    q='quiz'     limit=2  -> 11 cross-page duplicates
+    q='quiz'     limit=10 ->  7 (first at offset=18)
+    q='diabetes' limit=13 ->  1 (at offset=80)
+
+The fix is a bounded lookbehind: before filling a page at ``offset > 0``,
+seed the seen-set from the ``_CANONICAL_LOOKBEHIND`` ranked rows immediately
+before it. Duplicates are provably local — across 4251 ranked rows of five
+queries on that archive the gap between two rows sharing a canonical was
+never more than 2 (78 pairs at gap 1, 7 at gap 2) — so a small window makes
+the rule "emit a row unless an earlier row within K carries the same
+canonical", which is page-boundary independent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+from openzim_mcp.zim.search import _CANONICAL_LOOKBEHIND, canonical_result_path
+from tests.zim_stubs import make_archive_stub, make_ops, make_search_stub
+
+MEDLINEPLUS = Path("/Users/cameron/Developer/zim/medlineplus.gov_en_all_2025-01.zim")
+
+
+def _perform(ops, zim_file, entry_ids, limit, offset, estimated=None):
+    with patch("openzim_mcp.zim_operations.Searcher") as searcher:
+        searcher.return_value.search.return_value = make_search_stub(
+            entry_ids, estimated=estimated
+        )
+        return ops._perform_search(
+            make_archive_stub(), "quiz", limit, offset, validated_path=zim_file
+        )
+
+
+def _walk(ops, zim_file, entry_ids, limit, estimated=None):
+    """Page the stub stream exactly as the documented contract tells a
+    client to: ``offset += source_consumed`` (else ``returned_count``)."""
+    pages: List[List[str]] = []
+    offset = 0
+    for _ in range(20):
+        payload, _total = _perform(
+            ops, zim_file, entry_ids, limit, offset, estimated=estimated
+        )
+        rows = [r["path"] for r in payload["results"]]
+        if rows:
+            pages.append(rows)
+        info = payload["page_info"]
+        step = info.get("source_consumed", info.get("returned_count"))
+        if payload["done"] or not step:
+            break
+        offset += step
+    return pages
+
+
+@pytest.fixture()
+def ops_and_file(tmp_path):
+    ops = make_ops(tmp_path)
+    zim_file = tmp_path / "test.zim"
+    zim_file.write_bytes(b"zim")
+    return ops, zim_file
+
+
+class TestCrossPageCanonicalDedup:
+    def test_variant_does_not_leak_across_the_page_boundary(self, ops_and_file) -> None:
+        """The duplicate pair straddles the boundary at limit=2.
+
+        Before the lookbehind, page 2 opened with ``C/b.htm?x=1`` — the
+        variant of the ``C/b.htm`` page 1 had just shown.
+        """
+        ops, zim_file = ops_and_file
+        stream = ["C/a.htm", "C/b.htm", "C/b.htm?x=1", "C/c.htm", "C/d.htm"]
+
+        page1, _ = _perform(ops, zim_file, stream, 2, 0)
+        assert [r["path"] for r in page1["results"]] == ["C/a.htm", "C/b.htm"]
+        resume = page1["page_info"].get(
+            "source_consumed", page1["page_info"]["returned_count"]
+        )
+        assert resume == 2
+
+        page2, _ = _perform(ops, zim_file, stream, 2, resume)
+        assert [r["path"] for r in page2["results"]] == ["C/c.htm", "C/d.htm"]
+
+        canon1 = {canonical_result_path(r["path"]) for r in page1["results"]}
+        canon2 = {canonical_result_path(r["path"]) for r in page2["results"]}
+        assert canon1 & canon2 == set()
+
+    def test_no_canonical_repeats_across_a_full_contract_walk(
+        self, ops_and_file
+    ) -> None:
+        """Every duplicate geometry seen on the real index, at every page
+        size that could split it: gap-1 and gap-2 pairs, each landing on a
+        boundary for at least one of these limits."""
+        ops, zim_file = ops_and_file
+        stream = [
+            "C/a.htm",
+            "C/b.htm",
+            "C/b.htm?x=1",
+            "C/c.htm",
+            "C/d.htm",
+            "C/d.htm?x=1",
+            "C/e.htm",
+            "C/f.htm",
+            "C/e.htm?x=1",  # gap 2
+            "C/g.htm",
+            "C/h.htm",
+            "C/h.htm?x=1",
+        ]
+        distinct = {canonical_result_path(p) for p in stream}
+        for limit in (1, 2, 3, 4, 5, 6):
+            pages = _walk(ops, zim_file, stream, limit)
+            emitted = [p for page in pages for p in page]
+            canon = [canonical_result_path(p) for p in emitted]
+            assert len(canon) == len(
+                set(canon)
+            ), f"limit={limit}: canonical repeated across pages {pages}"
+            assert set(canon) == distinct, f"limit={limit}: rows lost {pages}"
+
+    def test_lookbehind_seed_never_marks_the_stream_exhausted(
+        self, ops_and_file
+    ) -> None:
+        """The seeding fetch is short by construction — it must not feed
+        the ``len(batch) < want -> exhausted`` heuristic that terminates
+        pagination, or a mid-stream page would claim to be the last."""
+        ops, zim_file = ops_and_file
+        entry_ids = [f"C/A_{i}" for i in range(180)]
+
+        # Estimate overshoot at the true end of the stream: still done.
+        payload, _ = _perform(ops, zim_file, entry_ids, 20, 170, estimated=250)
+        assert len(payload["results"]) == 10
+        assert payload["done"] is True
+        assert payload["next_cursor"] is None
+
+        # Mid-stream, with a full lookbehind window available: not done.
+        payload, _ = _perform(ops, zim_file, entry_ids, 10, 100, estimated=250)
+        assert len(payload["results"]) == 10
+        assert payload["done"] is False
+        assert payload["next_cursor"] is not None
+
+    def test_lookbehind_window_clamps_at_the_start_of_the_stream(
+        self, ops_and_file
+    ) -> None:
+        """``offset - K`` is negative for every offset below K.
+
+        ``getResults`` is a slice in the stubs and a C++ call in libzim; a
+        negative start silently reads the tail of the stream in the former
+        and is undefined in the latter, so the window must be clamped to 0.
+        """
+        assert _CANONICAL_LOOKBEHIND > 1
+        ops, zim_file = ops_and_file
+        # The stream's tail duplicates its head: an unclamped window would
+        # slice the tail in and suppress the very rows this page must show.
+        stream = ["C/a.htm", "C/b.htm", "C/c.htm", "C/d.htm", "C/a.htm?x=1"]
+
+        payload, _ = _perform(ops, zim_file, stream, 2, 1)
+        assert [r["path"] for r in payload["results"]] == ["C/b.htm", "C/c.htm"]
+
+    def test_clean_page_is_byte_identical(self, ops_and_file) -> None:
+        """No variants anywhere: no ``source_consumed`` key, same rows.
+
+        The lookbehind must be invisible on the overwhelming majority of
+        archives, which carry no query-string variants at all.
+        """
+        ops, zim_file = ops_and_file
+        stream = [f"C/{c}.htm" for c in "abcdefghij"]
+
+        payload, _ = _perform(ops, zim_file, stream, 3, 3)
+        assert [r["path"] for r in payload["results"]] == [
+            "C/d.htm",
+            "C/e.htm",
+            "C/f.htm",
+        ]
+        assert "source_consumed" not in payload["page_info"]
+
+    def test_lookbehind_costs_one_extra_getresults_and_only_when_paging(
+        self, ops_and_file
+    ) -> None:
+        """Cost pin: zero extra reads on page 1, exactly one after it, and
+        it never materialises an entry (it reads path strings only)."""
+        ops, zim_file = ops_and_file
+        stream = [f"C/{i}.htm" for i in range(40)]
+
+        for offset, extra in ((0, 0), (12, 1)):
+            stub = make_search_stub(stream)
+            with patch("openzim_mcp.zim_operations.Searcher") as searcher:
+                searcher.return_value.search.return_value = stub
+                ops._perform_search(
+                    make_archive_stub(), "quiz", 5, offset, validated_path=zim_file
+                )
+            assert stub.getResults.call_count == 1 + extra
+            if extra:
+                start, count = stub.getResults.call_args_list[0].args
+                assert (start, count) == (
+                    offset - _CANONICAL_LOOKBEHIND,
+                    _CANONICAL_LOOKBEHIND,
+                )
+
+
+# ---------------------------------------------------------------------------
+# Corpus-backed pin. The shipped fixtures are wikipedia/wikibooks exports and
+# carry no query-string variants at all, which is exactly why the cross-page
+# case escaped PR #374's stub-based pin. This needs a warc2zim-shaped archive,
+# so it is `live`-marked (the default ``addopts`` carries ``-m 'not live'``)
+# and skips when the archive is absent.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.live
+@pytest.mark.skipif(
+    not MEDLINEPLUS.exists(), reason="warc2zim-shaped archive not present"
+)
+@pytest.mark.parametrize(
+    ("query", "limit"), [("quiz", 2), ("quiz", 10), ("diabetes", 13)]
+)
+def test_real_archive_contract_walk_emits_each_page_once(
+    query: str, limit: int
+) -> None:
+    """Walk the real ranked stream by the documented resume rule and assert
+    no canonical is emitted on two different pages."""
+    from openzim_mcp.cache import OpenZimMcpCache
+    from openzim_mcp.config import CacheConfig, ContentConfig, OpenZimMcpConfig
+    from openzim_mcp.content_processor import ContentProcessor
+    from openzim_mcp.security import PathValidator
+    from openzim_mcp.zim_operations import ZimOperations
+
+    config = OpenZimMcpConfig(
+        allowed_directories=[str(MEDLINEPLUS.parent)],
+        cache=CacheConfig(enabled=False, max_size=10, ttl_seconds=60),
+        content=ContentConfig(max_content_length=10000, snippet_length=200),
+    )
+    ops = ZimOperations(
+        config,
+        PathValidator(config.allowed_directories),
+        OpenZimMcpCache(config.cache),
+        ContentProcessor(snippet_length=200),
+    )
+
+    seen: Dict[str, int] = {}
+    leaks: List[Any] = []
+    offset = 0
+    for page_no in range(12):
+        payload = ops.search_zim_file_data(
+            str(MEDLINEPLUS), query, limit=limit, offset=offset
+        )
+        rows = payload["results"]
+        if not rows:
+            break
+        for row in rows:
+            canonical = canonical_result_path(row["path"])
+            if seen.get(canonical, page_no) != page_no:
+                leaks.append((offset, row["path"]))
+            seen[canonical] = page_no
+        info = payload["page_info"]
+        step = info.get("source_consumed", info.get("returned_count"))
+        if payload.get("done") or not step:
+            break
+        offset += step
+
+    assert leaks == [], f"cross-page duplicates for {query!r} at limit={limit}"

--- a/tests/test_followup_unknown_arguments.py
+++ b/tests/test_followup_unknown_arguments.py
@@ -1,0 +1,219 @@
+"""Unknown tool arguments are rejected, not silently dropped.
+
+A follow-up surfaced by the v3.0.0 field-defect sweep (#374). The SDK builds
+one pydantic model per tool from the function signature and its base class sets
+only ``arbitrary_types_allowed``, so pydantic's default ``extra="ignore"``
+applied: ``zim_search(query=..., limitt=2)`` ran at the default page size and
+returned ten hits while the caller believed it had asked for two. Nothing on
+the wire contradicted them — the published ``inputSchema`` carries no
+``additionalProperties: false`` either — and the shipped server instructions
+already promise that "A rejected argument is flagged isError with a JSON body
+carrying 'error', 'operation' and a 'message' describing how to correct the
+call".
+
+Every assertion here drives a real client session over the in-memory transport,
+because the defect and its fix both live at the dispatch seam: calling a tool's
+function directly, or ``server.mcp.call_tool`` with a dict, never carries the
+stray key that far.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any, AsyncIterator, Optional
+
+import pytest
+
+from openzim_mcp.config import OpenZimMcpConfig
+from openzim_mcp.server import OpenZimMcpServer
+from tests.test_mcp_session import _connected_client, _text, advanced_session
+
+# Minimal *correctly spelled* arguments for each advanced tool, so the
+# parametrised rejection test differs from a valid call by the stray key alone.
+_MINIMAL_ARGS: dict[str, dict[str, Any]] = {
+    "zim_query": {"query": "climate"},
+    "zim_search": {"query": "climate"},
+    "zim_get": {"entry_path": "A/Anything"},
+    "zim_get_section": {"entry_path": "A/Anything", "section_id": "intro"},
+    "zim_browse": {"namespace": "M"},
+    "zim_metadata": {},
+    "zim_links": {"entry_path": "A/Anything"},
+    "zim_health": {},
+}
+
+
+@asynccontextmanager
+async def _session_over(directory: Path, tool_mode: str) -> AsyncIterator[Any]:
+    """A connected client session whose allowed directory is ``directory``.
+
+    ``tests.test_mcp_session.session_for`` always allows ``tmp_path``; the
+    positive-control test needs a session that can actually open the bundled
+    archive.
+    """
+    config = OpenZimMcpConfig(allowed_directories=[str(directory)], tool_mode=tool_mode)
+    async with _connected_client(OpenZimMcpServer(config)) as session:
+        yield session
+
+
+def _payload(result: Any) -> dict[str, Any]:
+    text = _text(result)
+    # Pinned alongside every parse: ``extra="forbid"`` would also reject the
+    # call, but as a pydantic ``ValidationError`` the SDK stringifies into a
+    # bare text block. That leak is what D04 removed from ``zim_browse``.
+    assert "pydantic" not in text, text
+    assert "validation error for" not in text, text
+    return json.loads(text)
+
+
+@pytest.mark.asyncio
+async def test_misspelled_argument_is_rejected_not_ignored(tmp_path: Path) -> None:
+    """The headline regression: ``limitt=2`` used to run at the default page
+    size and return ten hits with ``isError=false``."""
+    (tmp_path / "a.zim").write_bytes(b"ZIM\x04")
+    async with advanced_session(tmp_path) as session:
+        result = await session.call_tool(
+            "zim_search",
+            {
+                "query": "climate",
+                "zim_file_path": str(tmp_path / "a.zim"),
+                "limitt": 2,
+            },
+        )
+
+    assert result.is_error is True
+    payload = _payload(result)
+    assert payload["error"] is True
+    assert payload["operation"] == "unknown_argument"
+    assert "limitt" in payload["message"]
+    # The self-correction hint, mirroring the section-id repair in
+    # zim/structure.py: a model that reads only ``message`` can still retry.
+    assert "'limit'" in payload["message"]
+    assert payload["unknown_arguments"] == ["limitt"]
+    assert "limit" in payload["accepted_arguments"]
+    assert payload["closest_matches"] == {"limitt": "limit"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool_name", sorted(_MINIMAL_ARGS))
+async def test_every_advanced_tool_rejects_an_undeclared_argument(
+    tmp_path: Path, tool_name: str
+) -> None:
+    """The seam is generic, not ``zim_search``-specific — including
+    ``zim_health``, whose only declared property is optional."""
+    (tmp_path / "a.zim").write_bytes(b"ZIM\x04")
+    arguments = dict(_MINIMAL_ARGS[tool_name])
+    arguments["zim_file_path"] = str(tmp_path / "a.zim")
+    arguments["nonsense_argument_xyz"] = 1
+
+    async with advanced_session(tmp_path) as session:
+        result = await session.call_tool(tool_name, arguments)
+
+    assert result.is_error is True
+    payload = _payload(result)
+    assert payload["operation"] == "unknown_argument"
+    assert payload["unknown_arguments"] == ["nonsense_argument_xyz"]
+
+
+@pytest.mark.asyncio
+async def test_simple_mode_rejects_an_undeclared_argument(tmp_path: Path) -> None:
+    """Both tool surfaces share one dispatch seam, so simple mode is covered
+    by the same check rather than by a second implementation."""
+    (tmp_path / "a.zim").write_bytes(b"ZIM\x04")
+    async with _session_over(tmp_path, "simple") as session:
+        result = await session.call_tool(
+            "zim_query",
+            {
+                "query": "climate",
+                "zim_file_path": str(tmp_path / "a.zim"),
+                "limitt": 2,
+            },
+        )
+
+    assert result.is_error is True
+    payload = _payload(result)
+    assert payload["operation"] == "unknown_argument"
+
+
+@pytest.mark.asyncio
+async def test_did_you_mean_is_casefold_tolerant(tmp_path: Path) -> None:
+    """``difflib`` is case-sensitive and a pure case variant scores under the
+    0.6 cutoff, so the easiest typo to repair would otherwise get no
+    suggestion. Mirrors the ``sh2d``/``SH2d`` section-id case."""
+    (tmp_path / "a.zim").write_bytes(b"ZIM\x04")
+    async with advanced_session(tmp_path) as session:
+        result = await session.call_tool(
+            "zim_get",
+            {"zim_file_path": str(tmp_path / "a.zim"), "Entry_Path": "A/Anything"},
+        )
+
+    assert result.is_error is True
+    payload = _payload(result)
+    assert payload["closest_matches"] == {"Entry_Path": "entry_path"}
+    assert "'entry_path'" in payload["message"]
+
+
+@pytest.mark.asyncio
+async def test_reserved_meta_key_in_arguments_is_tolerated(tmp_path: Path) -> None:
+    """``_meta`` belongs on ``RequestParams`` (``mcp_types._types``), a sibling
+    of ``arguments``, so a client nesting it inside ``arguments`` is lenient
+    rather than wrong. Tolerating exactly that one key keeps a client's
+    protocol metadata from reading as the caller's typo; nothing else is
+    tolerated, including other underscore-prefixed keys."""
+    (tmp_path / "a.zim").write_bytes(b"ZIM\x04")
+    async with advanced_session(tmp_path) as session:
+        tolerated = await session.call_tool(
+            "zim_health",
+            {
+                "zim_file_path": str(tmp_path / "a.zim"),
+                "_meta": {"progressToken": 1},
+            },
+        )
+        rejected = await session.call_tool(
+            "zim_health",
+            {"zim_file_path": str(tmp_path / "a.zim"), "_limit": 2},
+        )
+
+    assert json.loads(_text(tolerated)).get("operation") != "unknown_argument"
+    assert rejected.is_error is True
+    assert _payload(rejected)["operation"] == "unknown_argument"
+
+
+@pytest.mark.asyncio
+async def test_correctly_spelled_argument_still_honoured(
+    real_content_zim_files: dict[str, Optional[Path]],
+) -> None:
+    """Positive control against over-rejection: the same call with ``limit``
+    spelled correctly still caps the result set."""
+    archive = real_content_zim_files["wikipedia_climate"]
+    if archive is None:  # pragma: no cover - fixture archive missing
+        pytest.skip("wikipedia_en_climate_change_mini fixture not available")
+
+    async with _session_over(archive.parent, "advanced") as session:
+        result = await session.call_tool(
+            "zim_search",
+            {"query": "climate", "zim_file_path": str(archive), "limit": 2},
+        )
+
+    assert result.is_error is False
+    assert len(_payload(result)["results"]) == 2
+
+
+def test_rejection_is_runtime_only_and_costs_no_schema_bytes(tmp_path: Path) -> None:
+    """Deliberately NOT published as ``additionalProperties: false``.
+
+    The keyword would cost ~29 bytes per tool (~232 across the advanced
+    surface) against roughly 159 bytes of headroom under the hard 25600-byte
+    cap in ``tests/test_phase_f_schema_budget.py``, and it would breach
+    ``zim_health``'s per-tool allocation, force a prototype-schema re-snapshot
+    and a Gate 0b re-run. It is also only a hint: a client that does not
+    validate still sends the stray key, so runtime enforcement is required
+    regardless. Enforcement is therefore runtime-only — do not "helpfully" add
+    the schema keyword without buying the bytes first.
+    """
+    config = OpenZimMcpConfig(allowed_directories=[str(tmp_path)], tool_mode="advanced")
+    server = OpenZimMcpServer(config)
+
+    for tool in server.mcp._tool_manager.list_tools():
+        assert "additionalProperties" not in tool.parameters, tool.name

--- a/tests/test_release_workflow_registry_verify.py
+++ b/tests/test_release_workflow_registry_verify.py
@@ -73,7 +73,10 @@ def test_registry_publish_is_skipped_when_the_version_is_already_live(
         for step in registry_job["steps"]
         if "run" in step and "mcp-publisher publish" in step["run"]
     )
-    assert "registry.modelcontextprotocol.io" in publish_step, publish_step
+    # Asserted on the endpoint path rather than the hostname: CodeQL reads a
+    # bare host substring test as py/incomplete-url-substring-sanitization,
+    # and the path is the more specific thing to pin anyway.
+    assert "/v0/servers?search=" in publish_step, publish_step
     assert "nothing to publish" in publish_step, publish_step
     # The read-back afterwards is what proves a skipped publish was correct.
     assert "Registry serves" in script, script

--- a/tests/test_release_workflow_registry_verify.py
+++ b/tests/test_release_workflow_registry_verify.py
@@ -57,6 +57,54 @@ def test_publish_registry_reads_the_published_version_back(
     assert "$VERSION" in script, script
 
 
+def test_registry_publish_is_skipped_when_the_version_is_already_live(
+    registry_job: Dict[str, Any],
+) -> None:
+    """A re-dispatch of an old tag must not re-publish a live version.
+
+    Backfilling the registry for an already-released tag re-runs this job.
+    ``mcp-publisher publish`` for a version the registry already serves is at
+    best a no-op and at worst a 409 that reds the job, so the publish is
+    gated on a read of the registry first.
+    """
+    script = _run_scripts(registry_job)
+    publish_step = next(
+        step["run"]
+        for step in registry_job["steps"]
+        if "run" in step and "mcp-publisher publish" in step["run"]
+    )
+    assert "registry.modelcontextprotocol.io" in publish_step, publish_step
+    assert "nothing to publish" in publish_step, publish_step
+    # The read-back afterwards is what proves a skipped publish was correct.
+    assert "Registry serves" in script, script
+
+
+def test_a_finished_release_keeps_its_published_assets(
+    workflow_text: str,
+) -> None:
+    """Re-running the release for a finished tag must not re-upload assets.
+
+    Wheels embed a build timestamp, so artifacts rebuilt from the same source
+    are not byte-identical; ``gh release upload --clobber`` over a published
+    release would change asset checksums that people may have pinned, for a
+    run that changed nothing. A draft — the release-please path — still gets
+    populated, which is the case the step exists for.
+    """
+    job = yaml.safe_load(workflow_text)["jobs"]["create-release"]
+    check = next(step for step in job["steps"] if step.get("id") == "check-release")
+    assert "release_is_complete" in check["run"], check["run"]
+    assert "isDraft" in check["run"] and "assets" in check["run"], check["run"]
+
+    # Selected on the command, not the flag name: check-release's own comment
+    # explains why --clobber is avoided, so a substring match finds it first.
+    upload = next(
+        step
+        for step in job["steps"]
+        if "run" in step and "gh release upload" in step["run"]
+    )
+    assert "release_is_complete" in upload["if"], upload["if"]
+
+
 def test_release_workflow_curls_pin_the_https_scheme(workflow_text: str) -> None:
     """Sonar's ``new_security_rating`` gate reds on any workflow ``curl``
     that lets the URL choose the scheme."""

--- a/tests/test_security_alert_fixes.py
+++ b/tests/test_security_alert_fixes.py
@@ -53,7 +53,7 @@ class TestRerankerWorkerAlwaysReportsBack:
         """
         from openzim_mcp.ml.reranker import BGEReranker, RerankerConfig
 
-        def abort(_model_id, _cache_dir):
+        def abort(_model_id, _cache_dir, **_kwargs):
             raise _WorkerAbort("interpreter is going down")
 
         cfg = RerankerConfig(first_call_timeout_seconds=5.0)
@@ -78,7 +78,7 @@ class TestRerankerWorkerAlwaysReportsBack:
         """
         from openzim_mcp.ml.reranker import BGEReranker, RerankerConfig
 
-        def abort(_model_id, _cache_dir):
+        def abort(_model_id, _cache_dir, **_kwargs):
             raise SystemExit(3)
 
         cfg = RerankerConfig(first_call_timeout_seconds=5.0)

--- a/tests/test_server_metadata_and_completions.py
+++ b/tests/test_server_metadata_and_completions.py
@@ -228,6 +228,39 @@ async def test_completion_reflects_archives_added_after_startup(
 
 
 @pytest.mark.asyncio
+async def test_completion_values_are_ordered_independently_of_the_filesystem(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A picker must not reorder itself between keystrokes.
+
+    ``list_zim_files_data`` globs each allowed directory, so it hands back
+    whatever order the filesystem walked — which differs between filesystems
+    and, on some, between two runs over the same directory. The listing is
+    stubbed here rather than staged on disk precisely because the bad order
+    cannot be provoked reliably; what is under test is that the handler sorts
+    whatever it is given, not that any particular filesystem misbehaves.
+    """
+    from openzim_mcp.zim.archive import ZimOperations
+
+    monkeypatch.setattr(
+        ZimOperations,
+        "list_zim_files_data",
+        lambda self: [
+            {"path": str(tmp_path / "second.zim")},
+            {"path": str(tmp_path / "first.zim")},
+        ],
+    )
+
+    async with _session(tmp_path) as session:
+        result = await session.complete(
+            ref=ResourceTemplateReference(type="ref/resource", uri="zim://{name}"),
+            argument={"name": "name", "value": ""},
+        )
+
+    assert result.completion.values == ["first", "second"]
+
+
+@pytest.mark.asyncio
 async def test_completion_scan_runs_off_the_event_loop(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_v3_field_fixes_errors.py
+++ b/tests/test_v3_field_fixes_errors.py
@@ -608,13 +608,20 @@ def _captured(caplog: pytest.LogCaptureFixture, logger_name: str):
     ``OpenZimMcpServer`` construction runs ``logging.basicConfig(force=True)``,
     which drops caplog's root handler, so ``caplog.at_level`` alone captures
     nothing once a real server exists in the process.
+
+    Captures at WARNING, not ERROR: caller faults (a security denial, a
+    validation rejection) now log at WARNING, and an ``at_level(ERROR)``
+    capture discards them silently — the record-shape assertions below would
+    then pass by capturing nothing. WARNING still captures ERROR, so the
+    server-fault cases are unaffected. The level itself is pinned in
+    ``test_v3_field_fixes_logging.py``.
     """
     import logging
 
     target = logging.getLogger(logger_name)
     target.addHandler(caplog.handler)
     try:
-        with caplog.at_level(logging.ERROR, logger=logger_name):
+        with caplog.at_level(logging.WARNING, logger=logger_name):
             yield
     finally:
         target.removeHandler(caplog.handler)

--- a/tests/test_v3_field_fixes_logging.py
+++ b/tests/test_v3_field_fixes_logging.py
@@ -1,0 +1,132 @@
+"""Log-record contract for the advanced tool seam.
+
+Sibling of ``test_v3_field_fixes_errors.py``. That module pinned the SHAPE of
+a log record (one physical line, R2-3); this one pins its LEVEL and its SIZE.
+
+A follow-up from PR #374, proved against ``a59eb03``:
+
+* every caller mistake on the whole tool surface — a mistyped ``entry_path``,
+  a path outside ``allowed_directories``, a rejected argument, a rate-limit
+  denial — was logged at ERROR, because ``tools/_common.tool_error_response``
+  called ``.error(...)`` unconditionally. An ERROR channel that fires on user
+  typos trains an operator to ignore it, which is how a real archive
+  corruption gets missed.
+"""
+
+import contextlib
+import logging
+from pathlib import Path
+from typing import Dict, Optional
+
+import pytest
+
+from openzim_mcp.config import OpenZimMcpConfig
+from openzim_mcp.exceptions import (
+    OpenZimMcpArchiveError,
+    OpenZimMcpEntryNotFoundError,
+)
+from openzim_mcp.server import OpenZimMcpServer
+from openzim_mcp.tools._common import tool_error_response
+
+
+@contextlib.contextmanager
+def _captured(caplog: pytest.LogCaptureFixture, logger_name: str, level: int):
+    """Attach caplog's handler to one named logger for the duration.
+
+    ``OpenZimMcpServer`` construction runs ``logging.basicConfig(force=True)``,
+    which drops caplog's root handler, so ``caplog.at_level`` alone captures
+    nothing once a real server exists in the process. ``level`` is explicit
+    here because this module asserts on records BELOW error level, which an
+    ``at_level(ERROR)`` capture silently discards.
+
+    Propagation is suspended for the duration: when the server is built in a
+    FIXTURE, ``basicConfig(force=True)`` runs before pytest installs its
+    call-phase root handler, so that handler survives and the same record is
+    appended to ``caplog.records`` twice — once here and once at the root.
+    These tests count records, so one record must mean one record.
+    """
+    target = logging.getLogger(logger_name)
+    propagate = target.propagate
+    target.addHandler(caplog.handler)
+    target.propagate = False
+    try:
+        with caplog.at_level(level, logger=logger_name):
+            yield
+    finally:
+        target.propagate = propagate
+        target.removeHandler(caplog.handler)
+
+
+def _records(caplog: pytest.LogCaptureFixture, logger_name: str):
+    return [r for r in caplog.records if r.name == logger_name]
+
+
+@pytest.fixture
+def advanced_server(temp_dir: Path) -> OpenZimMcpServer:
+    config = OpenZimMcpConfig(allowed_directories=[str(temp_dir)], tool_mode="advanced")
+    return OpenZimMcpServer(config)
+
+
+def test_entry_not_found_is_a_subclass_of_archive_error() -> None:
+    """The backward-compatibility contract: every existing
+    ``except OpenZimMcpArchiveError`` keeps catching a not-found unchanged, so
+    introducing the type is a pure classification change."""
+    assert issubclass(OpenZimMcpEntryNotFoundError, OpenZimMcpArchiveError)
+
+
+def test_entry_not_found_still_renders_the_resource_not_found_template(
+    advanced_server: OpenZimMcpServer,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Splitting the type must not change what the CLIENT reads.
+
+    ``get_error_config``'s type mapping is by EXACT type, so a new subclass
+    reaches the not-found template only via the prose check — which is the
+    same string-matching this change exists to stop relying on. The probe
+    message therefore deliberately omits the "entry not found" wording: the
+    TYPE alone must select the template, or a rephrase at any raise site
+    would start rendering "verify the ZIM file is not corrupted" for a
+    missing page.
+    """
+    with _captured(caplog, "openzim_mcp.tools.zim_get", logging.WARNING):
+        payload = tool_error_response(
+            advanced_server,
+            operation="zim_get",
+            error=OpenZimMcpEntryNotFoundError("No such article: 'A/Nope'."),
+        )
+
+    assert "Resource Not Found" in payload["message"], payload["message"]
+
+
+def test_structure_not_found_helper_raises_the_typed_error() -> None:
+    """``structure._entry_not_found_error`` is the shared constructor for the
+    section/structure miss; it must mint the typed error, not the parent."""
+    from openzim_mcp.zim.structure import _entry_not_found_error
+
+    assert isinstance(_entry_not_found_error("A/Nope"), OpenZimMcpEntryNotFoundError)
+
+
+def test_missing_entry_path_raises_the_typed_error(
+    basic_test_zim_files: Dict[str, Optional[Path]], temp_dir: Path
+) -> None:
+    """End to end through the data layer: the single most common user mistake
+    on this server — a wrong entry path — must arrive typed."""
+    zim_path = basic_test_zim_files["withns"]
+    if zim_path is None:
+        pytest.skip("ZIM test corpus not available")
+
+    from openzim_mcp.cache import OpenZimMcpCache
+    from openzim_mcp.content_processor import ContentProcessor
+    from openzim_mcp.security import PathValidator
+    from openzim_mcp.zim_operations import ZimOperations
+
+    config = OpenZimMcpConfig(allowed_directories=[str(zim_path.parent)])
+    ops = ZimOperations(
+        config,
+        PathValidator(config.allowed_directories),
+        OpenZimMcpCache(config.cache),
+        ContentProcessor(snippet_length=100),
+    )
+
+    with pytest.raises(OpenZimMcpEntryNotFoundError):
+        ops.get_zim_entry(str(zim_path), "A/NoSuchEntryXyz")

--- a/tests/test_v3_field_fixes_logging.py
+++ b/tests/test_v3_field_fixes_logging.py
@@ -3,7 +3,7 @@
 Sibling of ``test_v3_field_fixes_errors.py``. That module pinned the SHAPE of
 a log record (one physical line, R2-3); this one pins its LEVEL and its SIZE.
 
-A follow-up from PR #374, proved against ``a59eb03``:
+Two follow-ups from PR #374, both proved against ``a59eb03``:
 
 * every caller mistake on the whole tool surface — a mistyped ``entry_path``,
   a path outside ``allowed_directories``, a rejected argument, a rate-limit
@@ -11,6 +11,9 @@ A follow-up from PR #374, proved against ``a59eb03``:
   called ``.error(...)`` unconditionally. An ERROR channel that fires on user
   typos trains an operator to ignore it, which is how a real archive
   corruption gets missed.
+* PR #374 bounded the CLIENT-facing echo (``error_messages._bound_details``)
+  but not the log: a 1,000,000-char ``entry_path`` produced a 2,474-char
+  client message and a 1,000,067-char log record.
 """
 
 import contextlib
@@ -22,11 +25,24 @@ import pytest
 
 from openzim_mcp.config import OpenZimMcpConfig
 from openzim_mcp.exceptions import (
+    ArchiveOpenTimeoutError,
     OpenZimMcpArchiveError,
+    OpenZimMcpArchiveNameError,
+    OpenZimMcpCursorMismatchError,
     OpenZimMcpEntryNotFoundError,
+    OpenZimMcpFileNotFoundError,
+    OpenZimMcpRateLimitError,
+    OpenZimMcpSecurityError,
+    OpenZimMcpValidationError,
 )
+from openzim_mcp.security import _CONTEXT_MAX_LENGTH, sanitize_for_log
 from openzim_mcp.server import OpenZimMcpServer
 from openzim_mcp.tools._common import tool_error_response
+
+# A control-character-bearing path, mirroring ``_INJECTED_PATH`` in
+# ``test_v3_field_fixes_errors``: the new length bound must not be added in a
+# way that bypasses the R2-3 single-line guarantee.
+_INJECTED_PATH = "/tmp/foo\n\tbar\r.zim"
 
 
 @contextlib.contextmanager
@@ -65,6 +81,61 @@ def _records(caplog: pytest.LogCaptureFixture, logger_name: str):
 def advanced_server(temp_dir: Path) -> OpenZimMcpServer:
     config = OpenZimMcpConfig(allowed_directories=[str(temp_dir)], tool_mode="advanced")
     return OpenZimMcpServer(config)
+
+
+# --------------------------------------------------------------------------
+# Level: a caller mistake is not a server fault
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        OpenZimMcpValidationError("limit must be between 1 and 100"),
+        OpenZimMcpCursorMismatchError("cursor was issued for another archive"),
+        OpenZimMcpArchiveNameError("did not match any loaded archive"),
+        OpenZimMcpSecurityError("Access denied - Path is outside allowed directories"),
+        OpenZimMcpFileNotFoundError("File does not exist: /nowhere/x.zim"),
+        OpenZimMcpRateLimitError("Rate limit exceeded"),
+        OpenZimMcpEntryNotFoundError("Entry not found: 'A/Nope'."),
+    ],
+    ids=lambda e: type(e).__name__,
+)
+def test_caller_fault_logs_at_warning_not_error(
+    advanced_server: OpenZimMcpServer,
+    caplog: pytest.LogCaptureFixture,
+    error: Exception,
+) -> None:
+    """The request was wrong and the same request will always be wrong; the
+    process is healthy and no operator action exists."""
+    with _captured(caplog, "openzim_mcp.tools.zim_get", logging.WARNING):
+        tool_error_response(advanced_server, operation="zim_get", error=error)
+
+    (record,) = _records(caplog, "openzim_mcp.tools.zim_get")
+    assert record.levelno == logging.WARNING
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        RuntimeError("boom"),
+        OpenZimMcpArchiveError("libzim could not decode the cluster"),
+        ArchiveOpenTimeoutError("timed out opening archive"),
+    ],
+    ids=lambda e: type(e).__name__,
+)
+def test_server_fault_still_logs_at_error(
+    advanced_server: OpenZimMcpServer,
+    caplog: pytest.LogCaptureFixture,
+    error: Exception,
+) -> None:
+    """The guard that the demotion did not swallow real faults: without it a
+    later widening of the caller-fault tuple silences archive corruption."""
+    with _captured(caplog, "openzim_mcp.tools.zim_links", logging.WARNING):
+        tool_error_response(advanced_server, operation="zim_links", error=error)
+
+    (record,) = _records(caplog, "openzim_mcp.tools.zim_links")
+    assert record.levelno == logging.ERROR
 
 
 def test_entry_not_found_is_a_subclass_of_archive_error() -> None:
@@ -130,3 +201,67 @@ def test_missing_entry_path_raises_the_typed_error(
 
     with pytest.raises(OpenZimMcpEntryNotFoundError):
         ops.get_zim_entry(str(zim_path), "A/NoSuchEntryXyz")
+
+
+# --------------------------------------------------------------------------
+# Size: the log was the last unbounded amplifier
+# --------------------------------------------------------------------------
+
+
+def test_sanitize_for_log_bounds_oversized_text() -> None:
+    out = sanitize_for_log("z" * 1_000_000)
+
+    assert len(out) < 1200, len(out)
+    assert out.endswith("chars elided]"), out[-40:]
+
+
+def test_sanitize_for_log_leaves_a_legal_max_length_path_intact() -> None:
+    """The cap sits above ``INPUT_LIMITS.FILE_PATH`` (1000), the largest
+    documented argument, so a LEGAL value is never trimmed. This is the pin
+    that stops someone "tidying" the cap below it."""
+    legal = "/" + "p" * 999
+
+    assert sanitize_for_log(legal) == legal
+    assert len(legal) <= _CONTEXT_MAX_LENGTH
+
+
+def test_sanitize_for_log_still_collapses_control_chars() -> None:
+    """The bound must not be added in a way that bypasses R2-3."""
+    out = sanitize_for_log(f"Path contains suspicious pattern: {_INJECTED_PATH}")
+
+    assert "\n" not in out
+    assert "\t" not in out
+    assert "\r" not in out
+
+
+def test_tool_error_log_record_is_bounded_for_a_1mb_entry_path(
+    advanced_server: OpenZimMcpServer, caplog: pytest.LogCaptureFixture
+) -> None:
+    """THE regression test: at ``a59eb03`` this record measured 1,000,067
+    characters while the client envelope was already capped at ~2,500."""
+    huge = "A/" + "z" * 1_000_000
+    error = OpenZimMcpEntryNotFoundError(
+        f"Entry not found: '{huge}'. Double-check the spelling."
+    )
+
+    with _captured(caplog, "openzim_mcp.tools.zim_get", logging.WARNING):
+        tool_error_response(
+            advanced_server, operation="zim_get", error=error, context=f"Path: {huge}"
+        )
+
+    (record,) = _records(caplog, "openzim_mcp.tools.zim_get")
+    assert len(record.getMessage()) < 2000, len(record.getMessage())
+
+
+def test_short_log_message_round_trips_byte_for_byte(
+    advanced_server: OpenZimMcpServer, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The bound is a no-op below the cap — ``test_tools_common`` pins the
+    exact ``'Error in <op>: <err>'`` rendering."""
+    with _captured(caplog, "openzim_mcp.tools.zim_links", logging.WARNING):
+        tool_error_response(
+            advanced_server, operation="zim_links", error=RuntimeError("boom")
+        )
+
+    (record,) = _records(caplog, "openzim_mcp.tools.zim_links")
+    assert record.getMessage() == "Error in zim_links: boom"

--- a/tests/test_wildcard_prefix_highlighting.py
+++ b/tests/test_wildcard_prefix_highlighting.py
@@ -191,3 +191,100 @@ class TestPrefixTermSnippetAnchoring:
         )
         assert out.startswith("**Climate**")
         assert "Climbing" not in out
+
+
+class TestSnippetQueryStripsFieldPrefixes:
+    """``title:diabetes`` used to bold the word "title" in the article body."""
+
+    def test_title_prefix_is_stripped(self) -> None:
+        assert _snippet_query("title:diabetes") == "diabetes"
+
+    def test_path_prefix_is_stripped(self) -> None:
+        assert _snippet_query("path:Aspirin") == "Aspirin"
+
+    def test_field_prefix_and_wildcard_together(self) -> None:
+        assert _snippet_query("title:diabet*") == "diabet*"
+
+    def test_prose_colon_is_not_a_field_prefix(self) -> None:
+        # Allowlist, not a generic ``^\w+:`` strip: a ratio must survive.
+        assert _snippet_query("3:1 ratio") == "3:1 ratio"
+        assert _snippet_query("chapter:2 summary") == "chapter:2 summary"
+
+    def test_bare_field_prefix_is_left_alone(self) -> None:
+        assert _snippet_query("title:") == "title:"
+
+    def test_field_name_is_no_longer_highlighted_as_content(self) -> None:
+        text = "The title of the article on Diabetes mellitus is set."
+        out = _highlight_terms(text, _snippet_query("title:diabetes") or "", max_hits=5)
+        assert "**title**" not in out
+        assert "**Diabetes**" in out
+
+
+class TestSynthesizePathNormalisesTheQuery:
+    """``search_top_k`` fed the RAW query to the snippet builder.
+
+    D30 stripped operator words from the snippet query on the interactive
+    search path only, so the synthesize path kept bolding ``**and**`` and
+    anchoring on nav junk.
+    """
+
+    def test_search_top_k_strips_operator_words(self, tmp_path) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from tests.zim_stubs import make_archive_stub, make_ops, make_search_stub
+
+        ops = make_ops(tmp_path)
+
+        def _entry(eid: str) -> MagicMock:
+            entry = MagicMock()
+            entry.path = eid
+            entry.title = "Hypoglycemia"
+            item = MagicMock()
+            item.mimetype = "text/html"
+            item.content = (
+                b"<p>Diagnosis and Tests</p>"
+                b"<p>Insulin is a hormone that lowers blood glucose.</p>"
+            )
+            entry.get_item.return_value = item
+            return entry
+
+        with patch("openzim_mcp.zim_operations.Searcher") as searcher:
+            searcher.return_value.search.return_value = make_search_stub(["C/Hypo"])
+            hits = ops.search_top_k(
+                make_archive_stub(_entry), "(insulin) AND (NOT glucose)", k=1
+            )
+
+        snippet = hits[0]["snippet"]
+        assert "**Insulin**" in snippet, snippet
+        assert "**and**" not in snippet
+        assert "**AND**" not in snippet
+
+    def test_title_match_hit_keeps_its_raw_title(self, tmp_path) -> None:
+        """A title is not a query — ``and`` in it is a word, not an operator.
+
+        Pinned so a later sweep does not "fix" ``title_match_hit`` by
+        routing it through ``_snippet_query`` too.
+        """
+        from unittest.mock import MagicMock, patch
+
+        from tests.zim_stubs import make_archive_stub, make_ops
+
+        ops = make_ops(tmp_path)
+
+        def _entry(eid: str) -> MagicMock:
+            entry = MagicMock()
+            entry.path = eid
+            entry.title = "Sense and Sensibility"
+            entry.is_redirect = False
+            item = MagicMock()
+            item.mimetype = "text/html"
+            item.content = b"<p>Sense and Sensibility is a novel by Jane Austen.</p>"
+            entry.get_item.return_value = item
+            return entry
+
+        archive = make_archive_stub(_entry)
+        with patch.object(ops, "_find_entry_fast_path", return_value=_entry("A/Sense")):
+            hit = ops.title_match_hit(archive, "Sense and Sensibility")
+
+        assert hit is not None
+        assert "**and**" in hit["snippet"], hit["snippet"]

--- a/tests/test_wildcard_prefix_highlighting.py
+++ b/tests/test_wildcard_prefix_highlighting.py
@@ -1,0 +1,193 @@
+"""Regression tests for trailing-``*`` prefix terms in snippet highlighting.
+
+A wildcard query (``climat*``) retrieves fine — libzim hands the query to
+Xapian, whose stemmer matches ``climate`` — but the snippet came back with
+nothing bolded: ``_snippet_query`` peeled the ``*`` off and
+``_highlight_terms`` then hunted for a literal whole word ``climat`` that
+never occurs in prose. The very hit the stemmer found went unmarked, and the
+paragraph ANCHOR could land on a different paragraph than the one the
+highlighter would have bolded (the 2/3-stem fallback in ``create_snippet``
+is looser than the whole-word pass).
+
+Surfaces covered: ``zim_search`` (mode="fulltext", including the
+namespace/content-type-filtered projection) and ``zim_query`` — both funnel
+through ``_get_entry_snippet`` -> ``ContentProcessor.create_snippet`` ->
+``_highlight_terms``.
+"""
+
+import re
+
+from openzim_mcp.content_processor import (
+    ContentProcessor,
+    _highlight_terms,
+    _split_query_terms,
+    _split_query_terms_typed,
+)
+from openzim_mcp.zim.search import _snippet_query
+
+
+class TestSnippetQueryKeepsTheWildcardMarker:
+    """``_snippet_query`` must hand the ``*`` on, not eat it."""
+
+    def test_trailing_star_survives(self) -> None:
+        assert _snippet_query("climat*") == "climat*"
+
+    def test_grouping_punctuation_is_still_peeled(self) -> None:
+        assert _snippet_query("(climat*)") == "climat*"
+
+    def test_operator_words_are_still_dropped_when_starred(self) -> None:
+        # Without rstrip("*") on the operator test, ``and*`` slips past the
+        # operator filter and gets bolded as content again.
+        assert _snippet_query("insulin and* glucose") == "insulin glucose"
+
+    def test_bare_star_yields_no_terms(self) -> None:
+        assert _snippet_query("*") is None
+
+    def test_existing_operator_stripping_is_unchanged(self) -> None:
+        # Byte-identical to the D30 assertions; restated so a rewrite of
+        # ``_snippet_query`` cannot quietly regress them.
+        assert _snippet_query("(insulin) AND (NOT glucose)") == "insulin glucose"
+        assert _snippet_query("salt and pepper") == "salt pepper"
+        assert _snippet_query("AND OR NOT") is None
+
+
+class TestPrefixTermTokenizing:
+    """``_split_query_terms_typed`` marks only END-of-term ``*`` as a prefix."""
+
+    def test_trailing_star_marks_a_prefix_term(self) -> None:
+        assert _split_query_terms_typed("diabet*") == [("diabet", True)]
+
+    def test_plain_term_is_not_a_prefix(self) -> None:
+        assert _split_query_terms_typed("diabetes") == [("diabetes", False)]
+
+    def test_mid_word_star_is_two_ordinary_terms(self) -> None:
+        # Xapian honours ``*`` only at the end of a term, so ``clima*te``
+        # is two literals — not a prefix probe.
+        assert _split_query_terms_typed("clima*te") == [("clima", True), ("te", False)]
+
+    def test_bare_star_yields_nothing(self) -> None:
+        assert _split_query_terms_typed("*") == []
+        assert _split_query_terms_typed("**") == []
+
+    def test_untyped_splitter_still_returns_bare_terms(self) -> None:
+        assert _split_query_terms("Climat* change") == ["climat", "change"]
+
+
+class TestPrefixTermHighlighting:
+    """``_highlight_terms`` bolds the whole word a prefix term opens."""
+
+    def test_prefix_term_bolds_the_stemmed_word(self) -> None:
+        out = _highlight_terms(
+            "Diabetes mellitus, also called diabetes, affects patients.",
+            "diabet*",
+            max_hits=10,
+        )
+        assert "**Diabetes**" in out
+        assert "**diabetes**" in out
+
+    def test_prefix_term_anchors_at_the_word_start(self) -> None:
+        # The leading ``\b`` is Xapian's prefix semantics: ``diabet*`` does
+        # not match the middle of ``prediabetes``.
+        out = _highlight_terms("A prediabetes diagnosis.", "diabet*", max_hits=10)
+        assert out == "A prediabetes diagnosis."
+
+    def test_literal_term_is_still_whole_word_only(self) -> None:
+        # The guard that the change is prefix-ONLY and not a general
+        # substring loosening (mirrors test_word_boundaries_still_apply).
+        out = _highlight_terms("cafeteria and cafe", "cafe", max_hits=10)
+        assert "**cafeteria**" not in out
+        assert "**cafe**" in out
+
+    def test_star_makes_the_same_term_prefix_matching(self) -> None:
+        out = _highlight_terms("cafeteria and cafe", "cafe*", max_hits=10)
+        assert "**cafeteria**" in out
+        assert "**cafe**" in out
+
+    def test_short_prefix_is_ignored(self) -> None:
+        # Prefix terms need 4+ chars: ``car*`` would otherwise bold
+        # carbon/cardiac/carry/careful.
+        text = "Carbon and cardiac and carry."
+        assert _highlight_terms(text, "car*", max_hits=10) == text
+
+    def test_four_char_prefix_is_the_floor(self) -> None:
+        out = _highlight_terms("Carbon dioxide levels.", "carb*", max_hits=10)
+        assert "**Carbon**" in out
+
+    def test_bare_star_query_leaves_text_untouched(self) -> None:
+        text = "Nothing should be bolded here."
+        assert _highlight_terms(text, "*", max_hits=10) == text
+        assert _highlight_terms(text, "**", max_hits=10) == text
+        assert not re.search(r"\*\*", _highlight_terms(text, "*", max_hits=10))
+
+    def test_mid_word_star_does_not_prefix_match(self) -> None:
+        text = "Climate change is real."
+        # ``a*b``-shaped query: both halves are ordinary terms, and both are
+        # below the literal 3-char floor, so nothing is bolded.
+        assert _highlight_terms(text, "a*b", max_hits=10) == text
+
+    def test_prefix_match_folds_case_and_diacritics(self) -> None:
+        out = _highlight_terms("The Café is open.", "cafe*", max_hits=10)
+        assert "**Café**" in out
+
+    def test_prefix_match_spans_a_ligature_expansion(self) -> None:
+        # ``_fold("ﬁ") == "fi"``: the one-to-many index map must still map
+        # the (now longer) prefix span back onto the source characters.
+        out = _highlight_terms("The ﬁles are here.", "file*", max_hits=10)
+        assert "**ﬁles**" in out
+
+    def test_prefix_match_inside_a_link_is_still_protected(self) -> None:
+        text = '[Climate change](Climate_change "Climate change") and climate talk'
+        out = _highlight_terms(text, "climat*", max_hits=10)
+        assert '[Climate change](Climate_change "Climate change")' in out
+        assert "**climate**" in out
+        assert out.count("**") == 2
+
+    def test_prefix_match_skips_existing_emphasis(self) -> None:
+        text = "**Climate change** is real; climate matters"
+        out = _highlight_terms(text, "climat*", max_hits=10)
+        assert "**Climate change**" in out
+        assert "****" not in out
+        assert out.count("**") == 4
+
+    def test_longest_alternative_wins_over_a_shorter_one(self) -> None:
+        # First-match-wins alternation: a short term must not shadow a
+        # longer alternative that shares its opening characters.
+        out = _highlight_terms(
+            "Climate variability includes the climate.", "climate climat*", max_hits=10
+        )
+        assert out == "**Climate** variability includes the **climate**."
+
+    def test_overlapping_terms_produce_no_nested_markers(self) -> None:
+        out = _highlight_terms("Climatology matters.", "clim* climat*", max_hits=10)
+        assert out == "**Climatology** matters."
+
+
+class TestPrefixTermSnippetAnchoring:
+    """Paragraph selection must agree with what gets bolded."""
+
+    def test_snippet_bolds_the_wildcard_hit(self) -> None:
+        proc = ContentProcessor(snippet_length=400)
+        markdown = "Climate variability includes all the variations in the climate."
+        out = proc.create_snippet(
+            markdown, query=_snippet_query("climat*"), max_paragraphs=1
+        )
+        assert "**Climate**" in out
+
+    def test_anchor_agrees_with_the_highlighter(self) -> None:
+        """The 2/3-stem fallback used to anchor a paragraph nothing bolds.
+
+        ``climat`` has no whole-word hit anywhere here, so pass 2 probed the
+        4-char stem ``clim`` and stopped on "Climbing" — a paragraph the
+        highlighter would leave completely unmarked. The prefix-aware
+        whole-word pass now reaches "Climate" in paragraph 2.
+        """
+        proc = ContentProcessor(snippet_length=400)
+        markdown = (
+            "Climbing is a popular sport in the alps.\n\n"
+            "Climate change is real and ongoing."
+        )
+        out = proc.create_snippet(
+            markdown, query=_snippet_query("climat*"), max_paragraphs=1
+        )
+        assert out.startswith("**Climate**")
+        assert "Climbing" not in out

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -38,7 +38,7 @@ OpenZIM MCP provides **intelligent, structured access** that LLMs need:
 
 - **Research & knowledge management** — offline Wikipedia / Wiktionary / academic archives behind an MCP-aware assistant.
 - **Knowledge chatbots** — give a small/local LLM real reference material instead of relying on weights.
-- **Compliance / air-gapped environments** — offline knowledge access without internet egress.
+- **Compliance / air-gapped environments** — offline knowledge access without internet egress. The optional `[reranker]` extra also stays offline: its model is loaded from the local cache only, staged by an explicit `openzim-mcp download-models` run on a networked machine (see [docs/extras-reranker.md](https://github.com/cameronrye/openzim-mcp/blob/main/docs/extras-reranker.md)).
 - **Multi-agent workflows** — extract binary entries (PDFs, images) and pass to specialized processors.
 
 ## Project Status

--- a/website/src/content/docs/security-best-practices.mdx
+++ b/website/src/content/docs/security-best-practices.mdx
@@ -26,6 +26,7 @@ OpenZIM MCP serves offline knowledge archives to MCP clients. The relevant threa
 | Prompt injection via user args | Control characters stripped, backticks stripped (template delimiter), length capped before interpolation |
 | Resource exhaustion | Token-bucket rate limiter with per-operation costs, atomic acquire, per-client buckets with LRU eviction |
 | Self-referential redirects causing infinite loops | Bounded redirect-chain follow (`MAX_REDIRECT_DEPTH = 10`), self-referential refs rejected |
+| Unannounced outbound egress from a "retrieval only" server | The base install makes no outbound connections. The optional `[reranker]` extra loads its cross-encoder from the local model cache only (`ml.reranker.allow_model_download` defaults to `false`); fetching it requires an explicit `openzim-mcp download-models` run |
 | DNS rebinding against a local HTTP server | `Host`-header validation — only loopback hosts accepted by default; extend via `OPENZIM_MCP_ALLOWED_HOSTS` behind a Host-preserving reverse proxy |
 
 ## Path validation


### PR DESCRIPTION
> **Upgrade notes.** Two user-visible behaviour changes. Neither makes a call fail.
>
> 1. **`[reranker]` users:** the cross-encoder no longer downloads its model. If it was never staged, rerank-eligible queries fall back to Xapian-only ranking (results still return, without `rerank_score`) and log one warning naming the fix. Stage it once with `openzim-mcp download-models` — pin `OPENZIM_MCP_ML__RERANKER__CACHE_DIR` first, FastEmbed's default cache lives under the system temp dir. To restore download-on-first-use: `OPENZIM_MCP_ML__RERANKER__ALLOW_MODEL_DOWNLOAD=true`. The base install is unaffected.
> 2. **All clients:** an argument name a tool does not declare is now rejected with an `unknown_argument` error envelope instead of being silently dropped. `zim_search(query=…, limitt=2)` previously ran at the default page size and returned ten results with `isError: false`. `_meta` nested inside `arguments` is tolerated. The published `inputSchema` is unchanged, so `tools/list` is byte-identical.
>
> Also: caller mistakes now log at WARNING rather than ERROR. Alerting keyed on ERROR from `openzim_mcp.tools.*` will go quiet for user input — that is the point; add WARNING to keep seeing them.

## Summary

PR #374 fixed 65 field-test defects and, in passing, named six pre-existing problems it deliberately did not touch. This closes five of them. Each was first investigated independently (confirmed real, code located, repro run) before any fix was written, then implemented TDD-style in an isolated lane.

Full suite **4531 passed, 213 skipped**. Live suite **30 passed, 16 skipped, 0 failed** (the 27-test baseline plus three new live tests). **Zero schema bytes spent** — the advanced surface measures 25,432 B before and after.

Also here: a genuine flake fix that surfaced while merging (see the last section).

## What changed

### 1. Unknown arguments are rejected instead of silently ignored

`zim_search(query=..., limitt=2)` returned ten results with `isError=false` — a 14,202-byte body for a call the caller believed asked for two. Pydantic's default `extra="ignore"` dropped the key and nothing on the wire contradicted the caller.

An explicit unknown-key check now sits at the `EnvelopeAwareMCPServer.call_tool` seam and returns the house `tool_error` envelope with a difflib suggestion:

> `zim_search` does not accept argument(s): limitt. Did you mean 'limit' instead of 'limitt'? Accepted: content_type, cross_file, cursor, limit, mode, namespace, offset, query, zim_file_path.

This makes true a promise the shipped server instructions already made. `_meta` nested inside `arguments` is tolerated (the spec puts it on `RequestParams`, so a client nesting it is lenient rather than wrong); `_limit` is pinned as still rejected so nobody widens it to an underscore rule. **`additionalProperties: false` is deliberately not published** — it costs ~232 bytes against ~168 of headroom; the reasoning is in the docstring so it is not re-litigated.

### 2. Caller mistakes stop logging at ERROR, and stop writing unbounded log lines

A mistyped `entry_path` logged at ERROR with the full caller-supplied string — #374 bounded the *client response* but not the log record, so a 1 MB path still wrote a 1 MB log line.

Level is now chosen by exception **type**, never by string-matching the message (the rule the repo states at `simple_tools.py:1770`). A new `OpenZimMcpEntryNotFoundError(OpenZimMcpArchiveError)` makes "you asked for a page that isn't here" distinguishable from "this archive is corrupt" without breaking any existing `except OpenZimMcpArchiveError`. Caller faults log at WARNING — security denials included, so they stay visible for intrusion triage at the shipped `LOG_LEVEL=INFO`. Caller text in those records is bounded by the same 1024-byte constant already used for the client-facing `context` field, with an explicit `... [+N chars elided]` marker.

### 3. The reranker no longer contradicts the never-network promise — **BREAKING for `[reranker]` users**

`synthesize=True` opened connections to huggingface.co and pulled ~1.1 GB on a cold cache, while the `instructions` payload told every caller the tools never reach the network. Reproduced at the socket level.

`ml.reranker.allow_model_download` is new and **defaults to `false`**: the model loads from the local FastEmbed cache only. An existing `[reranker]` user with an unstaged model now gets Xapian-only ranking plus one actionable WARNING — nothing errors, no tool call fails, results keep coming back. Restore reranking with `openzim-mcp download-models` (pin `OPENZIM_MCP_ML__RERANKER__CACHE_DIR` first; FastEmbed's default cache lives under the system temp dir and does not survive a reboot), or restore the old behaviour with `OPENZIM_MCP_ML__RERANKER__ALLOW_MODEL_DOWNLOAD=true`.

The claim itself is corrected everywhere it appears — `instructions.py` (both modes), `docs/extras-reranker.md`, `docs/roadmap.md`, the air-gapped bullet on the docs index, and the security-best-practices threat table. The new instructions wording costs **0 bytes**.

### 4. Duplicate search variants no longer straddle a page boundary (D27a/D27c)

#374's review round already fixed the footer half (D27b). The remaining leak was the straddle itself: a bounded lookbehind now seeds `seen_canonical` from the ranked rows immediately preceding the page, `K = 8` as a module constant (measured max duplicate gap on the shipped corpora is 2). Measured on a warc2zim-shaped archive this removed **11 duplicate rows from a 12-page walk at `limit=2`** and 7 at `limit=10`.

Also fixed: the title-match splice overwrote the backend's ranked-row count with the number of rows it emitted, rewinding the advertised resume point into its own window.

No API, argument, cursor or tool-description change — `offset` stays a plain ranked-row index.

### 5. Wildcard queries highlight

`diabet*` bolded nothing. The investigation corrected the premise: the `*` is stripped twice over, and what kills the highlight is that the surviving stem is then matched **whole-word**, so `diabet` can never match inside `diabetes`.

A trailing `*` now marks a prefix term, closing on `\w*` instead of `\b`. Prefix terms require 4+ characters (`car*` bolding carbon/cardiac/carry/careful is noise); literal terms keep their 3-character floor. Paragraph anchoring uses the same rule so a snippet no longer opens on a paragraph containing no highlightable hit.

Worth a release-note sentence: highlighting is now slightly **more** generous than retrieval — `climat*` bolds `climatologist` too, because libzim ignores the `*` and retrieves by stem regardless.

Two adjacent defects in the same functions: a `title:`/`path:` field prefix is dropped before highlighting (`title:diabetes` used to bold the word "title" in the body), and Boolean operator words are now stripped on the synthesize path too. `title_match_hit` is deliberately left alone — its "query" is an article title, not a query — with a comment saying so.

### 6. Completion ordering (found while merging, not a follow-up)

`test_completion_reflects_archives_added_after_startup` failed on one CI runner in an unrelated dependency-bump PR. It was not a flake in that PR: `list_zim_files_data` globs the directory, so the picker's values arrive in filesystem-walk order, which is not stable across filesystems and on some is not stable between two runs. A picker that reorders itself between keystrokes is unusable. Sorted at the completion handler, so nothing else's ordering changes.

## Deferred, with reasons

- `tests/dispatch_eval/runner.py:735` still says "Unknown extras are allowed" — now false, but changing it re-scores committed Gate 0b runs, which is a measurement decision.
- `zim_search` still annotates `mode: Literal[...]`, so a bad *value* (not name) on a declared key still leaks pydantic's report. D04's fix was applied to `zim_browse` only.
- The splice's duplicate check still compares raw rather than canonical paths.
- Two comments in `tests/test_sweep5_splice_pagination.py` were falsified by #374's D27b fix; every assertion still passes, only the explanation is stale.
- The reranker's `cache_dir` still defaults to FastEmbed's `<tempdir>/fastembed_cache`, and the load timeout does not stop an in-flight download (the daemon thread outlives the bail).
- The sixth follow-up — `get article Immanuel Kant` resolving to *Immanuel Kant: Logic* without disambiguating — is untouched here.

## Test plan

- [x] `pytest -q` — 4531 passed, 213 skipped
- [x] `pytest -m live` — 30 passed, 16 skipped, 0 failed
- [x] Schema budget + prototype parity — 38 passed; advanced surface 25,432 B, unchanged
- [x] Each new test watched failing at `a59eb03` before its fix
- [x] `pre-commit run --files <every touched file>` — exit 0

## Added after review of the merge result

Three things that surfaced while landing the above, kept here rather than spun into their own PRs because each is a few lines and all three are about the same thing — keeping the signals a maintainer checks actually readable.

### Code-scanning tab

The three alerts open before this work (2× Bandit `B110`, 1× CodeQL `py/unused-global-variable`) are all **closed by #374** — the `try/except/pass` pair became `contextlib.suppress`, and the "unused" constant was a false positive that #374's `__all__` entry silenced.

#374 then introduced two new notes, both handled here:

- **`B112`** at the typo sweep's variant probe. The probe raises when a variant does not resolve — that is what probing means — so the `continue` is intentional. Marked with the same `# nosec B112 - <why>` spelling the filter skip a few hundred lines above already uses.
- **`py/unused-global-variable`** on `_WORKERS_START`. Genuinely a false positive: it is read at `zim/archive.py:263` and `:270`. CodeQL misses the reads because the declaration is an annotated module assignment and every write goes through a `global` statement — the same shape as the constant it false-positived on before. Dismissed on the alert with that reasoning rather than contorting the code for a linter.

The Scorecard workflow added in #375 no longer uploads its SARIF. Its first run opened **55 alerts** — 38 Pinned-Dependencies, 12 Token-Permissions — none of them wrong, but all of them standing open until the entire supply-chain backlog closes, and together they buried the two real notes above. `publish_results` still sends the score to the public OpenSSF dataset, which is what aggregators read and the reason the workflow exists; the full SARIF is kept as a build artifact. The 55 are dismissed with that explanation. **The Pinned-Dependencies and Token-Permissions findings are real and worth their own pass** — they are simply not 55 individual tickets.

### Re-dispatching a release is now idempotent

Backfilling the MCP Registry for a tag that shipped before the registry job existed means re-running `release.yml` against an old tag. Two steps treated that as a fresh release:

- `mcp-publisher publish` ran unconditionally, so a second backfill re-published a version the registry already serves. It now reads the registry first and skips; the read-back step still runs, so a skipped publish is proved rather than assumed.
- `gh release upload --clobber` re-uploaded artifacts over a finished release. Wheels embed a build timestamp, so a rebuild of the same source is **not** byte-identical — the run would have quietly changed published asset checksums while changing nothing else. The upload now skips only when the release is already published *and* already carries assets; a draft (the release-please path the step exists for) is populated exactly as before.

Both are pinned by tests that were watched failing against the unguarded workflow.

### Completion ordering

Covered above under §6 — worth repeating that it was misdiagnosed as a flake in an unrelated dependency-bump PR before being traced to glob order.

