### PR TITLE
chore(website): import z from astro/zod, not astro:content

### DIFF
--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -1,5 +1,11 @@
-import { defineCollection, z } from 'astro:content';
+import { defineCollection } from 'astro:content';
 import { glob } from 'astro/loaders';
+// `z` from `astro:content` is deprecated; `astro/zod` is the documented
+// replacement. It re-exports Zod from the already-declared `astro` package, so
+// there is nothing new to install — importing from `zod` directly would have
+// meant relying on a hoisted transitive, which is what broke every npm
+// Dependabot PR until `@astrojs/markdown-remark` was declared in #409.
+import { z } from 'astro/zod';
 
 const docs = defineCollection({
   loader: glob({ pattern: '**/*.{md,mdx}', base: './src/content/docs' }),


### PR DESCRIPTION
The astro 7.2 bump in #411 surfaced six `ts(6385) 'z' is deprecated` hints on
`content.config.ts`. Astro deprecated the `z` re-export from `astro:content`.

`astro/zod` is the documented replacement and re-exports Zod from the already-declared
`astro` package, so **nothing new is installed**.

Importing from `zod` directly would have been the wrong fix. `zod` is present only as a
hoisted transitive:

```
├─┬ @astrojs/sitemap@3.7.4
│ └── zod@4.5.4
└─┬ astro@7.2.10
  └── zod@4.5.4 deduped
```

That is precisely the shape that left `@astrojs/markdown-remark` resolvable right up until
a dependency bump reshaped the tree and broke every npm Dependabot PR with an error naming
the wrong culprit (fixed in #409). One of those per repo is enough.

## Verification

- `astro check`: 9 hints → **3**, still 0 errors and 0 warnings
- Build: 21 pages
- **Schema still enforced, not merely still compiling** — setting a page's `group` to a value
  outside the enum fails the build with
  `Invalid option: expected one of "Get started"|"Concepts"|"Reference"|"Operate"`, then
  reverted
- 4658 passed; 1683 internal links and 46 external URLs resolve
