### PR TITLE
deps(website): take @astrojs/mdx 8.0.0

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/markdown-remark": "^7.2.1",
-        "@astrojs/mdx": "^7.0.3",
+        "@astrojs/mdx": "^8.0.0",
         "@astrojs/sitemap": "^3.7.3",
         "astro": "^7.1.3"
       },
@@ -312,79 +312,40 @@
         "vfile": "^6.0.3"
       }
     },
-    "node_modules/@astrojs/mdx": {
-      "version": "7.0.8",
-      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-7.0.8.tgz",
-      "integrity": "sha512-RNuwq2ccTSi7NX9YqlR0noaWoVdOrZuJvdfWXotAzdhMVB0b0zEMLnNU+xar7le0GwTMlTObD/QAu8jeHA/3nA==",
+    "node_modules/@astrojs/markdown-satteri": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.4.0.tgz",
+      "integrity": "sha512-wykOOW9KsUVcZweOpY/CeXpdKcCKZy6fQbdcteWFuI75+sQCiqxYM7VKsGa5b+aGl3cYQscFY37rsbbyal5MRw==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.10.4",
-        "@astrojs/markdown-remark": "7.2.4",
-        "@mdx-js/mdx": "^3.1.1",
-        "acorn": "^8.16.0",
-        "es-module-lexer": "^2.0.0",
-        "estree-util-visit": "^2.0.0",
-        "hast-util-to-html": "^9.0.5",
-        "piccolore": "^0.1.3",
-        "rehype-raw": "^7.0.0",
-        "remark-gfm": "^4.0.1",
-        "remark-smartypants": "^3.0.2",
-        "source-map": "^0.7.6",
-        "unist-util-visit": "^5.1.0",
-        "vfile": "^6.0.3"
+        "@astrojs/internal-helpers": "0.11.0",
+        "@astrojs/prism": "4.0.2",
+        "github-slugger": "^2.0.0",
+        "satteri": "^0.10.3"
+      }
+    },
+    "node_modules/@astrojs/mdx": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-8.0.0.tgz",
+      "integrity": "sha512-4I/z+VgUO0B9I/+yhzIEpLyBYQZNJsInmrtqClP4lqX9yvUpbuV72zfRTZ8VqJLKABETUE5CYOl+23va8nqxZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.11.0",
+        "@astrojs/markdown-satteri": "0.4.0",
+        "es-module-lexer": "^2.0.0"
       },
       "engines": {
         "node": ">=22.12.0"
       },
       "peerDependencies": {
-        "@astrojs/markdown-satteri": "^0.3.1",
-        "astro": "^7.0.0"
+        "@astrojs/markdown-remark": "^7.3.0",
+        "@astrojs/markdown-satteri": "^0.4.0",
+        "astro": "^7.2.6"
       },
       "peerDependenciesMeta": {
-        "@astrojs/markdown-satteri": {
+        "@astrojs/markdown-remark": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@astrojs/mdx/node_modules/@astrojs/internal-helpers": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.4.tgz",
-      "integrity": "sha512-nozZSy/mKYLqe4YrqbKtdOszedAfXYCtw3wZ0d+CAjz4GqQ4L9rl1ltIL5BlgwmYVinJg/RZ0MgGuWOdlyRZlA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.4",
-        "@types/mdast": "^4.0.4",
-        "js-yaml": "^4.3.0",
-        "picomatch": "^4.0.4",
-        "retext-smartypants": "^6.2.0",
-        "shiki": "^4.0.2",
-        "smol-toml": "^1.6.0",
-        "unified": "^11.0.5"
-      }
-    },
-    "node_modules/@astrojs/mdx/node_modules/@astrojs/markdown-remark": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.4.tgz",
-      "integrity": "sha512-MvspGMynWKAjTe4/lTUdmBPHIFKNVLTCF6UlyWGogTGzNrTvjD+D4n48k7h8swxsEPKHK2TwxkZO7uoaCv1Pow==",
-      "license": "MIT",
-      "dependencies": {
-        "@astrojs/internal-helpers": "0.10.4",
-        "@astrojs/prism": "4.0.2",
-        "github-slugger": "^2.0.0",
-        "hast-util-from-html": "^2.0.3",
-        "hast-util-to-text": "^4.0.2",
-        "mdast-util-definitions": "^6.0.0",
-        "rehype-raw": "^7.0.0",
-        "rehype-stringify": "^10.0.1",
-        "remark-gfm": "^4.0.1",
-        "remark-parse": "^11.0.0",
-        "remark-rehype": "^11.1.2",
-        "remark-smartypants": "^3.0.2",
-        "unified": "^11.0.5",
-        "unist-util-remove-position": "^5.0.0",
-        "unist-util-visit": "^5.1.0",
-        "unist-util-visit-parents": "^6.0.2",
-        "vfile": "^6.0.3"
       }
     },
     "node_modules/@astrojs/prism": {
@@ -2664,18 +2625,6 @@
         "@astrojs/markdown-remark": {
           "optional": true
         }
-      }
-    },
-    "node_modules/astro/node_modules/@astrojs/markdown-satteri": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.4.0.tgz",
-      "integrity": "sha512-wykOOW9KsUVcZweOpY/CeXpdKcCKZy6fQbdcteWFuI75+sQCiqxYM7VKsGa5b+aGl3cYQscFY37rsbbyal5MRw==",
-      "license": "MIT",
-      "dependencies": {
-        "@astrojs/internal-helpers": "0.11.0",
-        "@astrojs/prism": "4.0.2",
-        "github-slugger": "^2.0.0",
-        "satteri": "^0.10.3"
       }
     },
     "node_modules/axobject-query": {

--- a/website/package.json
+++ b/website/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.1",
-    "@astrojs/mdx": "^7.0.3",
+    "@astrojs/mdx": "^8.0.0",
     "@astrojs/sitemap": "^3.7.3",
     "astro": "^7.1.3"
   },


### PR DESCRIPTION
The last held dependency. It was deferred with `typescript` 7 when the other website bumps
landed, on the assumption that an integration major would want an astro major alongside it.

It does not:

```
@astrojs/mdx@8.0.0 peerDependencies:
  astro:                     ^7.2.6   (we have 7.2.10)
  @astrojs/markdown-remark:  ^7.3.0   (we have 7.3.0)
```

Both were already satisfied by #411, so this is in reach today.

## Verified the MDX pipeline, not just the exit code

A broken MDX setup still emits pages, so "21 pages built" proves little on its own:

- `{/* ... */}` comments do not leak into the rendered HTML
- `rehypeHeadingIds` anchors survive — `#scaling-considerations` still resolves, which is the
  anchor the deployment-page reorganisation in #407 depends on
- pagefind still indexes
- 1683 internal links and 46 external URLs resolve
- `astro check`: 0 errors, 0 warnings

Validated with `rm -rf node_modules && npm ci` — what CI actually runs, and what a plain
`npm update` can silently leave unsatisfiable (as it did on the first push of #411).

`typescript` 7 remains held and is not fixable here: `@astrojs/check@0.9.10` declares
`peer typescript@"^5.0.0 || ^6.0.0"`.
