### PR TITLE
fix: skip non-article mimetypes when building the link graph

### DIFF
--- a/openzim_mcp/linkgraph/builder.py
+++ b/openzim_mcp/linkgraph/builder.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import os
 import sqlite3
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -155,7 +156,10 @@ def iter_article_links(archive: Any) -> Iterator[Tuple[str, List[Tuple[str, str]
 
     Walk the open archive once via ``_get_entry_by_id`` over ``entry_count``,
     keep only content sources (scheme-aware: see ``_is_content_source``), skip
-    redirects-as-source, and reuse ``_parse_internal_link_edges`` for
+    redirects-as-source and entries whose item mimetype is not an article type
+    (the path filter is namespace-only, so the images, fonts and styles ZIMIT
+    stores in the content namespace would otherwise be decoded and parsed as
+    HTML), and reuse ``_parse_internal_link_edges`` for
     extraction + redirect canonicalization. The yielded ``source_path`` is the
     raw ``entry.path`` exactly as libzim returns it for that scheme
     (``"C/Evolution"`` old-scheme, ``"Evolution"`` new-scheme) so it stays
@@ -164,7 +168,13 @@ def iter_article_links(archive: Any) -> Iterator[Tuple[str, List[Tuple[str, str]
     """
     # Imported here (not at module scope) so the pure ``build_from_link_stream``
     # core keeps no dependency on the ZIM/structure layer.
-    from openzim_mcp.zim.structure import _StructureMixin
+    from openzim_mcp.zim.structure import _HTML_MIME_PREFIX, _StructureMixin
+
+    # Mimetypes that can carry link structure. ``_HTML_MIME_PREFIX`` is matched
+    # as a prefix so charset parameters ride along ("text/html; charset=utf-8");
+    # the XHTML spelling is included because ``_is_non_article_target`` counts
+    # it as a real article too.
+    article_mimes = (_HTML_MIME_PREFIX, "application/xhtml+xml")
 
     has_new_scheme = bool(getattr(archive, "has_new_namespace_scheme", False))
     total = int(getattr(archive, "entry_count", 0) or 0)
@@ -179,7 +189,27 @@ def iter_article_links(archive: Any) -> Iterator[Tuple[str, List[Tuple[str, str]
         if getattr(entry, "is_redirect", False):
             continue
         try:
-            html = bytes(entry.get_item().content).decode("utf-8", "replace")
+            item = entry.get_item()
+            # ``_is_content_source`` is namespace-only and accepts EVERY entry
+            # on a new-scheme archive, so the images, fonts, styles and PDFs
+            # ZIMIT stores in the content namespace arrive here. Decoding those
+            # as UTF-8 and handing them to BeautifulSoup interns each asset as a
+            # source node with bogus edges and logs a parse failure.
+            # ``item.mimetype`` is a dirent header read (no cluster
+            # decompression) off the item already in hand, so this gate also
+            # skips the asset's content read.
+            mime = ""
+            with suppress(Exception):
+                # A corrupt mimetype code raises (zim-testing-suite ships
+                # ``invalid.bad_mimetype_in_dirent.zim``) and mock archives hand
+                # back a non-str. An unreadable mimetype fails OPEN: parse it
+                # rather than silently drop a real article's outbound edges.
+                # ``getattr(..., "")`` would not do — its default only catches
+                # AttributeError, letting a RuntimeError skip the entry.
+                mime = item.mimetype or ""
+            if isinstance(mime, str) and mime and not mime.startswith(article_mimes):
+                continue
+            html = bytes(item.content).decode("utf-8", "replace")
         except Exception:  # nosec B112 - skip entry whose content won't read
             continue
         try:

--- a/tests/linkgraph/test_builder.py
+++ b/tests/linkgraph/test_builder.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+import warnings
 from pathlib import Path
 from typing import Dict, Optional
 from unittest.mock import MagicMock
@@ -73,17 +74,27 @@ def test_build_force_overwrites_atomically(tmp_path: Path) -> None:
 class _FakeEntry:
     """Minimal stand-in for a libzim entry."""
 
-    def __init__(self, path: str, html: str, is_redirect: bool = False) -> None:
-        """Store the entry's path, HTML body, and redirect flag."""
+    def __init__(
+        self,
+        path: str,
+        html: str,
+        is_redirect: bool = False,
+        mimetype: str = "text/html",
+    ) -> None:
+        """Store the entry's path, HTML body, redirect flag, and mimetype."""
         self.path = path
         self._html = html
         self.is_redirect = is_redirect
+        # Default text/html so the path-filter tests are unaffected; per-row
+        # overrides drive the content-type gate.
+        self._mimetype = mimetype
 
     def get_item(self) -> MagicMock:
         """Return an item whose ``.content`` is the encoded HTML bytes."""
         # Mirrors the real idiom: bytes(entry.get_item().content).decode(...)
         item = MagicMock()
         item.content = self._html.encode()
+        item.mimetype = self._mimetype
         return item
 
 
@@ -114,6 +125,49 @@ def test_iter_article_links_walks_content_entries() -> None:
     assert ("C/A", [("C/T", "t")]) in pairs
     assert all(src.startswith("C/") for src, _ in pairs)
     assert not any(src == "C/Redir" for src, _ in pairs)
+
+
+def test_iter_article_links_skips_non_article_mimetypes() -> None:
+    """Assets in the content namespace are not decoded or parsed as HTML.
+
+    ``_is_content_source`` is namespace-only and returns True unconditionally
+    on a new-scheme archive, so the images, fonts and styles ZIMIT stores under
+    C reach the walk. Before this gate each one was UTF-8-decoded, handed to
+    BeautifulSoup, and interned as a source node — contributing bogus edges
+    (an SVG's ``<a>`` elements are drawing markup, not article links) and
+    emitting XMLParsedAsHTMLWarning.
+
+    The unknown-mimetype row pins the fail-open half: a corrupt dirent makes
+    ``item.mimetype`` raise (zim-testing-suite ships such an archive), and a
+    source whose type cannot be read must still be parsed rather than silently
+    losing its outbound edges.
+    """
+    entries = [
+        _FakeEntry("Evolution", '<a href="Mystery">m</a>'),
+        # Mimetype string copied verbatim from a real archive: the charset and
+        # profile parameters ride along, so the gate has to match on prefix.
+        _FakeEntry(
+            "graph.svg",
+            '<svg><a href="P">p</a></svg>',
+            mimetype='image/svg+xml; charset=utf-8; profile="https://example/1.0"',
+        ),
+        _FakeEntry("Mystery", '<a href="Evolution">e</a>', mimetype=""),
+    ]
+    archive = MagicMock()
+    archive.has_new_namespace_scheme = True
+    archive.entry_count = len(entries)
+    archive._get_entry_by_id.side_effect = lambda i: entries[i]
+    archive.get_entry_by_path.side_effect = KeyError("no entry")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        pairs = list(iter_article_links(archive))
+
+    # The SVG contributes neither a source node nor an edge; the row whose
+    # mimetype could not be read is still walked.
+    assert [src for src, _ in pairs] == ["Evolution", "Mystery"]
+    assert not any("graph.svg" in str(targets) for _, targets in pairs)
+    assert [type(w.message).__name__ for w in caught] == []
 
 
 def test_iter_article_links_old_scheme_accepts_a_namespace() -> None:


### PR DESCRIPTION
## Problem

The link-graph builder's only source filter is `_is_content_source`, which is namespace-based. On a **new-scheme archive it returns `True` for every entry unconditionally** — its own docstring says "accept all" — so the images, fonts, styles and PDFs ZIMIT parks in the content namespace reached the walk at [`builder.py`](../blob/main/openzim_mcp/linkgraph/builder.py), got UTF-8-decoded, and were handed to BeautifulSoup.

Each asset then:

- interned a **source node** in the sidecar,
- contributed **edges** from markup that is drawing instructions, not article links (an SVG's `<a>` elements), and
- occasionally logged `Internal-link parse failed` alongside `XMLParsedAsHTMLWarning`.

The parse guard in `_parse_internal_link_edges` swallowed the exception and returned `[]`, so the failures never surfaced as build errors — the junk nodes just accumulated silently.

## Fix

Gate on the item mimetype, as an allowlist (`text/html` prefix + `application/xhtml+xml`), matching how every other decode-then-parse site in the repo already guards itself.

`item.mimetype` is a dirent-header read off the item **already in hand**, so it costs no extra I/O — and it skips the asset's content read entirely. Asset-heavy builds get faster, not slower.

A prefix match is required because real mimetypes carry parameters; the test pins a string copied verbatim from a real archive (`image/svg+xml; charset=utf-8; profile="..."`).

### Fail-open is load-bearing

An unreadable mimetype is parsed anyway. `zim-testing-suite` ships `invalid.bad_mimetype_in_dirent.zim`, whose `.mimetype` **raises** while its content reads fine. Note `getattr(item, "mimetype", "")` would not be enough — its default only catches `AttributeError`, so a `RuntimeError` would escape and skip the entry, silently losing a real article's outbound edges. That is the exact failure class this guard exists to prevent, so it gets its own `suppress`.

## Measured effect

Rebuilt against `internet-encyclopedia-philosophy_en_all_2025-06.zim`:

| | nodes | edges | parse failures | warnings |
|---|---|---|---|---|
| before | 2560 | 45911 | 2 | `XMLParsedAsHTMLWarning` |
| after | **1189** | 45909 | **0** | **0** |

1371 spurious asset nodes removed. The archive's own `Counter` metadata reports `text/html=1186`, so **1189 nodes is consistent with reality where 2560 never was**. The 2 dropped edges are the bogus image-markup links.

Old-scheme archives are unaffected — verified unchanged on `wikibooks_be_all_nopic_2017-02` (66/89) and `wikipedia_en_climate_change_mini_2024-06` (3821/16325) — because every `A/`+`C/` entry there is already `text/html`. This is a new-scheme-specific defect, exactly as `_is_content_source`'s `if has_new_scheme: return True` implies.

## Sidecar compatibility

**No `SCHEMA_VERSION` bump.** Existing sidecars keep their asset nodes until rebuilt with `--force`. Those nodes carry zero inbound degree and no query surfaces them, so the stale state is inert — whereas bumping the schema would invalidate every sidecar and force multi-hour rebuilds.

## Test

`test_iter_article_links_skips_non_article_mimetypes` — verified non-vacuous: against the unpatched builder it fails with `graph.svg` present as a source node. Covers both halves (asset skipped, unknown-mimetype row still walked) and asserts no warnings are emitted.

Full suite: 4536 passed, 213 skipped. pre-commit exit 0.