### PR TITLE
perf: strip pydantic bookkeeping from generated tool schemas

### DIFF
--- a/openzim_mcp/mcp_envelope.py
+++ b/openzim_mcp/mcp_envelope.py
@@ -39,13 +39,20 @@ arguments, and a fault inside a prompt body ``-32603`` naming only the prompt.
 Prompts already rejected an undeclared argument; tools dropped one silently,
 because the SDK's generated argument models inherit pydantic's default
 ``extra="ignore"``. See :func:`_unknown_argument_error`.
+
+Finally, :meth:`~EnvelopeAwareMCPServer.add_tool` is where every tool's
+generated ``inputSchema`` loses the annotation keys pydantic emits for its own
+bookkeeping — see :mod:`openzim_mcp.schema_slimming`. Registration is the seam
+because it is the last point before the schema becomes shared: the SDK serves
+this same dict from ``tools/list``, :func:`_unknown_argument_error` reads it to
+reject undeclared arguments, and the schema-budget test measures it.
 """
 
 from __future__ import annotations
 
 import difflib
 import json
-from typing import Any
+from typing import Any, Callable
 
 import pydantic_core
 from mcp.server.mcpserver import Context, MCPServer
@@ -55,14 +62,17 @@ from mcp_types import (
     INVALID_PARAMS,
     CallToolResult,
     GetPromptResult,
+    Icon,
     InputRequiredResult,
     ReadResourceResult,
     TextContent,
     TextResourceContents,
+    ToolAnnotations,
 )
 from pydantic import ValidationError
 
 from .responses import tool_error
+from .schema_slimming import slim_input_schema
 
 __all__ = ["EnvelopeAwareMCPServer", "is_tool_error_envelope"]
 
@@ -210,12 +220,13 @@ def _unknown_argument_error(
     same ``tool_error`` envelope every other rejected argument gets, which is
     the contract ``instructions.py`` already advertises.
 
-    The rejection is deliberately runtime-only: publishing
-    ``additionalProperties: false`` costs ~232 bytes across the advanced
-    surface against ~159 bytes of headroom under the hard schema cap, and it
-    would only *hint* — a client that does not validate still sends the stray
-    key, so this check is required either way. Do not re-open that trade
-    without buying the bytes first.
+    The rejection is deliberately runtime-only. Publishing
+    ``additionalProperties: false`` would only *hint*: a client that does not
+    validate still sends the stray key, so this check is required either way,
+    and a second mechanism that catches a strict subset of what this one
+    catches is not worth ~232 bytes of the advanced surface. The cap is no
+    longer the argument — the schema trim left 1,789 bytes free, so the bytes
+    could be found — which leaves the redundancy as the whole of the case.
 
     ``tool.parameters["properties"]`` is the allow-list rather than
     ``arg_model.model_fields`` because it is alias-correct: ``func_metadata``
@@ -279,6 +290,46 @@ class EnvelopeAwareMCPServer(MCPServer):
         """Capture the archive TTL, then defer to the SDK constructor."""
         super().__init__(*args, **kwargs)
         self._archive_read_ttl_ms = archive_read_ttl_ms
+
+    def add_tool(
+        self,
+        fn: Callable[..., Any],
+        name: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
+        annotations: ToolAnnotations | None = None,
+        icons: list[Icon] | None = None,
+        meta: dict[str, Any] | None = None,
+        structured_output: bool | None = None,
+    ) -> None:
+        """Register a tool, then trim its generated schema down to what informs.
+
+        Every tool arrives here — ``@mcp.tool()`` is a thin wrapper over this
+        method — so applying the trim at this one seam covers the whole surface
+        without any registration site having to know about it, the same way
+        ``call_tool`` centralizes the error-envelope mapping.
+
+        The lookup repeats ``Tool.from_function``'s own ``name or fn.__name__``
+        because the SDK's ``add_tool`` returns ``None``. It is deliberately
+        silent when that misses rather than raising during import: the guard
+        that a registered schema is actually trimmed belongs in the test that
+        walks the published surface (``tests/test_schema_slimming.py``), which
+        names the tool it found untrimmed instead of failing server startup.
+        """
+        super().add_tool(
+            fn,
+            name=name,
+            title=title,
+            description=description,
+            annotations=annotations,
+            icons=icons,
+            meta=meta,
+            structured_output=structured_output,
+        )
+        registered_name: str = name or str(getattr(fn, "__name__", ""))
+        registered = self._tool_manager.get_tool(registered_name)
+        if registered is not None:
+            registered.parameters = slim_input_schema(registered.parameters)
 
     async def _handle_read_resource(
         self, ctx: Any, params: Any

--- a/openzim_mcp/schema_slimming.py
+++ b/openzim_mcp/schema_slimming.py
@@ -1,0 +1,114 @@
+"""Drop the keys pydantic adds to a generated tool schema for its own benefit.
+
+``func_metadata`` builds one pydantic model per tool and publishes
+``model_json_schema()`` as that tool's ``inputSchema``. The generator emits two
+keys that describe the model rather than the call:
+
+``title`` — a title-cased echo of the field name (``limit`` → ``"Limit"``,
+``zim_file_path`` → ``"Zim File Path"``) and, at the root, the generated
+argument model's class name (``"zim_healthArguments"``). A client already has
+the property key and the tool's ``name``; the echo tells it nothing further,
+and the root value names an implementation detail no user ever sees.
+
+``default: null`` — how an ``Optional[...] = None`` parameter renders. The
+property's own ``anyOf`` already carries a ``{"type": "null"}`` branch, so the
+key restates it.
+
+Together they cost 1,621 bytes across the eight advanced tools — 6% of a
+surface measured against a hard 25KiB cap in
+``tests/test_phase_f_schema_budget.py`` — and buy nothing a tool-calling model
+can act on. The trim runs once at registration
+(``EnvelopeAwareMCPServer.add_tool``) so the schema the SDK serves, the schema
+``mcp_envelope`` reads to reject undeclared arguments, and the schema the
+budget test measures stay the same object rather than three drifting copies.
+
+Argument validation is untouched by construction: the SDK validates against
+``fn_metadata.arg_model``, never against this dict (see ``Tool.run`` →
+``call_fn_with_arg_validation``), and the one in-repo consumer reads property
+*names* only (``mcp_envelope._unknown_argument_error``).
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+__all__ = ["slim_input_schema"]
+
+# JSON Schema 2020-12 applicator keywords, grouped by the shape of their value.
+# The grouping is the load-bearing part, not a tidiness choice: under a
+# map-valued applicator the KEYS are property or definition names chosen by the
+# schema author, so the walk has to enter its values while never testing its
+# keys against this vocabulary. That is what keeps ``title`` the keyword
+# distinguishable from a property literally named ``title``. (The SDK's own
+# schema walk in ``mcp.shared.inbound`` groups the same keywords the same way;
+# these are spec vocabulary rather than SDK internals, so they are restated
+# here instead of imported from a private name.)
+_SUBSCHEMA_MAP = frozenset(
+    {"properties", "patternProperties", "dependentSchemas", "$defs", "definitions"}
+)
+_SUBSCHEMA_LIST = frozenset({"allOf", "anyOf", "oneOf", "prefixItems"})
+_SUBSCHEMA_SINGLE = frozenset(
+    {
+        "items",
+        "contains",
+        "additionalProperties",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+        "propertyNames",
+        "not",
+        "if",
+        "then",
+        "else",
+        "contentSchema",
+    }
+)
+
+
+def slim_input_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Return ``schema`` with generated ``title``s and ``default: null`` removed.
+
+    Only those two keys change. Everything else — including a ``default`` that
+    is a real value, and ``0`` / ``""`` / ``false`` / ``[]`` are real values —
+    survives verbatim, and so does the set of declared properties, so the
+    schema still accepts and rejects exactly the arguments it did before.
+
+    The result shares no mutable structure with ``schema``, so a caller may
+    keep the original and it is safe to apply twice.
+    """
+    slimmed: dict[str, Any] = _slim(schema)
+    return slimmed
+
+
+def _slim(node: Any) -> Any:
+    """Recurse one schema position, rebuilding it without the two keys."""
+    if not isinstance(node, dict):
+        # A boolean schema (``"additionalProperties": false``) or a position
+        # that is not a schema object at all: nothing to drop, nothing below.
+        return copy.deepcopy(node)
+
+    out: dict[str, Any] = {}
+    for keyword, value in node.items():
+        # Reached only as a keyword of a schema object — a property named
+        # ``title`` arrives as a KEY of a ``properties`` map, which the
+        # map branch below consumes without ever looking at it here. The
+        # ``str`` test is the second line of that defence: were some future
+        # map-valued applicator missing from ``_SUBSCHEMA_MAP``, a member
+        # named ``title`` would still be a schema object, not a string.
+        if keyword == "title" and isinstance(value, str):
+            continue
+        if keyword == "default" and value is None:
+            continue
+        if keyword in _SUBSCHEMA_MAP and isinstance(value, dict):
+            out[keyword] = {name: _slim(sub) for name, sub in value.items()}
+        elif keyword in _SUBSCHEMA_LIST and isinstance(value, list):
+            out[keyword] = [_slim(sub) for sub in value]
+        elif keyword in _SUBSCHEMA_SINGLE:
+            out[keyword] = _slim(value)
+        else:
+            # Instance data (``default``, ``const``, ``enum``, ``examples``)
+            # and plain annotations. Copied verbatim and never walked, so a
+            # real default that happens to be ``{"title": "..."}`` keeps its
+            # key: the walk must not mistake a caller's data for a keyword.
+            out[keyword] = copy.deepcopy(value)
+    return out

--- a/tests/test_followup_unknown_arguments.py
+++ b/tests/test_followup_unknown_arguments.py
@@ -204,13 +204,14 @@ def test_rejection_is_runtime_only_and_costs_no_schema_bytes(tmp_path: Path) -> 
     """Deliberately NOT published as ``additionalProperties: false``.
 
     The keyword would cost ~29 bytes per tool (~232 across the advanced
-    surface) against roughly 159 bytes of headroom under the hard 25600-byte
-    cap in ``tests/test_phase_f_schema_budget.py``, and it would breach
-    ``zim_health``'s per-tool allocation, force a prototype-schema re-snapshot
-    and a Gate 0b re-run. It is also only a hint: a client that does not
-    validate still sends the stray key, so runtime enforcement is required
-    regardless. Enforcement is therefore runtime-only — do not "helpfully" add
-    the schema keyword without buying the bytes first.
+    surface) and force a prototype-schema re-snapshot and a Gate 0b re-run.
+    The 25600-byte cap in ``tests/test_phase_f_schema_budget.py`` used to be
+    the decisive half of that: the surface had ~159 bytes free, so the bytes
+    simply were not there. The schema trim freed 1,621 and the argument now
+    rests entirely on what the keyword buys, which is nothing — it is only a
+    hint, and a client that does not validate still sends the stray key, so
+    the runtime rejection below is required either way. Do not "helpfully" add
+    the schema keyword on the grounds that the budget can now afford it.
     """
     config = OpenZimMcpConfig(allowed_directories=[str(tmp_path)], tool_mode="advanced")
     server = OpenZimMcpServer(config)

--- a/tests/test_phase_f_prototype_parity.py
+++ b/tests/test_phase_f_prototype_parity.py
@@ -22,6 +22,27 @@ prototype (description rewrites, parameter additions), re-capture the
 snapshot AND append a ``scope_limitations`` entry to gate_0b_decision.json
 naming the divergence. The Stage E F2 enforcement (Task E3 Step 3) is the
 post-hoc dispatch check covering the re-snapshotted surface.
+
+The rc1 side is the *generated* schema — ``arg_model.model_json_schema()``,
+the value ``Tool.from_function`` assigns before ``add_tool`` trims it — not the
+published ``tool.parameters``. The snapshot holds the generated form (nothing
+trimmed it when it was captured), so measuring the published schema against it
+compares two different representations and reads ``schema_slimming`` as
+prototype drift. The loud half of that is the shape gate, which fails on all
+eight tools: ``_strip_descriptions`` drops only ``description``, so every
+``title`` the trim removed still stands on the snapshot side. The byte gate
+fails on two, zim_get_section at 11.3% and zim_browse at 5.1%.
+
+The quiet half is the reason no tolerance value would fix it. The trim shrinks
+the rc1 side, so it *nets against* prose growth instead of adding to it, and a
+tool whose description really has drifted reads as closer to the prototype than
+it is: zim_get's 195B of genuine description drift — 4.7% measured against the
+generated schema, the reading this gate has always taken — comes out as a 3.3%
+shrink once the trim's own saving is subtracted from it. A gate that
+under-reports the drift it exists to catch is worse than one that fails loudly.
+Comparing like with like keeps every reading here meaning what it has always
+meant. ``test_published_schema_is_the_generated_one_slimmed`` is what licenses
+the reconstruction: it pins that the trim is the only thing separating the two.
 """
 
 import json
@@ -31,6 +52,7 @@ import tempfile
 import pytest
 
 from openzim_mcp.config import OpenZimMcpConfig
+from openzim_mcp.schema_slimming import slim_input_schema
 from openzim_mcp.server import OpenZimMcpServer
 from tests.dispatch_eval import oneof_parse_benchmark
 
@@ -42,22 +64,36 @@ DESCRIPTION_EDIT_DISTANCE_TOLERANCE = 0.30  # ≤30% Levenshtein / max(len_a, le
 _ALLOWED_DIR = tempfile.mkdtemp(prefix="openzim_mcp_prototype_parity_")
 
 
-def _rc1_footprints() -> dict[str, dict]:
+def _advanced_tools():
     cfg = OpenZimMcpConfig(allowed_directories=[_ALLOWED_DIR], tool_mode="advanced")
-    srv = OpenZimMcpServer(cfg)
+    return OpenZimMcpServer(cfg).mcp._tool_manager._tools
+
+
+def _generated_schema(tool) -> dict:
+    """The pre-trim schema, rebuilt from the tool's own argument model.
+
+    Byte-identical to what ``Tool.from_function`` assigned to
+    ``tool.parameters`` before ``EnvelopeAwareMCPServer.add_tool`` slimmed it,
+    which is the form the committed snapshot holds.
+    """
+    return tool.fn_metadata.arg_model.model_json_schema(by_alias=True)
+
+
+def _rc1_footprints() -> dict[str, dict]:
     out = {}
-    for name, tool in srv.mcp._tool_manager._tools.items():
+    for name, tool in _advanced_tools().items():
+        schema = _generated_schema(tool)
         wire = json.dumps(
             {
                 "name": name,
                 "description": tool.description,
-                "inputSchema": tool.parameters,
+                "inputSchema": schema,
             }
         )
         out[name] = {
             "bytes": len(wire.encode()),
             "description": tool.description,
-            "inputSchema": tool.parameters,
+            "inputSchema": schema,
         }
     return out
 
@@ -92,6 +128,25 @@ def _normalized_edit_distance(a: str, b: str) -> float:
             curr[j] = min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost)
         prev = curr
     return prev[n] / max(m, n)
+
+
+def test_published_schema_is_the_generated_one_slimmed():
+    """The two representations this file straddles must differ only by the trim.
+
+    Every measurement above is taken against ``_generated_schema``, a
+    reconstruction; what ships is ``tool.parameters``. This pins the exact
+    relationship between them, so the parity guard cannot quietly start
+    measuring a fiction — if a future SDK builds ``parameters`` some other way,
+    or ``add_tool`` stops trimming, this fails by name instead of leaving the
+    tests above green against a schema no client receives.
+    """
+    for name, tool in _advanced_tools().items():
+        assert slim_input_schema(_generated_schema(tool)) == tool.parameters, (
+            f"{name}: the published inputSchema is no longer the generated "
+            "schema with schema_slimming applied. The parity measurements in "
+            "this file are taken against the generated form; re-derive them "
+            "from whatever the SDK now publishes."
+        )
 
 
 def test_prototype_parity_byte_budget():

--- a/tests/test_phase_f_schema_budget.py
+++ b/tests/test_phase_f_schema_budget.py
@@ -57,19 +57,33 @@ _ALLOWED_DIR = tempfile.mkdtemp(prefix="openzim_mcp_schema_budget_")
 # ``TOTAL_CAP - total``. In aggregate the ceilings over-commit on purpose
 # (26,460 > 25,600): eight tools each drifting 100B is precisely the drift no
 # per-tool ceiling can see and TOTAL_CAP exists to catch.
+#
+# Post-3.1.2, second change: ``openzim_mcp.schema_slimming`` stopped publishing
+# pydantic's ``title`` echoes and ``default: null`` entries, which cost 1,621B
+# and said nothing (25,432 → 23,811). The allocations below are deliberately
+# NOT re-derived from the new measurements, which is the opposite of the call
+# made above — the difference is where the bytes came from. That rebalance was
+# correcting ceilings that had drifted away from a surface nobody had shrunk;
+# these bytes were freed on purpose, as budget for the description and schema
+# work #370 defers. Re-deriving now would hand them straight back and make
+# spending a single byte of them a table edit. The property the rebalance was
+# protecting still holds meanwhile: every ceiling sits 186–438B above its
+# tool's measurement, all of them under the 1,789B the total now has left, so a
+# single tool's drift still trips its own named assertion first. Re-derive at
+# ``(measured + ~130) / 1.2`` once that work lands and the headroom is spent.
 TOTAL_CAP = 25 * 1024
-# Trailing comments are the wire bytes measured at 3.1.2. The allocation is
-# deliberately not that number any more, so it is recorded here — otherwise
-# the table stops telling a reader what the surface actually costs.
+# Trailing comments are the wire bytes measured after the schema trim. The
+# allocation is deliberately not that number any more, so it is recorded here —
+# otherwise the table stops telling a reader what the surface actually costs.
 ALLOCATION = {
-    "zim_query": 5_550,  # 6,534B
-    "zim_search": 3_620,  # 4,211B
-    "zim_get": 3_650,  # 4,249B
-    "zim_get_section": 1_840,  # 2,087B
-    "zim_browse": 2_080,  # 2,364B
-    "zim_metadata": 1_310,  # 1,442B
-    "zim_links": 2_700,  # 3,109B
-    "zim_health": 1_300,  # 1,436B
+    "zim_query": 5_550,  # 6,222B
+    "zim_search": 3_620,  # 3,937B
+    "zim_get": 3_650,  # 3,946B
+    "zim_get_section": 1_840,  # 1,863B
+    "zim_browse": 2_080,  # 2,170B
+    "zim_metadata": 1_310,  # 1,386B
+    "zim_links": 2_700,  # 2,920B
+    "zim_health": 1_300,  # 1,367B
 }
 
 
@@ -148,12 +162,17 @@ def test_per_tool_allocations():
 
     A tool that legitimately needs more (e.g., Stage E F2 traces a class
     regression to a too-tight description) can no longer just be handed a
-    bigger number. The surface sits within ~170B of TOTAL_CAP, so the bytes
-    have to be freed from another tool's prose before this ceiling can follow;
-    raising the allocation on its own only moves the failure to
+    bigger number without saying where the bytes come from. Raising an
+    allocation on its own only moves the failure to
     ``test_advanced_total_under_cap``, which names no tool. The total is the
     only hard cap — the per-tool split stays a distribution decision the gate
     can revise (see spec §Tool-by-tool budget allocation).
+
+    The schema trim left 1,789B under TOTAL_CAP, so for the moment a tool can
+    be handed some of that rather than taken from a neighbour's prose. That is
+    what the headroom is for; it is not a reason to raise a ceiling past its
+    measurement by more than the total can still absorb, which is the condition
+    that keeps this assertion firing before the aggregate one.
     """
     bytes_by_tool = _measure_tools("advanced")
     for name, alloc in ALLOCATION.items():

--- a/tests/test_schema_slimming.py
+++ b/tests/test_schema_slimming.py
@@ -1,0 +1,355 @@
+"""``schema_slimming`` — what it removes, and everything it must not.
+
+The transform runs over generated JSON Schema, where the same token can be a
+keyword or a name the schema author chose. The interesting tests here are the
+ones that pin the difference: a property literally named ``title``, a
+definition named ``title``, and a real ``default`` whose *value* is an object
+carrying a ``title`` key. None of the eight shipped tools declares any of
+those, so nothing on the live surface would notice a walk that confused data
+for vocabulary — the fixtures below are the only thing standing between that
+bug and a silently mangled schema.
+"""
+
+import json
+import tempfile
+from typing import Any
+
+import pytest
+
+from openzim_mcp.config import OpenZimMcpConfig
+from openzim_mcp.mcp_envelope import _unknown_argument_error
+from openzim_mcp.schema_slimming import slim_input_schema
+from openzim_mcp.server import OpenZimMcpServer
+
+_ALLOWED_DIR = tempfile.mkdtemp(prefix="openzim_mcp_schema_slimming_")
+
+
+@pytest.fixture(scope="module")
+def advanced_tools():
+    cfg = OpenZimMcpConfig(allowed_directories=[_ALLOWED_DIR], tool_mode="advanced")
+    return OpenZimMcpServer(cfg).mcp._tool_manager._tools
+
+
+# Keywords whose value is a map from author-chosen NAMES to subschemas. The
+# helper below needs them to say whether a given key is a keyword or a name;
+# the transform under test needs the full list, which is its own business.
+_NAME_MAPS = ("properties", "$defs", "definitions")
+
+
+def _schema_positions(node: Any, *, in_name_map: bool = False):
+    """Yield ``(is_keyword, key, value)`` for every dict entry below ``node``.
+
+    ``is_keyword`` is False exactly where the key is a property or definition
+    name rather than JSON Schema vocabulary — the distinction the transform has
+    to get right, restated independently here so the tests are not checking the
+    implementation against itself.
+
+    Otherwise deliberately naive: it descends into instance data too, so a
+    "nothing survived" assertion over-reports rather than under-reports.
+    """
+    if isinstance(node, dict):
+        for key, value in node.items():
+            yield not in_name_map, key, value
+            yield from _schema_positions(
+                value, in_name_map=not in_name_map and key in _NAME_MAPS
+            )
+    elif isinstance(node, list):
+        for item in node:
+            yield from _schema_positions(item)
+
+
+# ---------------------------------------------------------------------------
+# The live surface
+# ---------------------------------------------------------------------------
+
+
+def test_the_detector_sees_an_untrimmed_schema():
+    """Guards the guard below: a walk that finds nothing proves nothing.
+
+    Also pins the keyword/name split the detector is built on — the property
+    named ``title`` is not counted, the ``title`` inside its schema is.
+    """
+    untrimmed = {
+        "type": "object",
+        "title": "Root",
+        "properties": {
+            "a": {"type": "string", "title": "A", "default": None},
+            "title": {"type": "string"},
+        },
+    }
+    found = sorted(
+        key
+        for is_keyword, key, value in _schema_positions(untrimmed)
+        if is_keyword and (key == "title" or (key == "default" and value is None))
+    )
+    assert found == ["default", "title", "title"]
+
+
+def test_the_advanced_surface_publishes_no_generated_annotations(advanced_tools):
+    """No tool ships a ``title`` keyword or a ``default: null``.
+
+    This is the guard behind ``add_tool``'s deliberately silent tool lookup: a
+    seam that stopped firing shows up here, naming the tool, instead of raising
+    at server startup.
+    """
+    offenders = []
+    for name, tool in advanced_tools.items():
+        for is_keyword, key, value in _schema_positions(tool.parameters):
+            if not is_keyword:
+                continue
+            if key == "title":
+                offenders.append(f"{name}: title={value!r}")
+            if key == "default" and value is None:
+                offenders.append(f"{name}: default=null")
+    assert not offenders, (
+        "generated annotations reached the wire: "
+        + ", ".join(offenders)
+        + ". EnvelopeAwareMCPServer.add_tool should have slimmed these."
+    )
+
+
+def test_real_defaults_survive_on_the_live_surface(advanced_tools):
+    """The trim must not have taken the defaults that mean something.
+
+    ``zim_query.synthesize`` defaults to ``False`` and ``zim_links.direction``
+    to ``"outbound"``: a falsy default and a string one, both of which a
+    "drop empty defaults" implementation would eat.
+    """
+    assert advanced_tools["zim_query"].parameters["properties"]["synthesize"] == {
+        "default": False,
+        "type": "boolean",
+    }
+    assert (
+        advanced_tools["zim_links"].parameters["properties"]["direction"]["default"]
+        == "outbound"
+    )
+    assert (
+        advanced_tools["zim_query"].parameters["properties"]["offset"]["default"] == 0
+    )
+
+
+def test_every_declared_argument_survives_the_trim(advanced_tools):
+    """Same properties, same ``required`` — so the same calls are accepted.
+
+    ``mcp_envelope._unknown_argument_error`` builds its allow-list from
+    ``parameters["properties"]``, so a trim that dropped a property would turn
+    a valid argument into a rejected one.
+    """
+    for name, tool in advanced_tools.items():
+        generated = tool.fn_metadata.arg_model.model_json_schema(by_alias=True)
+        assert set(tool.parameters["properties"]) == set(generated["properties"]), name
+        assert tool.parameters.get("required", []) == generated.get(
+            "required", []
+        ), name
+        assert tool.parameters["type"] == "object", name
+
+
+def test_argument_acceptance_and_rejection_are_unchanged(advanced_tools):
+    """Every tool still takes the names it declares and still refuses the rest."""
+    for name, tool in advanced_tools.items():
+        declared = sorted(tool.parameters["properties"])
+        accepted = dict.fromkeys(declared, "x")
+        assert _unknown_argument_error(tool, name, accepted) is None, name
+
+        rejected = _unknown_argument_error(tool, name, {"not_a_parameter": 1})
+        assert rejected is not None, name
+        assert rejected["unknown_arguments"] == ["not_a_parameter"]
+        assert rejected["accepted_arguments"] == declared
+
+
+def test_the_trim_reclaims_over_a_kilobyte_of_the_advanced_surface(advanced_tools):
+    """Worth doing: the reclaimed bytes are budget, not rounding.
+
+    Asserted as a floor rather than an exact total so ordinary description
+    edits do not have to touch this test; the exact figure at the time of the
+    change was 1,621B (25,432 → 23,811 against the 25,600B cap in
+    ``test_phase_f_schema_budget``).
+    """
+
+    def wire(schema) -> int:
+        return len(json.dumps(schema, separators=(",", ":")).encode())
+
+    generated = sum(
+        wire(tool.fn_metadata.arg_model.model_json_schema(by_alias=True))
+        for tool in advanced_tools.values()
+    )
+    published = sum(wire(tool.parameters) for tool in advanced_tools.values())
+    assert generated - published >= 1_000, (
+        f"the trim now reclaims only {generated - published}B "
+        f"({generated} → {published}); it was worth 1,621B when it landed."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Keyword vs. name — the cases the live surface cannot exercise
+# ---------------------------------------------------------------------------
+
+
+def test_a_property_literally_named_title_is_kept():
+    """``properties`` keys are names. Only the value's own ``title`` goes."""
+    slimmed = slim_input_schema(
+        {
+            "type": "object",
+            "title": "ArgumentsModel",
+            "properties": {
+                "title": {"type": "string", "title": "Title"},
+                "default": {"type": "string", "title": "Default"},
+            },
+            "required": ["title"],
+        }
+    )
+    assert slimmed == {
+        "type": "object",
+        "properties": {"title": {"type": "string"}, "default": {"type": "string"}},
+        "required": ["title"],
+    }
+
+
+def test_a_definition_named_title_is_kept():
+    """``$defs``/``definitions`` keys are names too, and ``$ref`` targets them."""
+    slimmed = slim_input_schema(
+        {
+            "type": "object",
+            "$defs": {
+                "title": {"type": "string", "title": "Title", "default": None},
+                "default": {"type": "integer", "title": "Default"},
+            },
+            "properties": {"heading": {"$ref": "#/$defs/title", "title": "Heading"}},
+        }
+    )
+    assert slimmed == {
+        "type": "object",
+        "$defs": {"title": {"type": "string"}, "default": {"type": "integer"}},
+        "properties": {"heading": {"$ref": "#/$defs/title"}},
+    }
+
+
+def test_instance_data_carrying_a_title_key_is_untouched():
+    """A ``default``/``const``/``enum``/``examples`` value is data, not a schema.
+
+    An object-valued default that happens to contain ``{"title": ...}`` is the
+    caller's payload; walking into it would silently change what the tool
+    receives when the argument is omitted.
+    """
+    schema = {
+        "type": "object",
+        "properties": {
+            "header": {
+                "type": "object",
+                "title": "Header",
+                "default": {"title": "untitled", "level": 1},
+                "examples": [{"title": "Chapter 1"}],
+            },
+            "marker": {"const": {"title": "sentinel"}, "title": "Marker"},
+            "choice": {"enum": [{"title": "a"}, {"title": "b"}], "title": "Choice"},
+        },
+    }
+    slimmed = slim_input_schema(schema)
+    header = slimmed["properties"]["header"]
+    assert "title" not in header
+    assert header["default"] == {"title": "untitled", "level": 1}
+    assert header["examples"] == [{"title": "Chapter 1"}]
+    assert slimmed["properties"]["marker"] == {"const": {"title": "sentinel"}}
+    assert slimmed["properties"]["choice"] == {"enum": [{"title": "a"}, {"title": "b"}]}
+
+
+def test_falsy_defaults_are_not_null_defaults():
+    """Only ``None`` goes. ``0``/``""``/``False``/``[]``/``{}`` are real values."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "offset": {"type": "integer", "default": 0, "title": "Offset"},
+            "prefix": {"type": "string", "default": "", "title": "Prefix"},
+            "compact": {"type": "boolean", "default": False, "title": "Compact"},
+            "tags": {"type": "array", "default": [], "title": "Tags"},
+            "opts": {"type": "object", "default": {}, "title": "Opts"},
+            "cursor": {"type": "string", "default": None, "title": "Cursor"},
+        },
+    }
+    props = slim_input_schema(schema)["properties"]
+    assert props["offset"] == {"type": "integer", "default": 0}
+    assert props["prefix"] == {"type": "string", "default": ""}
+    assert props["compact"] == {"type": "boolean", "default": False}
+    assert props["tags"] == {"type": "array", "default": []}
+    assert props["opts"] == {"type": "object", "default": {}}
+    assert props["cursor"] == {"type": "string"}
+
+
+def test_every_applicator_shape_is_recursed():
+    """Map-valued, list-valued and single-valued applicators all get walked."""
+    schema = {
+        "type": "object",
+        "title": "Root",
+        "properties": {
+            "items_form": {
+                "type": "array",
+                "title": "Items Form",
+                "items": {"type": "string", "title": "Item", "default": None},
+                "prefixItems": [{"type": "integer", "title": "First"}],
+                "contains": {"type": "string", "title": "Contains"},
+            },
+            "union_form": {
+                "title": "Union Form",
+                "anyOf": [{"type": "string", "title": "A"}],
+                "oneOf": [{"type": "integer", "title": "B"}],
+                "allOf": [{"type": "object", "title": "C"}],
+                "not": {"type": "null", "title": "D"},
+            },
+            "object_form": {
+                "type": "object",
+                "title": "Object Form",
+                "additionalProperties": {"type": "string", "title": "Extra"},
+                "patternProperties": {"^x-": {"type": "string", "title": "Ext"}},
+                "propertyNames": {"pattern": "^a", "title": "Names"},
+                "if": {"required": ["a"], "title": "If"},
+                "then": {"required": ["b"], "title": "Then"},
+                "else": {"required": ["c"], "title": "Else"},
+            },
+        },
+    }
+    slimmed = slim_input_schema(schema)
+    remaining = [
+        key
+        for is_keyword, key, _ in _schema_positions(slimmed)
+        if is_keyword and key == "title"
+    ]
+    assert not remaining, f"titles survived at {len(remaining)} position(s)"
+    items_form = slimmed["properties"]["items_form"]
+    assert items_form["items"] == {"type": "string"}
+    assert items_form["prefixItems"] == [{"type": "integer"}]
+    assert slimmed["properties"]["object_form"]["patternProperties"] == {
+        "^x-": {"type": "string"}
+    }
+
+
+def test_a_boolean_subschema_is_left_alone():
+    """``additionalProperties: false`` is a schema, but not a dict to rebuild."""
+    assert slim_input_schema(
+        {"type": "object", "additionalProperties": False, "title": "Root"}
+    ) == {"type": "object", "additionalProperties": False}
+
+
+def test_the_input_schema_is_not_mutated():
+    """The trim returns a new schema and shares no mutable structure with it."""
+    schema = {
+        "type": "object",
+        "title": "Root",
+        "properties": {"a": {"type": "string", "title": "A", "default": None}},
+    }
+    original = json.loads(json.dumps(schema))
+    slimmed = slim_input_schema(schema)
+    assert schema == original
+
+    slimmed["properties"]["a"]["type"] = "integer"
+    assert schema == original
+
+
+def test_the_trim_is_idempotent():
+    """Applying it to an already-trimmed schema is a no-op."""
+    schema = {
+        "type": "object",
+        "title": "Root",
+        "properties": {"a": {"anyOf": [{"type": "string"}], "default": None}},
+    }
+    once = slim_input_schema(schema)
+    assert slim_input_schema(once) == once

--- a/tests/test_v3_field_fixes_errors.py
+++ b/tests/test_v3_field_fixes_errors.py
@@ -268,7 +268,13 @@ async def test_d04_invalid_mode_is_a_structured_envelope_over_the_wire(
 
 def test_d04_browse_mode_schema_still_advertises_the_enum(tmp_path: Path) -> None:
     """Dropping ``Literal`` must not drop the wire enum: the prototype-parity
-    snapshot (and dispatch quality) depend on clients seeing the two values."""
+    snapshot (and dispatch quality) depend on clients seeing the two values.
+
+    Compared whole rather than by key, so this also pins that ``"page"``
+    survives as the declared default — ``schema_slimming`` walks this property
+    and drops only ``title``, and a transform that took real defaults with it
+    would land here.
+    """
     config = OpenZimMcpConfig(allowed_directories=[str(tmp_path)], tool_mode="advanced")
     server = OpenZimMcpServer(config)
     mode_schema = server.mcp._tool_manager._tools["zim_browse"].parameters[
@@ -278,7 +284,6 @@ def test_d04_browse_mode_schema_still_advertises_the_enum(tmp_path: Path) -> Non
     assert mode_schema == {
         "default": "page",
         "enum": ["page", "walk"],
-        "title": "Mode",
         "type": "string",
     }
 


### PR DESCRIPTION
Unblocks the budget half of #370.

## What

Pydantic emits a `title` on every property and `default: null` on every `Optional`. Neither carries meaning for a tool-calling client — the title is a prose restatement of the property name, and a null default is the absence of a default.

**Result: 25,432 → 23,811 bytes against the unchanged 25,600 cap. Headroom goes from 168 bytes to 1,789.**

That reframes #370: the `outputSchema` / `structuredContent` question becomes a judgement call about response size, not an argument about budget. The two candidate tools' real output schemas total ~1,420 B, which now fits.

## Where

Tool registration (`add_tool`), because it's the last point before the schema becomes shared: `tools/list` serves this same dict, `_unknown_argument_error` reads it as its allow-list, and the budget test measures it.

## The trap

`title` is both a JSON Schema keyword **and** a plausible property name. Same for `default`. The transform only ever removes the keyword, never instance data.

Verified on the live surface: `zim_search`'s `mode` enum still carries the literal string `"title"` as a **value**. Also verified via the real pydantic → `func_metadata` → `Tool.from_function` pipeline (not hand-written dicts) that a parameter literally named `title` survives with its `required` intact, a parameter named `default` keeps its `""`, and a model class named `title` survives as a live `$ref` target.

Real defaults survive — only `None` goes, so `0`, `""`, `False`, `[]`, `{}` are untouched. A naive `if not default` would have eaten five of those.

## Verification

- Full suite **4555 passed** / 213 skipped (+15 tests)
- Independent wire check on a live stdio session: **0** residual `title` keywords, **0** `default: null`, payload exactly 23,811 B
- A generic structural differ across all 8 tools: the *only* differences are 60 `title` keywords and 21 `default: null` entries. Property lists and `required` are order-identical.
- **Argument validation byte-identical**: 8 tools × (valid call, stray argument, misspelled argument) captured over real client sessions on both trees. `stray_arg` and `typo_arg` identical; the only `valid_calls` difference is `zim_health`, which a baseline-vs-baseline control shows differs run-to-run anyway (pid, uptime, timestamps).
- Nested recursion verified on real generated schemas: `$defs`, `$ref`, `items`, `prefixItems`, `anyOf`/`oneOf`/`allOf`, `patternProperties`, `propertyNames`, `if`/`then`/`else`
- **Non-vacuity via two mutations**: disabling the seam fails 5 tests; neutering the transform fails 10. The 5 surviving a neutered transform are the deliberately-negative safety tests — correct by design.
- pre-commit exit 0

## Also corrected in passing

The parity-test docstring justified its comparison with arithmetic that was simply wrong (it claimed the trim moves a denominator that is actually a snapshot constant, and quoted a percentage belonging to a different tool). The decision it documents is right and load-bearing — pointing `_generated_schema` at `tool.parameters` fails the shape gate on all 8 tools — but the genuinely important property is the opposite of what was written: because the trim shrinks the rc1 side, the gate nets against prose growth and would **under**-report description drift. Rewritten with measured numbers.

`_unknown_argument_error`'s comment also said the cap was the reason not to publish `additionalProperties: false`. With 1,789 bytes free the bytes could now be found, so the real argument — that it's redundant with a check required either way — is stated on its own.