### PR TITLE
fix: raise a structured envelope instead of asserting a validator invariant

### DIFF
--- a/openzim_mcp/tools/zim_get.py
+++ b/openzim_mcp/tools/zim_get.py
@@ -58,6 +58,13 @@ _DESCRIPTION = load_description("zim_get")
 
 _VALID_VIEWS = {"full", "summary", "toc", "structure"}
 
+# Shared by ``_validate_branch_combination`` and the unreachable-branch guards
+# in the handler. Both must produce the identical envelope: the guards exist
+# only for the case where the validator has regressed, and a caller should not
+# be able to tell which layer answered.
+_ERR_BINARY_NEEDS_PATH = "Binary mode requires `entry_path`."
+_ERR_NO_BRANCH = "Provide one of `entry_path`, `entry_paths`, or `main_page=True`."
+
 
 def register(server: "OpenZimMcpServer") -> None:
     """Register the `zim_get` tool with the MCP server."""
@@ -190,7 +197,16 @@ def register(server: "OpenZimMcpServer") -> None:
                     max_content_length=max_content_length,
                 )
             if binary:
-                assert entry_path is not None  # validator guarantees this
+                # Not an ``assert``: this sits inside the b13 ``except
+                # Exception`` below, which would swallow the AssertionError
+                # into a generic envelope — and ``python -O`` strips the
+                # check entirely, passing None straight through to the data
+                # layer. Re-state the validator's own error instead.
+                if entry_path is None:
+                    return tool_error(
+                        operation="invalid_path_combination",
+                        message=_ERR_BINARY_NEEDS_PATH,
+                    )
                 # ``max_content_length`` caps the fetched BYTES here — it maps
                 # onto the data layer's ``max_size_bytes`` (default 10MB when
                 # None); oversize entries come back metadata-only with
@@ -215,7 +231,11 @@ def register(server: "OpenZimMcpServer") -> None:
                 )
 
             # Single-entry body view
-            assert entry_path is not None
+            if entry_path is None:
+                return tool_error(
+                    operation="invalid_path_combination",
+                    message=_ERR_NO_BRANCH,
+                )
             if view == "summary":
                 return await ops.get_entry_summary_data(
                     zim_file_path, entry_path, compact=compact
@@ -312,7 +332,7 @@ def _validate_branch_combination(
         if not entry_path:
             return tool_error(
                 operation="invalid_path_combination",
-                message="Binary mode requires `entry_path`.",
+                message=_ERR_BINARY_NEEDS_PATH,
             )
     if main_page:
         if entry_path or entry_paths:
@@ -331,8 +351,6 @@ def _validate_branch_combination(
     if not (entry_path or entry_paths or main_page):
         return tool_error(
             operation="invalid_path_combination",
-            message=(
-                "Provide one of `entry_path`, `entry_paths`, or " "`main_page=True`."
-            ),
+            message=_ERR_NO_BRANCH,
         )
     return None

--- a/tests/test_zim_get.py
+++ b/tests/test_zim_get.py
@@ -325,3 +325,53 @@ async def test_invalid_view_rejected(
     fn, _ = server._tools_store["zim_get"]
     result = await fn(zim_file_path="/x.zim", entry_path="A", view="bogus")  # type: ignore[arg-type]
     assert result["operation"] == "invalid_view"
+
+
+# ---------------------------------------------------------------------------
+# Validator-regression guards
+#
+# The two handler branches that need ``entry_path`` used to narrow it with a
+# bare ``assert``. That assert sat inside the b13 ``except Exception``, which
+# swallowed the AssertionError into a generic ``zim_get`` envelope — and
+# ``python -O`` strips asserts entirely, so under an optimised interpreter
+# None went straight through to the data layer. These tests simulate the
+# validator regressing (it is the only thing that makes the branches
+# reachable) and pin the structured envelope.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_binary_without_entry_path_returns_envelope_if_validator_regresses(
+    server: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ops = _patch_async_ops(monkeypatch, get_binary_entry_data={"content": b""})
+    monkeypatch.setattr(
+        "openzim_mcp.tools.zim_get._validate_branch_combination",
+        lambda **_kwargs: None,
+    )
+    register_zim_get(server)
+    fn, _ = server._tools_store["zim_get"]
+    result = await fn(zim_file_path="/x.zim", entry_path=None, binary=True)
+    assert result["operation"] == "invalid_path_combination"
+    assert result["message"] == "Binary mode requires `entry_path`."
+    ops.get_binary_entry_data.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_single_entry_without_entry_path_returns_envelope_if_validator_regresses(
+    server: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ops = _patch_async_ops(monkeypatch, get_zim_entry_data={"content": ""})
+    monkeypatch.setattr(
+        "openzim_mcp.tools.zim_get._validate_branch_combination",
+        lambda **_kwargs: None,
+    )
+    register_zim_get(server)
+    fn, _ = server._tools_store["zim_get"]
+    result = await fn(zim_file_path="/x.zim", entry_path=None)
+    assert result["operation"] == "invalid_path_combination"
+    assert (
+        result["message"]
+        == "Provide one of `entry_path`, `entry_paths`, or `main_page=True`."
+    )
+    ops.get_zim_entry_data.assert_not_awaited()


### PR DESCRIPTION
SonarCloud reliability sat at **D** on 8 open bugs. Two of them are real; this PR fixes those. The other six are triaged separately (four false positives, two deliberate) — details at the bottom.

## The defect

`python:S5779` on [`zim_get.py:193`](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/tools/zim_get.py#L193) and `:218` — *"Don't use assert inside a try-except that catches AssertionError."*

Both branches narrowed `entry_path` with a bare `assert entry_path is not None`. Both sit inside the `try:` whose `except Exception` builds the b13 envelope, so:

1. A validator regression raised `AssertionError`, got caught, and came back as a generic `zim_get` error naming neither the branch nor the missing argument — the least useful envelope available for the one failure that means the handler's own invariants broke.
2. Under `python -O` asserts are stripped. `entry_path=None` then passes straight into `ops.get_binary_entry_data(...)` / `ops.get_zim_entry_data(...)`. Nobody ships `-O` here today, but the guard silently not existing is the wrong failure mode for a defensive check.

## The fix

Return the validator's own `invalid_path_combination` envelope. A caller cannot tell which layer answered, which is the point — the handler guard is a backstop for `_validate_branch_combination`, not a second opinion.

The two messages are lifted to `_ERR_BINARY_NEEDS_PATH` / `_ERR_NO_BRANCH` and shared by both layers, so the copies cannot drift apart. (One of them was previously a two-part implicit string concat; the constant is byte-identical to what it produced.)

## Tests

The guards are unreachable while the validator is correct, so the tests monkeypatch `_validate_branch_combination` to return `None` — simulating exactly the regression the guards exist for — and pin both the envelope and that the data layer is never awaited. With the validator stubbed out, the asserted message can only have come from the handler guard.

No `# pragma: no cover`: the new tests cover both branches, confirmed by line-level coverage.

## Verification

- `pytest tests/test_zim_get.py` — 23 passed (21 existing + 2 new).
- Full suite: **4535 passed, 213 skipped, 0 failed**.
- black / isort / flake8 / mypy / bandit clean via pre-commit.

## The other six Sonar bugs

Handled by triage in SonarCloud rather than code, because the code is already correct:

- **4 × `python:S8904`** (`content_processor.py:741-742`, `zim/content.py:2100`) — "check if this element exists before accessing it". Every one of those sites is already inside an `isinstance(x, Tag)` guard; the rule does not follow `isinstance` narrowing. Marked false positive.
- **2 × `python:S5863`** (`test_pagination_cursor.py:121`, `test_content_processor.py:420`) — "same actual and expected expression". Both are determinism tests; `f(x) == f(x)` is the assertion's entire purpose. Marked won't fix.