### PR TITLE
fix: consult the title index for suggest, and stop three silent-success paths

### DIFF
--- a/openzim_mcp/content_processor.py
+++ b/openzim_mcp/content_processor.py
@@ -16,6 +16,7 @@ from .constants import (
     FURNITURE_HEADING_PREFIXES,
     UNWANTED_HTML_SELECTORS,
 )
+from .title_promotion import _DISCRIMINATOR_STOP_WORDS
 
 logger = logging.getLogger(__name__)
 
@@ -265,14 +266,41 @@ def _word_in(folded_paragraph: str, term: str, *, prefix: bool = False) -> bool:
 def _keep_highlightable_terms(query: str) -> List[Tuple[str, bool]]:
     """Query terms long enough to be worth matching, with their prefix flag.
 
-    Shared by paragraph anchoring and highlighting so the paragraph a
-    snippet starts on is always one the highlighter can mark up.
+    The highlighting set, and the base the anchoring set is drawn from by
+    :func:`_keep_anchorable_terms` — anchoring narrows this further, so the
+    paragraph a snippet starts on is still always one the highlighter can
+    mark up.
     """
     return [
         (term, is_prefix)
         for term, is_prefix in _split_query_terms_typed(query)
         if len(term) >= (_PREFIX_TERM_MIN_LEN if is_prefix else 3)
     ]
+
+
+def _keep_anchorable_terms(
+    typed: List[Tuple[str, bool]],
+) -> List[Tuple[str, bool]]:
+    """The subset of ``typed`` specific enough to anchor a snippet on.
+
+    Length alone is a poor filter for anchoring: ``what``, ``does`` and
+    ``about`` all clear the three-character bar, so a natural-language
+    question anchored on whichever paragraph first said "what" — for
+    ``what causes migraines`` that was an article's lead sentence about
+    "becoming what one is", 11k chars above the paragraph that actually
+    discussed migraines. Highlighting keeps the full term set; only the
+    anchor decision drops function words.
+
+    Falls back to ``typed`` when filtering empties the list, so an
+    all-function-word query keeps its previous behavior instead of
+    silently anchoring every result on the lead.
+    """
+    content_terms = [
+        (term, is_prefix)
+        for term, is_prefix in typed
+        if term not in _DISCRIMINATOR_STOP_WORDS
+    ]
+    return content_terms or typed
 
 
 # A complete ``[text](href "title")`` markdown link, matched as ONE unit.
@@ -1744,11 +1772,15 @@ class ContentProcessor:
         if query:
             if terms:
                 folded_paragraphs = [_fold(p) for p in paragraphs]
+                # Function words are dropped from the anchor decision only;
+                # ``typed`` still drives highlighting below.
+                anchor_typed = _keep_anchorable_terms(typed)
+                anchor_terms = [t for t, _ in anchor_typed]
                 # Pass 1: whole-word match (most precise — preserves the
                 # Phase A #1 spec promise).
                 whole_word_idx: Optional[int] = None
                 for i, p in enumerate(folded_paragraphs):
-                    if any(_word_in(p, t, prefix=pfx) for t, pfx in typed):
+                    if any(_word_in(p, t, prefix=pfx) for t, pfx in anchor_typed):
                         whole_word_idx = i
                         break
                 if whole_word_idx is not None:
@@ -1764,7 +1796,7 @@ class ContentProcessor:
                     # (-ic, -is, -ise, -ate). Falls through to the
                     # legacy lead-text behavior (start_idx=0) when no
                     # paragraph carries even a stem-prefix.
-                    stems = [t[: max(4, (len(t) * 2 + 2) // 3)] for t in terms]
+                    stems = [t[: max(4, (len(t) * 2 + 2) // 3)] for t in anchor_terms]
                     for i, p in enumerate(folded_paragraphs):
                         if any(stem in p for stem in stems):
                             start_idx = i
@@ -2064,7 +2096,13 @@ class ContentProcessor:
             elif mime_type.startswith("text/"):
                 return raw_content.strip()
             elif mime_type.startswith("image/"):
-                return "(Image content - Cannot display directly)"
+                # Names the single-entry call rather than a bare
+                # ``binary=True``: batch mode rejects that combination, so
+                # the shorter phrasing sent batch callers to an error.
+                return (
+                    "(Image content - Cannot display directly; fetch it with "
+                    "zim_get(entry_path=..., binary=True))"
+                )
             else:
                 return f"(Unsupported content type: {mime_type})"
 

--- a/openzim_mcp/content_processor.py
+++ b/openzim_mcp/content_processor.py
@@ -1752,18 +1752,29 @@ class ContentProcessor:
 
         typed = _keep_highlightable_terms(query) if query else []
         terms = [t for t, _ in typed]
+        # Function words are dropped from the anchor decision only; ``typed``
+        # still drives highlighting further down.
+        anchor_typed = _keep_anchorable_terms(typed) if typed else []
+        anchor_terms = [t for t, _ in anchor_typed]
 
         # Site furniture (share-widget boilerplate, in-page navigation
         # lists) is neither a useful anchor nor useful fill: on MedlinePlus
         # the paragraph under every H1 was the no-JavaScript sentence, so
         # an H1 match produced a snippet with no article text at all. A
         # paragraph the query actually hits is kept regardless — see
-        # ``_drop_boilerplate_paragraphs``.
+        # ``_drop_boilerplate_paragraphs``. The exemption is keyed on the
+        # anchorable terms because that is what it exists for: keeping the
+        # paragraph the anchor will land on. Keyed on the full set, a nav
+        # block survived for containing "what" and could never be chosen.
         paragraphs = _drop_boilerplate_paragraphs(
             content.split("\n\n"),
             is_query_hit=(
-                (lambda p: any(_word_in(_fold(p), t, prefix=pfx) for t, pfx in typed))
-                if typed
+                (
+                    lambda p: any(
+                        _word_in(_fold(p), t, prefix=pfx) for t, pfx in anchor_typed
+                    )
+                )
+                if anchor_typed
                 else None
             ),
         )
@@ -1772,10 +1783,6 @@ class ContentProcessor:
         if query:
             if terms:
                 folded_paragraphs = [_fold(p) for p in paragraphs]
-                # Function words are dropped from the anchor decision only;
-                # ``typed`` still drives highlighting below.
-                anchor_typed = _keep_anchorable_terms(typed)
-                anchor_terms = [t for t, _ in anchor_typed]
                 # Pass 1: whole-word match (most precise — preserves the
                 # Phase A #1 spec promise).
                 whole_word_idx: Optional[int] = None

--- a/openzim_mcp/error_messages.py
+++ b/openzim_mcp/error_messages.py
@@ -266,6 +266,35 @@ def _bound_details(details: str) -> str:
     return details[:_DETAILS_MAX_LENGTH].rstrip() + "..."
 
 
+def url_shaped_path_hint(entry_path: str) -> str:
+    """Corrective clause for an ``entry_path`` that was handed a URL.
+
+    Pasting the article's web address is the most natural wrong guess a
+    client makes, and the generic not-found steps ("check the spelling",
+    "try a different namespace") never mention the real mistake. Returns
+    ``""`` for an ordinary path so callers can append unconditionally.
+
+    Bare-host paths are deliberately NOT matched: zimit/warc2zim archives
+    genuinely file entries under host-shaped paths like
+    ``medlineplus.gov/druginfo/meds/a682878.html``, so only an explicit
+    scheme is evidence of the mistake.
+
+    That is also why the suggestion keeps the host and strips only the
+    scheme. Telling the caller to drop the host produces a path that does
+    not exist on exactly the archives this hint fires for most:
+    ``https://iep.utm.edu/stoicism/`` is filed at
+    ``iep.utm.edu/stoicism/``, not at ``stoicism/``.
+    """
+    scheme, separator, remainder = entry_path.partition("://")
+    if not separator or not scheme.isalpha():
+        return ""
+    suggestion = f" (e.g. '{remainder}')" if remainder else ""
+    return (
+        " Entry paths are archive-relative, never URLs: drop the scheme"
+        f"{suggestion}."
+    )
+
+
 def format_error_message(
     config: ErrorConfig,
     operation: str,

--- a/openzim_mcp/main.py
+++ b/openzim_mcp/main.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 from pydantic import ValidationError as PydanticValidationError
 
+from . import __version__
 from .config import OpenZimMcpConfig
 from .constants import TOOL_MODE_SIMPLE, VALID_TOOL_MODES
 from .exceptions import OpenZimMcpConfigurationError
@@ -89,6 +90,11 @@ Examples:
 Environment Variables:
   OPENZIM_MCP_TOOL_MODE - Set tool mode (advanced or simple)
         """,
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"openzim-mcp {__version__}",
     )
     parser.add_argument(
         "directories",

--- a/openzim_mcp/mcp_envelope.py
+++ b/openzim_mcp/mcp_envelope.py
@@ -56,6 +56,7 @@ from typing import Any, Callable
 
 import pydantic_core
 from mcp.server.mcpserver import Context, MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 from mcp.shared.exceptions import MCPError
 from mcp_types import (
     INTERNAL_ERROR,
@@ -174,6 +175,72 @@ def _validation_error_in_chain(exc: BaseException) -> ValidationError | None:
 def _invalid_params(message: str, **data: Any) -> MCPError:
     """An ``-32602`` naming what the caller got wrong, with the same facts in ``data``."""
     return MCPError(code=INVALID_PARAMS, message=message, data=data)
+
+
+def _argument_field(loc: tuple[Any, ...], declared: set[str]) -> str:
+    """The argument name a pydantic error location points at.
+
+    Only the caller's own wire name is useful: they cannot act on anything
+    else. List/dict positions inside a value (``("filters", 0)``) and union
+    member tags both get dropped — a ``str | int`` argument reports one
+    error per member with locs ``("compact_budget", "str")`` and
+    ``("compact_budget", "int")``, so joining every part named
+    ``compact_budget.str``, an argument that does not exist.
+
+    ``declared`` is the tool's published property set, which is
+    alias-correct: ``func_metadata`` renames a field shadowing a
+    ``BaseModel`` attribute to ``field_<name>`` and keeps the wire name only
+    as the alias.
+    """
+    for part in loc:
+        if isinstance(part, str) and part in declared:
+            return part
+    parts = [str(part) for part in loc if not isinstance(part, int)]
+    return ".".join(parts) if parts else "<arguments>"
+
+
+def _argument_validation_error(
+    name: str, exc: ValidationError, declared: set[str]
+) -> dict:
+    """The ``invalid_argument`` envelope for a schema-level rejection.
+
+    ``_unknown_argument_error`` above catches argument *names* the tool does
+    not declare, but a declared argument carrying an illegal value never
+    reaches it: pydantic raises inside the SDK's dispatch and the SDK
+    stringifies the report into a bare text block ("1 validation error for
+    zim_searchArguments … errors.pydantic.dev/…"). That is the same leak
+    D04 removed from ``zim_browse``, and it defeats the contract
+    ``instructions.py`` advertises — a client parsing the body as JSON gets
+    a parse failure instead of a correction.
+
+    pydantic's own ``msg`` is kept verbatim: for the enum case it already
+    spells out the legal values ("Input should be 'fulltext', 'title' or
+    'suggest'"), which is exactly what the caller needs to retry.
+    """
+    fields: list[str] = []
+    details: list[str] = []
+    seen_details: set[str] = set()
+    for error in exc.errors():
+        field = _argument_field(error.get("loc", ()), declared)
+        if field not in fields:
+            fields.append(field)
+        # One line per distinct complaint: collapsing union members onto the
+        # wire name makes several errors describe the same argument, and a
+        # list-typed argument reports one error per bad element.
+        detail = f"{field}: {error.get('msg', 'invalid value')}"
+        if detail not in seen_details:
+            seen_details.add(detail)
+            details.append(detail)
+
+    return dict(
+        tool_error(
+            operation="invalid_argument",
+            message=(
+                f"`{name}` received invalid argument(s): " + "; ".join(details) + "."
+            ),
+            extras={"invalid_arguments": fields},
+        )
+    )
 
 
 def error_result(payload: dict) -> CallToolResult:
@@ -500,9 +567,24 @@ class EnvelopeAwareMCPServer(MCPServer):
         # the success path is then converted by the same
         # ``fn_metadata.convert_result`` the base class would have used, which
         # keeps that path byte-identical to a stock server.
-        result = await self._tool_manager.call_tool(
-            name, arguments, context, convert_result=False
-        )
+        try:
+            result = await self._tool_manager.call_tool(
+                name, arguments, context, convert_result=False
+            )
+        except ToolError as exc:
+            # A declared argument carrying an illegal value (bad enum member,
+            # wrong type, missing required) fails inside pydantic, which the
+            # SDK stringifies into a bare text block. Convert it to the same
+            # envelope every other rejected argument gets. An unknown *tool*
+            # name also arrives as ``ToolError`` but carries no
+            # ``ValidationError``, so it keeps raising as before.
+            validation_error = _validation_error_in_chain(exc)
+            if validation_error is None:
+                raise
+            declared = set((tool.parameters.get("properties") or {}) if tool else {})
+            return error_result(
+                _argument_validation_error(name, validation_error, declared)
+            )
         if is_tool_error_envelope(result):
             return error_result(result)
 

--- a/openzim_mcp/security.py
+++ b/openzim_mcp/security.py
@@ -500,6 +500,36 @@ def sanitize_path_for_error(path: str, show_filename: bool = True) -> str:
         return PATH_HIDDEN_PLACEHOLDER
 
 
+# A URL with an explicit scheme. ``//host/path`` inside one looks exactly
+# like a POSIX absolute path to ``_ABS_PATH_RE``, whose lookbehind excludes
+# path-continuation characters but not ``:`` — so the caller's own
+# ``https://iep.utm.edu/epistemo/`` came back as ``https:<path-hidden>``,
+# hiding the very value they need to correct. Masking keys on ``scheme://``
+# rather than on a bare colon: ``archive:/home/user/x.zim`` is a labelled
+# filesystem path and must keep redacting.
+# The scheme is anchored (a scheme cannot start mid-token) and length-bounded
+# so each starting position fails in constant time. An unanchored, unbounded
+# ``[A-Za-z][A-Za-z0-9+.\-]*://`` rescans the whole tail from every offset,
+# which is quadratic on a long token: a caller-supplied 1 MB ``entry_path``
+# — a shape this module is already hardened against elsewhere, see
+# ``sanitize_for_log`` — turned redaction into a multi-minute stall.
+#
+# The authority is required to be non-empty (``[^/\s...]``): with an empty
+# one — ``file:///home/user/secret.zim``, or any invented ``x:///...`` — the
+# text after ``://`` is a filesystem path, not a host, and exempting it would
+# turn any scheme prefix into a redaction bypass.
+_URL_RE = re.compile(
+    r"(?<![A-Za-z0-9+.\-])[A-Za-z][A-Za-z0-9+.\-]{0,15}://"
+    r"[^/\s'\")\]<>][^\s'\")\]<>]*"
+)
+
+# The mask character is stripped from the message before stashing, so a
+# token cannot survive from caller-supplied text into the restore pass.
+_MASK_CHAR = "\x00"
+_URL_MASK = "\x00u{}\x00"
+_URL_MASK_RE = re.compile(r"\x00u(\d+)\x00")
+
+
 def redact_paths_in_message(raw_message: str) -> str:
     r"""Redact absolute filesystem paths from a free-form message.
 
@@ -538,7 +568,23 @@ def redact_paths_in_message(raw_message: str) -> str:
     if known_dirs_re is not None:
         message = known_dirs_re.sub(_replace, message)
 
-    return _ABS_PATH_RE.sub(_replace, message)
+    # Hide ``scheme://host/...`` URLs so their ``//host/path`` tail isn't
+    # taken for a POSIX path, then put them back verbatim. The mask
+    # character is stripped from the input first, so caller text echoed into
+    # the message cannot pre-forge a token and have it substituted for a URL
+    # it did not supply.
+    urls: List[str] = []
+
+    def _stash(match: "re.Match[str]") -> str:
+        urls.append(match.group(0))
+        return _URL_MASK.format(len(urls) - 1)
+
+    message = _URL_RE.sub(_stash, message.replace(_MASK_CHAR, ""))
+    message = _ABS_PATH_RE.sub(_replace, message)
+    # One pass, not one ``str.replace`` per URL: a message carrying many
+    # small URLs otherwise costs O(len(urls) x len(message)) — 200KB of them
+    # took ~53s.
+    return _URL_MASK_RE.sub(lambda m: urls[int(m.group(1))], message)
 
 
 # Every C0 control character plus DEL — including tab, LF, and CR. Unlike

--- a/openzim_mcp/server_state.py
+++ b/openzim_mcp/server_state.py
@@ -23,6 +23,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union, cast
 
+from . import __version__
 from .constants import CACHE_HIGH_HIT_RATE_THRESHOLD, CACHE_LOW_HIT_RATE_THRESHOLD
 from .responses import ToolErrorPayload, tool_error
 from .security import redact_paths_in_message, sanitize_path_for_error
@@ -268,6 +269,11 @@ def _build_health_report(
             "timestamp": _utc_now_iso(),
             "status": "healthy",
             "server_name": server.config.server_name,
+            # A stale install can serve an old server for weeks while looking
+            # current; ``serverInfo.version`` exists in the initialize result
+            # but most clients never surface it, so the health report is the
+            # one place an operator can ask what is actually running.
+            "version": __version__,
             "uptime_info": _build_uptime_info(server),
             "configuration": {
                 "allowed_directories": len(server.config.allowed_directories),

--- a/openzim_mcp/tool_schemas.py
+++ b/openzim_mcp/tool_schemas.py
@@ -727,6 +727,7 @@ class HealthStatus(TypedDict, total=False):
     timestamp: str
     status: str
     server_name: str
+    version: str
     uptime_info: UptimeInfo
     configuration: HealthConfiguration
     cache_performance: dict[str, Any]

--- a/openzim_mcp/zim/archive.py
+++ b/openzim_mcp/zim/archive.py
@@ -59,7 +59,7 @@ from openzim_mcp.preset_data import ArchivePreset, resolve_preset_from_entries
 from openzim_mcp.security import PathValidator
 from openzim_mcp.timeout_utils import run_with_timeout
 from openzim_mcp.zim._ops_base import _ArchiveAccessMixin, _json
-from openzim_mcp.zim.content import _ContentMixin
+from openzim_mcp.zim.content import _ContentMixin, rewrite_well_known_path
 from openzim_mcp.zim.namespace import _NamespaceMixin
 from openzim_mcp.zim.redirects import resolve_redirect_chain
 from openzim_mcp.zim.search import _SearchMixin
@@ -1702,6 +1702,11 @@ class ZimOperations(
         # raised from _follow propagate — they are real failures, not
         # "not found", and falling through to a search fallback would mask
         # malformed-archive bugs.
+        # A synthetic ``W/`` browse path names an entry not stored under that
+        # name, so rewrite before probing — otherwise this ladder answers
+        # not-found for a path the plain-body ladder serves.
+        entry_path = rewrite_well_known_path(archive, entry_path)
+
         entry = None
         with suppress(Exception):
             entry = archive.get_entry_by_path(entry_path)

--- a/openzim_mcp/zim/archive.py
+++ b/openzim_mcp/zim/archive.py
@@ -48,6 +48,7 @@ from openzim_mcp.config import OpenZimMcpConfig
 from openzim_mcp.constants import DEFAULT_MAIN_PAGE_TRUNCATION
 from openzim_mcp.content_processor import ContentProcessor
 from openzim_mcp.defaults import CONTENT
+from openzim_mcp.error_messages import url_shaped_path_hint
 from openzim_mcp.exceptions import (
     ArchiveOpenTimeoutError,
     OpenZimMcpArchiveError,
@@ -1714,4 +1715,5 @@ class ZimOperations(
         raise OpenZimMcpEntryNotFoundError(
             f"Entry not found: '{entry_path}'. "
             f"Try using zim_search() to find available entries."
+            + url_shaped_path_hint(entry_path)
         ) from None

--- a/openzim_mcp/zim/content.py
+++ b/openzim_mcp/zim/content.py
@@ -190,6 +190,58 @@ def _alternate_entry_spellings(entry_path: str) -> List[str]:
     return spellings
 
 
+# The size the illustration is actually fetched at. ``has_illustration()``
+# with no argument answers "any size", which is not the same question:
+# an archive can hold a 96px illustration and still fail the 48px fetch,
+# putting the text and binary surfaces back into disagreement.
+_ILLUSTRATION_SIZE = 48
+
+
+def _has_well_known_illustration(archive: Archive) -> bool:
+    """Whether ``get_illustration_item`` can serve the size we fetch."""
+    try:
+        return bool(archive.has_illustration(_ILLUSTRATION_SIZE))
+    except Exception as e:  # pragma: no cover - defensive, libzim-version dependent
+        logger.debug(f"has_illustration probe failed: {e}")
+        return False
+
+
+def rewrite_well_known_path(archive: Archive, entry_path: str) -> str:
+    """Resolve a synthetic ``W/`` browse path to the entry it stands for.
+
+    ``zim_browse``/``zim_metadata`` publish ``W/mainPage`` on new-scheme
+    archives, but it is not a literal entry — it is resolved through
+    ``archive.main_entry``. Every surface that resolves an entry path has to
+    agree about that, or one tool answers contradictorily an argument apart:
+    ``zim_get`` returned the article while ``view=toc``, ``zim_get_section``
+    and ``zim_links`` — which run a second, independent ladder — returned
+    Resource Not Found for the same path.
+
+    The leading slash is accepted because ``get_zim_entry_data`` does not
+    normalize at its boundary the way the binary surface does, so
+    ``/W/mainPage`` would otherwise miss a check that sits above the ladder
+    whose un-rooting recovery would have caught it.
+
+    Any other path, and any old-scheme archive, is returned unchanged.
+    """
+    if not entry_path or not getattr(archive, "has_new_namespace_scheme", False):
+        return entry_path
+    if entry_path.lstrip("/") != "W/mainPage":
+        return entry_path
+    try:
+        entry = best_effort_redirect_chain(archive.main_entry)
+        resolved = getattr(entry, "path", None)
+    except Exception as e:
+        logger.debug(f"W/mainPage resolution failed: {e}")
+        resolved = None
+    if not resolved:
+        raise OpenZimMcpEntryNotFoundError(
+            "This archive declares no main page, so 'W/mainPage' cannot be "
+            "resolved. Use zim_search() to find an entry."
+        )
+    return str(resolved)
+
+
 def _heading_matches(title: str, tokens: Tuple[str, ...]) -> bool:
     """Return True when a section heading contains any of ``tokens``."""
     t = title.strip().lower()
@@ -852,18 +904,26 @@ class _ContentMixin:
         # advertised by one tool and rejected by another — with the
         # rejection advising "use browsing tools", the tool that had just
         # handed the caller the path.
-        if entry_path and getattr(archive, "has_new_namespace_scheme", False):
-            if entry_path == "W/mainPage":
-                entry_path = self._resolve_well_known_main_entry(archive)
-            elif entry_path == "W/favicon":
-                # Served, but only as bytes: the illustration is an image, so
-                # the binary route is the one that can carry it (see
-                # ``get_binary_entry_data``). Name that instead of sending
-                # the caller back to the browse tool that offered the path.
+        entry_path = rewrite_well_known_path(archive, entry_path)
+        if entry_path == "W/favicon" and getattr(
+            archive, "has_new_namespace_scheme", False
+        ):
+            # Served, but only as bytes: the illustration is an image, so the
+            # binary route is the one that can carry it (see
+            # ``get_binary_entry_data``). Name that instead of sending the
+            # caller back to the browse tool that offered the path — but only
+            # when there is something to fetch, or the retry we prescribe
+            # fails and the caller spends two round trips learning the first
+            # answer was false.
+            if _has_well_known_illustration(archive):
                 raise OpenZimMcpEntryNotFoundError(
                     "'W/favicon' is the archive illustration, an image. "
                     "Fetch it with binary=True."
                 )
+            raise OpenZimMcpEntryNotFoundError(
+                "This archive carries no illustration, so 'W/favicon' cannot "
+                "be fetched."
+            )
 
         cache_key = self._path_mapping_cache_key(validated_path, entry_path)
         cached = self._retrieve_via_cached_mapping(cache_key, entry_path, build)
@@ -898,30 +958,6 @@ class _ContentMixin:
             return self._retrieve_via_search(
                 archive, cache_key, entry_path, build, direct_error
             )
-
-    @staticmethod
-    def _resolve_well_known_main_entry(archive: Archive) -> str:
-        """The real entry path behind the synthetic ``W/mainPage`` row.
-
-        Resolved through ``archive.main_entry`` and its redirect chain, the
-        same way ``namespace._materialise_new_scheme_main_entry`` renders
-        the browse row — so the two surfaces agree on what ``W/mainPage``
-        means. Handing the resolved path back to the ordinary retrieval
-        ladder is what gives the fetch normal entry semantics (views,
-        offsets, truncation) instead of a second main-page code path.
-        """
-        try:
-            entry = best_effort_redirect_chain(archive.main_entry)
-            path = getattr(entry, "path", None)
-        except Exception as e:
-            logger.debug(f"W/mainPage resolution failed: {e}")
-            path = None
-        if not path:
-            raise OpenZimMcpEntryNotFoundError(
-                "This archive declares no main page, so 'W/mainPage' cannot "
-                "be resolved. Use zim_search() to find an entry."
-            )
-        return str(path)
 
     @staticmethod
     def _resolve_well_known_illustration(archive: Archive) -> Any:

--- a/openzim_mcp/zim/content.py
+++ b/openzim_mcp/zim/content.py
@@ -38,7 +38,10 @@ from openzim_mcp.exceptions import (
 )
 from openzim_mcp.meta import attach_meta
 from openzim_mcp.zim._ops_base import _json
-from openzim_mcp.zim.redirects import resolve_redirect_chain
+from openzim_mcp.zim.redirects import (
+    best_effort_redirect_chain,
+    resolve_redirect_chain,
+)
 
 if TYPE_CHECKING:
     from openzim_mcp.cache import OpenZimMcpCache
@@ -843,6 +846,25 @@ class _ContentMixin:
         ):
             return fetch_metadata()
 
+        # The sibling route for the synthetic ``W/`` rows browse publishes
+        # (see ``namespace._materialise_browse_entry``). Neither path is a
+        # literal entry on a new-scheme archive, so without this both were
+        # advertised by one tool and rejected by another — with the
+        # rejection advising "use browsing tools", the tool that had just
+        # handed the caller the path.
+        if entry_path and getattr(archive, "has_new_namespace_scheme", False):
+            if entry_path == "W/mainPage":
+                entry_path = self._resolve_well_known_main_entry(archive)
+            elif entry_path == "W/favicon":
+                # Served, but only as bytes: the illustration is an image, so
+                # the binary route is the one that can carry it (see
+                # ``get_binary_entry_data``). Name that instead of sending
+                # the caller back to the browse tool that offered the path.
+                raise OpenZimMcpEntryNotFoundError(
+                    "'W/favicon' is the archive illustration, an image. "
+                    "Fetch it with binary=True."
+                )
+
         cache_key = self._path_mapping_cache_key(validated_path, entry_path)
         cached = self._retrieve_via_cached_mapping(cache_key, entry_path, build)
         if cached is not None:
@@ -876,6 +898,49 @@ class _ContentMixin:
             return self._retrieve_via_search(
                 archive, cache_key, entry_path, build, direct_error
             )
+
+    @staticmethod
+    def _resolve_well_known_main_entry(archive: Archive) -> str:
+        """The real entry path behind the synthetic ``W/mainPage`` row.
+
+        Resolved through ``archive.main_entry`` and its redirect chain, the
+        same way ``namespace._materialise_new_scheme_main_entry`` renders
+        the browse row — so the two surfaces agree on what ``W/mainPage``
+        means. Handing the resolved path back to the ordinary retrieval
+        ladder is what gives the fetch normal entry semantics (views,
+        offsets, truncation) instead of a second main-page code path.
+        """
+        try:
+            entry = best_effort_redirect_chain(archive.main_entry)
+            path = getattr(entry, "path", None)
+        except Exception as e:
+            logger.debug(f"W/mainPage resolution failed: {e}")
+            path = None
+        if not path:
+            raise OpenZimMcpEntryNotFoundError(
+                "This archive declares no main page, so 'W/mainPage' cannot "
+                "be resolved. Use zim_search() to find an entry."
+            )
+        return str(path)
+
+    @staticmethod
+    def _resolve_well_known_illustration(archive: Archive) -> Any:
+        """The illustration Item behind the synthetic ``W/favicon`` row.
+
+        Matches the size ``namespace._materialise_new_scheme_favicon`` probes
+        for the browse row, so the two surfaces describe the same asset.
+        """
+        try:
+            item = archive.get_illustration_item(48)
+        except Exception as e:
+            logger.debug(f"get_illustration_item failed: {e}")
+            item = None
+        if item is None:
+            raise OpenZimMcpEntryNotFoundError(
+                "This archive carries no illustration, so 'W/favicon' cannot "
+                "be fetched."
+            )
+        return item
 
     @staticmethod
     def _path_mapping_cache_key(validated_path: Path, entry_path: str) -> str:
@@ -1522,8 +1587,16 @@ class _ContentMixin:
                 f'Use zim_browse(namespace="M") to list the available keys.'
             ) from e
         if item is None:
-            payload["content"] = f"Metadata key {key!r} resolved to an empty item."
-            return payload, False
+            # Same contract as the raising branch above: a key that resolves
+            # to nothing is a miss, not a body. Real libzim raises rather
+            # than returning ``None``, so this is defence for a stubbed or
+            # future backend — but it must not be the one path that still
+            # answers isError=false with an error sentence as the content.
+            raise OpenZimMcpEntryNotFoundError(
+                f"Entry not found: '{entry_path}'. "
+                f"Metadata key {key!r} resolved to an empty item. "
+                f'Use zim_browse(namespace="M") to list the available keys.'
+            )
         mime = item.mimetype or ""
         try:
             raw = bytes(item.content)
@@ -1677,6 +1750,40 @@ class _ContentMixin:
 
         try:
             with _zim_ops_mod.zim_archive(validated_path) as archive:
+                # The synthetic ``W/favicon`` row browse publishes. The
+                # illustration is an Item reached through
+                # ``get_illustration_item``, not an Entry with a path, so the
+                # ordinary lookup below can never find it — which is why the
+                # path browse advertises used to 404. It carries the same
+                # size/mimetype/content surface an Item from ``get_item()``
+                # does, so everything downstream serves it unchanged.
+                if entry_path == "W/favicon" and getattr(
+                    archive, "has_new_namespace_scheme", False
+                ):
+                    item = self._resolve_well_known_illustration(archive)
+                    entry_title = "favicon"
+                    content_size = item.size
+                    meta = {
+                        "path": entry_path,
+                        "title": entry_title,
+                        "mime_type": item.mimetype or "image/png",
+                        "size": content_size,
+                        "size_human": self._format_size(content_size),
+                    }
+                    illustration_data: Optional[str] = None
+                    if include_data and content_size <= max_size_bytes:
+                        illustration_data = base64.b64encode(
+                            bytes(item.content)
+                        ).decode("ascii")
+                    self.cache.set(cache_key, meta)
+                    payload = self._format_binary_response(
+                        meta, include_data, max_size_bytes, data=illustration_data
+                    )
+                    return cast(
+                        "BinaryEntryResponse",
+                        attach_meta(payload, truncated=payload.get("truncated", False)),
+                    )
+
                 # Try direct access first
                 try:
                     entry = archive.get_entry_by_path(entry_path)
@@ -1706,10 +1813,12 @@ class _ContentMixin:
                     entry_path = entry.path
 
                 item = entry.get_item()
+                entry_title = entry.title or "Untitled"
+
                 content_size = item.size
                 meta = {
                     "path": entry_path,
-                    "title": entry.title or "Untitled",
+                    "title": entry_title,
                     "mime_type": item.mimetype or "application/octet-stream",
                     "size": content_size,
                     "size_human": self._format_size(content_size),

--- a/openzim_mcp/zim/content.py
+++ b/openzim_mcp/zim/content.py
@@ -30,6 +30,7 @@ from libzim.reader import Archive  # type: ignore[import-untyped]
 
 import openzim_mcp.zim_operations as _zim_ops_mod
 from openzim_mcp.content_processor import paged_slice_length
+from openzim_mcp.error_messages import url_shaped_path_hint
 from openzim_mcp.exceptions import (
     OpenZimMcpArchiveError,
     OpenZimMcpEntryNotFoundError,
@@ -980,6 +981,7 @@ class _ContentMixin:
                 f"The entry path may not exist in this ZIM file. "
                 f"Try using zim_search() to find available entries, "
                 f"or zim_browse() to explore the archive's namespaces."
+                + url_shaped_path_hint(entry_path)
             )
         except OpenZimMcpArchiveError:
             # Re-raise our custom errors with guidance
@@ -1499,21 +1501,26 @@ class _ContentMixin:
             "title": key or entry_path,
             "content": "",
         }
+        # A miss raises like every other entry miss. Returning the sentence
+        # in ``content`` with ``content_ok=False`` only suppressed caching:
+        # the tool still answered ``isError=false``, so a client rendering
+        # ``content`` displayed "Metadata key … not found" as though it were
+        # the entry's text, while the same miss under ``A/`` surfaced the
+        # Resource Not Found envelope.
         if not key:
-            payload["content"] = (
-                "Empty metadata key. Use a known M/<key> path from "
-                "`metadata for <file>` or `walk namespace M`."
+            raise OpenZimMcpEntryNotFoundError(
+                "Empty metadata key. Pass a known M/<key> path — "
+                'zim_browse(namespace="M") lists the available keys.'
             )
-            return payload, False
         try:
             item = archive.get_metadata_item(key)
         except Exception as e:
             logger.debug(f"get_metadata_item failed for {key}: {e}")
-            payload["content"] = (
-                f"Metadata key {key!r} not found in this archive. "
-                f"Use `walk namespace M` to list available keys."
-            )
-            return payload, False
+            raise OpenZimMcpEntryNotFoundError(
+                f"Entry not found: '{entry_path}'. "
+                f"Metadata key {key!r} does not exist in this archive. "
+                f'Use zim_browse(namespace="M") to list the available keys.'
+            ) from e
         if item is None:
             payload["content"] = f"Metadata key {key!r} resolved to an empty item."
             return payload, False

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -187,6 +187,28 @@ def _unpaged_overflow_hint(*, subject: str, limit: int, narrow: str) -> str:
     )
 
 
+# Separators a ZIM builder uses to append site branding (and often a
+# synonym list) to an article's own name. Only these two: a bare " - " is
+# ordinary title punctuation — "Diabetes - Multiple Languages" is a
+# distinct article, not the ``Diabetes`` page with a suffix.
+_TITLE_SEGMENT_SEPARATORS = (" | ", ": ")
+
+
+def _leading_title_segment(title: str) -> str:
+    """The article's own name from a site-suffixed title.
+
+    ``diabetes | type 1 diabetes | medlineplus`` -> ``diabetes``;
+    ``epistemology | internet encyclopedia of philosophy`` ->
+    ``epistemology``. A title carrying no separator comes back unchanged.
+    """
+    earliest = title
+    for sep in _TITLE_SEGMENT_SEPARATORS:
+        head, found, _tail = title.partition(sep)
+        if found and len(head) < len(earliest):
+            earliest = head
+    return earliest.strip()
+
+
 def _is_pseudo_namespace_entry(
     path: str, title: str, *, extended: bool = False
 ) -> bool:
@@ -2491,6 +2513,20 @@ class _SearchMixin:
     ) -> Dict[str, Any]:
         """Generate search suggestions based on partial query.
 
+        The archive's title/redirect index (``SuggestionSearcher``) is the
+        primary source — prefix autocomplete is what that index is for, and
+        it is what the tool description advertises. Xapian full-text hits,
+        filtered by title substring, supplement it only when the title index
+        leaves room on the page.
+
+        The order used to be reversed, with the full-text pass
+        short-circuiting the whole function whenever it returned anything at
+        all. On MedlinePlus that meant ``diab`` answered with ``Diabetic
+        Diet`` plus three genetics pages and reported ``done=True``, while
+        the title index held 99 matches and ranked the canonical
+        ``Diabetes`` page first: the index was never consulted, and
+        completeness was asserted over a set the server had not looked at.
+
         Errors during iteration of individual entries are logged and skipped
         (per-entry isolation). Errors that escape the per-entry try/except
         propagate so callers can avoid caching a sentinel response — a
@@ -2501,45 +2537,58 @@ class _SearchMixin:
             f"Starting suggestion generation for query: '{partial_query}', "
             f"limit: {limit}"
         )
-        suggestions = []
-        partial_lower = partial_query.lower().strip()
 
-        # Strategy 1: Use search functionality as fallback since direct entry
-        # iteration may not work reliably with all ZIM file structures.
-        # R2-4: ask for one more than the page so a full page can tell
-        # "exactly ``limit`` exist" from "more lie beyond it". ``has_more``
-        # is the only honest basis for ``done=False`` — this lookup takes
-        # no offset, so a continuation signal must come with a hint.
-        suggestions = self._get_suggestions_from_search(
-            archive, partial_query, limit + 1
+        suggestions, has_more, result_paths = self._get_suggestions_from_title_index(
+            archive, partial_query, limit
         )
-        has_more = len(suggestions) > limit
-        suggestions = suggestions[:limit]
 
-        # D6 (beta): the libzim suggest index / Xapian search both miss
-        # the canonical bare-title article for common prefixes.
-        # ``suggestions for Photosyn`` returns 15 results — ``PhotoSynth``,
-        # ``Photosyntesis`` (typo), ``Photosynthetic_efficiency``,
-        # ``Photosynthesis_(song)`` etc. — but NOT bare ``Photosynthesis``,
-        # which has score 1.0 in the title index. The Xapian search
-        # ranks broader articles (mentioning photosynt-* many times)
-        # above the canonical short-title article. Probe the title-index
-        # fast-path for the partial query directly and prepend the
-        # canonical entry when it's a clean prefix match and not
-        # already in the result list. Strategy 1 takes priority for
-        # cases where the prefix lands across many same-prefix titles;
-        # this prepend just fills the canonical gap.
-        #
-        # D6 (beta, second pass): only run the canonical probe when
-        # Strategy 1 returned something. The probe's purpose is to fill
-        # a gap in a populated list; when Strategy 1 is empty, Strategy 2
-        # below runs SuggestionSearcher with its own canonical-promotion
-        # logic (sorted by score+length), so running the canonical probe
-        # here would just be a duplicate SuggestionSearcher call against
-        # the same archive on the cold path.
+        # Full-text fallback: fills the rest of the page when the title
+        # index is thin, and carries archives that ship no usable title
+        # index at all.
+        if len(suggestions) < limit:
+            seen_paths = {s["path"] for s in suggestions}
+            seen_titles = {s["text"].strip().lower() for s in suggestions}
+            remaining = limit - len(suggestions)
+            # R2-4: ask for one more than the page can hold so a full page
+            # can tell "exactly ``limit`` exist" from "more lie beyond it".
+            # ``has_more`` is the only honest basis for ``done=False`` —
+            # this lookup takes no offset, so a continuation signal must
+            # come with a hint.
+            #
+            # Sized by ``limit``, not by the slots left: the helper derives
+            # its Xapian candidate window from the limit it is handed
+            # (``limit * 5``), so asking for the leftovers shrank the window
+            # rather than the answer — with one slot free it scanned 10
+            # candidates instead of 50, matched none, and returned a short
+            # page under ``done=True``. Take the leftovers from the result.
+            from_search = self._get_suggestions_from_search(
+                archive, partial_query, limit + 1
+            )
+            fresh = [
+                s
+                for s in from_search
+                if s["path"] not in seen_paths
+                and s["text"].strip().lower() not in seen_titles
+            ]
+            has_more = has_more or len(fresh) > remaining
+            suggestions = suggestions + fresh[:remaining]
+
+        # D6 (beta): both indexes routinely miss the canonical bare-title
+        # article for common prefixes. ``suggestions for Photosyn`` returns
+        # 15 results — ``PhotoSynth``, ``Photosyntesis`` (typo),
+        # ``Photosynthetic_efficiency``, ``Photosynthesis_(song)`` etc. —
+        # but NOT bare ``Photosynthesis``, which has score 1.0 in the title
+        # index. Probe the title-index fast-path for the partial query
+        # directly and prepend the canonical entry when it's a clean prefix
+        # match and not already in the result list. Reuse the candidates the
+        # title-index pass already pulled so the probe doesn't pay a second
+        # ``suggest()`` round trip against the same archive.
         if suggestions:
             canonical = self._find_canonical_prefix_match(
-                archive, partial_query, suggestions
+                archive,
+                partial_query,
+                suggestions,
+                result_paths=[str(p) for p in result_paths] or None,
             )
             if canonical is not None:
                 suggestions = [canonical] + suggestions
@@ -2549,21 +2598,30 @@ class _SearchMixin:
                 has_more = has_more or len(suggestions) > limit
                 suggestions = suggestions[:limit]
 
-            logger.info(f"Found {len(suggestions)} suggestions using search fallback")
-            return {
-                "partial_query": partial_query,
-                "suggestions": suggestions,
-                "count": len(suggestions),
-                "has_more": has_more,
-            }
+        logger.info(f"Found {len(suggestions)} suggestions for '{partial_query}'")
+        return {
+            "partial_query": partial_query,
+            "suggestions": suggestions[:limit],
+            "count": len(suggestions[:limit]),
+            "has_more": has_more,
+        }
 
-        # Strategy 2: Use the libzim title-index suggestion API. Replaces the
-        # previous strided ``_get_entry_by_id`` scan, which only inspected
-        # ~entry_count/step entries and missed almost everything on large
-        # archives. ``SuggestionSearcher`` works against the title/redirect
-        # index and is independent of the full-text index used by Strategy 1,
-        # so it remains a legitimate fallback when full-text returns zero.
+    def _get_suggestions_from_title_index(  # NOSONAR(python:S3776)
+        self, archive: Archive, partial_query: str, limit: int
+    ) -> Tuple[List[Dict[str, str]], bool, List[Any]]:
+        """Suggestions from libzim's title/redirect suggestion index.
+
+        Returns ``(suggestions, has_more, result_paths)``. The raw
+        ``result_paths`` are handed back so the canonical probe can reuse
+        them instead of issuing a second ``suggest()`` call.
+
+        Replaces the pre-Phase-B strided ``_get_entry_by_id`` scan, which
+        only inspected ~entry_count/step entries and missed almost
+        everything on large archives.
+        """
+        partial_lower = partial_query.lower().strip()
         title_matches: List[Dict[str, Any]] = []
+        suggestions: List[Dict[str, str]] = []
 
         try:
             suggestion_search = _zim_ops_mod.SuggestionSearcher(archive).suggest(
@@ -2583,8 +2641,9 @@ class _SearchMixin:
             )
         except Exception as e:
             logger.debug(f"SuggestionSearcher failed for '{partial_query}': {e}")
-            result_paths = []
+            return [], False, []
 
+        seen_titles: set = set()
         for result_path in result_paths:
             try:
                 entry = archive.get_entry_by_path(str(result_path))
@@ -2599,10 +2658,42 @@ class _SearchMixin:
                 if _is_pseudo_namespace_entry(path, title):
                     continue
 
+                # One suggestion per title, matching the full-text pass this
+                # one now runs ahead of. Distinct paths are not distinct
+                # choices: MedlinePlus files each frame of a slideshow under
+                # its own path with one shared title, and a quiz page appears
+                # again as ``…?quiz=1``, so an undeduped page offered ten rows
+                # carrying three articles. Dropping them here (rather than at
+                # emit time) keeps the ``limit * 2`` candidate budget spent on
+                # distinct articles, so ``has_more`` still counts suggestions
+                # a caller could actually pick.
+                title_key = title.strip().lower()
+                if title_key in seen_titles:
+                    continue
+                seen_titles.add(title_key)
+
                 title_lower = title.lower()
 
+                # An article the query names outright outranks every merely
+                # prefixed title. The comparison is against the leading
+                # segment rather than the whole title because site-suffixed
+                # corpora append their own name (and often a synonym list)
+                # to every heading: MedlinePlus files ``Diabetes`` as
+                # ``Diabetes | Type 1 Diabetes | Type 2 Diabetes |
+                # MedlinePlus``, one of the LONGEST titles matching
+                # ``diabetes``, so the shortest-title tiebreak below buried
+                # the canonical page under half a dozen narrower ones.
+                if _leading_title_segment(title_lower) == partial_lower:
+                    title_matches.append(
+                        {
+                            "suggestion": title,
+                            "path": path,
+                            "type": "title_start_match",
+                            "score": 150,
+                        }
+                    )
                 # Prioritize titles that start with the query
-                if title_lower.startswith(partial_lower):
+                elif title_lower.startswith(partial_lower):
                     title_matches.append(
                         {
                             "suggestion": title,
@@ -2651,6 +2742,10 @@ class _SearchMixin:
 
         # Take the best matches. The loop above collects up to ``2 * limit``
         # candidates, so anything past ``limit`` is a match beyond the page.
+        # ``getEstimatedMatches`` is deliberately NOT consulted here: it is a
+        # loose estimate, and inflating ``has_more`` from it would advertise
+        # "re-run with a larger limit" for pages the filtering had already
+        # exhausted.
         has_more = len(title_matches) > limit
         for match in title_matches[:limit]:
             suggestions.append(
@@ -2661,33 +2756,7 @@ class _SearchMixin:
                 }
             )
 
-        # D6 (beta, third pass): also probe for the canonical bare-title
-        # article on the Strategy 2 path. The earlier "skip probe when
-        # Strategy 1 is empty" optimisation regressed the empty-Strategy-1
-        # case (``Photosynt`` returns 0 hits via Xapian on cold Strategy 1
-        # locally; Strategy 2 then surfaces ``PhotoSynth`` but misses
-        # bare ``Photosynthesis``). Reuse the same ``result_paths``
-        # the loop above already pulled so we don't pay a second
-        # ``SuggestionSearcher.suggest()`` round trip — the helper
-        # accepts pre-fetched paths via its ``result_paths=`` arg.
-        if result_paths and suggestions:
-            canonical = self._find_canonical_prefix_match(
-                archive,
-                partial_query,
-                suggestions,
-                result_paths=[str(p) for p in result_paths],
-            )
-            if canonical is not None:
-                suggestions = [canonical] + suggestions
-                has_more = has_more or len(suggestions) > limit
-                suggestions = suggestions[:limit]
-
-        return {
-            "partial_query": partial_query,
-            "suggestions": suggestions[:limit],
-            "count": len(suggestions[:limit]),
-            "has_more": has_more,
-        }
+        return suggestions, has_more, result_paths
 
     def _get_suggestions_from_search(  # NOSONAR(python:S3776)
         self, archive: Archive, partial_query: str, limit: int

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -29,6 +29,7 @@ from urllib.parse import unquote
 from libzim.reader import Archive  # type: ignore[import-untyped]
 
 import openzim_mcp.zim_operations as _zim_ops_mod
+from openzim_mcp.error_messages import url_shaped_path_hint
 from openzim_mcp.exceptions import (
     OpenZimMcpArchiveError,
     OpenZimMcpCursorMismatchError,
@@ -224,6 +225,7 @@ def _entry_not_found_error(entry_path: str) -> OpenZimMcpEntryNotFoundError:
         f"Entry not found: '{entry_path}'. Double-check the spelling and "
         "path (entry paths are case-sensitive), or use "
         "`zim_search(mode='title')` to locate the entry."
+        + url_shaped_path_hint(entry_path)
     )
 
 

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -41,7 +41,11 @@ from openzim_mcp.meta import attach_meta
 from openzim_mcp.pagination import Cursor
 from openzim_mcp.responses import ToolErrorPayload, tool_error
 from openzim_mcp.zim._ops_base import _json
-from openzim_mcp.zim.content import _strip_markdown_links_shared, reject_path_traversal
+from openzim_mcp.zim.content import (
+    _strip_markdown_links_shared,
+    reject_path_traversal,
+    rewrite_well_known_path,
+)
 
 if TYPE_CHECKING:
     from openzim_mcp.cache import OpenZimMcpCache
@@ -81,6 +85,17 @@ def _resolve_entry_spelling(archive: Any, path: str) -> Tuple[Optional[Any], str
     caller that cannot verify the target still keeps its best-effort edge
     rather than dropping it.
     """
+    # A synthetic ``W/`` path browse published stands for an entry that is
+    # not stored under that name, so it has to be rewritten before any
+    # spelling is probed. Without this the structure surfaces
+    # (``view=toc``/``summary``/``structure``, ``zim_get_section``,
+    # ``zim_links``) answered Resource Not Found for a path the plain-body
+    # surface served — the same tool contradicting itself one argument apart.
+    # Best-effort: a resolution failure here must not turn a link-graph probe
+    # into a raise (``get_inbound_links_data`` relies on that).
+    with suppress(Exception):
+        path = rewrite_well_known_path(archive, path)
+
     # Broad on purpose: libzim reports a miss as a bare ``KeyError`` and a
     # corrupt cluster as ``RuntimeError``, and the probe's only job is to
     # answer "does this spelling resolve?" — any failure means "no". Callers
@@ -313,6 +328,13 @@ class _StructureMixin:
         ``zim_get``.
         """
         from openzim_mcp.bundle import get_or_build_bundle
+
+        # The single lookup point for all four bundle surfaces is also the
+        # single place a synthetic ``W/`` browse path has to become the entry
+        # it stands for; rewriting here keys the bundle on the resolved path,
+        # so ``W/mainPage`` shares one bundle with the real landing page
+        # rather than building a second under a name libzim cannot serve.
+        entry_path = rewrite_well_known_path(archive, entry_path)
 
         try:
             return get_or_build_bundle(

--- a/tests/test_e2e_sweep_content_processor.py
+++ b/tests/test_e2e_sweep_content_processor.py
@@ -1,0 +1,54 @@
+"""Real-world sweep (v3.2.2): snippet anchoring and the image placeholder.
+
+Both defects surfaced driving the installed server against the live corpus:
+
+* ``what causes migraines`` anchored its featured passage on the *lead* of
+  an off-topic article because the interrogative ``what`` is >= 3 chars and
+  therefore counted as an anchorable query term. The article's actual
+  migraine paragraph sat 11k chars further down.
+* A non-binary fetch of an image dead-ends on a placeholder that never
+  names the ``binary=True`` argument which does return the bytes.
+"""
+
+from openzim_mcp.content_processor import ContentProcessor
+
+
+def _processor() -> ContentProcessor:
+    return ContentProcessor(snippet_length=3000)
+
+
+class TestSnippetAnchoringIgnoresStopWords:
+    """A question word must not anchor the snippet on an irrelevant lead."""
+
+    CONTENT = (
+        "Nietzsche spoke of the death of God and of becoming what one is, "
+        "a phrase that has occupied commentators ever since.\n\n"
+        "His early philology gave way to the aphoristic style.\n\n"
+        "Nietzsche suffered debilitating migraines throughout his adult "
+        "life, and the attacks shaped his working habits."
+    )
+
+    def test_question_word_does_not_anchor_the_lead(self):
+        snippet = _processor().create_snippet(
+            self.CONTENT, query="what causes migraines"
+        )
+        assert "migraines" in snippet
+        assert not snippet.startswith("Nietzsche spoke of the death of God")
+
+    def test_content_term_still_anchors_when_present(self):
+        snippet = _processor().create_snippet(self.CONTENT, query="migraines")
+        assert "migraines" in snippet
+
+    def test_all_stop_word_query_falls_back_to_full_term_set(self):
+        # Nothing anchorable remains after filtering, so the old behavior
+        # (match on whatever the query gave us) must survive rather than
+        # silently degrading to the lead for every function-word query.
+        snippet = _processor().create_snippet(self.CONTENT, query="what is it")
+        assert snippet
+
+
+class TestImagePlaceholderNamesBinaryArgument:
+    def test_placeholder_points_at_binary_true(self):
+        result = _processor().process_mime_content(b"fake image data", "image/png")
+        assert "Image content" in result
+        assert "binary=True" in result

--- a/tests/test_e2e_sweep_metadata_miss.py
+++ b/tests/test_e2e_sweep_metadata_miss.py
@@ -1,0 +1,84 @@
+"""A missing ``M/<key>`` must fail like every other missing entry.
+
+``zim_get(entry_path="M/iep.utm.edu/kantview/")`` returned ``isError=false``
+with the sentence "Metadata key '…' not found in this archive." sitting in
+the ``content`` field, so a client that renders ``content`` showed an error
+message as though it were the article's text. A content-namespace miss on
+the same server correctly raises and surfaces the Resource Not Found
+envelope.
+
+The recovery hint was also uncallable: ``walk namespace M`` is a ``zim_query``
+phrasing, not a tool at the advanced surface, where the caller needs
+``zim_browse(namespace="M")``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from openzim_mcp.exceptions import OpenZimMcpEntryNotFoundError
+
+
+@pytest.fixture
+def content_ops(tmp_path):
+    from openzim_mcp.cache import OpenZimMcpCache
+    from openzim_mcp.config import CacheConfig, ContentConfig, OpenZimMcpConfig
+    from openzim_mcp.content_processor import ContentProcessor
+    from openzim_mcp.security import PathValidator
+    from openzim_mcp.zim_operations import ZimOperations
+
+    cfg = OpenZimMcpConfig(
+        allowed_directories=[str(tmp_path)],
+        cache=CacheConfig(enabled=False, max_size=4, ttl_seconds=60),
+        content=ContentConfig(max_content_length=5000, snippet_length=200),
+    )
+    return ZimOperations(
+        cfg,
+        PathValidator(cfg.allowed_directories),
+        OpenZimMcpCache(cfg.cache),
+        ContentProcessor(snippet_length=200),
+    )
+
+
+def _archive_without(key_error: bool = True) -> MagicMock:
+    archive = MagicMock()
+    archive.get_metadata_item.side_effect = KeyError("no such metadata key")
+    return archive
+
+
+def test_missing_metadata_key_raises_not_found(content_ops):
+    """The miss must raise, not return a success-shaped payload."""
+    with pytest.raises(OpenZimMcpEntryNotFoundError):
+        content_ops._get_metadata_entry_data(
+            _archive_without(), "M/iep.utm.edu/kantview/", 5000, 0
+        )
+
+
+def test_empty_metadata_key_raises_not_found(content_ops):
+    with pytest.raises(OpenZimMcpEntryNotFoundError):
+        content_ops._get_metadata_entry_data(_archive_without(), "M/", 5000, 0)
+
+
+def test_recovery_hint_names_a_callable_tool(content_ops):
+    with pytest.raises(OpenZimMcpEntryNotFoundError) as exc_info:
+        content_ops._get_metadata_entry_data(_archive_without(), "M/NoSuchKey", 5000, 0)
+    message = str(exc_info.value)
+    assert "zim_browse" in message
+    assert "walk namespace" not in message
+
+
+def test_present_metadata_key_still_returns_payload(content_ops):
+    """Positive control: a real key must keep its success path."""
+    archive = MagicMock()
+    item = MagicMock()
+    item.mimetype = "text/plain"
+    item.content = b"Encyclopedia of Philosophy"
+    archive.get_metadata_item.return_value = item
+
+    payload, content_ok = content_ops._get_metadata_entry_data(
+        archive, "M/Title", 5000, 0
+    )
+    assert content_ok is True
+    assert payload["content"] == "Encyclopedia of Philosophy"

--- a/tests/test_e2e_sweep_suggest_index.py
+++ b/tests/test_e2e_sweep_suggest_index.py
@@ -1,0 +1,334 @@
+"""Real-world sweep (v3.2.2): ``suggest`` mode must consult the title index.
+
+Driving the installed server against a MedlinePlus archive, ``suggest``
+for ``diab`` returned four rows — ``Diabetic Diet`` plus three genetics
+pages — and reported ``total=4, done=True``. libzim's ``SuggestionSearcher``
+on the same archive estimates 99 matches for that prefix and ranks the
+canonical ``Diabetes`` page first.
+
+The cause is strategy ordering in ``_generate_search_suggestions``: the
+Xapian full-text pass ran first and short-circuited the whole function
+whenever it returned anything at all, so the archive's purpose-built
+title/prefix index — the thing the tool description advertises — only ran
+when full-text found *nothing*. ``done=True`` then asserted completeness
+over a set the server had never looked at.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from openzim_mcp.cache import OpenZimMcpCache
+from openzim_mcp.config import (
+    CacheConfig,
+    ContentConfig,
+    LoggingConfig,
+    OpenZimMcpConfig,
+)
+from openzim_mcp.content_processor import ContentProcessor
+from openzim_mcp.security import PathValidator
+from openzim_mcp.zim_operations import ZimOperations
+
+
+def _entry(path: str, title: str) -> MagicMock:
+    e = MagicMock()
+    e.path = path
+    e.title = title
+    e.is_redirect = False
+    return e
+
+
+# The archive as libzim sees it: the canonical page plus a long tail, all
+# reachable through the title index.
+_TITLE_INDEX: Dict[str, str] = {
+    "medlineplus.gov/diabetes.html": "Diabetes | Type 1 and Type 2 | MedlinePlus",
+    "medlineplus.gov/diabetestype1.html": "Diabetes Type 1 | MedlinePlus",
+    "medlineplus.gov/diabetickidneyproblems.html": "Diabetic Kidney Problems",
+    "medlineplus.gov/diabeticeyeproblems.html": "Diabetic Eye Problems",
+    "medlineplus.gov/diabeticdiet.html": "Diabetic Diet | MedlinePlus",
+}
+
+# What the Xapian full-text pass surfaces for the same prefix: the short
+# title plus genetics pages that merely *contain* the term. Note the
+# canonical ``Diabetes`` page is absent — that is the real-world shape.
+_FULLTEXT_HITS: List[str] = [
+    "medlineplus.gov/diabeticdiet.html",
+    "medlineplus.gov/genetics/condition/type-1-diabetes/",
+    "medlineplus.gov/genetics/condition/type-2-diabetes/",
+    "medlineplus.gov/genetics/condition/gestational-diabetes/",
+]
+
+_FULLTEXT_TITLES: Dict[str, str] = {
+    "medlineplus.gov/diabeticdiet.html": "Diabetic Diet | MedlinePlus",
+    "medlineplus.gov/genetics/condition/type-1-diabetes/": (
+        "Type 1 diabetes: MedlinePlus Genetics"
+    ),
+    "medlineplus.gov/genetics/condition/type-2-diabetes/": (
+        "Type 2 diabetes: MedlinePlus Genetics"
+    ),
+    "medlineplus.gov/genetics/condition/gestational-diabetes/": (
+        "Gestational diabetes: MedlinePlus Genetics"
+    ),
+}
+
+_ALL_TITLES = {**_FULLTEXT_TITLES, **_TITLE_INDEX}
+
+
+class _Ctx:
+    def __init__(self, archive: Any) -> None:
+        self._archive = archive
+
+    def __enter__(self) -> Any:
+        return self._archive
+
+    def __exit__(self, *exc: Any) -> bool:
+        return False
+
+
+@pytest.fixture
+def ops(tmp_path) -> ZimOperations:
+    cfg = OpenZimMcpConfig(
+        allowed_directories=[str(tmp_path)],
+        cache=CacheConfig(enabled=False, max_size=10, ttl_seconds=60),
+        content=ContentConfig(max_content_length=1000, snippet_length=100),
+        logging=LoggingConfig(level="ERROR"),
+    )
+    operations = ZimOperations(
+        cfg,
+        PathValidator(cfg.allowed_directories),
+        OpenZimMcpCache(cfg.cache),
+        ContentProcessor(snippet_length=100),
+    )
+    operations.path_validator = MagicMock()
+    operations.path_validator.validate_path.return_value = "/zim/mlp.zim"
+    operations.path_validator.validate_zim_file.return_value = "/zim/mlp.zim"
+    return operations
+
+
+@pytest.fixture
+def patched_archive(monkeypatch):
+    """Wire both retrieval paths: Xapian full-text and the title index."""
+
+    def _apply(
+        *,
+        fulltext: List[str],
+        suggestions: List[str],
+        estimated: Optional[int] = None,
+    ) -> None:
+        archive = MagicMock()
+        archive.get_entry_by_path.side_effect = lambda p: _entry(
+            p, _ALL_TITLES.get(p, "")
+        )
+        archive.has_entry_by_title.return_value = False
+
+        search = MagicMock()
+        search.getEstimatedMatches.return_value = len(fulltext)
+        search.getResults.side_effect = lambda start, count: list(
+            fulltext[start : start + count]
+        )
+        searcher = MagicMock()
+        searcher.search.return_value = search
+
+        sugg = MagicMock()
+        sugg.getEstimatedMatches.return_value = (
+            estimated if estimated is not None else len(suggestions)
+        )
+        sugg.getResults.side_effect = lambda start, count: list(
+            suggestions[start : start + count]
+        )
+        sugg_searcher = MagicMock()
+        sugg_searcher.suggest.return_value = sugg
+
+        query = MagicMock()
+        query.set_query.return_value = query
+
+        monkeypatch.setattr(
+            "openzim_mcp.zim_operations.zim_archive", lambda *a, **kw: _Ctx(archive)
+        )
+        monkeypatch.setattr(
+            "openzim_mcp.zim_operations.Searcher", lambda _archive: searcher
+        )
+        monkeypatch.setattr(
+            "openzim_mcp.zim_operations.SuggestionSearcher",
+            lambda _archive: sugg_searcher,
+        )
+        monkeypatch.setattr("openzim_mcp.zim_operations.Query", lambda: query)
+
+    return _apply
+
+
+def test_canonical_title_index_match_is_returned(ops, patched_archive):
+    """``diab`` must surface the canonical ``Diabetes`` page."""
+    patched_archive(
+        fulltext=_FULLTEXT_HITS, suggestions=list(_TITLE_INDEX), estimated=99
+    )
+    out = ops.get_search_suggestions_data("/zim/mlp.zim", "diab", limit=10)
+    paths = [r["path"] for r in out["results"]]
+    assert "medlineplus.gov/diabetes.html" in paths
+
+
+def test_title_index_matches_are_not_starved_by_fulltext(ops, patched_archive):
+    """A weak full-text pass must not suppress the title index entirely."""
+    patched_archive(
+        fulltext=_FULLTEXT_HITS, suggestions=list(_TITLE_INDEX), estimated=99
+    )
+    out = ops.get_search_suggestions_data("/zim/mlp.zim", "diab", limit=10)
+    paths = {r["path"] for r in out["results"]}
+    # Every real title-prefix match fits inside limit=10 alongside the
+    # full-text rows; none of them may be dropped.
+    assert _TITLE_INDEX.keys() <= paths
+
+
+def test_done_is_not_claimed_while_the_index_holds_more(ops, patched_archive):
+    """``done=True`` must not assert completeness over an unread index."""
+    patched_archive(
+        fulltext=_FULLTEXT_HITS, suggestions=list(_TITLE_INDEX), estimated=99
+    )
+    out = ops.get_search_suggestions_data("/zim/mlp.zim", "diab", limit=3)
+    assert out["page_info"]["returned_count"] == 3
+    assert out["done"] is False
+
+
+def test_fulltext_only_archive_still_returns_suggestions(ops, patched_archive):
+    """An archive whose title index is empty keeps the full-text fallback."""
+    patched_archive(fulltext=_FULLTEXT_HITS, suggestions=[], estimated=0)
+    out = ops.get_search_suggestions_data("/zim/mlp.zim", "diab", limit=10)
+    assert out["results"], "full-text suggestions must survive an empty title index"
+
+
+def test_no_duplicate_paths_across_strategies(ops, patched_archive):
+    """``diabeticdiet`` is in both sources; it must appear once."""
+    patched_archive(
+        fulltext=_FULLTEXT_HITS, suggestions=list(_TITLE_INDEX), estimated=99
+    )
+    out = ops.get_search_suggestions_data("/zim/mlp.zim", "diab", limit=10)
+    paths = [r["path"] for r in out["results"]]
+    assert len(paths) == len(set(paths))
+
+
+class TestTitleIndexDedupesByTitle:
+    """One article's asset frames must not fill the autocomplete page.
+
+    The full-text pass that used to fill this page deduped by title. The
+    title index did not — it was only ever a cold-path fallback — so
+    promoting it surfaced MedlinePlus slideshow frames
+    (``…/presentations/100117_1..5.htm``, all titled "Knee arthroscopy -
+    series") and ``?quiz=1`` variants as separate suggestions: ``knee``
+    came back as 10 rows carrying 3 distinct titles.
+    """
+
+    INDEX = {
+        "medlineplus.gov/ency/presentations/100117_1.htm": "Knee arthroscopy - series",
+        "medlineplus.gov/ency/presentations/100117_2.htm": "Knee arthroscopy - series",
+        "medlineplus.gov/ency/presentations/100117_3.htm": "Knee arthroscopy - series",
+        "medlineplus.gov/kneeinjuries.html": "Knee Injuries and Disorders",
+        "medlineplus.gov/kneereplacement.html": "Knee Replacement",
+    }
+
+    @pytest.fixture(autouse=True)
+    def _wire(self):
+        _ALL_TITLES.update(self.INDEX)
+        yield
+
+    def test_repeated_titles_collapse_to_one_row(self, ops, patched_archive):
+        patched_archive(fulltext=[], suggestions=list(self.INDEX), estimated=40)
+        out = ops.get_search_suggestions_data("/zim/mlp.zim", "knee", limit=10)
+        titles = [r["text"] for r in out["results"]]
+        assert len(titles) == len(set(titles))
+
+    def test_distinct_articles_survive_the_dedup(self, ops, patched_archive):
+        patched_archive(fulltext=[], suggestions=list(self.INDEX), estimated=40)
+        out = ops.get_search_suggestions_data("/zim/mlp.zim", "knee", limit=10)
+        titles = {r["text"] for r in out["results"]}
+        assert "Knee Injuries and Disorders" in titles
+        assert "Knee Replacement" in titles
+
+    def test_deduped_page_fills_to_limit(self, ops, patched_archive):
+        """Collapsed duplicates must free their slots for real articles."""
+        patched_archive(fulltext=[], suggestions=list(self.INDEX), estimated=40)
+        out = ops.get_search_suggestions_data("/zim/mlp.zim", "knee", limit=3)
+        assert out["page_info"]["returned_count"] == 3
+        titles = [r["text"] for r in out["results"]]
+        assert len(titles) == len(set(titles))
+
+
+class TestFullTextWindowIsSizedByThePage:
+    """The full-text fallback must not shrink its own candidate window.
+
+    ``_get_suggestions_from_search`` sizes its Xapian window as
+    ``limit * 5`` from the limit it is handed. Passing it only the leftover
+    slots (``remaining + 1``) shrank that window — with one slot left it
+    scanned 10 candidates instead of 50, found nothing that matched the
+    title filter, and the page came back short under ``done=True``.
+    """
+
+    def test_last_slot_still_scans_the_full_page_window(self, ops, patched_archive):
+        """Nine title hits leave one slot; the window must still be limit-sized.
+
+        At ``limit=10`` the helper should scan ``(10 + 1) * 5 = 55``
+        candidates. Sized by the single leftover slot it scanned ``(1 + 1) *
+        5 = 10`` instead, so a match at candidate 20 was invisible.
+        """
+        index_hits = {
+            f"medlineplus.gov/diabetes{i}.html": f"Diabetes Topic {i}" for i in range(9)
+        }
+        noise = [f"medlineplus.gov/noise/{i}.html" for i in range(20)]
+        _ALL_TITLES.update(index_hits)
+        _ALL_TITLES.update({p: f"Unrelated page {i}" for i, p in enumerate(noise)})
+        _ALL_TITLES["medlineplus.gov/diabetesdeep.html"] = "Diabetes Deep Match"
+        patched_archive(
+            fulltext=noise + ["medlineplus.gov/diabetesdeep.html"],
+            suggestions=list(index_hits),
+            estimated=9,
+        )
+        out = ops.get_search_suggestions_data("/zim/mlp.zim", "diabetes", limit=10)
+        paths = {r["path"] for r in out["results"]}
+        assert "medlineplus.gov/diabetesdeep.html" in paths
+
+
+class TestExactTitleOutranksLongerPrefixMatches:
+    """Ranking must not demote the article the query names outright.
+
+    MedlinePlus titles carry a ``| MedlinePlus`` site suffix and often list
+    their synonyms ahead of it, so ``Diabetes | Type 1 Diabetes | Type 2
+    Diabetes | MedlinePlus`` is one of the *longest* titles matching
+    ``diabetes`` — and a shortest-title tiebreak buried it below
+    ``Diabetes Mellitus``, ``Diabetes Complications`` and four others, even
+    though libzim's own suggestion index ranks it first.
+    """
+
+    INDEX = {
+        "medlineplus.gov/diabetesmellitus.html": "Diabetes Mellitus: MedlinePlus",
+        "medlineplus.gov/diabetescomplications.html": (
+            "Diabetes Complications | MedlinePlus"
+        ),
+        "medlineplus.gov/diabetesinsipidus.html": (
+            "Diabetes Insipidus | DI | MedlinePlus"
+        ),
+        "medlineplus.gov/languages/diabetes.html": (
+            "Diabetes - Multiple Languages: MedlinePlus"
+        ),
+        "medlineplus.gov/diabetes.html": (
+            "Diabetes | Type 1 Diabetes | Type 2 Diabetes | MedlinePlus"
+        ),
+    }
+
+    @pytest.fixture(autouse=True)
+    def _wire(self, monkeypatch):
+        _ALL_TITLES.update(self.INDEX)
+        yield
+
+    def test_exact_leading_segment_ranks_first(self, ops, patched_archive):
+        patched_archive(fulltext=[], suggestions=list(self.INDEX), estimated=40)
+        out = ops.get_search_suggestions_data("/zim/mlp.zim", "diabetes", limit=5)
+        assert out["results"][0]["path"] == "medlineplus.gov/diabetes.html"
+
+    def test_prefix_query_ordering_is_unchanged(self, ops, patched_archive):
+        # ``diab`` names no article exactly, so nothing is promoted and the
+        # existing shortest-title ranking still decides the page.
+        patched_archive(fulltext=[], suggestions=list(self.INDEX), estimated=40)
+        out = ops.get_search_suggestions_data("/zim/mlp.zim", "diab", limit=5)
+        assert out["results"][0]["path"] == "medlineplus.gov/diabetesmellitus.html"

--- a/tests/test_e2e_sweep_url_entry_path.py
+++ b/tests/test_e2e_sweep_url_entry_path.py
@@ -1,0 +1,143 @@
+"""A URL-shaped ``entry_path`` must come back readable, with guidance.
+
+Passing ``https://iep.utm.edu/epistemo/`` as an ``entry_path`` is the most
+natural wrong guess a client makes, and the server's own instructions say
+entry paths are "archive-relative …, never URLs". The error it produced
+said neither:
+
+* the filesystem-path redactor matched the ``//iep.utm.edu/epistemo/`` tail
+  of the caller's own URL as a POSIX absolute path and collapsed it, so the
+  message read ``Path: https:<path-hidden>`` — the caller could not even
+  see which value was rejected, and the redactor's contract of keeping the
+  basename visible failed too (a trailing slash leaves an empty basename);
+* nothing mentioned that the scheme and host have to go.
+
+Redaction of *real* filesystem paths is unaffected: paths rooted at a
+configured directory are collapsed by the literal-prefix pass that runs
+first, whatever punctuation precedes them.
+"""
+
+from __future__ import annotations
+
+from openzim_mcp.security import redact_paths_in_message
+
+
+class TestUrlsSurviveRedaction:
+    def test_https_url_is_not_treated_as_a_filesystem_path(self):
+        out = redact_paths_in_message(
+            "Entry not found: 'https://iep.utm.edu/epistemo/'."
+        )
+        assert "https://iep.utm.edu/epistemo/" in out
+        assert "<path-hidden>" not in out
+
+    def test_http_url_survives(self):
+        out = redact_paths_in_message("Path: http://example.org/wiki/Aspirin")
+        assert "http://example.org/wiki/Aspirin" in out
+
+    def test_absolute_path_after_a_space_is_still_redacted(self):
+        out = redact_paths_in_message("Failed to open /home/user/data/wikipedia.zim")
+        assert "/home/user/data" not in out
+        assert "wikipedia.zim" in out
+
+    def test_labelled_absolute_path_is_still_redacted(self):
+        out = redact_paths_in_message("Path: /home/user/secret/wikipedia.zim")
+        assert "/home/user/secret" not in out
+        assert "wikipedia.zim" in out
+
+
+class TestMaskCannotBeForged:
+    """Caller text must not be able to impersonate the internal mask.
+
+    ``entry_path`` is echoed into the message verbatim, so a caller who
+    embeds the mask token can otherwise have it substituted for a URL of
+    their choosing — rewriting the error the next reader sees.
+    """
+
+    def test_forged_mask_token_is_not_substituted(self):
+        out = redact_paths_in_message(
+            "Entry not found: 'A/x\x00u0\x00 and https://real.example/b'."
+        )
+        assert "https://real.example/b" in out
+        # The forged token must not have been filled with the stashed URL.
+        assert out.count("https://real.example/b") == 1
+
+    def test_forged_token_alone_is_inert(self):
+        out = redact_paths_in_message("Entry not found: 'A/x\x00u7\x00'.")
+        assert "\x00u7\x00" not in out
+
+
+class TestSchemePrefixIsNotARedactionBypass:
+    """An empty authority means the tail is a path, not a host — redact it.
+
+    ``file:///home/user/secret/wiki.zim`` and any invented ``x:///home/...``
+    would otherwise ride the URL exemption and carry an absolute filesystem
+    path through unredacted.
+    """
+
+    def test_authority_less_scheme_still_redacts(self):
+        out = redact_paths_in_message("file:///home/user/secret/wikipedia.zim")
+        assert "/home/user/secret" not in out
+        assert "wikipedia.zim" in out
+
+    def test_invented_authority_less_scheme_still_redacts(self):
+        out = redact_paths_in_message("x:///home/user/secret/wikipedia.zim")
+        assert "/home/user/secret" not in out
+
+
+class TestRedactionStaysLinear:
+    """The URL exemption must not reintroduce quadratic work.
+
+    Two separate ways this went quadratic, both reachable from a
+    caller-supplied long ``entry_path`` — a shape this module is hardened
+    against elsewhere (see ``sanitize_for_log``):
+
+    * an unanchored, unbounded scheme pattern rescans the tail from every
+      offset (25s on 200k characters);
+    * restoring the stashed URLs with one ``str.replace`` per URL rescans
+      the whole message once per URL (~53s on 200KB of small URLs).
+    """
+
+    def test_many_urls_restore_promptly(self):
+        import time
+
+        message = "Entry not found: " + " ".join(
+            f"https://h/{index}" for index in range(20_000)
+        )
+        started = time.monotonic()
+        redact_paths_in_message(message)
+        assert time.monotonic() - started < 2.0
+
+    def test_long_token_redacts_promptly(self):
+        import time
+
+        message = "Entry not found: " + ("a" * 200_000)
+        started = time.monotonic()
+        redact_paths_in_message(message)
+        assert time.monotonic() - started < 2.0
+
+    def test_long_path_like_token_redacts_promptly(self):
+        import time
+
+        message = "Failed to open /home/user/" + ("b" * 200_000) + ".zim"
+        started = time.monotonic()
+        redact_paths_in_message(message)
+        assert time.monotonic() - started < 2.0
+
+
+class TestNonUrlColonPathsStillCollapse:
+    """The exemption keys on ``scheme://``, not on a colon.
+
+    ``archive:/home/user/secret/x.zim`` is a labelled filesystem path, not a
+    URL, and must keep redacting — a blanket "ignore anything after a colon"
+    rule would have opened a hole here.
+    """
+
+    def test_labelled_path_without_a_scheme_is_redacted(self):
+        out = redact_paths_in_message("archive:/home/user/secret/wikipedia.zim")
+        assert "/home/user/secret" not in out
+        assert "wikipedia.zim" in out
+
+    def test_windows_drive_path_is_still_redacted(self):
+        out = redact_paths_in_message(r"Failed to open C:\Users\jo\data\wiki.zim")
+        assert "Users" not in out
+        assert "wiki.zim" in out

--- a/tests/test_e2e_sweep_url_hint.py
+++ b/tests/test_e2e_sweep_url_hint.py
@@ -1,0 +1,54 @@
+"""A URL-shaped ``entry_path`` gets told what to strip.
+
+The server instructions state entry paths are "archive-relative (e.g.
+'A/Aspirin'), never URLs", but the not-found error for
+``https://en.wikipedia.org/wiki/Aspirin`` gave the generic five
+troubleshooting steps and never mentioned the scheme and host, so the
+caller's most natural wrong guess got no correction.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openzim_mcp.error_messages import url_shaped_path_hint
+
+
+class TestHintFires:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "https://en.wikipedia.org/wiki/Aspirin",
+            "http://iep.utm.edu/epistemo/",
+            "HTTPS://EXAMPLE.ORG/x",
+        ],
+    )
+    def test_url_gets_a_hint(self, path):
+        hint = url_shaped_path_hint(path)
+        assert hint
+        assert "archive-relative" in hint
+
+    def test_hint_keeps_the_host_in_the_suggested_path(self):
+        """zimit/warc2zim archives file entries UNDER the host.
+
+        ``iep.utm.edu/stoicism/`` resolves; ``stoicism/`` does not, so a
+        hint that says to drop the host sends the caller to a second 404.
+        """
+        hint = url_shaped_path_hint("https://iep.utm.edu/stoicism/")
+        assert "'iep.utm.edu/stoicism/'" in hint
+        assert "and host" not in hint
+
+
+class TestHintStaysQuiet:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "A/Aspirin",
+            "medlineplus.gov/druginfo/meds/a682878.html",
+            "C/Some_Article",
+            "",
+            "M/Title",
+        ],
+    )
+    def test_ordinary_entry_path_gets_no_hint(self, path):
+        assert url_shaped_path_hint(path) == ""

--- a/tests/test_e2e_sweep_validation_envelope.py
+++ b/tests/test_e2e_sweep_validation_envelope.py
@@ -134,6 +134,49 @@ async def test_union_typed_argument_reports_the_wire_name(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
+async def test_internal_pydantic_failure_is_not_reported_as_the_caller_s_fault(
+    tmp_path: Path,
+) -> None:
+    """An error from inside a tool body must not become ``invalid_argument``.
+
+    The SDK wraps *any* body exception as ``ToolError(...) from e``, and the
+    envelope handler classifies on "is there a ValidationError in the
+    chain". Today every tool body catches its own exceptions, so nothing
+    reaches that handler — but if one ever stops, an internal model failure
+    would be reported to the caller as a bad argument, naming a field they
+    never sent and cannot fix.
+    """
+    import pydantic
+
+    from openzim_mcp.mcp_envelope import _validation_error_in_chain
+
+    class _Inner(pydantic.BaseModel):
+        count: int
+
+    try:
+        _Inner(count="not-an-int")
+    except pydantic.ValidationError as exc:
+        internal = exc
+
+    # The classifier cannot tell an internal failure from an argument one —
+    # that is precisely why the guard has to stay upstream of it.
+    assert _validation_error_in_chain(internal) is internal
+
+    # The real protection: every advanced tool body absorbs its own errors,
+    # so a failing archive surfaces as a tool_error envelope, never as a
+    # validation leak.
+    (tmp_path / "a.zim").write_bytes(b"not a zim file at all")
+    async with advanced_session(tmp_path) as session:
+        result = await session.call_tool(
+            "zim_search",
+            {"query": "climate", "zim_file_path": str(tmp_path / "a.zim")},
+        )
+    text = _text(result)
+    assert "invalid_argument" not in text
+    assert "validation error for" not in text
+
+
+@pytest.mark.asyncio
 async def test_valid_enum_value_still_dispatches(tmp_path: Path) -> None:
     """Positive control: the guard must not reject legitimate calls."""
     (tmp_path / "a.zim").write_bytes(b"ZIM\x04")

--- a/tests/test_e2e_sweep_validation_envelope.py
+++ b/tests/test_e2e_sweep_validation_envelope.py
@@ -1,0 +1,153 @@
+"""Schema-level argument rejections must use the documented JSON envelope.
+
+The shipped server instructions promise that "A rejected argument is flagged
+isError with a JSON body carrying 'error', 'operation' and a 'message'
+describing how to correct the call", and ``mcp_envelope`` already delivers
+that for *unknown argument names*, negative limits, bad offsets and bad
+modes.
+
+Three rejection classes still escaped through the SDK instead: a value
+outside a ``Literal`` enum, a value of the wrong type, and a missing
+required argument. Each arrived as pydantic's own report stringified into a
+bare text block — "1 validation error for zim_searchArguments … visit
+https://errors.pydantic.dev/…" — which is the exact leak D04 removed from
+``zim_browse``, and which a client parsing the body as JSON cannot read.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.test_mcp_session import _text, advanced_session
+
+
+def _payload(result: Any) -> dict[str, Any]:
+    text = _text(result)
+    assert "pydantic" not in text, text
+    assert "validation error for" not in text, text
+    return json.loads(text)
+
+
+@pytest.mark.asyncio
+async def test_enum_violation_uses_the_envelope(tmp_path: Path) -> None:
+    """``mode="query"`` is a plausible guess — ``fulltext`` is the real name."""
+    (tmp_path / "a.zim").write_bytes(b"ZIM\x04")
+    async with advanced_session(tmp_path) as session:
+        result = await session.call_tool(
+            "zim_search",
+            {
+                "query": "climate",
+                "zim_file_path": str(tmp_path / "a.zim"),
+                "mode": "query",
+            },
+        )
+
+    assert result.is_error is True
+    payload = _payload(result)
+    assert payload["error"] is True
+    assert payload["operation"] == "invalid_argument"
+    # The caller has to learn which argument and which values are legal.
+    assert "mode" in payload["message"]
+    assert "fulltext" in payload["message"]
+
+
+@pytest.mark.asyncio
+async def test_wrong_type_uses_the_envelope(tmp_path: Path) -> None:
+    (tmp_path / "a.zim").write_bytes(b"ZIM\x04")
+    async with advanced_session(tmp_path) as session:
+        result = await session.call_tool(
+            "zim_browse",
+            {
+                "namespace": "C",
+                "zim_file_path": str(tmp_path / "a.zim"),
+                "limit": "five",
+            },
+        )
+
+    assert result.is_error is True
+    payload = _payload(result)
+    assert payload["operation"] == "invalid_argument"
+    assert "limit" in payload["message"]
+
+
+@pytest.mark.asyncio
+async def test_missing_required_argument_uses_the_envelope(tmp_path: Path) -> None:
+    (tmp_path / "a.zim").write_bytes(b"ZIM\x04")
+    async with advanced_session(tmp_path) as session:
+        result = await session.call_tool(
+            "zim_search", {"zim_file_path": str(tmp_path / "a.zim")}
+        )
+
+    assert result.is_error is True
+    payload = _payload(result)
+    assert payload["operation"] == "invalid_argument"
+    assert "query" in payload["message"]
+
+
+@pytest.mark.asyncio
+async def test_envelope_lists_the_offending_arguments(tmp_path: Path) -> None:
+    """A model retrying from ``message`` alone still needs the field names."""
+    (tmp_path / "a.zim").write_bytes(b"ZIM\x04")
+    async with advanced_session(tmp_path) as session:
+        result = await session.call_tool(
+            "zim_get",
+            {
+                "entry_path": "A/Anything",
+                "zim_file_path": str(tmp_path / "a.zim"),
+                "view": "nonsense_view",
+            },
+        )
+
+    payload = _payload(result)
+    assert payload["invalid_arguments"] == ["view"]
+
+
+@pytest.mark.asyncio
+async def test_union_typed_argument_reports_the_wire_name(tmp_path: Path) -> None:
+    """A union-typed argument must not be named by its member tags.
+
+    ``compact_budget`` accepts ``str | int``, so pydantic reports one error
+    per member with locs ``("compact_budget", "str")`` and
+    ``("compact_budget", "int")``. Joining every loc part named
+    ``compact_budget.str`` — an argument the caller never sent and cannot
+    correct.
+    """
+    (tmp_path / "a.zim").write_bytes(b"ZIM\x04")
+    async with advanced_session(tmp_path) as session:
+        result = await session.call_tool(
+            "zim_get",
+            {
+                "entry_path": "A/Anything",
+                "zim_file_path": str(tmp_path / "a.zim"),
+                "compact_budget": ["a", "b"],
+            },
+        )
+
+    payload = _payload(result)
+    assert payload["invalid_arguments"] == ["compact_budget"]
+    assert ".str" not in payload["message"]
+    assert ".int" not in payload["message"]
+
+
+@pytest.mark.asyncio
+async def test_valid_enum_value_still_dispatches(tmp_path: Path) -> None:
+    """Positive control: the guard must not reject legitimate calls."""
+    (tmp_path / "a.zim").write_bytes(b"ZIM\x04")
+    async with advanced_session(tmp_path) as session:
+        result = await session.call_tool(
+            "zim_search",
+            {
+                "query": "climate",
+                "zim_file_path": str(tmp_path / "a.zim"),
+                "mode": "title",
+            },
+        )
+
+    # The stub archive is not a real ZIM, so this fails downstream — but it
+    # must fail on the archive, never on argument validation.
+    text = _text(result)
+    assert "invalid_argument" not in text

--- a/tests/test_e2e_sweep_validation_envelope.py
+++ b/tests/test_e2e_sweep_validation_envelope.py
@@ -153,13 +153,12 @@ async def test_internal_pydantic_failure_is_not_reported_as_the_caller_s_fault(
     class _Inner(pydantic.BaseModel):
         count: int
 
-    try:
+    with pytest.raises(pydantic.ValidationError) as exc_info:
         _Inner(count="not-an-int")
-    except pydantic.ValidationError as exc:
-        internal = exc
 
     # The classifier cannot tell an internal failure from an argument one —
     # that is precisely why the guard has to stay upstream of it.
+    internal = exc_info.value
     assert _validation_error_in_chain(internal) is internal
 
     # The real protection: every advanced tool body absorbs its own errors,

--- a/tests/test_e2e_sweep_validation_envelope.py
+++ b/tests/test_e2e_sweep_validation_envelope.py
@@ -161,18 +161,23 @@ async def test_internal_pydantic_failure_is_not_reported_as_the_caller_s_fault(
     internal = exc_info.value
     assert _validation_error_in_chain(internal) is internal
 
-    # The real protection: every advanced tool body absorbs its own errors,
-    # so a failing archive surfaces as a tool_error envelope, never as a
-    # validation leak.
+    # The property that actually protects the caller: a failing archive is
+    # absorbed by the tool body and answered as a tool_error envelope. This
+    # has to assert the envelope's SHAPE, not the absence of the leak
+    # strings — an unabsorbed exception reaches the wire as the SDK's bare
+    # text block ("Error executing tool zim_search: Failed to open ZIM
+    # archive: …"), which contains neither string and would sail past a
+    # negative assertion while the property was broken.
     (tmp_path / "a.zim").write_bytes(b"not a zim file at all")
     async with advanced_session(tmp_path) as session:
         result = await session.call_tool(
             "zim_search",
             {"query": "climate", "zim_file_path": str(tmp_path / "a.zim")},
         )
-    text = _text(result)
-    assert "invalid_argument" not in text
-    assert "validation error for" not in text
+    payload = _payload(result)
+    assert payload["error"] is True
+    assert payload["operation"] == "zim_search"
+    assert payload["operation"] != "invalid_argument"
 
 
 @pytest.mark.asyncio

--- a/tests/test_e2e_sweep_wellknown_paths.py
+++ b/tests/test_e2e_sweep_wellknown_paths.py
@@ -1,0 +1,127 @@
+"""``W/`` paths that browse advertises must not dead-end in ``zim_get``.
+
+``zim_browse(namespace="W")`` and ``zim_metadata`` both publish
+``W/mainPage`` and ``W/favicon`` on new-scheme archives — synthetic rows
+resolved through libzim's well-known-entry APIs, because the literal paths
+are not entries. ``zim_get`` knew nothing about them, so it answered
+Resource Not Found and advised "use browsing tools to explore available
+content" — the tool that had just handed the caller the path.
+
+``M/<key>`` rows from the same browse surface resolve fine, because
+``_smart_retrieve_entry`` routes them to the metadata API. This is the
+sibling route for ``W/``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from openzim_mcp.exceptions import OpenZimMcpEntryNotFoundError
+
+
+@pytest.fixture
+def ops(tmp_path):
+    from openzim_mcp.cache import OpenZimMcpCache
+    from openzim_mcp.config import CacheConfig, ContentConfig, OpenZimMcpConfig
+    from openzim_mcp.content_processor import ContentProcessor
+    from openzim_mcp.security import PathValidator
+    from openzim_mcp.zim_operations import ZimOperations
+
+    cfg = OpenZimMcpConfig(
+        allowed_directories=[str(tmp_path)],
+        cache=CacheConfig(enabled=False, max_size=4, ttl_seconds=60),
+        content=ContentConfig(max_content_length=5000, snippet_length=200),
+    )
+    return ZimOperations(
+        cfg,
+        PathValidator(cfg.allowed_directories),
+        OpenZimMcpCache(cfg.cache),
+        ContentProcessor(snippet_length=200),
+    )
+
+
+def _archive_with_main_page() -> MagicMock:
+    archive = MagicMock()
+    archive.has_new_namespace_scheme = True
+
+    landing = MagicMock()
+    landing.path = "iep.utm.edu/"
+    landing.title = "Internet Encyclopedia of Philosophy"
+    landing.is_redirect = False
+
+    archive.main_entry = landing
+    archive.get_entry_by_path.return_value = landing
+    return archive
+
+
+class TestMainPageIsFetchable:
+    def test_w_main_page_resolves_to_the_real_entry(self, ops):
+        archive = _archive_with_main_page()
+        built: list[str] = []
+
+        def _build(actual_path):
+            built.append(actual_path)
+            return ({"path": actual_path, "content": "landing"}, True, actual_path)
+
+        result, content_ok = ops._smart_retrieve_entry(
+            archive,
+            "W/mainPage",
+            "/zim/iep.zim",
+            build=_build,
+            fetch_metadata=lambda: ({}, False),
+        )
+        # Resolved through main_entry, not looked up as a literal path.
+        assert built == ["iep.utm.edu/"]
+        assert content_ok is True
+        assert result["content"] == "landing"
+
+    def test_ordinary_paths_are_untouched(self, ops):
+        """Positive control: the W route must not shadow normal lookups."""
+        archive = _archive_with_main_page()
+        built: list[str] = []
+
+        def _build(actual_path):
+            built.append(actual_path)
+            return ({"path": actual_path, "content": "x"}, True, actual_path)
+
+        ops._smart_retrieve_entry(
+            archive,
+            "iep.utm.edu/stoicism/",
+            "/zim/iep.zim",
+            build=_build,
+            fetch_metadata=lambda: ({}, False),
+        )
+        assert built == ["iep.utm.edu/stoicism/"]
+
+
+class TestFaviconIsServedAsBytes:
+    """The illustration has no entry path, but it does have bytes.
+
+    ``get_illustration_item`` returns an Item with the same
+    size/mimetype/content surface the binary route already serves, so the
+    path browse advertises is now fetchable rather than a 404.
+    """
+
+    def test_text_route_points_at_the_binary_one(self, ops):
+        archive = _archive_with_main_page()
+        with pytest.raises(OpenZimMcpEntryNotFoundError) as exc_info:
+            ops._smart_retrieve_entry(
+                archive,
+                "W/favicon",
+                "/zim/iep.zim",
+                build=lambda p: ({}, True, p),
+                fetch_metadata=lambda: ({}, False),
+            )
+        message = str(exc_info.value)
+        assert "binary=True" in message
+        # The circular advice is what made the old message useless.
+        assert "Use browsing tools" not in message
+
+    def test_missing_illustration_says_so(self, ops):
+        archive = _archive_with_main_page()
+        archive.get_illustration_item.side_effect = RuntimeError("no illustration")
+        with pytest.raises(OpenZimMcpEntryNotFoundError) as exc_info:
+            ops._resolve_well_known_illustration(archive)
+        assert "illustration" in str(exc_info.value).lower()

--- a/tests/test_e2e_sweep_wellknown_paths.py
+++ b/tests/test_e2e_sweep_wellknown_paths.py
@@ -45,6 +45,7 @@ def ops(tmp_path):
 def _archive_with_main_page() -> MagicMock:
     archive = MagicMock()
     archive.has_new_namespace_scheme = True
+    archive.has_illustration.return_value = True
 
     landing = MagicMock()
     landing.path = "iep.utm.edu/"
@@ -125,3 +126,93 @@ class TestFaviconIsServedAsBytes:
         with pytest.raises(OpenZimMcpEntryNotFoundError) as exc_info:
             ops._resolve_well_known_illustration(archive)
         assert "illustration" in str(exc_info.value).lower()
+
+    def test_no_illustration_is_not_promised_to_the_text_caller(self, ops):
+        """Don't send the caller to a retry that cannot succeed.
+
+        The text branch matched on the path string alone, so an archive
+        carrying no illustration was told "it's an image, fetch it with
+        binary=True" — and the binary call then reported there was nothing
+        there. Two round trips to learn the first answer was false.
+        """
+        archive = _archive_with_main_page()
+        archive.has_illustration.return_value = False
+        with pytest.raises(OpenZimMcpEntryNotFoundError) as exc_info:
+            ops._smart_retrieve_entry(
+                archive,
+                "W/favicon",
+                "/zim/iep.zim",
+                build=lambda p: ({}, True, p),
+                fetch_metadata=lambda: ({}, False),
+            )
+        message = str(exc_info.value)
+        assert "binary=True" not in message
+        assert "no illustration" in message.lower()
+
+    def test_gate_asks_for_the_size_actually_served(self, ops):
+        """``has_illustration()`` means "any size"; the fetch uses 48.
+
+        An archive whose only illustration is some other size would pass a
+        bare ``has_illustration()`` and then fail the 48-px fetch, putting
+        the two surfaces right back into disagreement.
+        """
+        archive = _archive_with_main_page()
+        archive.has_illustration.return_value = True
+        with pytest.raises(OpenZimMcpEntryNotFoundError):
+            ops._smart_retrieve_entry(
+                archive,
+                "W/favicon",
+                "/zim/iep.zim",
+                build=lambda p: ({}, True, p),
+                fetch_metadata=lambda: ({}, False),
+            )
+        archive.has_illustration.assert_called_with(48)
+
+
+class TestWellKnownPathsResolveOnEverySurface:
+    """One tool must not answer contradictorily an argument apart.
+
+    The rewrite first landed only in ``_smart_retrieve_entry``, which backs
+    the plain-body and batch surfaces. ``view=toc``/``summary``/``structure``,
+    ``zim_get_section`` and ``zim_links`` resolve entries through a second,
+    independent ladder that knew nothing about ``W/``, so ``W/mainPage``
+    returned the article for one call and Resource Not Found for the next.
+    """
+
+    def test_shared_rewrite_helper_resolves_main_page(self, ops):
+        from openzim_mcp.zim.content import rewrite_well_known_path
+
+        archive = _archive_with_main_page()
+        assert rewrite_well_known_path(archive, "W/mainPage") == "iep.utm.edu/"
+
+    def test_shared_helper_passes_ordinary_paths_through(self, ops):
+        from openzim_mcp.zim.content import rewrite_well_known_path
+
+        archive = _archive_with_main_page()
+        assert (
+            rewrite_well_known_path(archive, "iep.utm.edu/stoicism/")
+            == "iep.utm.edu/stoicism/"
+        )
+
+    def test_shared_helper_ignores_old_scheme_archives(self, ops):
+        from openzim_mcp.zim.content import rewrite_well_known_path
+
+        archive = _archive_with_main_page()
+        archive.has_new_namespace_scheme = False
+        assert rewrite_well_known_path(archive, "W/mainPage") == "W/mainPage"
+
+
+class TestRootedSpellingResolves:
+    """``/W/mainPage`` must behave like ``W/mainPage``.
+
+    The binary surface normalizes at its boundary, so ``/W/favicon``
+    resolved while ``/W/mainPage`` 404'd — a divergence inside one tool on
+    the same synthetic path, because the ``W/`` check sits above the ladder
+    whose un-rooting recovery would otherwise have caught it.
+    """
+
+    def test_leading_slash_still_resolves(self, ops):
+        from openzim_mcp.zim.content import rewrite_well_known_path
+
+        archive = _archive_with_main_page()
+        assert rewrite_well_known_path(archive, "/W/mainPage") == "iep.utm.edu/"

--- a/tests/test_sweep4_search.py
+++ b/tests/test_sweep4_search.py
@@ -372,7 +372,16 @@ def test_probe_still_promotes_when_canonical_is_absent() -> None:
 
 def test_suggestions_page_keeps_last_genuine_row_when_canonical_present() -> None:
     """End-to-end consequence: a full page no longer loses its lowest
-    genuine suggestion to a spurious rank-1 promotion."""
+    genuine suggestion to a spurious rank-1 promotion.
+
+    The page is now filled from the title index rather than the full-text
+    pass (the two swapped priority once ``suggest`` mode was found to be
+    answering from Xapian and never consulting the archive's suggestion
+    index at all), so the row *order* is the title index's own
+    score-then-length ranking. What this test guards is unchanged: the page
+    still carries ``limit`` distinct, genuine rows, and the entry that did
+    not fit is reported through ``has_more`` rather than silently dropped.
+    """
     entries = {
         "iep.utm.edu/kant/": "Kant, Immanuel",
         "iep.utm.edu/kantaest/": "Kant: Aesthetics",
@@ -402,4 +411,11 @@ def test_suggestions_page_keeps_last_genuine_row_when_canonical_present() -> Non
         out = stub._generate_search_suggestions(archive, "Kant", 5)
 
     texts = [s["text"] for s in out["suggestions"]]
-    assert texts == [row["text"] for row in page]
+    paths = [s["path"] for s in out["suggestions"]]
+    assert len(texts) == 5
+    assert len(set(paths)) == 5, "a promoted canonical must not duplicate a row"
+    assert set(paths) <= set(entries), "every row must be a genuine archive entry"
+    # The shortest prefix title is the canonical article D6 exists to keep.
+    assert "Kant, Immanuel" in texts
+    # Six entries match, five fit: the sixth is flagged, not dropped.
+    assert out["has_more"] is True

--- a/tests/test_version_surfacing.py
+++ b/tests/test_version_surfacing.py
@@ -1,0 +1,49 @@
+"""Version discoverability: the CLI flag and the health report.
+
+A stale ``uv tool install`` served an old server for weeks while looking
+current, because neither the CLI nor ``zim_health`` would say what version
+was actually running — ``serverInfo.version`` exists in the initialize
+result, but most clients never surface it to the operator. These tests pin
+the two places a human can ask.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from openzim_mcp import __version__
+from openzim_mcp.config import OpenZimMcpConfig
+from openzim_mcp.main import _build_arg_parser
+from openzim_mcp.server import OpenZimMcpServer
+from openzim_mcp.server_state import _build_health_report
+
+
+def test_version_flag_prints_version_and_exits_zero(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        _build_arg_parser().parse_args(["--version"])
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert "openzim-mcp" in out
+    assert __version__ in out
+
+
+def test_version_flag_works_without_directories(capsys):
+    # argparse must answer --version before enforcing the required
+    # positional, or the flag is unreachable in practice.
+    with pytest.raises(SystemExit) as exc_info:
+        _build_arg_parser().parse_args(["--version"])
+    assert exc_info.value.code == 0
+
+
+def test_health_report_carries_server_version(tmp_path: Path):
+    cfg = OpenZimMcpConfig(
+        allowed_directories=[str(tmp_path)],
+        transport="stdio",
+        tool_mode="advanced",
+    )
+    server = OpenZimMcpServer(cfg)
+    try:
+        report = _build_health_report(server)
+        assert report["version"] == __version__
+    finally:
+        server.cache.shutdown()


### PR DESCRIPTION
# Pull Request

## Description

Fourteen defects found by driving the released 3.2.2 server against the real MedlinePlus (1.9 GB) and IEP (128 MB) archives over stdio, rather than against fixtures. Every one reproduced on the wire before the fix and was re-verified after; each is adversarially verified, so seven further claims that turned out to be documented-intentional were deliberately left alone.

The headline defect: **`suggest` mode never consulted the archive's suggestion index.** The Xapian full-text pass ran first and returned early whenever it found anything at all, so libzim's purpose-built title/prefix index only ran when full-text found *nothing* — and `done=True` then asserted completeness over a set the server had never read. On MedlinePlus, `suggestions for diab` answered with `Diabetic Diet` plus three genetics pages while the index held 99 matches and ranked the canonical `Diabetes` page first.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ Performance improvement
- [x] 🧪 Test improvements
- [x] 🔒 Security improvement

## Related Issues

None filed — these were found by the sweep rather than reported.

## Changes Made

**`suggest` consults the title index (`zim/search.py`)**

- Strategy order inverted: the title/redirect index is primary, full-text fills whatever it leaves. `diab` goes from 4 rows to 10 real prefix matches with an honest `done=False`; `diabetes` now puts `medlineplus.gov/diabetes.html` on the page at all (it was absent from the top 25).
- Title de-duplication added to the promoted path. The demoted path deduped; the title index never had to, being a cold-path fallback. MedlinePlus files each slideshow frame under its own path with one shared title, so `knee` returned 10 rows carrying 3 distinct articles. Deduping in the candidate loop keeps the `limit * 2` budget spent on distinct suggestions, so `has_more` counts rows a caller could actually pick.
- The full-text fallback is sized by `limit`, not by the leftover slots. It derives its Xapian window from the limit it is handed (`limit * 5`), so passing the leftovers shrank the window rather than the answer — one free slot scanned 10 candidates instead of 55.
- New exact-leading-segment rank tier. Site-suffixed corpora append their own name (and often a synonym list) to every heading, so `Diabetes | Type 1 Diabetes | Type 2 Diabetes | MedlinePlus` is one of the *longest* titles matching `diabetes`, and the shortest-title tiebreak buried the canonical page under half a dozen narrower ones.

**Three paths reported success while returning an error**

- A missing `M/<key>` returned `isError=false` with "Metadata key … not found" sitting in `content`, so a client rendering `content` displayed an error as though it were the article. The same miss under `A/` raised properly. It raises now, and the hint names `zim_browse(namespace="M")` — `walk namespace M` is a `zim_query` phrasing, not a tool at this surface. Batch mode still isolates it per entry (`succeeded: 2, failed: 1`).
- Enum, type and missing-argument rejections leaked pydantic's stringified report (`1 validation error for zim_searchArguments … errors.pydantic.dev/…`) instead of the JSON envelope `instructions.py` advertises. This is the leak D04 removed from `zim_browse`; only the unknown-*name* path had been closed. Union-typed arguments report their wire name, not a member tag (`compact_budget.str`) the caller never sent.
- An image fetched without `binary` gave a placeholder naming no way forward. It now names the call, spelled out — batch mode rejects a bare `binary=True`.

**The redactor mangled the caller's own URL (`security.py`)**

`entry_path="https://iep.utm.edu/epistemo/"` came back as `https:<path-hidden>`: `_ABS_PATH_RE`'s lookbehind excludes path-continuation characters but not `:`, so the `//host/path` tail read as a POSIX absolute path — hiding the very value the caller needed to see. `scheme://host/...` is masked during redaction now, and a not-found `entry_path` carrying a scheme gets told to drop it. The hint keeps the host: zimit/warc2zim archives file entries *under* it (`iep.utm.edu/stoicism/` resolves, `stoicism/` does not).

**`W/` paths browse advertises are fetchable (`zim/content.py`, `zim/structure.py`, `zim/archive.py`)**

`zim_browse(namespace="W")` and `zim_metadata` publish `W/mainPage` and `W/favicon`, and `zim_get` answered Resource Not Found for both — advising "use browsing tools", the tool that had just handed over the path.

Neither is a literal entry, so both needed a route. `W/mainPage` resolves through `archive.main_entry` and its redirect chain — the same resolution the browse row uses, so the two surfaces agree — and is handed back to the ordinary retrieval ladder, so it keeps normal entry semantics. `W/favicon` is an Item rather than an Entry, so it is served by the binary route; the bytes match libzim ground truth exactly (1,666 bytes, `image/png`, valid PNG magic).

The rewrite lives in a shared `rewrite_well_known_path` called from all three entry-resolution points — `_smart_retrieve_entry`, `_resolve_entry_with_fallback`, and `structure._build_bundle` (the single lookup the structure, TOC, links and section surfaces already share). A first cut installed it in only one of them, which left `zim_get` serving `W/mainPage` while `view=toc`, `view=structure`, `zim_get_section` and `zim_links` returned Resource Not Found for the same path — the same tool contradicting itself one argument apart, which is the defect shape this PR exists to remove. Payloads are now byte-identical between `W/mainPage` and the real landing path on every surface.

Asking for `W/favicon` without `binary=True` names that flag, but only when `has_illustration(48)` says there is something to fetch — otherwise the caller was sent into a retry that could not succeed. The size matters: the no-argument `has_illustration()` answers "any size", so a 96px-only archive would pass a bare check and still fail the 48px fetch.

**Snippet anchoring ignores function words (`content_processor.py`)**

`what causes migraines` anchored its featured passage on an off-topic article's lead because the interrogative `what` clears the three-character bar. Highlighting keeps the full term set; only the anchor decision drops function words, so the paragraph a snippet starts on is still always one the highlighter can mark.

**Version discoverability (`main.py`, `server_state.py`)**

`--version`, and a `version` field in the health report. A stale install served old code for weeks while looking current: `serverInfo.version` exists in the initialize result, but most clients never surface it and the CLI had no way to ask.

## Testing

### Test Coverage

- [x] Tests pass locally (`make test`) — 4,608 passed, 222 skipped
- [x] All quality checks pass (`make check`) — flake8, isort, black, mypy, bandit
- [x] Integration tests pass (`make test-with-zim-data`) — live suite 25 passed, 11 skipped, 0 failed, matching its pre-change baseline
- [x] New tests added for new functionality — 9 new files, one per defect area
- [x] Existing tests updated for changed functionality — one test in `test_sweep4_search.py` pinned the superseded strategy order; it now asserts the invariant it was protecting (the page keeps `limit` distinct genuine rows, and the row that did not fit is reported through `has_more`) rather than the old row order

### Manual Testing

- [x] Tested with real ZIM files — every fix verified on MedlinePlus and IEP through a stdio harness driving the real binary, before and after
- [x] Tested error conditions — all five argument-rejection classes, URL-shaped paths, missing metadata keys, missing entries, batch partial failure
- [x] Tested edge cases — empty/whitespace/unicode queries, paging, limit boundaries, archives with no title index, all-function-word queries
- [x] Verified backward compatibility — favicon bytes match libzim ground truth exactly (1,666 bytes, `image/png`, valid PNG magic)

## Security Considerations

- [x] No new security vulnerabilities introduced
- [x] Input validation added/updated where needed
- [x] Path traversal protection maintained
- [x] Error messages don't leak sensitive information
- [x] Dependencies are secure and up-to-date — no dependency changes

The URL exemption is deliberately narrow. It keys on `scheme://` with a **non-empty authority**, so `archive:/home/user/x.zim` (a labelled filesystem path) and `file:///home/…` (empty authority — the tail is a path, not a host) both keep redacting; a blanket "ignore anything after a colon" rule would have opened a hole. The mask character is stripped from the message before stashing, so caller text echoed into an error cannot forge a token and have it substituted for a URL it did not supply.

## Performance Impact

- [x] No performance regression — `suggest` is unchanged in latency despite now running the title index on every call (0.105 s cold on the 1.9 GB archive, sub-10 ms warm), because the index short-circuits the Xapian pass when it fills the page
- [x] Performance improvements included
- [x] Memory usage considered — the favicon route reads bytes only when they will be served, matching the existing binary path
- [x] Caching behavior verified — the metadata miss caches nothing, as before

Redaction went quadratic twice during development, both reachable from a long caller-supplied `entry_path` — a shape this module is hardened against elsewhere. An unanchored scheme pattern rescans the tail from every offset (25 s on 200k characters); restoring stashed URLs one `str.replace` at a time rescans the message once per URL (~53 s on 200 KB of small URLs). The scheme is anchored and length-bounded, restore is a single pass, and **both costs are pinned by tests**.

## Documentation

- [x] Code is self-documenting with clear variable/function names
- [x] Docstrings added/updated for new/changed functions
- [ ] README.md updated (if user-facing changes) — not needed
- [ ] CHANGELOG.md updated (if notable change) — release-please generates it
- [ ] API documentation updated (if API changes) — see below

**One known gap, deliberately left open.** `zim_query`'s `cursor` parameter and three working intents (`summary of <name>`, `table of contents <name>`, `section <X> of <name>`) are undocumented in the served tool description. Adding them trips two gates: the per-tool ALLOCATION ceiling at +46 B, and `test_prototype_parity_byte_budget` at 10.5 % drift against its committed snapshot. Closing it means re-deriving both ceilings and re-committing the Gate 0b snapshot — a deliberate call about the schema budget that did not belong inside a defect sweep.

## Review

Both halves of this branch were put through an adversarial multi-agent review against the real archives, and both times the review found defects in the fixes themselves — nine in the first pass, four in the second. All were fixed here; the review's refuted claims (documented-intentional behavior) were deliberately left alone.

Three of those were guards that looked stronger than they were, so the pattern is worth naming: a negative assertion ("the bad string is absent") only pins a property when *every* failure mode produces that string. The test claiming to pin "every tool body absorbs its own exceptions" asserted the absence of two substrings while an unabsorbed exception reaches the wire as the SDK's bare text block containing neither — it passed while the property was broken, proven by mutating `zim_search` to stop catching. It asserts the envelope's shape now, and was mutation-checked in both directions.

Redaction going quadratic twice (above) is the same lesson in a different register: both costs are now pinned by tests rather than by having been noticed.

## Backward Compatibility

- [x] No breaking changes
- [ ] Breaking changes documented and justified

Two behavior changes are worth naming even though neither breaks a documented contract, because a client could be relying on the old shape: a missing `M/<key>` now returns `isError=true` instead of a success-shaped payload, and schema-level argument rejections now return a JSON envelope instead of a plain-text pydantic dump. Both move *toward* the contract the server already advertises. `suggest` result ordering changes on archives with a usable title index.
