### PR TITLE
ci: pin every action by digest and close the workflow injection sinks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -89,3 +89,24 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  # Docker base images. The Dockerfile pins python:3.13-slim and the uv binary
+  # image by digest (Scorecard Pinned-Dependencies), which freezes them until
+  # something advances the digest — without this ecosystem a pinned base image
+  # quietly stops receiving upstream security patches.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:30"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    assignees:
+      - "cameronrye"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,14 @@ on:
   schedule:
     - cron: "0 6 * * 1" # Weekly on Mondays at 6 AM UTC
 
+# Least-privilege default: every job below either declares its own
+# ``permissions`` (which replaces this wholesale) or needs nothing beyond
+# reading the checkout. Without a top-level block a job inherits the
+# repository default, which is a setting that can be widened out from under
+# this file (Scorecard Token-Permissions).
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze Code
@@ -26,17 +34,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.7
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 
@@ -50,6 +58,6 @@ jobs:
           uv sync --locked
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.7
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -14,6 +14,14 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+# Least-privilege default: every job below either declares its own
+# ``permissions`` (which replaces this wholesale) or needs nothing beyond
+# reading the checkout. Without a top-level block a job inherits the
+# repository default, which is a setting that can be widened out from under
+# this file (Scorecard Token-Permissions).
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -21,17 +29,17 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: website/package-lock.json
 
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
       - name: Install deps
         working-directory: website
@@ -49,16 +57,21 @@ jobs:
           BUILD_REF: ${{ github.ref_name }}
 
       - name: Stamp build info
+        # Branch names are attacker-chooseable; passed through env they are
+        # data, interpolated into the script they are shell source.
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          BRANCH: ${{ github.ref_name }}
         run: |
           echo "Built on: $(date -u +%Y-%m-%dT%H:%M:%SZ)" > website/dist/build-info.txt
-          echo "Commit: ${{ github.sha }}" >> website/dist/build-info.txt
-          echo "Branch: ${{ github.ref_name }}" >> website/dist/build-info.txt
+          echo "Commit: $COMMIT_SHA" >> website/dist/build-info.txt
+          echo "Branch: $BRANCH" >> website/dist/build-info.txt
 
       - name: List built files
         run: find website/dist -maxdepth 3 -type f | head -40
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: website/dist
 
@@ -74,4 +87,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,6 +16,14 @@ on:
         required: true
         type: string
 
+# Least-privilege default: every job below either declares its own
+# ``permissions`` (which replaces this wholesale) or needs nothing beyond
+# reading the checkout. Without a top-level block a job inherits the
+# repository default, which is a setting that can be widened out from under
+# this file (Scorecard Token-Permissions).
+permissions:
+  contents: read
+
 jobs:
   # Build once with the classic (non-BuildKit) builder. The publish job below
   # goes through buildx, which is always BuildKit — so BuildKit-only Dockerfile
@@ -30,7 +38,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # No setup-buildx-action on purpose: DOCKER_BUILDKIT=0 selects the
       # classic builder, which rejects BuildKit-only flags the way a
@@ -46,7 +54,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
@@ -67,9 +75,12 @@ jobs:
       - name: Extract version from tag
         id: meta
         if: github.event_name != 'pull_request'
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ github.event.inputs.tag }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
           else
             TAG="${GITHUB_REF#refs/tags/}"
           fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,14 @@ on:
       - main
   workflow_dispatch:
 
+# Least-privilege default: every job below either declares its own
+# ``permissions`` (which replaces this wholesale) or needs nothing beyond
+# reading the checkout. Without a top-level block a job inherits the
+# repository default, which is a setting that can be widened out from under
+# this file (Scorecard Token-Permissions).
+permissions:
+  contents: read
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -59,7 +67,7 @@ jobs:
         # env var and JSON.parse to avoid embedding the body content into
         # the github-script source, which previously broke when commit
         # subjects contained single-quoted tokens like ``plumb 'rc1'``.
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           RELEASE_PR_JSON: ${{ needs.release-please.outputs.pr }}
         with:
@@ -133,7 +141,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: release-please--branches--main
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -184,7 +192,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
@@ -252,10 +260,12 @@ jobs:
       actions: write
     steps:
       - name: Trigger release workflow
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
         with:
           script: |
-            const tagName = '${{ needs.release-please.outputs.tag_name }}';
+            const tagName = process.env.TAG_NAME;
             console.log(`Triggering release workflow for tag: ${tagName}`);
 
             try {
@@ -289,10 +299,12 @@ jobs:
       actions: write
     steps:
       - name: Trigger docker-publish workflow
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
         with:
           script: |
-            const tagName = '${{ needs.release-please.outputs.tag_name }}';
+            const tagName = process.env.TAG_NAME;
             console.log(`Triggering docker-publish workflow for tag: ${tagName}`);
 
             try {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,14 @@ on:
           - major
         default: patch
 
+# Least-privilege default: every job below either declares its own
+# ``permissions`` (which replaces this wholesale) or needs nothing beyond
+# reading the checkout. Without a top-level block a job inherits the
+# repository default, which is a setting that can be widened out from under
+# this file (Scorecard Token-Permissions).
+permissions:
+  contents: read
+
 jobs:
   validate-and-prepare:
     name: Validate and Prepare Release
@@ -36,16 +44,19 @@ jobs:
       tag_name: ${{ steps.prepare.outputs.tag_name }}
       should_create_tag: ${{ steps.prepare.outputs.should_create_tag }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       - name: Validate and prepare release
         id: prepare
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          INPUT_RELEASE_TYPE: ${{ github.event.inputs.release_type }}
         run: |
-          if [ -n "${{ github.event.inputs.tag }}" ]; then
+          if [ -n "$INPUT_TAG" ]; then
             # Use provided tag
-            TAG="${{ github.event.inputs.tag }}"
+            TAG="$INPUT_TAG"
             if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
               echo "Error: Invalid tag format. Expected format: v1.2.3"
               exit 1
@@ -60,7 +71,7 @@ jobs:
             IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
 
             # Increment based on release type
-            case "${{ github.event.inputs.release_type }}" in
+            case "$INPUT_RELEASE_TYPE" in
               major)
                 MAJOR=$((MAJOR + 1))
                 MINOR=0
@@ -113,7 +124,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && (needs.validate-and-prepare.outputs.tag_name || github.event.inputs.tag) || github.ref }}
 
@@ -146,7 +157,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && (needs.validate-and-prepare.outputs.tag_name || github.event.inputs.tag) || github.ref }}
 
@@ -163,7 +174,7 @@ jobs:
           uv build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist
           path: dist/
@@ -180,7 +191,7 @@ jobs:
         run: uv run --locked python scripts/build_mcpb.py --output dist-mcpb
 
       - name: Upload .mcpb bundle
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mcpb
           path: dist-mcpb/
@@ -198,12 +209,22 @@ jobs:
       id-token: write # Required for trusted publishing to PyPI
     steps:
       - name: Validate deployment context
+        # Everything below arrives through env, never through ``${{ }}`` inside
+        # the script. Branch, tag and ref names are attacker-chooseable strings:
+        # interpolated into the shell source they are executed, while as env
+        # vars they are only ever data. TAG especially — it is a
+        # workflow_dispatch input, and the regex check under it cannot help
+        # when the assignment itself is the injection point.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          HEAD_BRANCH: ${{ github.head_ref || github.ref_name }}
+          TAG: ${{ needs.validate-and-prepare.outputs.tag_name || github.event.inputs.tag }}
         run: |
-          echo "Event: ${{ github.event_name }}"
-          echo "Ref: ${{ github.ref }}"
-          echo "Head branch: ${{ github.head_ref || github.ref_name }}"
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            TAG="${{ needs.validate-and-prepare.outputs.tag_name || github.event.inputs.tag }}"
+          echo "Event: $EVENT_NAME"
+          echo "Ref: $REF"
+          echo "Head branch: $HEAD_BRANCH"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             echo "Tag input: $TAG"
             # Ensure the tag input is provided and starts with 'v'
             if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
@@ -213,7 +234,7 @@ jobs:
           fi
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist
           path: dist/
@@ -239,7 +260,7 @@ jobs:
       id-token: write # GitHub OIDC login to the registry (io.github.* namespace)
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && (needs.validate-and-prepare.outputs.tag_name || github.event.inputs.tag) || github.ref }}
 
@@ -258,12 +279,16 @@ jobs:
       # serve a freshly uploaded release. Assert the version lockstep on the
       # manual-tag path too, then wait for PyPI rather than racing it.
       - name: Wait for PyPI to serve the released version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_TAG: ${{ needs.validate-and-prepare.outputs.tag_name || github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ needs.validate-and-prepare.outputs.tag_name || github.event.inputs.tag }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$DISPATCH_TAG"
           else
-            TAG="${{ github.ref_name }}"
+            TAG="$REF_NAME"
           fi
           VERSION="${TAG#v}"
           SERVERJSON_VERSION=$(jq -r '.packages[0].version' server.json)
@@ -335,13 +360,13 @@ jobs:
     permissions:
       contents: write # Creates GitHub release and uploads release assets
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && (needs.validate-and-prepare.outputs.tag_name || github.event.inputs.tag) || github.ref }}
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist
           path: dist/
@@ -350,18 +375,22 @@ jobs:
       # dist/* upload paths below attach it to the GitHub release. This artifact
       # is intentionally kept out of the PyPI publish (see the build job).
       - name: Download .mcpb bundle
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: mcpb
           path: dist/
 
       - name: Determine tag name
         id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_TAG: ${{ needs.validate-and-prepare.outputs.tag_name || github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG_NAME="${{ needs.validate-and-prepare.outputs.tag_name || github.event.inputs.tag }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG_NAME="$DISPATCH_TAG"
           else
-            TAG_NAME="${{ github.ref_name }}"
+            TAG_NAME="$REF_NAME"
           fi
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
           echo "Tag name: $TAG_NAME"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,7 +39,7 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # Scorecard reads the repo through the API, not the checkout, and a
           # persisted credential in the working tree is one of the things it
@@ -64,7 +64,7 @@ jobs:
       # does. `publish_results` above already puts the score where the
       # aggregators read it; the artifact keeps the detail one click away.
       - name: Upload results as an artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: scorecard-results
           path: results.sarif

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Least-privilege default: every job below either declares its own
+# ``permissions`` (which replaces this wholesale) or needs nothing beyond
+# reading the checkout. Without a top-level block a job inherits the
+# repository default, which is a setting that can be widened out from under
+# this file (Scorecard Token-Permissions).
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}
@@ -24,7 +32,7 @@ jobs:
         python-version: ["3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -90,7 +98,7 @@ jobs:
 
       - name: Upload coverage reports as artifacts
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-reports
           path: |
@@ -126,7 +134,7 @@ jobs:
         python-version: ["3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -190,7 +198,7 @@ jobs:
       actions: read
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -231,7 +239,7 @@ jobs:
           uv run --locked bandit -c pyproject.toml -r openzim_mcp --exit-zero -f sarif -o bandit-report.sarif
 
       - name: Upload Bandit SARIF results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v4.37.7
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         if: always() && hashFiles('bandit-report.sarif') != ''
         continue-on-error: true
         with:
@@ -281,7 +289,7 @@ jobs:
           echo "4. Or download the security-reports artifact to view results locally"
 
       - name: Upload security scan results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always() && (hashFiles('bandit-report.json') != '' || hashFiles('bandit-report.sarif') != '')
         with:
           name: security-reports
@@ -307,7 +315,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,13 @@
 # do not re-add the directive without adding a feature that needs it.
 
 # ---- builder stage ----
-FROM python:3.13-slim AS builder
+FROM python:3.13-slim@sha256:ffb752e139c0a19692a43af8d8523b274222dd68eebad5d583b45c2201c6e30a AS builder
 
-# Install uv (fast Python package manager). Pin to a specific tag so the
-# image is reproducible — using :latest changes the binary out from under us
-# every time the upstream image is rebuilt.
-COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /usr/local/bin/uv
+# Install uv (fast Python package manager). Pinned by digest, not tag, so the
+# image is reproducible — a floating tag changes the binary out from under us
+# every time the upstream image is rebuilt. The tag is kept alongside the
+# digest for readability; Dependabot's docker ecosystem advances both.
+COPY --from=ghcr.io/astral-sh/uv:0.11@sha256:77280f2f771df71f90786c314fe1bbc1e023feac652969bbf139c280babf2eb7 /uv /usr/local/bin/uv
 
 WORKDIR /app
 
@@ -41,7 +42,7 @@ RUN uv sync --frozen --no-dev
 RUN chmod -R a-w /app/.venv /app/openzim_mcp
 
 # ---- final stage ----
-FROM python:3.13-slim
+FROM python:3.13-slim@sha256:ffb752e139c0a19692a43af8d8523b274222dd68eebad5d583b45c2201c6e30a
 
 # Create the non-root runtime user. No extra apt packages are needed —
 # the image defaults to stdio transport (see ENTRYPOINT note below), so


### PR DESCRIPTION
Three OpenSSF Scorecard checks were scoring at or near zero — Pinned-Dependencies 6, Token-Permissions 0, Dangerous-Workflow 0. They are three views of one exposure: a workflow run trusting input it does not control.

## Pinned dependencies

35 GitHub-owned actions were still floating on major tags (`actions/checkout@v7`, `github-script@v9`, `download-artifact@v8`, …). Third-party actions were already 20/20 pinned, so this just brings the rest up to the convention already in the file — `@<sha> # vN`.

Both `python:3.13-slim` base images and the `ghcr.io/astral-sh/uv` binary image are now pinned to their multi-arch index digests, so `linux/amd64,linux/arm64` builds are unaffected.

Pinning a base image freezes it. Without automation that trades supply-chain integrity for a base image that quietly stops receiving upstream security patches — so `docker` joins `pip` and `github-actions` in `.github/dependabot.yml`.

## Token permissions

Six workflows had no top-level `permissions:` block, leaving them on whatever the repository default happens to be. Every job in all six already declares its own block (verified by parsing each workflow), and a job-level block replaces the top-level one wholesale — so adding a `contents: read` floor changes no job's effective permissions today. It stops a future job from silently inheriting a widened repository default.

The remaining six Token-Permissions warnings are job-level `contents: write` / `actions: write` in `release.yml` and `release-please.yml`. Those are load-bearing — tag pushes, release asset uploads, workflow re-dispatch — and are left as-is by design. This check will land around 7, not 10.

## Script injection

Scorecard flagged one line. There were six of the same shape, plus two `github-script` steps interpolating into JavaScript source:

| Workflow | Step |
|---|---|
| `release.yml` | Validate deployment context *(the flagged one)* |
| `release.yml` | Validate and prepare release |
| `release.yml` | Wait for PyPI to serve the released version |
| `release.yml` | Determine tag name |
| `docker-publish.yml` | Extract version from tag |
| `deploy-website.yml` | Stamp build info |
| `release-please.yml` | Trigger release workflow *(JS)* |
| `release-please.yml` | Trigger docker-publish workflow *(JS)* |

Branch names, tag names and `workflow_dispatch` inputs are attacker-chooseable strings. Interpolated into a `run:` body they become shell source; passed through `env:` they are only ever data. Worth calling out that `release.yml`'s tag-format regex could never have defended the assignment above it — `TAG="${{ ... }}"` *is* the injection point, and validation runs after the shell has already parsed it.

Fixing only the flagged line would have left Scorecard to re-flag the next one, so all eight are converted.

## Verification

- All seven workflows re-parsed after editing; job-level permission coverage confirmed programmatically.
- Re-swept every `run:` and `script:` body for injectable contexts — clean.
- Base-image digests resolved from the registries directly (both are OCI image indexes, not platform-specific manifests).
- `tests/test_release_workflow_registry_verify.py` and `tests/test_mcpb_distribution.py` pass (22 passed).
- The `Dockerfile` change puts this PR in `docker-publish.yml`'s `pull_request` paths filter, so the classic non-BuildKit builder job verifies the digest pins on this PR.