### PR TITLE
feat: deprecate the legacy sse transport ahead of its 4.0.0 removal

### DIFF
--- a/openzim_mcp/config.py
+++ b/openzim_mcp/config.py
@@ -374,7 +374,8 @@ class OpenZimMcpConfig(BaseSettings):
         default="stdio",
         description=(
             "Transport protocol: 'stdio' (default), 'http' (streamable HTTP), "
-            "or 'sse' (legacy SSE — no auth middleware, intended for local use)"
+            "or 'sse' (DEPRECATED, removed in 4.0.0 — legacy SSE, no auth "
+            "middleware, intended for local use)"
         ),
     )
     host: str = Field(

--- a/openzim_mcp/main.py
+++ b/openzim_mcp/main.py
@@ -111,8 +111,9 @@ Environment Variables:
         default=None,
         help=(
             "Transport: 'stdio' (default, for local MCP clients), 'http' "
-            "(streamable HTTP), or 'sse' (legacy SSE — no auth middleware, "
-            "localhost only). Env: OPENZIM_MCP_TRANSPORT"
+            "(streamable HTTP), or 'sse' (DEPRECATED, removed in 4.0.0 — "
+            "legacy SSE, no auth middleware, localhost only). "
+            "Env: OPENZIM_MCP_TRANSPORT"
         ),
     )
     parser.add_argument(

--- a/openzim_mcp/server.py
+++ b/openzim_mcp/server.py
@@ -525,6 +525,26 @@ class OpenZimMcpServer:
                 if transport == "sse":
                     from . import http_app
 
+                    # This is the one site that runs exactly once per SSE
+                    # start and never on stdio/http, so the deprecation
+                    # notice lives here rather than in main.py's argparse:
+                    # operators who select SSE through
+                    # OPENZIM_MCP_TRANSPORT, an MCP client config, or a
+                    # library call never see argparse help at all. It is a
+                    # logger.warning and not a DeprecationWarning because
+                    # Python's default filters hide DeprecationWarning
+                    # outside __main__ — the notice would be swallowed for
+                    # exactly the operators it is aimed at — and because the
+                    # other operator-facing startup notice (the INSECURE
+                    # banner in check_safe_startup) already uses the logger.
+                    logger.warning(
+                        "DEPRECATED: the 'sse' transport is deprecated and "
+                        "will be removed in the next major release (4.0.0). "
+                        "Switch to --transport http (streamable HTTP): it is "
+                        "the transport the current MCP revision specifies, "
+                        "and the only network transport here that can "
+                        "enforce an auth token."
+                    )
                     http_app.check_safe_startup(self.config)
                     # The v2 SDK has no settings object: the SSE path takes
                     # host/port (and transport security) as run() kwargs, which

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -666,6 +666,57 @@ class TestOpenZimMcpServerRun:
         assert "SSE transport" in str(exc.value)
         server.mcp.run.assert_not_called()
 
+    def test_run_sse_warns_deprecated_but_stdio_and_http_do_not(
+        self, test_config: OpenZimMcpConfig, monkeypatch
+    ):
+        """Starting on SSE logs a deprecation notice; the others stay silent.
+
+        The notice is the only warning 3.x users get before SSE disappears
+        in 4.0.0, so it has to name the replacement transport — and it must
+        not fire for operators already on a supported transport, or it
+        becomes background noise nobody reads.
+
+        Records are collected with a handler attached to the server module
+        logger AFTER each server is constructed: ``OpenZimMcpConfig``'s
+        ``setup_logging`` runs ``logging.basicConfig(force=True)`` during
+        server init, which strips pytest's ``caplog`` handler off the root.
+        """
+        import logging
+
+        monkeypatch.setattr(
+            "openzim_mcp.http_app.serve_streamable_http", lambda s: None
+        )
+
+        def deprecation_warnings_for(transport: str) -> list[str]:
+            test_config.transport = transport
+            server = OpenZimMcpServer(test_config)
+            server.mcp.run = MagicMock()
+
+            captured: list[str] = []
+
+            class _Capture(logging.Handler):
+                def emit(self, record: logging.LogRecord) -> None:
+                    captured.append(record.getMessage())
+
+            srv_logger = logging.getLogger("openzim_mcp.server")
+            handler = _Capture(level=logging.WARNING)
+            srv_logger.addHandler(handler)
+            try:
+                server.run()
+            finally:
+                srv_logger.removeHandler(handler)
+
+            return [msg for msg in captured if "DEPRECATED" in msg]
+
+        sse_warnings = deprecation_warnings_for("sse")
+        assert len(sse_warnings) == 1, sse_warnings
+        assert "'sse'" in sse_warnings[0]
+        assert "4.0.0" in sse_warnings[0]
+        assert "--transport http" in sse_warnings[0]
+
+        assert deprecation_warnings_for("stdio") == []
+        assert deprecation_warnings_for("http") == []
+
 
 class TestOpenZimMcpServerNewTools:
     """Test new MCP tools in OpenZimMcpServer."""

--- a/website/src/content/docs/configuration.mdx
+++ b/website/src/content/docs/configuration.mdx
@@ -46,7 +46,7 @@ openzim-mcp --mode advanced /path/to/zim/files
 
 ```bash
 # Default: stdio (no network)
-# Other values: http (streamable HTTP), sse (legacy, localhost-only)
+# Other values: http (streamable HTTP), sse (legacy, localhost-only, deprecated — removed in 4.0.0)
 export OPENZIM_MCP_TRANSPORT=http
 export OPENZIM_MCP_HOST=127.0.0.1            # default 127.0.0.1
 export OPENZIM_MCP_PORT=8000                 # default 8000
@@ -60,7 +60,7 @@ export OPENZIM_MCP_CORS_ORIGINS='["https://app.example"]'  # JSON list; "*" reje
 | `cors_origins` | `OPENZIM_MCP_CORS_ORIGINS` | `[]` | JSON list of allowed origins. Wildcard `"*"` is rejected at startup (whitespace-padded `" * "` too). |
 | `host` | `OPENZIM_MCP_HOST` | `127.0.0.1` | Bind address. Non-loopback hosts require `auth_token` for `http`; `sse` always rejects non-loopback. |
 | `port` | `OPENZIM_MCP_PORT` | `8000` | 1-65535. |
-| `transport` | `OPENZIM_MCP_TRANSPORT` | `stdio` | One of `stdio`/`http`/`sse`. `sse` has no auth middleware and is loopback-only. |
+| `transport` | `OPENZIM_MCP_TRANSPORT` | `stdio` | One of `stdio`/`http`/`sse`. `sse` has no auth middleware and is loopback-only, and is **deprecated** — it warns on every start and is removed in 4.0.0. |
 
 **Safe-default startup check** — the server *refuses* to bind if either:
 
@@ -239,7 +239,7 @@ Sorted alphabetically by field name within each grouping.
 | `server_name` | `OPENZIM_MCP_SERVER_NAME` | `openzim-mcp` | reported in serverInfo |
 | `subscriptions_enabled` | `OPENZIM_MCP_SUBSCRIPTIONS_ENABLED` | `true` | watcher master switch |
 | `tool_mode` | `OPENZIM_MCP_TOOL_MODE` | `simple` | `simple` or `advanced` |
-| `transport` | `OPENZIM_MCP_TRANSPORT` | `stdio` | `stdio`/`http`/`sse` |
+| `transport` | `OPENZIM_MCP_TRANSPORT` | `stdio` | `stdio`/`http`/`sse` (`sse` deprecated, removed in 4.0.0) |
 | `watch_interval_seconds` | `OPENZIM_MCP_WATCH_INTERVAL_SECONDS` | `5` | 1-60 |
 
 Further nested groups exist for specialized tuning — `search.*` (e.g. `OPENZIM_MCP_SEARCH__SEARCH_ALL_TOTAL_TIMEOUT_SECONDS`), `query_rewrite.*`, `synthesize.*`, `meta.*`, and `ml.reranker.*` (documented in [docs/extras-reranker.md](https://github.com/cameronrye/openzim-mcp/blob/main/docs/extras-reranker.md)). Their fields and defaults live in [`openzim_mcp/config.py`](https://github.com/cameronrye/openzim-mcp/blob/main/openzim_mcp/config.py).

--- a/website/src/content/docs/http-and-docker-deployment.mdx
+++ b/website/src/content/docs/http-and-docker-deployment.mdx
@@ -19,7 +19,7 @@ If you only want to use OpenZIM MCP locally with Claude Desktop, Cursor, or anot
 |-----------|----------|
 | `stdio` (default) | Local desktop MCP hosts (Claude Desktop, Inspector, MCP-aware editors). The host owns the process lifetime. |
 | `http` (streamable HTTP) | Long-running service. Multiple clients, possibly across the network. Bearer-token auth, CORS, health probes. |
-| `sse` (legacy) | Older clients that haven't migrated to streamable HTTP. **Loopback only** — no auth middleware. |
+| `sse` (legacy, **deprecated**) | Older clients that haven't migrated to streamable HTTP. **Loopback only** — no auth middleware. Deprecated and removed in 4.0.0 — the server logs a deprecation warning on every SSE start; migrate to `http`. |
 
 The rest of this page assumes `--transport http`.
 


### PR DESCRIPTION
Closes the deprecation half of #366. **No removal here** — that needs 4.0.0, because `VALID_TRANSPORT_TYPES` is re-exported (`constants.py:121`).

## Why now

`--transport sse` is still fully live: I drove a real server end to end (`GET /sse` → 200 → `POST /messages/` → `initialize` / `tools/list` OK). There's no upstream forcing function either — `mcp` 2.0.0 still ships `server/sse.py`.

The 3.x deprecation warning decided in #366 has since missed 3.1.0, 3.1.1 and 3.1.2, and `grep -i deprecat openzim_mcp/` returned nothing user-visible. The 3.1.3 window (#388) is open, so this lands in it and its changelog line becomes the migration notice the eventual `BREAKING CHANGE:` points back at.

## Where the warning lives, and why

In the `sse` branch of the transport dispatch (`server.py`) — the one site that fires exactly once per sse start and never on stdio/http. Verified by grep that `mcp.run(transport="sse")` is the only sse start path; `http_app` has no sse app factory.

Not in argparse help, because the operators who matter never see it: selecting sse via `OPENZIM_MCP_TRANSPORT`, an MCP client config, or a library call never renders argparse output.

`logger.warning`, not `DeprecationWarning` — Python's default filters hide `DeprecationWarning` outside `__main__`, which would swallow the notice for exactly that audience. It also matches the existing operator-facing startup notice (`check_safe_startup`'s INSECURE banner at `http_app.py:174`).

## Three copies of one sentence

The transport description was duplicated in places that would have shipped **disagreeing** after a naive edit:

- `main.py` argparse help
- `config.py:377` pydantic `Field` description — the identical sentence
- the docs-site transport-choice tables (`http-and-docker-deployment.mdx`, `configuration.mdx`)

All now carry the marker. Deliberately **not** tagged: `security-best-practices.mdx:104-105` and `http-and-docker-deployment.mdx:130-131` — those document `check_safe_startup`'s bind/refusal matrix, not transport selection, so a deprecation tag there is noise.

## Verification

- Full suite **4537 passed** / 213 skipped (baseline 4536 — exactly +1 test, no hidden shift)
- **Negative control**: reverting only `server.py` with the test in place → the new test **fails**. Not vacuous.
- **Live suite** (excluded by `addopts -m 'not live'`, so easy to miss): 25 passed / 17 skipped on both patched and baseline trees. `test_live_sse.py::test_sse_safe_default_refuses_public_bind` greps the subprocess's stderr, and the new warning now prints there first — confirmed it neither breaks nor vacuates that assertion (it ORs over `loopback`/`localhost`/`127.0.0.1`/`host`, none of which appear in the new message).
- No test asserts on the `--transport` help string; rendered help still wraps cleanly.
- pre-commit exit 0.

## Known wrinkles

- The warning fires **before** `check_safe_startup`, so an sse start that is then refused for a non-loopback bind prints the deprecation line first and the refusal second. Correct ordering for a start-time notice, but worth knowing.
- `4.0.0` is now hardcoded in five places plus the test's assertion. If the removal target ever moves, grep for it.
- The `.mdx` edits are covered by no hook — `markdownlint` and `prettier` do not process `.mdx` in this repo (both report "no files to check" even when passed explicitly). I verified the edits introduce no `{`, `}` or `<` and stay inside existing table rows.