### PR TITLE
fix: catch a version-lockstep break before the tag is cut

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -161,6 +161,21 @@ jobs:
           git commit -m "chore: sync uv.lock to release version"
           git push origin HEAD:release-please--branches--main
 
+      # The release-please PR is opened by GITHUB_TOKEN, and GitHub does not
+      # fire workflows on events that token creates — so `test.yml` never runs
+      # on it and the release PR carries no test signal at all. The version
+      # guards in this file only fail once the tag exists, which is far too
+      # late: taking 3.0.0 to 3.1.0, three doc lines describing what v3.0.0
+      # broke were no longer the current version, and the release job's test
+      # gate went red on the tag with the tag and the GitHub release already
+      # created. This job is already on the PR branch with the bumped version
+      # in place, so run the version-lockstep guards here, where a failure is
+      # still just a red release PR.
+      - name: Guard the version lockstep before the tag exists
+        run: |
+          uv sync --locked
+          uv run --locked pytest tests/test_mcpb_distribution.py -q --no-cov
+
   # Validate version synchronization after release creation
   validate-release:
     runs-on: ubuntu-latest

--- a/tests/test_mcpb_distribution.py
+++ b/tests/test_mcpb_distribution.py
@@ -130,7 +130,16 @@ def test_doc_version_annotations_are_current() -> None:
 # which is exactly the drift these annotations exist to prevent. The hero
 # "Latest release" stat on the landing page sat at v2.5.1 through four
 # releases because nothing checked this.
-_HISTORICAL_VERSIONS = {"1.0.0", "1.2.0", "2.0.0", "2.5.0", "2.6.0"}
+#
+# THIS SET IS PART OF CUTTING A RELEASE. The moment the version bumps, every
+# doc line that describes the *previous* release in the past tense stops being
+# a current-version claim and starts being history — so it lands here, or the
+# release job's test gate fails on the tag, after release-please has already
+# created the tag and the GitHub release. That is what happened taking 3.0.0
+# to 3.1.0: three lines describing what v3.0.0 broke ("**v3.0.0 is a breaking
+# release for HTTP subscription clients**", the FAQ link, the changelog
+# pointer) reddened the release with the tag already pushed.
+_HISTORICAL_VERSIONS = {"1.0.0", "1.2.0", "2.0.0", "2.5.0", "2.6.0", "3.0.0"}
 
 # ``v`` immediately followed by a semver, not preceded by a word char or dot
 # (so SVG path data like ``a4 4 0 0 0-2.526 5.77`` can't match).


### PR DESCRIPTION
## What happened

Merging the 3.1.0 release PR tagged `v3.1.0` and published a GitHub release. The release workflow then failed at **Test before release**:

```
FAILED tests/test_mcpb_distribution.py::test_no_unannotated_current_version_claims
  unannotated version strings that are neither the current version (3.1.0) nor a
  declared historical reference:
  ['README.md:149: v3.0.0',
   'website/src/content/docs/index.mdx:57: v3.0.0',
   'website/src/content/docs/http-and-docker-deployment.mdx:622: v3.0.0']
```

By then the tag and the release existed, so the result was a **published v3.1.0 with zero assets and nothing on PyPI or the MCP Registry**.

The three lines are correct English — they describe what v3.0.0 broke, in the past tense:

- `README.md:149` — *"**v3.0.0 is a breaking release for HTTP subscription clients**"*
- `index.mdx:57` — *"What changed in v3.0.0?"*
- `http-and-docker-deployment.mdx:622` — *"the v3.0.0 breaking-changes entry"*

They were current-version claims right up until the version moved, and then they were history. Nothing had said so.

## The two fixes

**Declare them historical.** `3.0.0` joins `_HISTORICAL_VERSIONS`, which is what the assertion message already advises. The comment above the set now says plainly that extending it is part of cutting a release — this is a per-release ritual, not a one-off.

**Run the guard while it can still help.** This is the part that matters. The release-please PR is opened by `GITHUB_TOKEN`, and GitHub does not fire workflows on events that token creates — so `test.yml` never runs on it. That PR carried exactly one check (SonarCloud) and no test signal at all, which is why a failure this mechanical got all the way to a tag.

`sync-uv-lock` already runs on the release PR, already checks out that branch, and already has the bumped version in place. The distribution guards now run there too, so this class of failure is a red release PR rather than a broken tag.

## Test plan

- [x] `pytest tests/test_mcpb_distribution.py` — 17 passed (was 1 failed)
- [x] The new step re-uses the `uv sync --locked` / `uv run --locked` idiom the rest of the repo now uses
- [x] `pre-commit run --files <touched>` — exit 0

## Follow-up, not done here

The real root cause is that release PRs get no CI. Running the guards in `sync-uv-lock` covers the version-lockstep class specifically; giving release-please a PAT so its PRs run the full suite would cover everything, and needs a secret this PR cannot add.