### PR TITLE
fix(ci): check the site links nothing was checking, and gate sidebar_order

### DIFF
--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -5,12 +5,24 @@ name: Website CI
 # unclosed MDX tag, or a link to a page that no longer exists merged green and
 # reddened the deploy instead. This runs the same build on the PR, plus the
 # link check the deploy path has no reason to run.
+#
+# The repo markdown paths below are here because the link check reads them too:
+# it resolves the site URLs in them against the build it just made. On a
+# website/**-only trigger this job does not run for a PR that edits only
+# README.md, so a link from there to a docs page that does not exist would
+# reach main without the one job that can see it ever starting. Keep this list
+# in step with MARKDOWN_ROOT_FILES / MARKDOWN_GLOBS in the script.
 on:
   pull_request:
     paths:
       - "website/**"
       - "scripts/check_docs_links.py"
       - ".github/workflows/website-ci.yml"
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "SECURITY.md"
+      - "CODE_OF_CONDUCT.md"
+      - "docs/*.md"
   workflow_dispatch:
 
 # PR builds are throwaway; superseding one is fine. Deliberately NOT the
@@ -56,8 +68,8 @@ jobs:
       # internal pass is offline and deterministic, so a failure there is
       # unambiguously this repo's fault, while the external pass depends on
       # remote hosts. Splitting them means the Actions UI says which kind of
-      # breakage happened without anyone reading the log. The internal pass is
-      # ~1s for 900+ links, so the repeat costs nothing.
+      # breakage happened without anyone reading the log. The internal pass
+      # resolves ~1,700 links in under 0.1s, so the repeat costs nothing.
       # The script is stdlib-only, so no Python setup step is needed.
       - name: Check internal links and anchors
         run: python3 scripts/check_docs_links.py

--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -1,20 +1,32 @@
 #!/usr/bin/env python3
-"""Link checker for the built docs site and the repo-root markdown.
+"""Link checker for the built docs site and the repo's own markdown.
 
-Two failure modes this exists to catch, both of which shipped to production:
+Three failure modes this exists to catch. The first two shipped to production;
+the third is a gap in this checker itself — nothing is known to have gone wrong
+through it, and nothing would have noticed if it had:
 
 * **Internal links and heading anchors.** Astro will happily build a page whose
   ``[text](/openzim-mcp/docs/nope/)`` goes nowhere, and an ``#anchor`` pointing
   at a heading that was renamed is invisible until a reader clicks it.
 * **External links to things that no longer exist.** The site offered GitHub
-  Discussions as its primary support channel on four pages while Discussions
-  was disabled on the repository, and advertised a ``.well-known/security.txt``
+  Discussions as a support channel on six pages while Discussions was
+  disabled on the repository, and advertised a ``.well-known/security.txt``
   that GitHub Pages cannot serve from a project path.
+* **Links to our own site written absolutely.** ``README.md`` points readers at
+  ``https://cameronrye.github.io/openzim-mcp/docs/...`` throughout. Such a URL
+  used to fall between the two halves below and be checked by neither: the
+  internal pass skipped every absolute href, and the external pass skipped
+  every URL under the site's own base on the assumption that the internal pass
+  had already covered it. A wrong one — a page renamed, or a path typed by
+  hand — would have been reported by nothing. No such link is known to have
+  shipped; the point is that one could have. Both halves now resolve them
+  against the build, sharing one index and one matcher so they cannot disagree.
 
 Internal checking is offline and deterministic, so it always runs. External
 checking needs the network and is opt-in via ``--external``; it fails only on a
 definitive 4xx, because a 5xx or a timeout says something about the remote host
-rather than about this repository.
+rather than about this repository. Resolving a link to our own site is offline
+either way — it is answered by the build, never by an HTTP probe.
 
 Usage::
 
@@ -33,7 +45,8 @@ import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
-from urllib.parse import unquote, urldefrag
+from typing import NamedTuple
+from urllib.parse import unquote, urldefrag, urlsplit
 
 REPO = Path(__file__).resolve().parents[1]
 DEFAULT_DIST = REPO / "website" / "dist"
@@ -41,19 +54,71 @@ BASE = "/openzim-mcp"
 
 HREF_RE = re.compile(r'href="([^"]+)"')
 ID_RE = re.compile(r'id="([^"]+)"')
-# Markdown URLs may contain balanced parentheses — Wikipedia's
-# ``ZIM_(file_format)`` is the case in this repo — so a lazy ``[^)]+`` would
-# truncate the URL and then report the truncation as a 404.
-MD_LINK_RE = re.compile(r"\[[^\]]*\]\((https?://(?:[^()\s]|\([^()\s]*\))+)\)")
+
+# A fenced code block, opening or closing. Everything between a pair of these
+# is blanked before any of MARKDOWN_URL_RES runs, so a URL in a shell
+# transcript or a config sample is never mistaken for a link this repo makes.
+# Today that blanking removes nothing: every URL currently written inside a
+# fence is bare, and bare URLs are already excluded below. It earns its place
+# on the sample that is written as a markdown link or an ``<a href>`` — the
+# forms below cannot tell that one from a real one, and this can.
+MD_FENCE_RE = re.compile(r"^\s{0,3}(?:```|~~~)")
+
+# The link forms a URL can take in this repo's markdown. All four are needed:
+# matching only the first left README.md's own most prominent docs pointer —
+# written as an autolink — collected by nothing.
+#
+# NOT collected, deliberately: a bare unbracketed URL in prose. CommonMark does
+# not linkify one, GitHub's renderer does, and telling the two apart from a
+# regex is guesswork that costs false positives on every URL this repo writes
+# inside backticks. Write a URL you want checked as a link, not as bare text.
+MARKDOWN_URL_RES = (
+    # ``[text](url)``. Markdown URLs may contain balanced parentheses —
+    # Wikipedia's ``ZIM_(file_format)`` is the case in this repo — so a lazy
+    # ``[^)]+`` would truncate the URL and report the truncation as a 404.
+    re.compile(r"\[[^\]]*\]\((https?://(?:[^()\s]|\([^()\s]*\))+)\)"),
+    # ``<url>`` autolink. README.md's "Full documentation lives at" pointer,
+    # the most prominent docs link it has, is written this way.
+    re.compile(r"<(https?://[^<>\s]+)>"),
+    # ``[label]: url`` reference definition, optionally angle-bracketed.
+    re.compile(r"^ {0,3}\[[^\]]+\]:\s*<?(https?://[^>\s]+?)>?\s*$", re.M),
+    # Raw HTML in markdown: README.md's logo and badge block is written as
+    # ``<a href>`` and ``<img src>``, which none of the three forms above
+    # match. Inline links still outnumber them in that file; the point is not
+    # that they are the majority, it is that nothing else collects them.
+    re.compile(r'(?:href|src)="(https?://[^"]+)"'),
+)
+
+# Repo markdown that is an input to this check. The four at the root are the
+# repository's front-matter documents — GitHub renders README.md on the project
+# page and surfaces the other three through the community profile and their own
+# tabs; docs/ holds operator notes that are not
+# part of the built site but link into it — docs/extras-reranker.md and
+# docs/roadmap.md each carry a site URL. These live outside website/, so
+# website-ci.yml lists them in its `paths:` trigger: without that, a PR
+# touching only README.md never runs the job that reads it. Add a path here
+# and add it there too.
+MARKDOWN_ROOT_FILES = (
+    "README.md",
+    "CONTRIBUTING.md",
+    "SECURITY.md",
+    "CODE_OF_CONDUCT.md",
+)
+MARKDOWN_GLOBS = ("docs/*.md",)
 
 NON_HTTP_SCHEMES = ("mailto:", "javascript:", "tel:", "data:", "#")
+
+# A link to the reader's own machine — CONTRIBUTING.md tells contributors to
+# open the dev server at <http://localhost:4321/openzim-mcp/>. There is nothing
+# to probe, and its http:// is correct rather than a downgrade to flag.
+LOCAL_HOSTS = ("localhost", "127.0.0.1", "0.0.0.0", "[::1]", "::1")
 
 # The site's own absolute URL. Every page emits its own canonical link, and
 # cross-page links are sometimes written absolute, so probing these against the
 # live deployment asks "is this page already published?" — which is false for
 # every page a PR adds. That made the check structurally red on exactly the
-# change it most needed to pass. Internal reachability is already proven
-# offline by check_internal(), so these are resolved there, not over HTTP.
+# change it most needed to pass. So these are never probed; they are resolved
+# against the build, by _resolve_path() on both sides of the checker.
 SITE_ORIGIN = "https://cameronrye.github.io"
 SITE_BASE = f"{SITE_ORIGIN}{BASE}"
 
@@ -77,17 +142,44 @@ def _url_path(dist: Path, path: Path) -> str:
     return f"{BASE}/{rel}".replace("//", "/")
 
 
-def check_internal(dist: Path) -> tuple[list[str], int]:
-    """Return (problems, number of links checked)."""
+class NoBuild(Exception):
+    """website/dist is missing or empty. Both halves of the checker need it."""
+
+
+class SiteIndex(NamedTuple):
+    """The built site, indexed once so both halves resolve links identically.
+
+    Before this existed, check_internal() built these maps privately and
+    check_external() had no way to reach them, so it skipped every URL under
+    SITE_BASE on the assumption that the internal pass had already proven it.
+    That was true for relative hrefs in built HTML and false for absolute
+    site URLs — most of all the ones in the repo's markdown, which the
+    internal pass never reads at all.
+
+    * ``sources`` — page URL path -> the HTML text of that page.
+    * ``ids`` — page URL path -> the set of ``id=""`` values on that page.
+    * ``pages`` — every page URL path (the keys of ``ids``).
+    * ``assets`` — every file in the build as a URL path, HTML included.
+    """
+
+    sources: dict[str, str]
+    ids: dict[str, set[str]]
+    pages: set[str]
+    assets: set[str]
+
+
+def build_index(dist: Path) -> SiteIndex:
+    """Index the built site. Raises NoBuild when there is nothing to index."""
     if not dist.is_dir():
-        return [f"dist directory not found: {dist} (run `npm run build` first)"], 0
+        raise NoBuild(f"dist directory not found: {dist} (run `npm run build` first)")
 
-    pages = {p: p.read_text(encoding="utf-8") for p in dist.rglob("*.html")}
-    if not pages:
-        return [f"no HTML found under {dist}"], 0
+    sources = {
+        _url_path(dist, p): p.read_text(encoding="utf-8") for p in dist.rglob("*.html")
+    }
+    if not sources:
+        raise NoBuild(f"no HTML found under {dist}")
 
-    ids = {_url_path(dist, p): set(ID_RE.findall(src)) for p, src in pages.items()}
-    known = set(ids)
+    ids = {here: set(ID_RE.findall(src)) for here, src in sources.items()}
 
     assets: set[str] = set()
     for p in dist.rglob("*"):
@@ -98,49 +190,139 @@ def check_internal(dist: Path) -> tuple[list[str], int]:
                 else f"{BASE}/{p.relative_to(dist).as_posix()}"
             )
 
+    return SiteIndex(sources=sources, ids=ids, pages=set(ids), assets=assets)
+
+
+def _site_target(url: str) -> tuple[str, str] | None:
+    """Split a URL of *our own* site into (site path, fragment), else None.
+
+    Two things this gets right that a bare ``url.startswith(SITE_BASE)`` did
+    not. The prefix tested is ``SITE_BASE + "/"``, so a sibling project on the
+    same GitHub Pages user site — ``…github.io/openzim-mcp-other/`` — reads as
+    somebody else's URL to probe rather than as a page of ours gone missing.
+    And the query string is dropped before matching, because a static build has
+    no query strings in its filenames: keeping one would turn a working link
+    into a phantom "no such page".
+    """
+    rest, frag = urldefrag(url)
+    rest = rest.partition("?")[0]
+    if not rest.startswith(SITE_BASE + "/"):
+        return None
+    return rest[len(SITE_ORIGIN) :], frag
+
+
+def _resolve_path(target: str, frag: str, index: SiteIndex) -> str | None:
+    """Match one absolute site path plus fragment against the build.
+
+    Returns a short reason the link does not resolve, or None when it does.
+    This is the whole of the matching rule — percent-decoding included — and
+    both halves of the checker call it, so neither can drift into accepting a
+    link the other rejects. Matching is exact: ``/openzim-mcp/docs`` does not
+    match the built ``/openzim-mcp/docs/``, because the trailing slash is what
+    the build actually emits and a redirect is not a link that resolves.
+    """
+    target = unquote(target)
+    if target in index.pages:
+        if frag and frag not in index.ids[target]:
+            return "no such anchor on target"
+        return None
+    if target in index.assets:
+        return None
+    return "no such page"
+
+
+def _resolve_href(here: str, link: str, index: SiteIndex) -> str | None:
+    """Resolve one href as written on the page at ``here``.
+
+    Handles the two forms an absolute site URL never takes — a bare
+    ``#fragment`` and a page-relative path — then defers to _resolve_path().
+    """
+    target, frag = urldefrag(link)
+    if not target:
+        if frag and frag not in index.ids.get(here, set()):
+            return "no such anchor on this page"
+        return None
+    if not target.startswith("/"):
+        base_dir = os.path.dirname(here.rstrip("/") + "/x")
+        target = os.path.normpath(os.path.join(base_dir, target))
+        # normpath eats a trailing slash; the build's page paths carry one.
+        if link.endswith("/") and not target.endswith("/"):
+            target += "/"
+    return _resolve_path(target, frag, index)
+
+
+def check_internal(index: SiteIndex) -> tuple[list[str], int]:
+    """Return (problems, number of links checked).
+
+    Checks every href in the built HTML that points inside the site: relative
+    paths, same-page ``#anchor``s, and absolute URLs under SITE_BASE. Hrefs to
+    another host are left to check_external(); the first four NON_HTTP_SCHEMES
+    (``mailto:``, ``javascript:``, ``tel:``, ``data:``) are checked by neither
+    half — the fifth, ``#``, is the same-page anchor case, which is checked
+    here. This reads built HTML only: the site URLs in the repo's markdown are
+    check_external()'s, and only its.
+    """
     problems: list[str] = []
     checked = 0
-    for page, src in pages.items():
-        here = _url_path(dist, page)
+    for here, src in index.sources.items():
         for raw_href in HREF_RE.findall(src):
             raw = html.unescape(raw_href)
-            if raw.startswith(NON_HTTP_SCHEMES[:-1]) or raw.startswith(
+            site = _site_target(raw)
+            if site is not None:
+                # An absolute link to our own site is an internal link written
+                # the long way — every page's canonical <link> is one, and
+                # hand-written cross-page links sometimes are. Resolving it
+                # here keeps it in the offline, always-on pass instead of
+                # leaving it to a network pass that is opt-in.
+                reason = _resolve_path(site[0], site[1], index)
+            elif raw.startswith(NON_HTTP_SCHEMES[:-1]) or raw.startswith(
                 ("http://", "https://")
             ):
                 continue
+            else:
+                reason = _resolve_href(here, raw, index)
             checked += 1
-            target, frag = urldefrag(raw)
-            if not target:
-                if frag and frag not in ids.get(here, set()):
-                    problems.append(f"{here} -> {raw} (no such anchor on this page)")
-                continue
-            if not target.startswith("/"):
-                base_dir = os.path.dirname(here.rstrip("/") + "/x")
-                target = os.path.normpath(os.path.join(base_dir, target))
-                if raw.endswith("/") and not target.endswith("/"):
-                    target += "/"
-            target = unquote(target)
-            if target in known:
-                if frag and frag not in ids[target]:
-                    problems.append(f"{here} -> {raw} (no such anchor on target)")
-            elif target not in assets:
-                problems.append(f"{here} -> {raw} (no such page)")
+            if reason:
+                problems.append(f"{here} -> {raw} ({reason})")
     return problems, checked
 
 
-def _collect_external(dist: Path) -> dict[str, set[str]]:
+def _markdown_files() -> list[tuple[str, Path]]:
+    """(display name, path) for every repo markdown file this check reads."""
+    found = [(name, REPO / name) for name in MARKDOWN_ROOT_FILES]
+    for pattern in MARKDOWN_GLOBS:
+        found += [
+            (p.relative_to(REPO).as_posix(), p) for p in sorted(REPO.glob(pattern))
+        ]
+    return [(name, path) for name, path in found if path.is_file()]
+
+
+def _outside_fences(text: str) -> str:
+    """``text`` with every line of every fenced code block replaced by ""."""
+    kept: list[str] = []
+    in_fence = False
+    for line in text.splitlines():
+        if MD_FENCE_RE.match(line):
+            in_fence = not in_fence
+            kept.append("")
+        else:
+            kept.append("" if in_fence else line)
+    return "\n".join(kept)
+
+
+def _collect_external(index: SiteIndex) -> dict[str, set[str]]:
+    """Absolute URL -> the pages and files that reference it."""
     urls: dict[str, set[str]] = {}
-    for page in dist.rglob("*.html"):
-        here = _url_path(dist, page)
-        for raw in HREF_RE.findall(page.read_text(encoding="utf-8")):
+    for here, src in index.sources.items():
+        for raw in HREF_RE.findall(src):
             url = html.unescape(raw)
             if url.startswith(("http://", "https://")):
                 urls.setdefault(url, set()).add(here)
-    for name in ("README.md", "CONTRIBUTING.md", "SECURITY.md", "CODE_OF_CONDUCT.md"):
-        md = REPO / name
-        if md.is_file():
-            for url in MD_LINK_RE.findall(md.read_text(encoding="utf-8")):
-                urls.setdefault(url, set()).add(name)
+    for name, md in _markdown_files():
+        prose = _outside_fences(md.read_text(encoding="utf-8"))
+        for pattern in MARKDOWN_URL_RES:
+            for url in pattern.findall(prose):
+                urls.setdefault(html.unescape(url), set()).add(name)
     return urls
 
 
@@ -187,19 +369,51 @@ def _probe(url: str, timeout: float) -> int | None:
     return None
 
 
-def check_external(dist: Path, timeout: float) -> tuple[list[str], list[str], int]:
-    """Return (problems, skipped, number probed)."""
+def check_external(
+    index: SiteIndex, timeout: float
+) -> tuple[list[str], list[str], int]:
+    """Return (problems, skipped, number probed).
+
+    Sources: every absolute ``href`` in the built HTML, plus the URLs in the
+    repo markdown that _markdown_files() lists — collected from the four link
+    forms in MARKDOWN_URL_RES (inline, autolink, reference definition, raw
+    ``href``/``src`` attribute).
+
+    Not covered, so that nobody reads more into a green run than it means: a
+    bare unbracketed URL in markdown prose; anything inside a fenced code
+    block; and, in the built HTML, an absolute ``src`` — HREF_RE reads
+    ``href`` alone, so an ``<img src>`` pointing at another host is collected
+    by neither half of this checker. A URL written any of those ways is
+    checked by nothing at all.
+
+    Only the URLs that reach the ``_probe`` call at the bottom are counted as
+    probed: links to our own site are resolved against the build, "edit this
+    page" links against the working tree, and loopback URLs and the
+    rate-limiting hosts are listed as skipped.
+    """
     problems: list[str] = []
     skipped: list[str] = []
     probed = 0
-    for url, sources in sorted(_collect_external(dist).items()):
+    for url, sources in sorted(_collect_external(index).items()):
+        site = _site_target(url)
+        if site is not None:
+            # Our own page, resolved against the build rather than probed: the
+            # live site lags by a deploy, so an HTTP probe would ask "is this
+            # page already published?" — false for every page a PR adds.
+            # check_internal() covers the hrefs in built HTML but not the repo
+            # markdown, which only this function reads; before both halves
+            # shared this matcher, a site URL written there was resolved by
+            # neither. Same matcher as check_internal(), so the two cannot
+            # disagree about what resolves.
+            reason = _resolve_path(site[0], site[1], index)
+            if reason:
+                problems.append(f"{url} ({reason}; referenced by {sorted(sources)[0]})")
+            continue
+        if (urlsplit(url).hostname or "") in LOCAL_HOSTS:
+            skipped.append(f"{url} (loopback — nothing to probe)")
+            continue
         if not url.startswith("https://"):
             problems.append(f"{url} (non-HTTPS; referenced by {sorted(sources)[0]})")
-            continue
-        if url.startswith(SITE_BASE):
-            # Our own page. check_internal() already proved it resolves in the
-            # build we just made; the live site is irrelevant and lags by a
-            # deploy.
             continue
         if url.startswith(EDIT_LINK_PREFIX):
             # A repo file. Check the working tree, not github.com — on a branch
@@ -240,14 +454,26 @@ def main() -> int:
     ap.add_argument("--timeout", type=float, default=20.0)
     args = ap.parse_args()
 
-    internal, n_internal = check_internal(args.dist)
+    # Indexed once and shared: both halves resolve in-site links against the
+    # same page, anchor and asset maps, so neither can accept a link the other
+    # rejects. Without a build there is nothing for either half to resolve
+    # against, so stop rather than report every in-site link as broken.
+    try:
+        index = build_index(args.dist)
+    except NoBuild as exc:
+        print("internal links checked: 0")
+        print(f"  BROKEN  {exc}")
+        print("\n1 broken link(s).")
+        return 1
+
+    internal, n_internal = check_internal(index)
     print(f"internal links checked: {n_internal}")
     for problem in internal:
         print(f"  BROKEN  {problem}")
 
     external: list[str] = []
     if args.external:
-        external, skipped, n_external = check_external(args.dist, args.timeout)
+        external, skipped, n_external = check_external(index, args.timeout)
         print(f"external URLs probed: {n_external}")
         for problem in external:
             print(f"  BROKEN  {problem}")

--- a/tests/test_docs_freshness.py
+++ b/tests/test_docs_freshness.py
@@ -344,7 +344,7 @@ def test_api_reference_enum_values_match() -> None:
 
 
 # --------------------------------------------------------------------------
-# 4. The sidebar's group list must cover the schema's group enum.
+# 4. The docs ordering surface: group lists, and sidebar_order within them.
 # --------------------------------------------------------------------------
 
 _CONTENT_CONFIG = REPO / "website/src/content.config.ts"
@@ -395,6 +395,82 @@ def test_every_doc_group_is_renderable() -> None:
         elif match.group(1).strip().strip("\"'") not in nav_groups:
             bad.append(f"{page.name}: group {match.group(1).strip()!r}")
     assert not bad, f"pages with a group the sidebar cannot render: {bad}"
+
+
+# `sidebar_order` had no gate at all: `grep -rl sidebar_order tests/ scripts/
+# .github/` returned nothing. It is the one field in the ordering surface that
+# a renumber touches on every page it moves, which makes a collision cheap to
+# introduce and invisible once introduced.
+def _sidebar_orders_by_group() -> dict[str, list[tuple[int, str]]]:
+    """Map each frontmatter ``group`` to its ``(sidebar_order, filename)`` pairs."""
+    by_group: dict[str, list[tuple[int, str]]] = {}
+    unparsed: list[str] = []
+    for page in sorted((REPO / "website/src/content/docs").glob("*.mdx")):
+        text = page.read_text(encoding="utf-8")
+        group = re.search(r"^group:\s*(.+)$", text, re.M)
+        order = re.search(r"^sidebar_order:\s*(-?\d+)\s*$", text, re.M)
+        if group is None or order is None:
+            unparsed.append(page.name)
+            continue
+        key = group.group(1).strip().strip("\"'")
+        by_group.setdefault(key, []).append((int(order.group(1)), page.name))
+    assert not unparsed, (
+        f"pages with no group or no integer sidebar_order: {unparsed}. "
+        "Every .mdx under content/docs carries both; a page this helper "
+        "cannot read is a page the gate below would have skipped."
+    )
+    return by_group
+
+
+def test_sidebar_order_is_unique_and_dense_within_each_group() -> None:
+    """Each group's ``sidebar_order`` values must be exactly 1..n.
+
+    This reads the numbers out of frontmatter and compares them to
+    ``range(1, n + 1)``. It says nothing about whether that sequence is the
+    intended reading order — only that it is a permutation of 1..n.
+
+    ``sortDocsForNav`` is the field's only reader and ``content.config.ts``
+    types it as a bare ``z.number()``, so two pages in one group sharing a
+    number is valid frontmatter. It builds clean with no warning, and because
+    the sort is stable the tie falls through to whatever order the content
+    loader emitted — an order nobody authored. ``docs-order.ts`` calls
+    ``sortDocsForNav`` "the single sort every navigation surface uses", and it
+    means every one: the sidebar, the prev/next chain, and the ``llms.txt``
+    and ``llms-full.txt`` endpoints all ship the tie. They agree with each
+    other, since all apply the same stable sort to the same collection. What
+    is lost is the author's intent, silently, while the frontmatter claims
+    otherwise.
+
+    A hole in a group's sequence renders identically to a dense one, so it is
+    not itself a rendering bug. It is gated because it is the visible trace of
+    a half-applied renumber, and a half-applied renumber is what leaves the
+    duplicate behind.
+    """
+    offenders: list[str] = []
+    for group, pages in sorted(_sidebar_orders_by_group().items()):
+        orders = sorted(order for order, _ in pages)
+        expected = list(range(1, len(pages) + 1))
+        if orders == expected:
+            continue
+        duplicated = sorted({o for o in orders if orders.count(o) > 1})
+        holes = sorted(set(expected) - set(orders))
+        detail = f"{group!r}: {len(pages)} pages numbered {orders}, expected {expected}"
+        if duplicated:
+            detail += f"; duplicated: {duplicated}"
+        if holes:
+            detail += f"; missing: {holes}"
+        listing = ", ".join(f"{order}={name}" for order, name in sorted(pages))
+        offenders.append(f"{detail}\n      {listing}")
+    assert not offenders, (
+        "sidebar_order must be a permutation of 1..n within each group.\n  "
+        + "\n  ".join(offenders)
+        + "\n  Neither shape errors the build. On a duplicate the sort is "
+        "stable, so tied pages fall back to the content loader's own emission "
+        "order on every navigation surface sortDocsForNav feeds and ship in an "
+        "order nobody wrote. A hole is a renumber that missed a page: the sort "
+        "still resolves, so the group silently stops saying what its author "
+        "meant. Both stay green."
+    )
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Two gaps the accuracy sweep exposed but did not close, plus the gate that makes the
sidebar regroup safe to attempt.

## The link checker could not see its own site links

A URL pointing at our own site fell between the checker's two passes. `check_internal`
walks the built HTML and skips every absolute href. `check_external` then skipped
everything under `SITE_BASE`, on a comment's assumption that the internal pass had
already proved it. That assumption holds for relative hrefs in built HTML and fails for
absolute ones — and for the four root markdown files, which the internal pass never reads.

Net: **17 site URLs in README.md and CONTRIBUTING.md were validated by nothing.**

Both halves now share one site index and one matcher, so they cannot disagree about what
resolves. Site URLs are resolved offline against the build rather than probed — asking
the live site whether a page exists is the wrong question on a PR that adds the page.

Collection was the other half of the same gap: only `[text](url)` was collected, so
autolinks, reference-style definitions and raw `href` attributes were invisible. That
included README.md's most prominent docs pointer, which is written as an autolink — I
confirmed by mutation that pointing it at a nonexistent page printed "All links resolve."
All four forms are collected now, from `docs/*.md` as well as the four root files.

`internal links checked: 1645 → 1665` (each page's own canonical link, previously skipped
by both halves). `external URLs probed: 31 → 46`.

Deliberately not closed, and named in the docstring rather than implied away: `src=`
attributes are collected by neither half. The two that exist are shields.io badges, and
probing them would put a live network dependency on every pull request.

`website-ci.yml` only triggered on `website/**`, so a PR touching only README.md never ran
the checker that reads it. The root files and `docs/*.md` are in its `paths:` now.

## sidebar_order was guarded by nothing

`grep -rl sidebar_order tests/ scripts/ .github/` returned nothing, while `sidebar_order`
is half of the sort key every navigation surface uses. Neither failure shape errors: a
duplicate falls through to the content loader's emission order, so tied pages ship in an
order nobody wrote across the sidebar, prev/next, `llms.txt` and `llms-full.txt`; a hole
is a renumber that missed a page. Both stay green.

The gate asserts each group's numbers are a permutation of 1..n. It passes on the current
corpus unchanged, and a legitimate reorder within a group still passes — which is the case
that matters, since the planned sidebar regroup is exactly the edit that would otherwise
introduce a duplicate.

## Verification

Every claim above was proved by mutation and reverted: autolink and reference-style
definitions to missing pages, a bogus anchor, a query-string URL (passes on a real page,
caught on a missing one), a prefix-sharing sibling path (treated as external, not as a
missing page of ours), coverage of both `docs/*.md` files, and the sidebar gate's
duplicate / hole / legitimate-renumber cases.

4657 passed, 222 skipped, 46 deselected. black, flake8, mypy clean. Site builds; checker
green with and without `--external`.
