### PR TITLE
docs: ship the three deferred judgement calls, in their decided form

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -443,12 +443,46 @@ Include:
 - **Error messages**: Full stack traces
 - **ZIM files**: Information about test files used
 
+## Project scope
+
+The feature-request template requires you to confirm that a proposal "aligns
+with the project's goals and scope". This section is what that checkbox
+points at.
+
+OpenZIM MCP is a retrieval server over ZIM archives held on the machine it
+runs on. The list below is the standing set of non-goals — things deliberately
+not built, rather than things not built yet. A proposal that lands in one of
+them is not necessarily a bad idea; it belongs in a layer above this server,
+or in a different project.
+
+- **No network-fetching tools.** Every answer comes out of a local archive.
+  Tools that reach the live web are out of scope.
+- **No built-in summarization LLM.** `zim_query`'s `synthesize=True` mode runs
+  search, fusion, passage extraction, section attribution and citation
+  rendering — retrieval and assembly, not generation. Writing prose over the
+  passages is the calling model's job.
+- **No HyDE** (hypothetical document expansion). Rejected as a non-goal during
+  the v2 work; see `docs/roadmap.md` for that record.
+- **The advanced tool surface is 8 tools** — `zim_query`, `zim_search`,
+  `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`,
+  `zim_health`. Adding or removing one breaks every client that enumerates
+  tools, so the count changes only at a major version. New capability goes on
+  an existing tool as a mode, a view or an argument.
+- **No federated search beyond the archives this server is configured with.**
+  Cross-archive search is `zim_search(cross_file=True)`, which fans out over
+  the configured archives. Querying remote OpenZIM MCP instances or
+  third-party indexes is out of scope.
+- **libzim stays the reader.** Swapping it for another ZIM implementation is
+  out of scope.
+
+Something not on this list is fair game — open a feature request.
+
 ## Feature Requests
 
 ### Before Requesting
 
 1. **Check existing issues**
-2. **Consider scope**: Does it fit the project goals?
+2. **Consider scope**: Does it fit the project goals? See [Project scope](#project-scope) for the standing non-goals.
 3. **Think about implementation**: How might it work?
 
 ### Feature Request Template

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,9 @@ We actively support the following versions of OpenZIM MCP with security updates:
 | older majors                         | No (upgrade to the latest release)                          |
 | < 2.0                                | No (the v1.x window closed when v2.5.0 shipped, 2026-06-18) |
 
-The supported row tracks the current major automatically (release-please bumps it), so a major release never leaves this table pointing at a retired line.
+The supported row tracks the current major automatically (release-please bumps it), so a major release never leaves this table pointing at a retired line. "Supported" means the latest patch release of that major line: earlier patches on the line are not separately maintained, and a fix ships forward in a new patch release rather than being reissued against an older one. Upgrading to the newest patch is therefore how you receive one.
+
+Individual features are retired on their own schedule, independent of the table above. The [Deprecations in flight](https://cameronrye.github.io/openzim-mcp/docs/upgrading/#deprecations-in-flight) table lists each feature that still works but is scheduled for removal, the release that removes it, and its replacement.
 
 ## Reporting a Vulnerability
 
@@ -233,7 +235,7 @@ When security updates are released:
 
 1. **Immediate**: Critical vulnerabilities require immediate updates
 2. **Scheduled**: Lower severity issues may be bundled with regular releases
-3. **Backports**: Security fixes are backported to supported versions
+3. **Backports**: A fix ships in the next patch release of the current major. There is no scheduled backport program; issuing a fix on a superseded major line is at the maintainer's discretion, decided per report.
 
 ## Bug Bounty Program
 

--- a/tests/test_docs_consistency.py
+++ b/tests/test_docs_consistency.py
@@ -95,12 +95,29 @@ def test_no_doc_pins_the_support_policy_to_a_hardcoded_series() -> None:
 
 
 def test_security_policy_supports_the_current_major() -> None:
-    """SECURITY.md's supported row names the major the package actually is.
+    """SECURITY.md's table names one supported major and defines the word.
 
-    The table said 2.6.x while 3.0.0 was the shipped release; it drifts
-    because SECURITY.md is hand-maintained. The row now carries an
-    x-release-please-major marker so release-please bumps it, and this test
-    fails if either the marker or the sync is ever lost.
+    Three separate failures, one test:
+
+    * **The row goes stale.** The table said 2.6.x while 3.0.0 was the shipped
+      release, because SECURITY.md is hand-maintained. The row now carries an
+      x-release-please-major marker so release-please bumps it; the first
+      assertion fails if either the marker or the sync is lost.
+    * **The definition gets dropped.** "Supported" is ambiguous between "any
+      release on that major line" and "the newest patch on it"; the prose says
+      the latter. Nothing else in the repo states it, so an editing pass that
+      trims the paragraph would silently un-define the policy.
+    * **A second supported line creeps back.** 3c03dbf added a
+      "Yes (through <date> or until vX ships)" row for the previous major on
+      v2.0.0 GA day; it named the wrong series, produced no release, and was
+      removed by dbcd3f7. release-please's updater bumps exactly one row and
+      does no date arithmetic, so any second Yes is hand-maintained prose in
+      the one file automated because hand-maintenance drifted. Exactly one
+      Yes cell is the invariant.
+
+    This checks the table's shape and the definition sentence. It does not
+    check that the No rows describe real releases, or that any of the policy
+    is honoured in practice.
     """
     import openzim_mcp
 
@@ -109,3 +126,24 @@ def test_security_policy_supports_the_current_major() -> None:
     assert re.search(
         rf"\|\s*{major}\.x[^|]*\|\s*Yes", security
     ), f"SECURITY.md must list {major}.x as supported"
+
+    # The section, not the whole file: SECURITY.md carries other tables
+    # (the response-timeline one) whose cells must not be counted here.
+    section = security.split("## Supported Versions", 1)[1].split("\n## ", 1)[0]
+
+    assert "the latest patch release of that major line" in section, (
+        "SECURITY.md's Supported Versions section must keep defining "
+        '"supported" as the latest patch release of the major line'
+    )
+
+    cells = [
+        cell.strip()
+        for line in section.splitlines()
+        if line.strip().startswith("|")
+        for cell in line.strip().strip("|").split("|")
+    ]
+    supported = [cell for cell in cells if cell.startswith("Yes")]
+    assert len(supported) == 1, (
+        "SECURITY.md's supported-versions table must have exactly one Yes "
+        f"cell (one supported major line); found {supported}"
+    )

--- a/tests/test_docs_freshness.py
+++ b/tests/test_docs_freshness.py
@@ -25,6 +25,7 @@ a test rather than a review habit:
 
 from __future__ import annotations
 
+import datetime as dt
 import json
 import re
 import tempfile
@@ -2286,4 +2287,220 @@ def test_every_doc_page_carries_the_support_policy_footer() -> None:
         "blocks not counting — so the exemption is buying nothing. Put it back "
         "in the hero blockquote or give the page the footer every other page "
         "has."
+    )
+
+
+# --------------------------------------------------------------------------
+# 14. The release stamp: both halves on the machine routes, version alone on
+#     the human page.
+# --------------------------------------------------------------------------
+
+# `website/src/pages/llms.txt.ts` holds the two stamped literals the whole site
+# derives its release stamp from — `VERSION`, carrying an
+# `x-release-please-version` annotation, and `RELEASED`, carrying an
+# `x-release-please-date` one. The file is registered in
+# release-please-config.json's extra-files as a `generic` entry, which is what
+# makes both annotations live.
+#
+# Everything else imports them. That is the whole point of this gate: a second
+# stamped literal anywhere would be a second thing to keep in step, and the
+# stamped-literal-that-nobody-stamps is the defect this module was opened for
+# (see the module docstring, item 2).
+_LLMS_FULL_SRC = REPO / "website" / "src" / "pages" / "llms-full.txt.ts"
+_MD_ROUTE_SRC = REPO / "website" / "src" / "pages" / "docs" / "[...slug].md.ts"
+_DOCS_LAYOUT_SRC = REPO / "website" / "src" / "layouts" / "DocsLayout.astro"
+
+# `export const NAME = 'value'; // x-release-please-<scope>`
+_STAMP_DECL_RE = re.compile(
+    r"^export const (VERSION|RELEASED) = '([^']*)'; // (x-release-please-\w+)$",
+    re.MULTILINE,
+)
+
+# A bare `YYYY-MM-DD`, to prove the human layout carries none.
+_ISO_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
+
+# Comments in an `.astro` file: a line whose first non-space characters are
+# `//` (inside the frontmatter fence), and `<!-- ... -->` blocks in the markup.
+# Both are stripped before the layout is checked for a date or a `RELEASED`
+# reference, because the layout *explains* the no-date decision in prose and
+# that prose is not a rendered date.
+#
+# Known limits, stated rather than implied: only line-leading `//` is
+# recognised — a trailing `// RELEASED` comment would still trip the check, and
+# `//` inside a string (every URL in the file) is deliberately left alone. The
+# failure direction is a false alarm with a message naming the line, not a
+# silent pass.
+#
+# The two alternations carry their own flags rather than sharing `re.DOTALL`.
+# Written as `re.compile(r"(?m)^\s*//.*$|<!--.*?-->", re.DOTALL)` the `.*` in
+# the line-comment branch ran past its newline and swallowed the entire rest of
+# the file from the first `//` comment onwards — which in this layout is the
+# comment above `releaseUrl`, i.e. everything the checks below actually read. A
+# mutation that inserted a literal date into the rendered markup passed.
+_ASTRO_COMMENT_RE = re.compile(r"(?m:^[ \t]*//[^\n]*)|(?s:<!--.*?-->)")
+
+
+def _stamp_constants() -> dict[str, tuple[str, str]]:
+    """The two stamped literals, as ``{name: (value, annotation)}``."""
+    src = _LLMS_TXT_SRC.read_text(encoding="utf-8")
+    found = {
+        name: (value, marker) for name, value, marker in _STAMP_DECL_RE.findall(src)
+    }
+    # Guard the guard: if the declarations are reformatted out of the regex's
+    # reach, every check below would pass on an empty dict.
+    assert set(found) == {"VERSION", "RELEASED"}, (
+        f"{_LLMS_TXT_SRC.relative_to(REPO)} no longer declares both stamped "
+        f"literals in the form this gate reads "
+        f"(`export const NAME = '...'; // x-release-please-<scope>`); found "
+        f"{sorted(found)}. Update _STAMP_DECL_RE and this test together."
+    )
+    return found
+
+
+def _emitted_body(path: Path) -> str:
+    """The template literal a text route returns, as written in its source.
+
+    Not the built file: pytest does not run the Astro build, so what is
+    checked here is the template that produces the response, not bytes under
+    `website/dist`. A build that dropped an interpolation is therefore out of
+    scope — the interpolations are plain `${...}` in a template literal, with
+    no conditional around them.
+    """
+    src = path.read_text(encoding="utf-8")
+    marker = "const body = `"
+    assert marker in src, (
+        f"{path.relative_to(REPO)}: no `{marker}` — this gate reads the "
+        "response template by that marker and would otherwise check nothing."
+    )
+    body = src.split(marker, 1)[1].split("\n`;", 1)[0]
+    assert body.strip(), f"{path.relative_to(REPO)}: response template is empty"
+    return body
+
+
+def test_release_stamp_is_derived_and_split_by_surface() -> None:
+    """Version and date on the machine routes; version only on doc pages.
+
+    The doc corpus carries no per-page date and deliberately never has — the
+    reasoning, the four rejected designs and the measurement to re-run before
+    re-opening them are recorded above ``RELEASED`` in
+    ``website/src/pages/llms.txt.ts``. What is stamped instead is the release,
+    once, and this gate pins the two halves of that decision:
+
+    * the three machine surfaces — ``llms.txt``, ``llms-full.txt`` and the
+      per-page ``docs/<slug>.md`` route — interpolate BOTH constants into the
+      text they return;
+    * ``DocsLayout.astro``, the HTML every doc page is rendered into, shows the
+      version and no date at all. A date under an article reads as that
+      article's date, and all nineteen pages would print the same one.
+
+    Both constants must be derived from the single stamped pair, so the check
+    is for the interpolation, not for the value: a file that copied the version
+    or the date out as its own literal would satisfy a value comparison today
+    and rot at the next release, which is the failure this module exists for.
+    Copied literals are rejected explicitly for that reason.
+
+    What this does NOT cover: it reads the route sources, not ``website/dist``
+    — pytest does not run the Astro build. It also does not verify that
+    release-please actually rewrites the annotated lines. That contract is
+    evidenced in git rather than here: ``git log -L 129,129:website/src/pages/
+    index.astro`` (line 129 being that file's ``dateModified`` when this test
+    was written) shows the bot moving a date from one release to the next. The
+    version half is additionally pinned by
+    ``test_doc_version_annotations_are_current`` in
+    ``tests/test_mcpb_distribution.py``; nothing but a real release exercises
+    the date half.
+    """
+    stamps = _stamp_constants()
+    version, version_marker = stamps["VERSION"]
+    released, released_marker = stamps["RELEASED"]
+
+    assert version_marker == "x-release-please-version", (
+        f"VERSION carries {version_marker!r}; release-please stamps the "
+        "version scope only under `x-release-please-version`."
+    )
+    assert version == __version__, (
+        f"llms.txt.ts stamps version {version} but the package is "
+        f"{__version__} — release-please did not update the annotated line."
+    )
+
+    assert released_marker == "x-release-please-date", (
+        f"RELEASED carries {released_marker!r}; the generic updater rewrites a "
+        "date only under the `date` scope, so any other annotation leaves this "
+        "constant frozen at whatever it was last set to by hand."
+    )
+    # Parse *and* round-trip: release-please replaces a `YYYY-MM-DD` run, so a
+    # value it cannot recognise (`2026-8-28`) would silently never be updated.
+    try:
+        parsed = dt.date.fromisoformat(released)
+    except ValueError as exc:  # pragma: no cover - the assert reports it
+        raise AssertionError(
+            f"RELEASED = {released!r} is not an ISO date: {exc}"
+        ) from exc
+    assert parsed.isoformat() == released, (
+        f"RELEASED = {released!r} parses but is not canonical `YYYY-MM-DD` "
+        f"({parsed.isoformat()}). release-please rewrites a zero-padded "
+        "`YYYY-MM-DD` run, so a non-canonical spelling is never stamped."
+    )
+
+    # --- machine surfaces: both halves, interpolated, never restated --------
+    missing: list[str] = []
+    restated: list[str] = []
+    for path in (_LLMS_TXT_SRC, _LLMS_FULL_SRC, _MD_ROUTE_SRC):
+        body = _emitted_body(path)
+        rel = path.relative_to(REPO)
+        for token in ("${VERSION}", "${RELEASED}"):
+            if token not in body:
+                missing.append(f"{rel}: emits no {token}")
+        if path is _LLMS_TXT_SRC:
+            continue  # the declarations themselves live here
+        source = path.read_text(encoding="utf-8")
+        for name, literal in (("VERSION", version), ("RELEASED", released)):
+            if f"'{literal}'" in source or f'"{literal}"' in source:
+                restated.append(f"{rel}: restates {name} as a literal {literal!r}")
+
+    assert not missing, (
+        "machine surfaces must carry BOTH the version and the release date in "
+        "the header block they emit — an agent fetching /docs/<slug>.md "
+        "otherwise gets title, summary and canonical URL with no token to "
+        "invalidate against:\n  " + "\n  ".join(missing)
+    )
+    assert not restated, (
+        "these files must import VERSION/RELEASED from "
+        "website/src/pages/llms.txt.ts, which release-please stamps:\n  "
+        + "\n  ".join(restated)
+    )
+
+    for path in (_LLMS_FULL_SRC, _MD_ROUTE_SRC):
+        source = path.read_text(encoding="utf-8")
+        assert re.search(r"import \{[^}]*\} from '\.{1,2}/llms\.txt';", source), (
+            f"{path.relative_to(REPO)}: no import from llms.txt — the two "
+            "constants must come from the stamped file, not from a copy."
+        )
+
+    # --- human surface: the version, and provably no date -------------------
+    layout = _DOCS_LAYOUT_SRC.read_text(encoding="utf-8")
+    assert (
+        "import { VERSION } from '../pages/llms.txt';" in layout
+    ), "DocsLayout.astro must import VERSION from website/src/pages/llms.txt.ts"
+    assert "Documentation for" in layout and "{VERSION}" in layout, (
+        "DocsLayout.astro no longer renders the 'Documentation for v<version>' "
+        "stamp; doc pages would carry no release signal at all."
+    )
+    assert "releases/tag/v${VERSION}" in layout, (
+        "the rendered version must link to its GitHub release tag, built from "
+        "VERSION rather than written out."
+    )
+    code = _ASTRO_COMMENT_RE.sub("", layout)
+    assert "RELEASED" not in code, (
+        "DocsLayout.astro references RELEASED. Doc pages carry the version and "
+        "NO date on purpose: the date is a corpus-wide release stamp, but "
+        "rendered under an article it reads as that article's date, so faq and "
+        "troubleshooting would make identical freshness claims whether one was "
+        "rewritten yesterday or untouched for six months. See the note above "
+        "RELEASED in website/src/pages/llms.txt.ts."
+    )
+    dates = _ISO_DATE_RE.findall(code)
+    assert not dates, (
+        f"DocsLayout.astro contains date literals {dates} — doc pages are "
+        "date-free by decision, and a hand-written date is also unstamped."
     )

--- a/tests/test_mcpb_distribution.py
+++ b/tests/test_mcpb_distribution.py
@@ -100,7 +100,7 @@ def test_server_json_versions_match_package(server_json: dict) -> None:
 # annotation is present AND it carried the current version.
 _VERSION_ANNOTATED_DOCS = {
     "README.md": 1,
-    "website/src/pages/llms.txt.ts": 1,
+    "website/src/pages/llms.txt.ts": 1,  # + 1 date-only annotation, not counted
     "website/src/content/docs/index.mdx": 2,
     "website/src/content/docs/http-and-docker-deployment.mdx": 5,
     "website/src/pages/index.astro": 2,  # + 1 date-only annotation, not counted

--- a/website/public/assets/styles.css
+++ b/website/public/assets/styles.css
@@ -705,8 +705,8 @@ main:focus-visible { outline: 2px solid var(--signal); outline-offset: -4px; }
   position: sticky;
   top: 2rem;
   align-self: start;
-  /* Without these, a long page's table of contents (the API reference has
-     53 entries) runs past the bottom of the viewport with no way to reach
+  /* Without these, a long page's table of contents (the FAQ's is the longest
+     at 53 entries) runs past the bottom of the viewport with no way to reach
      the tail — the element is stuck to the top and the page scrolls under it. */
   max-height: calc(100vh - 84px - var(--space-6));
   overflow-y: auto;
@@ -715,6 +715,10 @@ main:focus-visible { outline: 2px solid var(--signal); outline-offset: -4px; }
 
 .docs-toc .toc-h3 {
   padding-left: 1rem;
+}
+
+.docs-toc .toc-h4 {
+  padding-left: 2rem;
 }
 
 .docs-breadcrumbs {

--- a/website/src/components/TableOfContents.astro
+++ b/website/src/components/TableOfContents.astro
@@ -1,6 +1,6 @@
 ---
 const { headings } = Astro.props as { headings: Array<{ depth: number; slug: string; text: string }> };
-const tocItems = headings.filter((h) => h.depth >= 2 && h.depth <= 3);
+const tocItems = headings.filter((h) => h.depth >= 2 && h.depth <= 4);
 ---
 <aside class="docs-toc" aria-label="On this page">
   <h4>On this page</h4>

--- a/website/src/content/docs/http-and-docker-deployment.mdx
+++ b/website/src/content/docs/http-and-docker-deployment.mdx
@@ -55,6 +55,8 @@ The published image:
 
 Binding a non-loopback host (`0.0.0.0`) requires `OPENZIM_MCP_AUTH_TOKEN` as a safe default; the bind is refused without it.
 
+For an end-to-end deployment rather than a one-off `docker run` — Compose files, TLS, client wiring — see [Deployment patterns](#deployment-patterns) at the foot of this page.
+
 > **Tool surface.** The image sets `OPENZIM_MCP_TOOL_MODE=advanced`, so it registers all 8 tools. That matches the `.mcpb` bundle and the MCP Registry entry, and it is what directory listings show. The code default elsewhere (a bare `uvx openzim-mcp`) is still `simple`, the single `zim_query` entry point. Add `-e OPENZIM_MCP_TOOL_MODE=simple` to get that narrower surface in a container.
 
 > **Upgrading an existing HTTP deployment?** Earlier images defaulted the *container* to HTTP, so a token-only `docker run -p 8000:8000 -e OPENZIM_MCP_AUTH_TOKEN=… <image>` was enough. The image now defaults to **stdio**, so that same command starts a stdio server instead — nothing listens on `:8000`. Add `-e OPENZIM_MCP_TRANSPORT=http -e OPENZIM_MCP_HOST=0.0.0.0` (as shown above) when you pull the new image.
@@ -311,7 +313,13 @@ spec:
 
 Each replica has its own in-memory cache. Persistent cache on shared storage is *not* recommended unless you handle concurrent-writer issues at the storage layer (the on-disk cache uses simple file rewrites).
 
-Clients reaching the pods through a Service/Ingress hostname should have that hostname in `OPENZIM_MCP_ALLOWED_HOSTS`. Note what the Deployment above does *without* it: because it binds `0.0.0.0` with an empty allow-list, `Host` validation is switched off and the bearer token is the only control — add the hostname to turn DNS-rebinding protection back on. And with `replicas: 2`, session affinity is required — see [Scaling considerations](#scaling-considerations).
+Clients reaching the pods through a Service/Ingress hostname should have that hostname in `OPENZIM_MCP_ALLOWED_HOSTS`. Note what the Deployment above does *without* it: because it binds `0.0.0.0` with an empty allow-list, `Host` validation is switched off and the bearer token is the only control — add the hostname to turn DNS-rebinding protection back on.
+
+### Scaling considerations
+
+Horizontal scaling works — add replicas and front them with any L7 load balancer that supports HTTP/1.1 keep-alive and forwards `Authorization` unchanged. A 2026-07-28 client is stateless, so any replica can answer any request; a long-lived `subscriptions/listen` stream is naturally pinned to the replica holding it, and each replica runs its own watcher over the same directories, so it publishes to its own listeners.
+
+Handshake-era clients still need session-stickiness: their session state lives in the process that issued it, and a replica that doesn't recognize the presented `Mcp-Session-Id` returns `404 Session not found`. If any of your clients still use `initialize`, forward `Mcp-Session-Id` unchanged and use cookie- or header-based affinity (e.g. hash on `Mcp-Session-Id`), or run one replica.
 
 ## Hardening checklist
 
@@ -337,6 +345,21 @@ Common failure modes:
 - **Browser clients get 403 / CORS errors.** Either `OPENZIM_MCP_CORS_ORIGINS` is unset (and a browser is calling) or the client's origin isn't in the allow-list. The browser console shows the offending origin; add it.
 - **`/readyz` returns 503.** None of the configured ZIM directories are readable from inside the container. (With multiple allowed directories, one bad mount is fine — readiness flips only when *all* of them fail.) Check the volume mount path (host side and `/data` side) and that the mount isn't empty. Permissions: the in-container user is UID 10001; the host directory needs to be world-readable or owned by UID 10001.
 - **Subscriptions stop firing.** Confirm `OPENZIM_MCP_SUBSCRIPTIONS_ENABLED` isn't set to `false` — a disabled server refuses `subscriptions/listen` with method-not-found, so that misconfiguration is loud. If the listen was acknowledged but nothing arrives, check the acknowledgement's echoed filter: a client that asked for `zim://files` under `resourceSubscriptions` gets an ack and silence, because directory-membership changes are published as `notifications/resources/list_changed` (opt in with `resourcesListChanged`).
+
+{/*
+  Deliberately one page, not two. Commit 2beed02 (PR #206) merged docs/deployment.md
+  into this file and deleted the standalone file; the recipes and Operations sections
+  below descend from it, demoted one heading level and revised since (the "Deployment
+  patterns" wrapper heading is new). Splitting them back out was proposed and declined:
+  api-reference.mdx is both longer and more linked-to than this page (measured at a36b2d2 — 783 lines
+  and 18 inbound links from 13 docs pages, against 624 lines and 15 links from 9
+  here; this file has grown since, which is the point: length alone was never the
+  trigger), so page length on its own is not the trigger.
+
+  Reopen the question when a PR adds a third topology recipe — a `### Recipe 3`
+  heading in this file. Two recipes plus the reference above fit one page; three
+  is the point to re-measure.
+*/}
 
 ---
 
@@ -585,7 +608,6 @@ curl -sf -X POST https://zim.example.com/mcp \
 #### Production hardening checklist (per-recipe)
 
 - **Token rotation.** Generate a new token, update `.env`, run `docker compose up -d` to pick up the change. Distribute the new token to clients out-of-band.
-- **CORS.** Set `OPENZIM_MCP_CORS_ORIGINS` to the exact origins of any browser clients that connect directly. Skip if no browser clients connect.
 - **Non-root.** The published image already runs as `appuser` (UID 10001). Confirm with `docker compose exec openzim-mcp id` — output should be `uid=10001(appuser)`.
 - **Log review.** `docker compose logs -f openzim-mcp` shows auth failures (the attempted token is *not* logged, but the request and outcome are). A burst of 401s from one client usually means a stale token.
 - **Read-only ZIM mount.** Already in the compose (`:ro`). Don't remove it.
@@ -610,12 +632,6 @@ docker compose logs -f openzim-mcp
 ```
 
 A clean startup logs the bind host/port and the configured allowed directory. An auth failure logs the route, status, and client IP — *not* the attempted token. Subscription updates are delivered silently; the SDK logs a warning when it ends a listen stream whose client stopped reading and overran its event backlog.
-
-#### Scaling considerations
-
-Each replica has its own in-memory cache; persistent cache on shared storage isn't recommended (see the Kubernetes section above). Horizontal scaling works — add replicas and front them with any L7 load balancer that supports HTTP/1.1 keep-alive and forwards `Authorization` unchanged. A 2026-07-28 client is stateless, so any replica can answer any request; a long-lived `subscriptions/listen` stream is naturally pinned to the replica holding it, and each replica runs its own watcher over the same directories, so it publishes to its own listeners.
-
-Handshake-era clients still need session-stickiness: their session state lives in the process that issued it, and a replica that doesn't recognize the presented `Mcp-Session-Id` returns `404 Session not found`. If any of your clients still use `initialize`, forward `Mcp-Session-Id` unchanged and use cookie- or header-based affinity (e.g. hash on `Mcp-Session-Id`), or run one replica.
 
 ---
 

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -5,6 +5,7 @@ import TableOfContents from '../components/TableOfContents.astro';
 import PrevNext from '../components/PrevNext.astro';
 import SiteHeader from '../components/SiteHeader.astro';
 import SiteFooter from '../components/SiteFooter.astro';
+import { VERSION } from '../pages/llms.txt';
 
 export interface Props {
   title: string;
@@ -15,6 +16,19 @@ export interface Props {
 }
 const { title, description, group, slug, headings } = Astro.props;
 const repoEditUrl = `https://github.com/cameronrye/openzim-mcp/blob/main/website/src/content/docs/${slug === 'index' ? 'index' : slug}.mdx`;
+// Version, and deliberately no date. `VERSION` comes from `pages/llms.txt.ts`,
+// which release-please stamps at each release, so this cannot drift on its own.
+//
+// The generated text routes (`llms.txt`, `llms-full.txt`, `docs/<slug>.md`)
+// print the release DATE beside the version; this page does not, and that
+// split is the decision, not an oversight. A date rendered under an article
+// reads as that article's date. Every doc page would print the same one, so
+// `faq` and `troubleshooting` would make identical freshness claims whether
+// one was rewritten yesterday or had gone untouched for six months. A version
+// makes no per-page claim and so cannot mislead. The long note above
+// `RELEASED` in `pages/llms.txt.ts` records the four per-page-date designs
+// that were rejected, and the measurement to re-run before re-opening them.
+const releaseUrl = `https://github.com/cameronrye/openzim-mcp/releases/tag/v${VERSION}`;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const canonicalUrl = `https://cameronrye.github.io${base}/docs/${slug === 'index' ? '' : slug + '/'}`;
 const pageTitle = `${title} — OpenZIM MCP docs`;
@@ -108,7 +122,11 @@ const breadcrumbLd = {
           <slot />
         </article>
         <PrevNext currentSlug={slug} />
-        <p class="docs-edit"><a href={repoEditUrl} target="_blank" rel="noopener">Edit this page on GitHub ↗</a></p>
+        <!-- One line on purpose: the Astro compiler trims the leading
+             whitespace of a text node that starts a line, so wrapping the
+             `· ` separator onto its own line closed the gap up against the
+             preceding link — no space between the version and the bullet. -->
+        <p class="docs-edit">Documentation for <a href={releaseUrl} target="_blank" rel="noopener">v{VERSION}</a> · <a href={repoEditUrl} target="_blank" rel="noopener">Edit this page on GitHub ↗</a></p>
       </main>
       <TableOfContents headings={headings} />
     </div>

--- a/website/src/pages/docs/[...slug].md.ts
+++ b/website/src/pages/docs/[...slug].md.ts
@@ -1,5 +1,6 @@
 import type { APIRoute, GetStaticPaths } from 'astro';
 import { getCollection } from 'astro:content';
+import { RELEASED, VERSION } from '../llms.txt';
 
 /**
  * `/docs/<slug>.md` — one page's Markdown source, without the site shell.
@@ -12,6 +13,15 @@ import { getCollection } from 'astro:content';
  *
  * The body is the collection entry's own source, so it cannot drift from the
  * rendered page — there is no second copy to keep in step.
+ *
+ * The header block carries the release stamp as well as the title, summary and
+ * canonical URL. Without it an agent that fetches this route has nothing to
+ * invalidate against — no way to tell a page pulled today from one pulled six
+ * releases ago. `VERSION` and `RELEASED` are imported from `llms.txt.ts`,
+ * which release-please stamps at each release; the stamp describes the RELEASE, not this
+ * page, which is why the line says so out loud. The human HTML route beside
+ * this one prints the version and no date at all — the note above `RELEASED`
+ * in `llms.txt.ts` has the reasoning and the four rejected alternatives.
  */
 
 export const getStaticPaths: GetStaticPaths = async () => {
@@ -29,6 +39,8 @@ export const GET: APIRoute = ({ props }) => {
 > ${doc.data.summary}
 
 Source: ${canonical}
+Version: ${VERSION}
+Released: ${RELEASED} (the release this documentation describes; not this page's edit date)
 
 ---
 

--- a/website/src/pages/llms-full.txt.ts
+++ b/website/src/pages/llms-full.txt.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getCollection } from 'astro:content';
 import { sortDocsForNav } from '../lib/docs-order';
-import { VERSION } from './llms.txt';
+import { RELEASED, VERSION } from './llms.txt';
 
 /**
  * `/llms-full.txt` — the whole documentation corpus as one plain-text file.
@@ -14,11 +14,16 @@ import { VERSION } from './llms.txt';
  * module the sidebar uses, so neither can fall behind a page that was added,
  * renamed, or moved between groups.
  *
- * `VERSION` is imported rather than restated: it carries the
- * `x-release-please-version` marker in `llms.txt.ts`, which is the file
+ * `VERSION` and `RELEASED` are imported rather than restated: they carry the
+ * release-please line annotations in `llms.txt.ts`, which is the file
  * registered in `release-please-config.json`. A second stamped literal here
  * would be a second thing to keep in step, which is the failure this whole
  * sweep has been about.
+ *
+ * Both are printed here because this is a machine surface. The human doc
+ * layout deliberately prints the version alone — see the long note above
+ * `RELEASED` in `llms.txt.ts` for why, and for the four per-page-date designs
+ * that were rejected.
  */
 
 const SITE = 'https://cameronrye.github.io/openzim-mcp';
@@ -49,6 +54,7 @@ ${doc.body ?? ''}`;
 > Stack Exchange dumps — with no internet connection.
 
 Version: ${VERSION}
+Released: ${RELEASED} (the release this corpus describes; not a per-page edit date)
 Documentation: ${SITE}/
 Index (links only): ${SITE}/llms.txt
 Source: https://github.com/cameronrye/openzim-mcp

--- a/website/src/pages/llms.txt.ts
+++ b/website/src/pages/llms.txt.ts
@@ -27,10 +27,68 @@ import { GROUP_ORDER, sortDocsForNav } from '../lib/docs-order';
 
 const SITE = 'https://cameronrye.github.io/openzim-mcp';
 
-// The one stamped version literal on the site's generated text routes.
-// `llms-full.txt.ts` imports it rather than restating it, so
-// release-please-config.json still has exactly one file to update.
+// The stamped version literal for the site's generated text routes.
+// `llms-full.txt.ts`, `docs/[...slug].md.ts` and `layouts/DocsLayout.astro`
+// import it rather than restating it, so release-please-config.json still has
+// exactly one file to update — this one, already registered there as a
+// `generic` extra-file.
 export const VERSION = '3.2.3'; // x-release-please-version
+
+// The date that release went out, stamped by the same release-please generic
+// updater under the `date` scope. The annotation is not theoretical: `git log
+// -L 129,129:website/src/pages/index.astro` — line 129 being that file's
+// `dateModified` when this was written — shows the bot rewriting it from
+// 2026-08-26 to 2026-08-28 across a release, replacing only the `YYYY-MM-DD`
+// run on the annotated line and nothing else.
+//
+// This is a CORPUS stamp, not a page stamp — every surface that prints it
+// prints the same value on every page — and which surfaces print it is split
+// on purpose. The machine routes (this file, `llms-full.txt.ts`, and
+// `docs/[...slug].md.ts`) carry the version AND this date, because an agent
+// fetching `/docs/configuration.md` otherwise gets title, summary and
+// canonical URL with no token to invalidate against. The human layout
+// (`layouts/DocsLayout.astro`) carries the version ONLY: a date rendered on a
+// page reads as *that page's* date, and `faq` and `troubleshooting` would both
+// claim this one whether one was rewritten yesterday or had gone untouched for
+// six months. A version cannot be misread that way.
+//
+// Four routes to real per-page dates were considered for the docs sweep and
+// all four were rejected:
+//
+//   1. An `updated:` field in each page's frontmatter — hand-maintained, and
+//      hand-maintained copies in this repo have a perfect record of rotting.
+//   2. Dates derived from git history at build time — and therefore also no
+//      `fetch-depth: 0` on the checkout in `.github/workflows/deploy-website.yml`,
+//      which is the only thing that would have needed it.
+//   3. `lastmod` in the sitemap, fed from either of the above.
+//   4. TechArticle JSON-LD (`datePublished` / `dateModified`) on doc pages.
+//      The landing page keeps the TechArticle block it already has; doc pages
+//      get none, and `DocsLayout.astro` emits BreadcrumbList only.
+//
+// All four rest on one measurement — that a per-page date would not
+// discriminate between pages. Re-run it before re-opening any of them:
+//
+//   for f in website/src/content/docs/*.mdx; do git log -1 --format=%cs -- "$f"; done | sort | uniq -c
+//
+// Run on 2026-08-31 it printed one line, `19 2026-08-31`: the 135-defect
+// sweep had just rewritten every page in one commit, so all nineteen pages
+// would have shown the same date. Run against the commit before that sweep it
+// printed five distinct dates over nine days, and two of the fifteen pages the
+// collection held at that commit were dated by a `chore: release` commit — a
+// release-please bump, which changed nothing but a version literal on either
+// page. Publishing either shape as "last updated"
+// would have been a fresh falsehood in the release that removed 135 of them.
+// Six or more distinct dates spread over a month would mean per-page dates had
+// become meaningful, and this decision should be re-opened.
+//
+// Hazard for whoever implements option 2 anyway: in a `--depth 1` clone,
+// `git log -1 --format=%cs -- <file>` returns HEAD's date for every file and
+// exits 0. Verified by cloning this repo at `--depth 1` and running it against
+// `faq.mdx` and `api-reference.mdx`: both answered 2026-08-31, HEAD's date,
+// rc=0. There is no error and no empty result to branch on, so a git-derived
+// scheme fails silently — every page stamped with the date of the last deploy
+// — rather than loudly. The website deploy checks out shallow.
+export const RELEASED = '2026-08-28'; // x-release-please-date
 
 /** The eight advanced-mode tools, in registration order. Gated in Python. */
 const TOOLS: Array<[name: string, blurb: string]> = [
@@ -99,6 +157,7 @@ export const GET: APIRoute = async () => {
 > and never writes to them.
 
 - Version: ${VERSION}
+- Released: ${RELEASED} (the release this documentation describes; not a per-page edit date)
 - License: MIT
 - Python: 3.12+
 - Repository: https://github.com/cameronrye/openzim-mcp


### PR DESCRIPTION
Three of the five items the accuracy sweep deferred as judgement calls. Each ships in the
form the decision landed on, which in two cases is not the form originally proposed.

## Say what "supported" means, and answer the scope question we ask

`SECURITY.md` promised "security fixes are backported to supported versions". That has
never happened: across 72 stable tags no patch release ever landed on a superseded major —
the last 1.x tag predates v2.0.0, the last 2.x tag predates v3.0.0. The table also never
defined its own term, so an operator pinned to 3.0.0 reads "3.x | Yes" and concludes they
are receiving fixes.

**The "previous major, 90 days" row was rejected, not deferred again.** The project already
ran that experiment: `3c03dbf` shipped a dated window on v2.0.0 GA day naming 1.1.x while
1.3.0 was the actual tip. Its escape clause voided it 22 days later when v2.5.0 shipped,
and the void row stayed published for another 51 days until `dbcd3f7` deleted it.
release-please has no N-1 scope and no date arithmetic, so both numbers would be
permanently hand-maintained — in the one file that was automated *because* hand-maintenance
drifted.

Separately: `feature_request.yml` **requires** contributors to confirm a feature "aligns
with the project's goals and scope", and CONTRIBUTING asked "Does it fit the project
goals?" and answered nowhere. `grep -rniE "non-goal|out of scope"` across the website and
README returns nothing. The non-goals existed only inside a closed v2.5 roadmap linked from
nothing. They are in CONTRIBUTING now, present-tense, with the two corrections the move
required — the roadmap still names `search_all` (retired at v2.0.0) and pins libzim 9+ as
a v2.5 fact. The roadmap itself is untouched; it reads correctly as the historical record
it is.

## Surface the headings the deployment page already had

**The page split was declined.** Its two stated premises do not survive checking —
`api-reference.mdx` is longer (783 vs 624 lines at `a36b2d2`) and more linked-to (18 refs
from 13 pages vs 15 from 9) — and it would reverse `2beed02`, which merged
`docs/deployment.md` into this page four months ago. The reasoning and the trigger that
should reopen it (a PR adding a third topology recipe) are recorded at the seam.

What was actually wrong is smaller and real: **15 h4 headings existed in the HTML with
working ids and appeared in no table of contents**, because the component filtered to
`depth <= 3`. The recipes were hard to reach because of a one-character filter, not because
the page is long. Raising it to 4 touches exactly two pages (21→36 rows here, 19→22 on
resources-prompts-subscriptions).

`Scaling considerations` — Kubernetes material, filed under Operations in the Compose
recipes, 300 lines from the manifest that told you to read it — moves up beside that
manifest, promoted h4→h3, **which keeps the slug so no anchor moves** (verified in the
built HTML). That also removes the file's only cross-reference the link checker cannot see.

## Stamp the release, split by who reads it

**Per-page dates were rejected.** Today every doc page reports the same git date, because
one commit rewrote them all; a per-page "last updated" would be a fresh falsehood in the
release that removed 135 of them.

What ships: generated text routes print version *and* release date — an agent fetching
`/docs/configuration.md` previously had nothing to invalidate against. The human page
prints version and **no date**, and that split is the decision: a date under an article
reads as that article's date, and `faq` and `troubleshooting` would make identical
freshness claims either way. Both values are stamped by release-please in `llms.txt.ts`,
already a registered extra-file, so this adds no new registration.

The four rejected designs and the shallow-clone hazard that sinks the git-derived one
(`git log -1` in a `--depth 1` clone returns HEAD's date for every file and exits 0 — it
fails silently, not loudly) are recorded above the constant, with the command to re-run the
measurement before reopening.

## Verification

4658 passed, 222 skipped, 46 deselected. Site builds clean; all internal links and external
URLs resolve. `#scaling-considerations` confirmed unchanged in the built HTML; the five
`x-release-please-version` markers intact. New gates mutation-tested 18/18.
