### PR TITLE
fix(ci): unblock the release and dependency PRs

### DIFF
--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -130,6 +130,17 @@ EDIT_LINK_PREFIX = "https://github.com/cameronrye/openzim-mcp/blob/main/"
 # Skipped rather than silently passed, and reported in the summary.
 EXTERNAL_SKIP_HOSTS = ("badge.fury.io", "img.shields.io", "codecov.io")
 
+# The docs footer links its version at this release tag. release-please bumps
+# the version in the release PR, and the tag is created by MERGING that PR, so
+# on exactly the commit that most needs to pass, the tag is a 404 that becomes
+# valid minutes later. Probing it asks "has this release happened yet", which
+# is the same wrong question `SITE_BASE` and `EDIT_LINK_PREFIX` above already
+# decline to ask. The URL is correct by construction: `DocsLayout.astro` builds
+# it from `VERSION`, which release-please stamps, and a test pins that it is
+# derived rather than written by hand — so there is no hand-typed tag here for
+# a probe to catch.
+RELEASE_TAG_PREFIX = "https://github.com/cameronrye/openzim-mcp/releases/tag/v"
+
 USER_AGENT = (
     "openzim-mcp-docs-linkcheck/1.0 (+https://github.com/cameronrye/openzim-mcp)"
 )
@@ -434,6 +445,9 @@ def check_external(
                         f"{url} (no heading anchor #{frag} in {rel}; "
                         f"referenced by {sorted(sources)[0]})"
                     )
+            continue
+        if url.startswith(RELEASE_TAG_PREFIX):
+            skipped.append(f"{url} (release tag — created by merging the release PR)")
             continue
         if any(host in url for host in EXTERNAL_SKIP_HOSTS):
             skipped.append(url)

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,6 +8,7 @@
       "name": "openzim-mcp-website",
       "version": "0.0.1",
       "dependencies": {
+        "@astrojs/markdown-remark": "^7.2.1",
         "@astrojs/mdx": "^7.0.3",
         "@astrojs/sitemap": "^3.7.3",
         "astro": "^7.1.3"

--- a/website/package.json
+++ b/website/package.json
@@ -12,6 +12,7 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@astrojs/markdown-remark": "^7.2.1",
     "@astrojs/mdx": "^7.0.3",
     "@astrojs/sitemap": "^3.7.3",
     "astro": "^7.1.3"


### PR DESCRIPTION
Two CI-blocking defects, both introduced by today's documentation work, each breaking a
different queued PR. Neither is broken on `main`.

## 1. `@astrojs/markdown-remark` was imported but never declared

Both npm Dependabot PRs (#404, #405) fail at `astro check` with the same error, and neither
failure is about the dependency it bumps:

```
Cannot find module '@astrojs/markdown-remark' imported from website/astro.config.mjs
```

`astro.config.mjs:4` imports `rehypeHeadingIds` from it, but it is not in `package.json`.
It resolved only because npm hoisted it to the top level as a shared transitive of `astro`
and `@astrojs/mdx`. Any bump that reshapes the tree removes the copy the import was relying
on — and both Dependabot PRs do exactly that.

The import arrived with the heading-anchor work in `a36b2d2` and passed CI there, because
that run resolved against the lockfile where the hoisting lined up.

## 2. The release PR probes a tag that merging the release PR creates

#403 fails on:

```
BROKEN https://github.com/cameronrye/openzim-mcp/releases/tag/v3.2.4 -> HTTP 404
```

The docs footer links its version at that tag. release-please bumps the version inside the
release PR, so on exactly the commit that most needs to pass, the tag is a 404 that becomes
valid minutes later. **Every future release PR would have failed this way.**

Probing it asks "has this release happened yet" — the same wrong question the checker
already declines to ask about our own site pages ("is this page published yet", false on any
PR that adds one) and `blob/main` edit links ("is this file on main yet", false on any
branch that adds one). Those resolve locally; this one is correct by construction, since
`DocsLayout` builds the URL from the stamped `VERSION` and a test pins that it is derived
rather than hand-written. There is no typo for a probe to catch.

Verified by simulating the failing state — `VERSION` set to `3.2.4` with no such tag
published — where the checker reports the tag as skipped and everything else resolves.

## Verification

`astro check` 0 errors, `npm run build` 21 pages, link checker green with and without
`--external`, black/flake8/mypy clean.
