### PR TITLE
fix: make namespace discovery deterministic and its counts add up

### DIFF
--- a/openzim_mcp/tool_schemas.py
+++ b/openzim_mcp/tool_schemas.py
@@ -177,7 +177,8 @@ class NamespaceSummary(TypedDict):
     # True when the bucket was discovered exhaustively (full iteration,
     # or a deterministic source like ``archive.metadata_keys`` /
     # canonical-probes-only). False when the bucket's ``total`` was
-    # extrapolated from random sampling.
+    # extrapolated from a sample (the sample itself is deterministic per
+    # archive, but a projection is still an estimate).
     is_authoritative: bool
     # Diagnostic fields surfaced for callers that want to reason about
     # the discovery method. ``description`` and ``sample_entries`` come

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -17,11 +17,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
 from libzim.reader import Archive  # type: ignore[import-untyped]
 
 import openzim_mcp.zim_operations as _zim_ops_mod
-from openzim_mcp.constants import (
-    NAMESPACE_MAX_ENTRIES,
-    NAMESPACE_MAX_SAMPLE_SIZE,
-    NAMESPACE_SAMPLE_ATTEMPTS_MULTIPLIER,
-)
+from openzim_mcp.constants import NAMESPACE_MAX_ENTRIES, NAMESPACE_MAX_SAMPLE_SIZE
 from openzim_mcp.exceptions import (
     OpenZimMcpArchiveError,
     OpenZimMcpValidationError,
@@ -193,6 +189,15 @@ def _deterministic_sample_ids(
 
     The UUID-derived phase keeps two same-sized archives from probing the
     identical offsets, without reintroducing any run-to-run variation.
+
+    The trade being made: a systematic sample is biased whenever the
+    population has a period that divides the stride. An archive whose
+    dirent table repeated a namespace pattern with period
+    ``total/sample_size`` would land every draw in the same namespace. ZIM
+    dirents are sorted by path, so namespaces appear as contiguous runs
+    rather than as a repeating cycle, and no corpus archive exercises it —
+    but that is the failure mode to look for if a projection ever comes back
+    absurd, and it is why ``_probe_known_namespaces`` still runs afterwards.
     """
     if total_entries <= 0 or sample_size <= 0:
         return []
@@ -371,7 +376,7 @@ class _NamespaceMixin:
             self._iterate_all_entries(archive, total_entries, record)
             self._finalise_full_iteration(namespaces)
         else:
-            self._sample_entries(archive, total_entries, seen_entries, record)
+            self._sample_entries(archive, total_entries, record)
             self._probe_known_namespaces(archive, seen_entries, record)
             self._finalise_sampled(namespaces, total_entries)
 
@@ -574,13 +579,14 @@ class _NamespaceMixin:
             ns_info.pop("_sampled_count", None)
 
     @staticmethod
-    def _sample_entries(
-        archive: Archive, total_entries: int, seen_entries: set[str], record: Any
-    ) -> None:
+    def _sample_entries(archive: Archive, total_entries: int, record: Any) -> None:
         """Sample up to NAMESPACE_MAX_SAMPLE_SIZE distinct entries.
 
         Deterministic by construction — see :func:`_deterministic_sample_ids`
-        for why ``get_random_entry`` could not be used here.
+        for why ``get_random_entry`` could not be used here. That helper
+        yields exactly ``sample_size`` distinct ids, so the old
+        retry-until-distinct loop (and the "stop once we have enough" bound
+        that went with it) has no work left to do.
         """
         sample_size = min(NAMESPACE_MAX_SAMPLE_SIZE, total_entries)
         logger.debug(
@@ -591,8 +597,6 @@ class _NamespaceMixin:
                 total_entries, sample_size, _archive_sample_seed(archive)
             )
             for entry_id in entry_ids:
-                if len(seen_entries) >= sample_size:
-                    break
                 try:
                     entry = archive._get_entry_by_id(entry_id)
                     record(entry.path, entry.title or "", is_probe=False)
@@ -606,10 +610,15 @@ class _NamespaceMixin:
     ) -> None:
         """Probe canonical paths to surface namespaces missed by sampling.
 
-        Random sampling on a large archive will silently miss minority
-        namespaces (e.g. M, W, X, I when A holds 99%+ of entries). Trying
-        canonical paths in each common namespace surfaces them
-        deterministically.
+        A 1-in-N sample of a large archive can still miss minority
+        namespaces (e.g. M, W, X, I when A holds 99%+ of entries) — with
+        ``NAMESPACE_MAX_SAMPLE_SIZE`` draws over a 20k-entry archive the
+        stride is ~20, so a namespace with fewer than ~20 entries may fall
+        entirely between two steps. Trying canonical paths in each common
+        namespace surfaces those, independently of where the stride lands.
+
+        A probe proves existence only; the hit is recorded as a floor, not
+        as sampled signal, so it never feeds the ratio projection.
         """
         for canonical_path in self._get_known_namespace_probes():
             try:
@@ -633,7 +642,7 @@ class _NamespaceMixin:
     ) -> None:
         """Project per-namespace totals from sample counts.
 
-        We extrapolate ONLY the randomly-sampled count via sampling ratio —
+        We extrapolate ONLY the sampled count via the sampling ratio —
         probed entries are confirmed-present-but-frequency-unknown, so they
         only contribute a lower-bound floor. Project only when we have
         enough sampled signal to make a stable estimate; below the
@@ -873,12 +882,18 @@ class _NamespaceMixin:
         # cursor ``s.o`` is therefore a row offset again; ``total`` stays the
         # authoritative ``entry_count``. The bump stops pre-fix cached pages —
         # with the old entry-id-offset cursor — from leaking through.
+        # Bumped again v2e -> v2f when the old-scheme sampled branch stopped
+        # drawing from ``get_random_entry``: the archive does not change when
+        # the sampler does, so a persisted snapshot would keep serving the
+        # pre-fix pages (a different random population per page, and an empty
+        # result for every namespace the article index cannot reach) until TTL
+        # expiry.
         # The stat token (mtime_ns:size) invalidates the page when the
         # archive is replaced in place (archive_stat_token contract).
         from openzim_mcp.bundle import archive_stat_token
 
         cache_key = (
-            f"browse_ns_data:v2e:{validated_path}:"
+            f"browse_ns_data:v2f:{validated_path}:"
             f"{archive_stat_token(validated_path)}:{namespace}:"
             f"{limit}:{offset}:assets={include_assets}"
         )
@@ -1521,8 +1536,8 @@ class _NamespaceMixin:
 
         Returns ``(sorted_paths, full_iteration)`` where ``full_iteration`` is
         True when every entry in the archive was inspected (so the result is
-        exhaustive). For larger archives, falls back to random sampling and
-        returns False — counts/paths are then a lower bound.
+        exhaustive). For larger archives, falls back to a systematic sample of
+        entry ids and returns False — counts/paths are then a lower bound.
 
         New-scheme dispatch: M is enumerated from ``archive.metadata_keys``
         (full iteration, exhaustive); namespaces other than C/M return empty
@@ -1624,19 +1639,41 @@ class _NamespaceMixin:
     def _sample_namespace_entries(
         self, archive: Archive, namespace: str, has_new_scheme: bool = False
     ) -> Tuple[List[str], set[str]]:
-        """Sample random entries until ``NAMESPACE_MAX_ENTRIES`` matches found."""
+        """Sample entry ids until ``NAMESPACE_MAX_ENTRIES`` matches are found.
+
+        Uses the same systematic walk as the ``list_namespaces`` sampler
+        (:func:`_deterministic_sample_ids`), for the same two reasons:
+
+        * **agreement.** ``get_random_entry`` draws from the *article*
+          index, so on an archive whose articles all live in ``A`` this
+          function could never return an ``I`` or ``-`` entry however many
+          draws it took — while ``list_namespaces``, which walks entry ids,
+          reports both. Two tools describing the same archive differently
+          is worse than either being imprecise.
+        * **determinism.** ``browse_namespace`` is cached and paginated;
+          a sample that re-rolls on every call hands page 2 a different
+          population than page 1.
+
+        The returned ``total`` is still a lower bound (capped at
+        ``NAMESPACE_MAX_ENTRIES``), which is what
+        ``page_info.total_is_lower_bound`` advertises.
+        """
         total_entries = archive.entry_count
         max_samples = min(NAMESPACE_MAX_SAMPLE_SIZE * 2, total_entries)
-        max_attempts = max_samples * NAMESPACE_SAMPLE_ATTEMPTS_MULTIPLIER
         logger.debug(f"Sampling for entries in namespace '{namespace}'")
 
         results: List[str] = []
         seen: set[str] = set()
+        entry_ids = _deterministic_sample_ids(
+            total_entries, max_samples, _archive_sample_seed(archive)
+        )
         attempts = 0
-        while len(results) < NAMESPACE_MAX_ENTRIES and attempts < max_attempts:
+        for entry_id in entry_ids:
+            if len(results) >= NAMESPACE_MAX_ENTRIES:
+                break
             attempts += 1
             try:
-                path = archive.get_random_entry().path
+                path = archive._get_entry_by_id(entry_id).path
                 if path in seen:
                     continue
                 seen.add(path)
@@ -1648,7 +1685,7 @@ class _NamespaceMixin:
                 ):
                     results.append(path)
             except Exception as e:
-                logger.debug(f"Error sampling entry: {e}")
+                logger.debug(f"Error sampling entry {entry_id}: {e}")
 
         logger.info(
             f"Found {len(results)} entries in namespace '{namespace}' "
@@ -1687,8 +1724,19 @@ class _NamespaceMixin:
                 logger.debug(f"Error checking pattern {pattern}: {e}")
 
     def _get_common_namespace_patterns(self, namespace: str) -> List[str]:
-        """Get common path patterns for a namespace."""
-        patterns = []
+        """Get common path patterns for a namespace.
+
+        Seeded with the canonical probes ``list_namespaces`` uses, so a
+        namespace that tool surfaces by probe alone (``X`` is found via
+        ``X/fulltext/xapian``, which is not in the browse-specific list
+        below) is never advertised as non-empty by one tool and reported
+        empty by the other.
+        """
+        patterns = [
+            probe
+            for probe in self._get_known_namespace_probes()
+            if probe.split("/", 1)[0] == namespace
+        ]
 
         # Common patterns based on namespace
         if namespace == "C":

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -9,6 +9,7 @@ without changes.
 """
 
 import contextlib
+import hashlib
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
@@ -163,6 +164,98 @@ def _scan_fill_c_namespace(
 _NAMESPACE_PROJECTION_MIN_SAMPLES = 3
 
 
+def _deterministic_sample_ids(
+    total_entries: int, sample_size: int, seed_token: str
+) -> List[int]:
+    """Pick ``sample_size`` entry ids out of ``total_entries``, reproducibly.
+
+    This replaces ``Archive.get_random_entry()`` on the namespace-discovery
+    path. libzim exposes no seed for that call, so it made
+    ``list_namespaces`` answer differently on every invocation — and the
+    answer is cached, so each cache fill froze one arbitrary roll of the
+    dice. It was also *blind*: ``get_random_entry`` draws from the archive's
+    **article** index, so namespaces that hold no articles (``I`` images,
+    ``-`` layout assets) could never be sampled at all, however many entries
+    they held.
+
+    The replacement is a systematic sample: walk the id space at a fixed
+    stride ``total/sample_size``, starting from a phase derived from the
+    archive's UUID. That gives us three things at once:
+
+    * **determinism** — same archive, same ids, same payload, forever.
+    * **spread** — the walk covers the whole id space rather than the first
+      N entries. Old-scheme ZIM archives store dirents grouped by namespace,
+      so a strided walk represents each namespace roughly in proportion to
+      its true size (systematic sampling over an ordered population), which
+      is what the ratio projection downstream assumes.
+    * **distinct draws** — ids are unique by construction, so the old
+      retry-until-distinct loop (and its attempts multiplier) is gone.
+
+    The UUID-derived phase keeps two same-sized archives from probing the
+    identical offsets, without reintroducing any run-to-run variation.
+    """
+    if total_entries <= 0 or sample_size <= 0:
+        return []
+    if sample_size >= total_entries:
+        return list(range(total_entries))
+
+    step = total_entries / sample_size
+    digest = hashlib.blake2b(seed_token.encode("utf-8"), digest_size=8).digest()
+    offset = int.from_bytes(digest, "big") % total_entries
+    # ``int(i * step)`` is strictly increasing while ``step >= 1`` (which
+    # holds because sample_size < total_entries), and rotating a set of
+    # distinct values modulo ``total_entries`` keeps them distinct.
+    return [(offset + int(i * step)) % total_entries for i in range(sample_size)]
+
+
+def _archive_sample_seed(archive: Archive) -> str:
+    """Stable per-archive seed for :func:`_deterministic_sample_ids`."""
+    try:
+        return str(getattr(archive, "uuid", "") or "")
+    except Exception as e:  # pragma: no cover - defensive, libzim may raise
+        logger.debug(f"Unable to read archive uuid for sampling seed: {e}")
+        return ""
+
+
+def _clamp_projections_to_total(
+    estimates: Dict[str, int], floors: Dict[str, int], total_entries: int
+) -> None:
+    """Shrink projections in place so they cannot sum above the archive total.
+
+    The per-namespace estimate is ``max(projected, observed)``: a ratio
+    extrapolation for namespaces with enough sampled signal, floored by the
+    entries we actually laid eyes on (sampled + probed). Both halves are
+    individually reasonable and their sum was not — a namespace discovered
+    only by a canonical-path probe adds its floor on top of a projection
+    that has already spent the whole budget, so ``list_namespaces`` reported
+    per-namespace counts summing past its own ``total_entries``.
+
+    Observed counts are facts, so only the extrapolated part above each
+    floor is scaled down, proportionally, into whatever headroom the floors
+    leave. Truncating each share keeps the result at or below the total.
+
+    This runs on the sampled branch only, where every bucket comes from the
+    iterable entry surface that ``entry_count`` counts. It does not touch
+    the new-scheme M/W namespaces added afterwards, which legitimately sit
+    outside ``entry_count`` (see ``render_namespaces``' "+N" reconciliation).
+    """
+    projected = sum(estimates.values())
+    if projected <= total_entries:
+        return
+    observed = sum(floors.values())
+    headroom = total_entries - observed
+    if headroom < 0:
+        # What we observed already exceeds the stated total, so the total
+        # is not describing the same population. Under-reporting entries we
+        # have seen with our own eyes would be the worse lie; leave them.
+        return
+    # Positive by construction here: projected > total_entries >= observed.
+    projected_excess = projected - observed
+    for ns in estimates:
+        excess = estimates[ns] - floors[ns]
+        estimates[ns] = floors[ns] + int(excess * headroom / projected_excess)
+
+
 class _NamespaceMixin:
     """Namespace listing / browsing / walking methods for ZimOperations."""
 
@@ -204,13 +297,18 @@ class _NamespaceMixin:
 
         # Cache key bumped to v2b (Phase B) so v1.x cached responses (old
         # shape: entry_count key) don't leak through after the rename to ``total``.
+        # Bumped again to v2c when the sampled branch stopped drawing from
+        # ``get_random_entry``: the archive does not change when the sampler
+        # does, so a persisted snapshot would keep serving pre-fix listings
+        # (random ``sample_entries``, no ``I`` bucket, per-namespace counts
+        # summing above ``total_entries``) until TTL expiry.
         # The stat token (mtime_ns:size) invalidates the listing when the
         # archive is replaced in place (archive_stat_token contract, which
         # names namespace listings explicitly).
         from openzim_mcp.bundle import archive_stat_token
 
         cache_key = (
-            f"namespaces_data:v2b:{validated_path}:"
+            f"namespaces_data:v2c:{validated_path}:"
             f"{archive_stat_token(validated_path)}"
         )
         cached_result = self.cache.get(cache_key)
@@ -248,9 +346,10 @@ class _NamespaceMixin:
 
         For small archives (entry_count <= NAMESPACE_MAX_SAMPLE_SIZE) iterate
         every entry by ID so the namespace inventory is exhaustive. For larger
-        archives, fall back to random sampling and return estimated counts.
-        Random sampling on small entry pools collides heavily, leaving
-        namespaces undiscovered and counts wildly off.
+        archives, fall back to a systematic sample of entry ids (see
+        :func:`_deterministic_sample_ids`) and return estimated counts —
+        deterministic per archive, and projected so the buckets cannot sum
+        above ``entry_count``.
 
         For new-scheme archives, the iterable surface only contains C
         entries; M is enumerated separately via ``archive.metadata_keys`` and
@@ -478,21 +577,27 @@ class _NamespaceMixin:
     def _sample_entries(
         archive: Archive, total_entries: int, seen_entries: set[str], record: Any
     ) -> None:
-        """Random-sample up to NAMESPACE_MAX_SAMPLE_SIZE distinct entries."""
+        """Sample up to NAMESPACE_MAX_SAMPLE_SIZE distinct entries.
+
+        Deterministic by construction — see :func:`_deterministic_sample_ids`
+        for why ``get_random_entry`` could not be used here.
+        """
         sample_size = min(NAMESPACE_MAX_SAMPLE_SIZE, total_entries)
-        max_sample_attempts = sample_size * NAMESPACE_SAMPLE_ATTEMPTS_MULTIPLIER
         logger.debug(
             f"Sampling {sample_size} entries from {total_entries} total entries"
         )
         try:
-            for _ in range(max_sample_attempts):
+            entry_ids = _deterministic_sample_ids(
+                total_entries, sample_size, _archive_sample_seed(archive)
+            )
+            for entry_id in entry_ids:
                 if len(seen_entries) >= sample_size:
                     break
                 try:
-                    entry = archive.get_random_entry()
+                    entry = archive._get_entry_by_id(entry_id)
                     record(entry.path, entry.title or "", is_probe=False)
                 except Exception as e:
-                    logger.debug(f"Error sampling entry: {e}")
+                    logger.debug(f"Error sampling entry {entry_id}: {e}")
         except Exception as e:
             logger.warning(f"Error during namespace sampling: {e}")
 
@@ -534,24 +639,36 @@ class _NamespaceMixin:
         enough sampled signal to make a stable estimate; below the
         threshold, single-hit projections vary by 100%+ and effectively
         manufacture numbers.
+
+        The projections are then clamped as a set: a bucket found only by a
+        canonical-path probe used to add its floor on top of a ratio
+        projection that had already accounted for the entire archive, so the
+        published per-namespace counts summed above ``total_entries``. See
+        :func:`_clamp_projections_to_total`.
         """
         sampled_only_count = sum(v["_sampled_count"] for v in namespaces.values())
         sampling_ratio = (
             sampled_only_count / total_entries if sampled_only_count else 0.0
         )
-        for ns_info in namespaces.values():
+        floors: Dict[str, int] = {}
+        estimates: Dict[str, int] = {}
+        for namespace, ns_info in namespaces.items():
             sampled = ns_info["_sampled_count"]
             probed = ns_info["_probed_count"]
             if sampling_ratio > 0 and sampled >= _NAMESPACE_PROJECTION_MIN_SAMPLES:
                 estimated_from_sample = int(sampled / sampling_ratio)
             else:
                 estimated_from_sample = 0
-            estimated_total = max(estimated_from_sample, sampled + probed)
+            floors[namespace] = sampled + probed
+            estimates[namespace] = max(estimated_from_sample, floors[namespace])
 
-            ns_info["sampled_count"] = sampled
-            ns_info["probed_count"] = probed
-            ns_info["estimated_total"] = estimated_total
-            ns_info["total"] = estimated_total
+        _clamp_projections_to_total(estimates, floors, total_entries)
+
+        for namespace, ns_info in namespaces.items():
+            ns_info["sampled_count"] = ns_info["_sampled_count"]
+            ns_info["probed_count"] = ns_info["_probed_count"]
+            ns_info["estimated_total"] = estimates[namespace]
+            ns_info["total"] = estimates[namespace]
             # Sampling-derived counts are projections, not exact totals.
             ns_info["is_authoritative"] = False
             ns_info.pop("_probed_count", None)
@@ -624,9 +741,11 @@ class _NamespaceMixin:
     def _get_known_namespace_probes() -> List[str]:
         """Canonical paths that, if present, prove a namespace exists.
 
-        Used by list_namespaces to deterministically surface minority
-        namespaces (M, W, X, I, -) that random sampling would otherwise miss
-        on archives where one namespace dominates.
+        Used by list_namespaces to surface minority namespaces (M, W, X, I,
+        -) that a 1-in-N sample can still miss on archives where one
+        namespace dominates. A probe proves existence; it says nothing about
+        how many entries the namespace holds, which is why probed hits are
+        counted separately from sampled ones.
         """
         return [
             # Metadata

--- a/openzim_mcp/zim/namespace.py
+++ b/openzim_mcp/zim/namespace.py
@@ -1780,7 +1780,9 @@ class _NamespaceMixin:
         elif namespace == "I":
             patterns.extend(["I/favicon.png", "I/logo.png", "I/image.jpg"])
 
-        return patterns
+        # The two lists overlap (M/Title, I/favicon.png, ...); de-duplicate
+        # so a caller doesn't pay for the same has_entry_by_path twice.
+        return list(dict.fromkeys(patterns))
 
     def walk_namespace_data(
         self,

--- a/tests/test_cache_invalidation_on_file_changes.py
+++ b/tests/test_cache_invalidation_on_file_changes.py
@@ -122,8 +122,8 @@ _CONTENT_CACHE_CASES = [
     (
         "namespaces_data",
         lambda zo, p: zo.list_namespaces_data(p),
-        lambda vp: f"namespaces_data:v2b:{vp}",
-        lambda vp, tok: f"namespaces_data:v2b:{vp}:{tok}",
+        lambda vp: f"namespaces_data:v2c:{vp}",
+        lambda vp, tok: f"namespaces_data:v2c:{vp}:{tok}",
     ),
     (
         "main_page",

--- a/tests/test_cache_invalidation_on_file_changes.py
+++ b/tests/test_cache_invalidation_on_file_changes.py
@@ -140,8 +140,8 @@ _CONTENT_CACHE_CASES = [
     (
         "browse_ns_data",
         lambda zo, p: zo.browse_namespace_data(p, "A", 50, 0),
-        lambda vp: f"browse_ns_data:v2e:{vp}:A:50:0:assets=False",
-        lambda vp, tok: f"browse_ns_data:v2e:{vp}:{tok}:A:50:0:assets=False",
+        lambda vp: f"browse_ns_data:v2f:{vp}:A:50:0:assets=False",
+        lambda vp, tok: f"browse_ns_data:v2f:{vp}:{tok}:A:50:0:assets=False",
     ),
     (
         # An explicit limit is passed so the key is not affected by the

--- a/tests/test_namespace_sampling_determinism.py
+++ b/tests/test_namespace_sampling_determinism.py
@@ -54,8 +54,10 @@ from openzim_mcp.constants import NAMESPACE_MAX_SAMPLE_SIZE
 from openzim_mcp.content_processor import ContentProcessor
 from openzim_mcp.security import PathValidator
 from openzim_mcp.zim.namespace import (
+    _NAMESPACE_PROJECTION_MIN_SAMPLES,
     _clamp_projections_to_total,
     _deterministic_sample_ids,
+    _NamespaceMixin,
 )
 from openzim_mcp.zim_operations import ZimOperations
 
@@ -131,9 +133,13 @@ def test_per_namespace_totals_cannot_sum_above_the_archive_total(
 def test_sampling_sees_namespaces_the_article_index_hides(sampled_ops) -> None:
     """``I`` holds 110 real entries and was invisible to random sampling.
 
-    ``get_random_entry`` draws from the article index, so images, layout
-    assets and metadata could only ever be found by the canonical-path
-    probe list — which has no ``I`` probe at all.
+    ``get_random_entry`` draws from the article index, so images and layout
+    assets could only ever be reached by the canonical-path probe list. The
+    ``I`` probe on that list (``I/favicon.png``) does not exist in this
+    archive — ``has_entry_by_path`` returns False for it, while ``-/favicon``
+    matches, which is why ``-`` showed up at 1 and ``I`` not at all. Probing
+    proves existence at one guessed path; only walking entry ids finds a
+    namespace whose paths you cannot guess.
     """
     ops, zim = sampled_ops
     found = set(ops.list_namespaces_data(zim)["namespaces"])
@@ -145,9 +151,13 @@ def test_projections_track_the_true_distribution(sampled_ops) -> None:
 
     Full iteration of 20,565 entries is cheap enough to do here, and it is
     the only honest way to say the projection is *right* rather than merely
-    self-consistent. A 10% band is generous but still far tighter than the
-    pre-fix behaviour, which put ``A`` at 100.9% of truth and every other
-    namespace at its probe count.
+    self-consistent.
+
+    The two namespaces are checked against different bands on purpose,
+    because they rest on wildly different amounts of signal. Pinning both
+    to one tight number would pin this fixture's luck rather than the
+    projection, and would red on any future change to the stride or the
+    UUID phase with a message that reads like an accuracy regression.
     """
     ops, zim = sampled_ops
     from libzim.reader import Archive
@@ -158,14 +168,111 @@ def test_projections_track_the_true_distribution(sampled_ops) -> None:
         path = archive._get_entry_by_id(entry_id).path
         truth[path.split("/", 1)[0] if "/" in path else "?"] += 1
 
-    estimates = {
-        k: v["total"] for k, v in ops.list_namespaces_data(zim)["namespaces"].items()
+    buckets = ops.list_namespaces_data(zim)["namespaces"]
+
+    # ``A`` is 99% of the archive, so its projection rests on ~1,000 sampled
+    # hits. 5% is a real constraint here (measured error: 0.06%) and does
+    # not care where the stride lands.
+    a_actual, a_estimated = truth["A"], buckets.get("A", {}).get("total", 0)
+    assert abs(a_estimated - a_actual) <= 0.05 * a_actual, (
+        f"namespace A: estimated {a_estimated}, actual {a_actual} — the "
+        f"dominant namespace's projection should be near-exact"
+    )
+
+    # ``I`` is the namespace the article-index sampler could never reach.
+    # Split into two claims so a failure says which half broke.
+    assert "I" in buckets, f"image namespace never discovered: {sorted(buckets)}"
+    i_bucket = buckets["I"]
+    assert i_bucket["sampled_count"] >= _NAMESPACE_PROJECTION_MIN_SAMPLES, (
+        f"the stride landed only {i_bucket['sampled_count']} draws in I, below "
+        f"the {_NAMESPACE_PROJECTION_MIN_SAMPLES}-hit floor for projecting at "
+        f"all — I's total is now a probe floor, not an estimate"
+    )
+    # 50%, not 10%: at ~5 hits the sampling standard error is already ~45%,
+    # so a tighter band asserts luck. It still fails loudly on the pre-fix
+    # behaviour, which estimated 0 against a true 110 (100% error).
+    i_actual, i_estimated = truth["I"], i_bucket["total"]
+    assert (
+        abs(i_estimated - i_actual) <= 0.50 * i_actual
+    ), f"namespace I: estimated {i_estimated}, actual {i_actual}"
+
+
+# ---------------------------------------------------------------------------
+# The sibling sampler: browse_namespace must describe the same archive.
+# ---------------------------------------------------------------------------
+
+
+def test_browse_agrees_with_list_about_which_namespaces_have_entries(
+    sampled_ops,
+) -> None:
+    """Two tools must not contradict each other about one archive.
+
+    ``browse_namespace``'s own sampler used ``get_random_entry`` too, so it
+    inherited the article-index blindness: ``list_namespaces`` advertised
+    ``I`` at 102 entries and ``browse_namespace('I')`` answered ``total: 0,
+    results: []``. An agent that reads the first and then calls the second
+    concludes the archive — or the server — is broken.
+
+    The counts themselves are not compared: browse returns a lower bound
+    capped at ``NAMESPACE_MAX_ENTRIES`` and says so via
+    ``page_info.total_is_lower_bound``. Non-emptiness is the claim both
+    tools make, so non-emptiness is what has to match.
+    """
+    ops, zim = sampled_ops
+    advertised = {
+        ns: info["total"]
+        for ns, info in ops.list_namespaces_data(zim)["namespaces"].items()
+        if info["total"] > 0
     }
-    for namespace in ("A", "I"):
-        actual, estimated = truth[namespace], estimates.get(namespace, 0)
-        assert (
-            abs(estimated - actual) <= 0.10 * actual
-        ), f"namespace {namespace}: estimated {estimated}, actual {actual}"
+    assert advertised, "fixture surfaced no namespaces at all"
+
+    empty_in_browse = {}
+    for namespace in sorted(advertised):
+        page = ops.browse_namespace_data(zim, namespace, 5, 0)
+        if page["total"] == 0 or not page["results"]:
+            empty_in_browse[namespace] = page["total"]
+
+    assert not empty_in_browse, (
+        f"list_namespaces advertises {advertised} but browse_namespace "
+        f"reports these empty: {empty_in_browse}"
+    )
+
+
+def test_browse_returns_a_byte_identical_page_on_the_sampled_path(
+    sampled_ops,
+) -> None:
+    """Same archive, same page — browse is cached and paginated.
+
+    A sampler that re-rolls per call gives page 2 a different population
+    than page 1, so a client walking the cursor sees entries appear, vanish
+    and repeat.
+    """
+    ops, zim = sampled_ops
+    blobs = [
+        json.dumps(ops.browse_namespace_data(zim, "A", 5, 0), sort_keys=True)
+        for _ in range(3)
+    ]
+    assert (
+        blobs[0] == blobs[1] == blobs[2]
+    ), "browse_namespace_data is non-deterministic on the sampled path"
+
+
+def test_browse_probes_cover_every_namespace_list_can_surface_by_probe() -> None:
+    """Structural guard behind the agreement test above.
+
+    ``list_namespaces`` finds ``X`` only via ``X/fulltext/xapian``; browse's
+    own pattern list guessed ``X/fulltext`` and missed. Rather than keeping
+    two hand-maintained lists in sync, browse now seeds its patterns from
+    the canonical probe list, so this holds for namespaces no fixture in the
+    corpus happens to contain.
+    """
+    ops = _NamespaceMixin()
+    for probe in ops._get_known_namespace_probes():
+        namespace = probe.split("/", 1)[0]
+        assert probe in ops._get_common_namespace_patterns(namespace), (
+            f"{probe} proves {namespace!r} exists to list_namespaces but "
+            f"browse_namespace never tries it"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -222,8 +329,6 @@ def test_a_sample_of_unreadable_entries_degrades_instead_of_raising() -> None:
     """
     from unittest.mock import MagicMock
 
-    from openzim_mcp.zim.namespace import _NamespaceMixin
-
     archive = MagicMock()
     archive.entry_count = 5_000
     archive.uuid = "unreadable"
@@ -231,14 +336,48 @@ def test_a_sample_of_unreadable_entries_degrades_instead_of_raising() -> None:
     archive.has_entry_by_path.return_value = False
     archive._get_entry_by_id.side_effect = RuntimeError("corrupt dirent")
 
-    seen: set = set()
     recorded: list = []
-    _NamespaceMixin._sample_entries(
-        archive, 5_000, seen, lambda *a, **kw: recorded.append(a)
-    )
+    _NamespaceMixin._sample_entries(archive, 5_000, lambda *a, **kw: recorded.append(a))
 
     assert recorded == []
     assert archive._get_entry_by_id.call_count == NAMESPACE_MAX_SAMPLE_SIZE
+
+
+def test_finalise_sampled_actually_clamps_what_it_publishes() -> None:
+    """Pin the clamp *call site*, not just the clamp.
+
+    The three ``test_clamp_*`` cases below call the helper directly, so they
+    stay green if the call disappears from ``_finalise_sampled``; and on the
+    one corpus archive large enough to sample, the projections happen to fit
+    under ``total_entries`` on their own, so the integration invariant is
+    green either way. Deleting the call really did leave the whole suite
+    passing. This drives the production function with the shape that
+    overflows — a sample that lands entirely in one namespace, plus buckets
+    known only from canonical-path probes stacking their floors on top — and
+    reads the published ``total`` values back out.
+    """
+    namespaces = {
+        "A": {"_sampled_count": 1_000, "_probed_count": 0},
+        "M": {"_sampled_count": 0, "_probed_count": 1},
+        "X": {"_sampled_count": 0, "_probed_count": 1},
+        "-": {"_sampled_count": 0, "_probed_count": 1},
+    }
+    _NamespaceMixin._finalise_sampled(namespaces, 10_000)
+
+    published = {ns: info["total"] for ns, info in namespaces.items()}
+    assert sum(published.values()) <= 10_000, (
+        f"published per-namespace totals sum to {sum(published.values())} "
+        f"against total_entries 10000: {published}"
+    )
+    # The clamp must shave the extrapolation, never the entries we saw:
+    # the three probe-only buckets keep their floor of 1 each.
+    assert published["M"] == 1
+    assert published["X"] == 1
+    assert published["-"] == 1
+    # ...and ``A`` must still carry essentially the whole archive rather
+    # than collapsing to its 1,000-entry sampled floor.
+    assert published["A"] > 9_000
+    assert namespaces["A"]["estimated_total"] == published["A"]
 
 
 def test_clamp_is_a_no_op_when_the_projection_already_fits() -> None:
@@ -277,3 +416,14 @@ def test_namespaces_cache_key_is_versioned() -> None:
     assert re.search(
         r'f"namespaces_data:v\d+[a-z]?:', _NAMESPACE_SRC
     ), "namespaces cache key lost its version segment"
+
+
+def test_browse_cache_key_moved_past_the_3_2_5_spelling() -> None:
+    """``browse_namespace``'s payload changed too, so its key must move.
+
+    Same reasoning as the ``namespaces_data`` bump: a restored
+    ``persistence_enabled`` snapshot holds pages built by the random
+    sampler, including the empty ``I`` / ``-`` listings this release exists
+    to correct.
+    """
+    assert "browse_ns_data:v2e:" not in _NAMESPACE_SRC

--- a/tests/test_namespace_sampling_determinism.py
+++ b/tests/test_namespace_sampling_determinism.py
@@ -269,10 +269,14 @@ def test_browse_probes_cover_every_namespace_list_can_surface_by_probe() -> None
     ops = _NamespaceMixin()
     for probe in ops._get_known_namespace_probes():
         namespace = probe.split("/", 1)[0]
-        assert probe in ops._get_common_namespace_patterns(namespace), (
+        patterns = ops._get_common_namespace_patterns(namespace)
+        assert probe in patterns, (
             f"{probe} proves {namespace!r} exists to list_namespaces but "
             f"browse_namespace never tries it"
         )
+        # The two lists overlap, so the union has to be de-duplicated or
+        # browse pays for the same has_entry_by_path lookup twice.
+        assert len(patterns) == len(set(patterns)), f"duplicate probes: {patterns}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_namespace_sampling_determinism.py
+++ b/tests/test_namespace_sampling_determinism.py
@@ -1,0 +1,279 @@
+"""``list_namespaces`` on any archive over 1,000 entries was a coin flip.
+
+``_list_archive_namespaces`` takes the sampled branch whenever
+``entry_count > NAMESPACE_MAX_SAMPLE_SIZE`` — i.e. for every real archive.
+That branch called ``archive.get_random_entry()`` a thousand times, which
+made the response:
+
+* **non-deterministic** — three consecutive calls returned three different
+  ``sample_entries`` lists, so the response the cache stores is a lottery
+  ticket and every warm read hands the client a payload that disagrees with
+  the last one. Determinism is repo doctrine (see
+  ``tests/test_list_ordering_determinism.py``: "a list whose order wobbles
+  turns every cache entry into a miss"), and the cache block in
+  ``namespace.py`` already carries a scar from the same class of bug.
+* **blind** — libzim's ``get_random_entry`` draws from the *article* index,
+  not the entry index, so on the climate-change fixture all 1,000 draws
+  landed in ``A``. The 110 ``I/`` images and the 54 ``-/`` layout entries
+  were structurally undiscoverable; only the canonical-path probes ever
+  surfaced anything outside ``A``.
+* **arithmetically impossible** — because 100% of the sample landed in
+  ``A``, ``A`` was projected at the archive's entire ``entry_count`` and the
+  probed namespaces were then stacked on top: ``A=20565 + M=5 + X=2 + -=1``
+  summed to 20,573 against a stated ``total_entries`` of 20,565.
+
+The sample is now a systematic (strided) walk over entry ids, phase-shifted
+by a digest of the archive UUID: same archive, same sample, forever — and
+because old-scheme ZIM archives store dirents grouped by namespace, an
+evenly strided walk represents every namespace in proportion to its real
+size instead of missing the small ones.
+
+The fixture used here is the one already in the corpus:
+``wikipedia_en_climate_change_mini_2024-06.zim``, 20,565 entries, whose true
+namespace distribution is ``A=20387, I=110, -=54, M=12, X=2``.
+"""
+
+from __future__ import annotations
+
+import collections
+import json
+import re
+from pathlib import Path
+from typing import Dict, Optional
+
+import pytest
+
+from openzim_mcp.cache import OpenZimMcpCache
+from openzim_mcp.config import (
+    CacheConfig,
+    ContentConfig,
+    LoggingConfig,
+    OpenZimMcpConfig,
+)
+from openzim_mcp.constants import NAMESPACE_MAX_SAMPLE_SIZE
+from openzim_mcp.content_processor import ContentProcessor
+from openzim_mcp.security import PathValidator
+from openzim_mcp.zim.namespace import (
+    _clamp_projections_to_total,
+    _deterministic_sample_ids,
+)
+from openzim_mcp.zim_operations import ZimOperations
+
+_NAMESPACE_SRC = Path("openzim_mcp/zim/namespace.py").read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def sampled_ops(real_content_zim_files: Dict[str, Optional[Path]]):
+    """Ops bound to the one corpus archive big enough to sample, cache OFF.
+
+    The cache is disabled deliberately: a cached payload would mask the
+    non-determinism by serving the first roll of the dice back to every
+    later caller.
+    """
+    zim = real_content_zim_files.get("wikipedia_climate")
+    if zim is None:
+        pytest.skip("climate-change ZIM fixture not available")
+    cfg = OpenZimMcpConfig(
+        allowed_directories=[str(zim.parent)],
+        cache=CacheConfig(enabled=False, max_size=10, ttl_seconds=60),
+        content=ContentConfig(max_content_length=100_000, snippet_length=100),
+        logging=LoggingConfig(level="ERROR"),
+    )
+    ops = ZimOperations(
+        cfg,
+        PathValidator(cfg.allowed_directories),
+        OpenZimMcpCache(cfg.cache, enable_background_cleanup=False),
+        ContentProcessor(snippet_length=100),
+    )
+    return ops, str(zim)
+
+
+def test_the_fixture_really_takes_the_sampled_branch(sampled_ops) -> None:
+    """Vacuity guard for every other test in this file.
+
+    If the fixture were ever swapped for one under the threshold, the
+    assertions below would all pass against the exhaustive branch without
+    exercising a single line of the sampling code they exist to pin.
+    """
+    ops, zim = sampled_ops
+    payload = ops.list_namespaces_data(zim)
+    assert payload["total_entries"] > NAMESPACE_MAX_SAMPLE_SIZE
+    assert payload["discovery_method"] == "sampling"
+    assert payload["is_total_authoritative"] is False
+
+
+def test_repeated_calls_return_a_byte_identical_payload(sampled_ops) -> None:
+    """The whole point: the same archive must answer the same thing."""
+    ops, zim = sampled_ops
+    blobs = [
+        json.dumps(ops.list_namespaces_data(zim), sort_keys=True) for _ in range(3)
+    ]
+    assert blobs[0] == blobs[1] == blobs[2], (
+        "list_namespaces_data is non-deterministic on the sampled path; "
+        "every cache entry it feeds is a lottery ticket"
+    )
+
+
+def test_per_namespace_totals_cannot_sum_above_the_archive_total(
+    sampled_ops,
+) -> None:
+    """A projection that sums past the authoritative total is nonsense."""
+    ops, zim = sampled_ops
+    payload = ops.list_namespaces_data(zim)
+    total = payload["total_entries"]
+    per_ns = {k: v["total"] for k, v in payload["namespaces"].items()}
+    assert sum(per_ns.values()) <= total, (
+        f"per-namespace projections sum to {sum(per_ns.values())} against a "
+        f"stated total_entries of {total}: {per_ns}"
+    )
+
+
+def test_sampling_sees_namespaces_the_article_index_hides(sampled_ops) -> None:
+    """``I`` holds 110 real entries and was invisible to random sampling.
+
+    ``get_random_entry`` draws from the article index, so images, layout
+    assets and metadata could only ever be found by the canonical-path
+    probe list — which has no ``I`` probe at all.
+    """
+    ops, zim = sampled_ops
+    found = set(ops.list_namespaces_data(zim)["namespaces"])
+    assert "I" in found, f"image namespace never discovered; found {sorted(found)}"
+
+
+def test_projections_track_the_true_distribution(sampled_ops) -> None:
+    """Compare the sampled estimate against an exhaustive count.
+
+    Full iteration of 20,565 entries is cheap enough to do here, and it is
+    the only honest way to say the projection is *right* rather than merely
+    self-consistent. A 10% band is generous but still far tighter than the
+    pre-fix behaviour, which put ``A`` at 100.9% of truth and every other
+    namespace at its probe count.
+    """
+    ops, zim = sampled_ops
+    from libzim.reader import Archive
+
+    archive = Archive(zim)
+    truth: collections.Counter = collections.Counter()
+    for entry_id in range(archive.entry_count):
+        path = archive._get_entry_by_id(entry_id).path
+        truth[path.split("/", 1)[0] if "/" in path else "?"] += 1
+
+    estimates = {
+        k: v["total"] for k, v in ops.list_namespaces_data(zim)["namespaces"].items()
+    }
+    for namespace in ("A", "I"):
+        actual, estimated = truth[namespace], estimates.get(namespace, 0)
+        assert (
+            abs(estimated - actual) <= 0.10 * actual
+        ), f"namespace {namespace}: estimated {estimated}, actual {actual}"
+
+
+# ---------------------------------------------------------------------------
+# The two pieces of arithmetic, unit-tested away from libzim.
+# ---------------------------------------------------------------------------
+
+
+def test_sample_ids_are_stable_distinct_and_spread() -> None:
+    ids = _deterministic_sample_ids(20_565, 1_000, "some-archive-uuid")
+    assert ids == _deterministic_sample_ids(20_565, 1_000, "some-archive-uuid")
+    assert len(ids) == 1_000
+    assert len(set(ids)) == 1_000, "ids must be distinct — a repeat wastes a draw"
+    assert all(0 <= i < 20_565 for i in ids)
+    # Spread, not "the first N": the walk must reach both ends of the id
+    # space, or a namespace stored at the tail of the dirent table is
+    # unreachable by construction.
+    assert min(ids) < 0.05 * 20_565
+    assert max(ids) > 0.95 * 20_565
+
+
+def test_sample_ids_are_phase_shifted_per_archive() -> None:
+    """Two archives of identical size must not sample identical positions."""
+    a = _deterministic_sample_ids(20_565, 1_000, "uuid-a")
+    b = _deterministic_sample_ids(20_565, 1_000, "uuid-b")
+    assert a != b
+
+
+def test_sample_ids_degenerate_cases() -> None:
+    assert _deterministic_sample_ids(0, 1_000, "x") == []
+    assert _deterministic_sample_ids(100, 0, "x") == []
+    # Asking for at least as many as exist is exhaustive iteration.
+    assert _deterministic_sample_ids(7, 7, "x") == list(range(7))
+    assert _deterministic_sample_ids(7, 99, "x") == list(range(7))
+
+
+def test_clamp_shrinks_projections_but_never_the_observed_floor() -> None:
+    """Probed floors are facts; only the extrapolated part may be shaved."""
+    # 900 of 1000 samples in A, 100 in C; four namespaces known only from
+    # canonical-path probes then stack their floors on top.
+    estimates = {"A": 9_000, "C": 1_000, "M": 6, "W": 3, "X": 2, "-": 1}
+    floors = {"A": 900, "C": 100, "M": 6, "W": 3, "X": 2, "-": 1}
+    _clamp_projections_to_total(estimates, floors, 10_000)
+    assert sum(estimates.values()) <= 10_000
+    for ns, floor in floors.items():
+        assert estimates[ns] >= floor, f"{ns} clamped below what we observed"
+
+
+def test_a_sample_of_unreadable_entries_degrades_instead_of_raising() -> None:
+    """A dirent that libzim refuses to read must not sink the whole listing.
+
+    The old sampler swallowed per-draw failures; the id-driven one has to
+    keep doing so, or one bad entry in a 20,000-entry archive turns
+    ``list_namespaces`` into an ``OpenZimMcpArchiveError``.
+    """
+    from unittest.mock import MagicMock
+
+    from openzim_mcp.zim.namespace import _NamespaceMixin
+
+    archive = MagicMock()
+    archive.entry_count = 5_000
+    archive.uuid = "unreadable"
+    archive.has_new_namespace_scheme = False
+    archive.has_entry_by_path.return_value = False
+    archive._get_entry_by_id.side_effect = RuntimeError("corrupt dirent")
+
+    seen: set = set()
+    recorded: list = []
+    _NamespaceMixin._sample_entries(
+        archive, 5_000, seen, lambda *a, **kw: recorded.append(a)
+    )
+
+    assert recorded == []
+    assert archive._get_entry_by_id.call_count == NAMESPACE_MAX_SAMPLE_SIZE
+
+
+def test_clamp_is_a_no_op_when_the_projection_already_fits() -> None:
+    estimates = {"A": 9_000, "M": 6}
+    floors = {"A": 900, "M": 6}
+    _clamp_projections_to_total(estimates, floors, 10_000)
+    assert estimates == {"A": 9_000, "M": 6}
+
+
+def test_clamp_leaves_floors_alone_when_they_already_exceed_the_total() -> None:
+    """A pathological total is not a licence to under-report real entries."""
+    estimates = {"A": 50, "M": 40}
+    floors = {"A": 50, "M": 40}
+    _clamp_projections_to_total(estimates, floors, 10)
+    assert estimates == {"A": 50, "M": 40}
+
+
+# ---------------------------------------------------------------------------
+# Cache versioning: the payload changed, so the key must too.
+# ---------------------------------------------------------------------------
+
+
+def test_namespaces_cache_key_moved_past_the_3_2_5_spelling() -> None:
+    """An operator with ``persistence_enabled`` restores a snapshot whose
+    namespace listings were built by the random sampler. Nothing in the
+    ``namespaces_data:v2b:<path>:<stat_token>`` key changes when the *code*
+    changes, so those pre-fix payloads — wrong sums, missing ``I``, a random
+    ``sample_entries`` — would be re-served verbatim until TTL expiry, with
+    this release's fix inert on exactly the archives it was written for.
+    Same rule as the ``bundle:v2d`` and ``browse_ns_data:v2e`` bumps.
+    """
+    assert "namespaces_data:v2b:" not in _NAMESPACE_SRC
+
+
+def test_namespaces_cache_key_is_versioned() -> None:
+    assert re.search(
+        r'f"namespaces_data:v\d+[a-z]?:', _NAMESPACE_SRC
+    ), "namespaces cache key lost its version segment"

--- a/tests/test_post_a16_beta_fixes.py
+++ b/tests/test_post_a16_beta_fixes.py
@@ -1296,12 +1296,10 @@ class TestP3D3NamespaceCountAggregatorAgreement:
                 self,
                 _archive: Any,
                 _total: int,
-                seen_entries: set,
                 record: Any,
             ) -> None:
                 # Record one C-namespace hit so the projection fires.
                 record("Berlin", "Berlin")
-                seen_entries.add("Berlin")
 
             def _probe_known_namespaces(self, *_a: Any, **_kw: Any) -> None:
                 pass
@@ -1371,11 +1369,9 @@ class TestP3D3NamespaceCountAggregatorAgreement:
                 self,
                 _archive: Any,
                 _total: int,
-                seen_entries: set,
                 record: Any,
             ) -> None:
                 record("Berlin", "Berlin")
-                seen_entries.add("Berlin")
 
             def _probe_known_namespaces(self, *_a: Any, **_kw: Any) -> None:
                 pass

--- a/tests/test_zim_operations.py
+++ b/tests/test_zim_operations.py
@@ -1649,8 +1649,9 @@ class TestZimOperations:
         # Test list_namespaces_data cache hit.
         # Phase B #12 fix: the cache now stores POST-ATTACH payloads
         # (with ``_meta`` already attached), and cache hits return them
-        # verbatim. Seed accordingly.
-        cache_key = f"namespaces_data:v2b:{validated_path}:{stat_token}"
+        # verbatim. Seed accordingly. Key bumped v2b -> v2c when the
+        # sampled branch became deterministic (payload contents changed).
+        cache_key = f"namespaces_data:v2c:{validated_path}:{stat_token}"
         cached_ns = {"cached": "namespaces", "_meta": {"chars": 1}}
         zim_operations.cache.set(cache_key, cached_ns)
 

--- a/tests/test_zim_operations.py
+++ b/tests/test_zim_operations.py
@@ -1661,9 +1661,11 @@ class TestZimOperations:
 
         # Test browse_namespace_data cache hit. Same contract — cache
         # stores the post-attach payload. Key bumped v2b -> v2c when
-        # new-scheme C browse began filtering _zim_static infra assets.
+        # new-scheme C browse began filtering _zim_static infra assets, and
+        # v2e -> v2f when the old-scheme sampled branch became deterministic
+        # (pre-fix pages listed nothing for I / -).
         cache_key = (
-            f"browse_ns_data:v2e:{validated_path}:{stat_token}:A:50:0:assets=False"
+            f"browse_ns_data:v2f:{validated_path}:{stat_token}:A:50:0:assets=False"
         )
         cached_browse = {"cached": "browse", "_meta": {"chars": 1}}
         zim_operations.cache.set(cache_key, cached_browse)

--- a/website/src/content/docs/api-reference.mdx
+++ b/website/src/content/docs/api-reference.mdx
@@ -454,7 +454,7 @@ zim_metadata(zim_file_path: str) -> Any
 **Returns:** structured response with:
 
 - **`metadata`** — archive M-namespace fields, keyed exactly as libzim emits them, which is **capitalized**: `Title`, `Language`, `Creator`, `Publisher`, `Date`, `Flavour`, and so on. `metadata["title"]` raises `KeyError` — use `metadata["Title"]`.
-- **`namespaces`** — a deterministic namespace breakdown (surfaces minority namespaces — `M`, `W`, `X`, `I` — that random sampling could miss).
+- **`namespaces`** — a namespace breakdown. Archives above 1,000 entries are sampled rather than walked, so the per-namespace counts outside the dominant namespace are projections, not exact totals (each bucket carries `is_authoritative`). The sample is a fixed stride over entry ids, seeded from the archive UUID: the same archive always answers the same thing, and minority namespaces (`M`, `W`, `X`, `I`, `-`) are surfaced rather than lost to whichever entries a random draw happened to hit.
 - **`archive_identity`** — `{uuid, is_multipart}`, the libzim archive identity (*added in v2.1*).
 - **`index_capabilities`** — `{has_fulltext_index, has_title_index}`: whether full-text search and title suggestions will work against this archive (*added in v2.1*).
 - **`counter_breakdown`** — `{mimetype: count}` parsed from the `M/Counter` metadata, so you can profile an archive's content composition without walking it. Omitted when the archive has no `M/Counter` entry (*added in v2.1*).


### PR DESCRIPTION
`list_namespaces` and `browse_namespace` were both a coin flip on every archive
that matters, and they disagreed with each other.

The namespace inventory only iterates every entry for archives of 1,000 entries
or fewer. Everything larger — i.e. every real archive — takes the sampled
branch, and that branch built its sample out of `Archive.get_random_entry()`,
for which libzim exposes no seed. Three consecutive calls on the same
unchanged file returned three different payloads. Since the listing is cached,
each cache fill froze one arbitrary roll of the dice, and two clients (or the
same client either side of a TTL) saw listings that disagreed for no reason.

`get_random_entry` also draws from the archive's **article** index rather than
its entry index. On the 20,565-entry climate-change corpus archive, all 1,000
draws landed in `A` — so the 110 `I/` images and 54 `-/` layout entries were
undiscoverable by construction, no matter how many draws you took. Only the
canonical-path probe list ever surfaced anything outside `A`, and probing finds
a namespace only where the guessed path happens to exist: the list's `I` probe
(`I/favicon.png`) is absent from this archive, while `-/favicon` is present,
which is why `-` appeared at 1 and `I` not at all.

That in turn broke the arithmetic. With 100% of the sample in `A`, the ratio
projection handed `A` the archive's entire `entry_count`, and the probe-only
namespaces then added their floors on top:

```
A=20565 + M=5 + X=2 + -=1  =  20573   against total_entries = 20565
```

## What changed

- **Sampling is deterministic.** Both samplers now walk entry ids at a fixed
  stride (`total / sample_size`), phased by a BLAKE2b digest of the archive
  UUID, instead of asking libzim for random entries. Same archive, same sample,
  same payload — forever. Ids are distinct by construction, so the old
  retry-until-distinct loop is gone.
- **Sampling now sees the whole archive.** Old-scheme ZIM files store dirents
  grouped by namespace, so an evenly spread walk is a systematic sample of an
  ordered population: each namespace is represented roughly in proportion to
  its real size. On the climate-change archive `A` now estimates 20,400 against
  a true 20,387 (was 20,565), and `I` is discovered at 102 against a true 110
  (was absent entirely).
- **`browse_namespace` agrees with `list_namespaces` again.** The browse path
  had its own copy of the same sampler, so fixing only the listing would have
  had `list_namespaces` advertise `I` at 102 entries while
  `browse_namespace('I')` returned `total: 0, results: []`. Browse now walks
  the same strided ids, and seeds its canonical-path probes from the same list
  the inventory uses — that last part is what fixes `X`, which exists at
  `X/fulltext/xapian` while browse only ever guessed `X/fulltext`. On the
  climate archive every namespace the inventory reports is now non-empty in
  browse: `I` 11, `-` 6, `M` 6, `X` 2, `A` 200 (browse totals stay lower
  bounds capped at `NAMESPACE_MAX_ENTRIES`, as `page_info.total_is_lower_bound`
  says).
- **Projections are clamped as a set.** Observed entries are a floor and are
  never reduced; only the extrapolated part above each floor is scaled, in
  proportion, into whatever headroom the floors leave. The per-namespace counts
  can no longer sum above `total_entries`.
- **Cache keys `namespaces_data:v2b` → `v2c` and `browse_ns_data:v2e` →
  `v2f`.** Nothing in the old keys changes when the *sampler* changes, so an
  operator running with `persistence_enabled` would have restored a snapshot of
  pre-fix payloads and been served them until TTL expiry — this fix inert on
  exactly the archives it was written for. Same rule as the earlier
  `bundle:v2d` bump.

## Testing

The sampled branch had never executed in the test suite: the 24 statements in
`_sample_entries` and `_probe_known_namespaces` were dead, even though the
fixture big enough to reach them has been in the corpus all along. There is now
an integration test that drives both tools against it with the cache disabled
and asserts each payload is byte-identical across repeated calls, that the
per-namespace counts fit inside `total_entries`, that `I` is found, that every
namespace `list_namespaces` advertises is non-empty in `browse_namespace`, and
that the estimates track an exhaustive count taken in the same test — banded by
how much signal each rests on (5% for `A`'s ~1,000 sampled hits, 50% for `I`'s
five, plus an explicit check that `I` clears the minimum-sample floor at all, so
a future stride change reports what actually broke).

Every test here was mutation-tested by reverting the specific source change it
claims to guard. That caught one that was not pinning anything: deleting the
`_clamp_projections_to_total` call from `_finalise_sampled` left the entire
suite green, because the clamp's unit tests call the helper directly and the one
corpus archive large enough to sample happens to fit under `total_entries`
without it. `_finalise_sampled` is now driven with the shape that does overflow
and its published totals read back out; removing the call reds at
`10003 <= 10000`.

## Upgrade notes

No API or response-shape change. `list_namespaces` and `browse_namespace` will
return different numbers than 3.2.5 did for archives over 1,000 entries —
closer to the truth, and the same numbers every time. Browse in particular now
returns entries for namespaces that previously came back empty (images, layout
assets, search indexes on old-scheme archives). Any cached namespace listing or
browse page is invalidated by the key bumps and rebuilt on first use.

Existing tests that hard-coded the `v2b` / `v2e` spellings were updated;
none pinned the defect (they pin the stat-token-in-key contract and the
cache-hit plumbing) and all pass unchanged in substance.
