### PR TITLE
docs(website): regroup the sidebar into four groups

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -324,10 +324,11 @@ detaches, so stop it with `cd website && npx astro dev stop` rather than
 Ctrl-C alone.
 
 Each page under `website/src/content/docs/` needs four frontmatter fields:
-`title`, `summary`, `group` (one of `Get started`, `Reference`, `Guides`,
-`Operations` — the enum is pinned in `src/content.config.ts`, and a value
-outside it fails the build) and `sidebar_order` (numbered **per group**, not
-globally). Internal links use the full base path, e.g.
+`title`, `summary`, `group` (the allowed values are the `z.enum` in
+`src/content.config.ts` — that enum is the source of truth, and a value outside
+it fails the build) and `sidebar_order` (numbered **per group**, not globally;
+`tests/test_docs_freshness.py` requires each group's numbers to be exactly
+1..n). Internal links use the full base path, e.g.
 `/openzim-mcp/docs/api-reference/`, with a trailing slash.
 
 Some doc facts are gated by tests rather than review — see

--- a/README.md
+++ b/README.md
@@ -138,10 +138,10 @@ Full documentation lives at **<https://cameronrye.github.io/openzim-mcp/docs/>**
 
 | Group | Pages |
 | --- | --- |
-| [Get started](https://cameronrye.github.io/openzim-mcp/docs/) | Introduction · Installation · Quick start · ZIM concepts |
+| [Get started](https://cameronrye.github.io/openzim-mcp/docs/) | Introduction · Installation · Quick start · ZIM concepts · LLM integration patterns · Worked examples |
+| [Concepts](https://cameronrye.github.io/openzim-mcp/docs/smart-retrieval/) | Smart retrieval · Search reranking · Architecture overview |
 | [Reference](https://cameronrye.github.io/openzim-mcp/docs/api-reference/) | API reference · Configuration · Resources, prompts & subscriptions · CLI reference |
-| [Guides](https://cameronrye.github.io/openzim-mcp/docs/llm-integration-patterns/) | LLM integration patterns · Smart retrieval · HTTP & Docker deployment · Performance optimization · Security best practices · Worked examples · Search reranking |
-| [Operations](https://cameronrye.github.io/openzim-mcp/docs/troubleshooting/) | Troubleshooting · FAQ · Architecture overview · Upgrading |
+| [Operate](https://cameronrye.github.io/openzim-mcp/docs/http-and-docker-deployment/) | HTTP and Docker deployment · Performance optimization · Security best practices · Troubleshooting · FAQ · Upgrading |
 
 ## Project status
 

--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -6,7 +6,7 @@ const docs = defineCollection({
   schema: z.object({
     title: z.string(),
     summary: z.string(),
-    group: z.enum(['Get started', 'Reference', 'Guides', 'Operations']),
+    group: z.enum(['Get started', 'Concepts', 'Reference', 'Operate']),
     sidebar_order: z.number(),
   }),
 });

--- a/website/src/content/docs/architecture-overview.mdx
+++ b/website/src/content/docs/architecture-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Architecture overview
 summary: Module map, transports and the zim/ package layout — the 8-tool surface, caching, smart-retrieval fallback, MCP transport layer, and the subscription watcher.
-group: Operations
+group: Concepts
 sidebar_order: 3
 ---
 

--- a/website/src/content/docs/faq.mdx
+++ b/website/src/content/docs/faq.mdx
@@ -1,8 +1,8 @@
 ---
 title: FAQ
 summary: Common questions — v1 → v2 migration, simple vs advanced mode, the 8-tool context-tax win, ZIM files, configuration, security and where to get help
-group: Operations
-sidebar_order: 2
+group: Operate
+sidebar_order: 5
 ---
 
 Common questions and answers about OpenZIM MCP.

--- a/website/src/content/docs/http-and-docker-deployment.mdx
+++ b/website/src/content/docs/http-and-docker-deployment.mdx
@@ -1,8 +1,8 @@
 ---
 title: HTTP and Docker deployment
 summary: Run OpenZIM MCP as a networked service — streamable HTTP transport, bearer-token auth, CORS, health probes, the Docker image and LAN, Tailscale and TLS recipes
-group: Guides
-sidebar_order: 3
+group: Operate
+sidebar_order: 1
 ---
 
 How to run OpenZIM MCP as a long-running networked service. Covers the streamable HTTP transport, the published Docker image, operational concerns (TLS, reverse proxy, health probes, systemd), and end-to-end deployment recipes for LAN, Tailscale tailnet, and public VPS topologies.

--- a/website/src/content/docs/llm-integration-patterns.mdx
+++ b/website/src/content/docs/llm-integration-patterns.mdx
@@ -1,8 +1,8 @@
 ---
 title: LLM integration patterns
 summary: Patterns for wiring OpenZIM MCP into LLM apps — simple-mode dispatch, advanced-mode 8-tool composition, progressive discovery, batching and error handling
-group: Guides
-sidebar_order: 1
+group: Get started
+sidebar_order: 5
 ---
 
 Best practices and patterns for integrating OpenZIM MCP with large language models.

--- a/website/src/content/docs/performance-optimization.mdx
+++ b/website/src/content/docs/performance-optimization.mdx
@@ -1,8 +1,8 @@
 ---
 title: Performance optimization
 summary: Cache tuning, rate limiting, batching, and symptom-to-knob guidance for OpenZIM MCP — including HTTP transport, monitoring endpoints, and latency targets.
-group: Guides
-sidebar_order: 4
+group: Operate
+sidebar_order: 2
 ---
 
 Cache tuning, rate limiting, batching, and request-pattern guidance for OpenZIM MCP.

--- a/website/src/content/docs/search-reranking.mdx
+++ b/website/src/content/docs/search-reranking.mdx
@@ -1,8 +1,8 @@
 ---
 title: Search reranking
 summary: The optional [reranker] extra — cross-encoder relevance reranking over Xapian's BM25 results, the mandatory model-staging step, and the knobs that turn it off.
-group: Guides
-sidebar_order: 7
+group: Concepts
+sidebar_order: 2
 ---
 
 The only optional install OpenZIM MCP ships, and the only one that changes

--- a/website/src/content/docs/security-best-practices.mdx
+++ b/website/src/content/docs/security-best-practices.mdx
@@ -1,8 +1,8 @@
 ---
 title: Security best practices
 summary: Security model and operator hardening — path validation, redaction, input sanitization, bearer-token auth, CORS, rate limits and a production checklist
-group: Guides
-sidebar_order: 5
+group: Operate
+sidebar_order: 3
 ---
 
 OpenZIM MCP's security model and operator-level hardening. This page covers the in-process protections (path validation, redaction, input sanitization, prompt hardening, rate limiting) and the network-layer protections (bearer-token auth, CORS, safe-default startup, container hardening) as they ship in the current release.

--- a/website/src/content/docs/smart-retrieval.mdx
+++ b/website/src/content/docs/smart-retrieval.mdx
@@ -1,8 +1,8 @@
 ---
 title: Smart retrieval
 summary: How OpenZIM MCP resolves entry paths when direct access fails — the five-step fallback inside zim_get, the path-mapping cache, and how to debug resolutions.
-group: Guides
-sidebar_order: 2
+group: Concepts
+sidebar_order: 1
 ---
 
 How OpenZIM MCP resolves entry paths when direct access fails — and how to debug it when it doesn't.

--- a/website/src/content/docs/troubleshooting.mdx
+++ b/website/src/content/docs/troubleshooting.mdx
@@ -1,8 +1,8 @@
 ---
 title: Troubleshooting
 summary: Common failure modes — installation, ZIM file access, client config, search and content issues, HTTP transport, cache, subscriptions and the error envelope
-group: Operations
-sidebar_order: 1
+group: Operate
+sidebar_order: 4
 ---
 
 Common issues, error messages, and solutions for OpenZIM MCP.

--- a/website/src/content/docs/upgrading.mdx
+++ b/website/src/content/docs/upgrading.mdx
@@ -1,8 +1,8 @@
 ---
 title: Upgrading
 summary: What breaks between major versions and what to do about it — v2 to v3 for subscription clients and link-graph sidecars, plus a pointer to the v1 to v2 mapping.
-group: Operations
-sidebar_order: 4
+group: Operate
+sidebar_order: 6
 ---
 
 Newest first. The sections below concern crossing a major boundary, but a minor release can still change behaviour without breaking a call — v3.1.0 stopped the reranker downloading its own model and moved caller-error logs from ERROR to WARNING — so read the `Upgrade notes` block of any release you move to.

--- a/website/src/content/docs/worked-examples.mdx
+++ b/website/src/content/docs/worked-examples.mdx
@@ -1,7 +1,7 @@
 ---
 title: Worked examples
 summary: Five end-to-end case studies of the advanced 8-tool surface — search, get, summarize, browse namespaces and follow related links in a Wikipedia archive.
-group: Guides
+group: Get started
 sidebar_order: 6
 ---
 

--- a/website/src/lib/docs-order.ts
+++ b/website/src/lib/docs-order.ts
@@ -3,23 +3,26 @@ import type { CollectionEntry } from 'astro:content';
 /**
  * The sidebar's group order, and the single sort every navigation surface uses.
  *
- * This lives in its own module because two components need the same answer and
- * had drifted apart: `Sidebar.astro` bucketed pages by group and rendered the
- * buckets in a fixed order, while `PrevNext.astro` sorted the whole collection
- * by `sidebar_order` alone. `sidebar_order` restarts at 1 in every group, so
- * the footer chain interleaved groups — "Quick start" was followed by "API
- * reference" in the sidebar but by whichever other page also happened to carry
- * `sidebar_order: 1`.
+ * `GROUP_ORDER` must list exactly the values of the `group` enum in
+ * `src/content.config.ts`, and the two failure modes differ by surface.
+ * `Sidebar.astro` and `llms.txt.ts` iterate this list and filter the
+ * collection to it, so a page whose group the schema accepts but this list
+ * omits is dropped from them entirely. `PrevNext.astro` and `llms-full.txt.ts`
+ * order the whole collection through `sortDocsForNav`, where `docsGroupIndex`
+ * returns `GROUP_ORDER.length` for an unknown group, so the same page merely
+ * sorts to the end. Vanishing from two surfaces while trailing on two others
+ * is not something a build error will tell you about, which is why the set
+ * equality is checked by `test_sidebar_group_order_covers_the_schema_enum` in
+ * `tests/test_docs_freshness.py`. The order of the list is an editorial choice
+ * no test makes for you.
  *
- * Keep `GROUP_ORDER` in step with the `group` enum in `src/content.config.ts`:
- * a value in the schema but missing here is silently dropped from the sidebar,
- * and `docsOrderIndex` sorts it to the end.
+ * All four surfaces read from this module, so a change here moves all four.
  */
 export const GROUP_ORDER = [
   'Get started',
+  'Concepts',
   'Reference',
-  'Guides',
-  'Operations',
+  'Operate',
 ] as const;
 
 export type DocGroup = (typeof GROUP_ORDER)[number];


### PR DESCRIPTION
The last of the five deferred judgement calls.

## Why

"Guides" had become a seven-page grab bag holding an internals explainer beside three
operator manuals, and `architecture-overview` — a module map — sat at position **18 of 19**
under "Operations", a heading that promises runbooks. `content.config.ts` has exactly one
commit (`3ef225e`), written when the collection held a single placeholder page: this
taxonomy was never designed for the corpus it ended up describing.

## What changes

| Group | Pages |
|---|---|
| **Get started** (6) | Introduction, Installation, Quick start, ZIM concepts, LLM integration patterns, Worked examples |
| **Concepts** (3) | Smart retrieval, Search reranking, Architecture overview |
| **Reference** (4) | API reference, Configuration, Resources/prompts/subscriptions, CLI reference |
| **Operate** (6) | HTTP and Docker deployment, Performance optimization, Security best practices, Troubleshooting, FAQ, Upgrading |

Eleven pages move; eight are untouched. Architecture overview goes from 18/19 to 8/19.

**No slug, filename, URL or page body changes.** The diff over the content directory is
twenty frontmatter lines each way — verified with `git diff -U0`, which shows only `group:`
and `sidebar_order:` lines on both sides.

## Why this was safe to attempt

The `sidebar_order` density gate from #406 is doing exactly the job it was added for. An
eleven-page renumber is precisely the edit that introduces a duplicate, and a duplicate does
not error — it falls through to the content loader's emission order in the sidebar, the
prev/next chain, `llms.txt` and `llms-full.txt`, so pages ship in an order nobody wrote and
the build stays green. The gate asserts each group's numbers are a permutation of 1..n.

## Verification

Nothing here fails loudly, so it was verified against the **built output**, not the source:

- **Rendered sidebar** read out of `dist/docs/index.html` matches the target exactly, group
  order and per-group order.
- **Prev/next chain** walked in the built HTML: 19 steps, 19 unique URLs, no cycle, first
  page has no prev and last has no next. Walking backwards from Upgrading reproduces the
  same sequence, so the chain is consistent in both directions and identical to the sidebar.
- **`llms.txt`** emits the four new group headings in order with matching membership.
- All four README group-cell links confirmed by hand against `dist`, each landing on its
  group's new first page.

4658 passed, 222 skipped. `astro check` 0 errors. 1683 internal links and 47 external URLs
all resolve.

## Also

`docs-order.ts`'s header comment was still narrating a PrevNext bug that has since been
fixed, and instructed readers to keep `GROUP_ORDER` in step with the enum — a rule now
mechanically enforced. It states the invariant and names the gate instead, and is precise
about what breaks, which differs by surface: `Sidebar.astro` and `llms.txt.ts` iterate
`GROUP_ORDER` and filter to it, so an unlisted group's pages are dropped entirely;
`PrevNext.astro` and `llms-full.txt.ts` sort the whole collection, so the same pages merely
trail at the end.

CONTRIBUTING now points at the enum rather than restating the four values — a hand-copied
list is what drifted here in the first place.
