### PR TITLE
fix: say where a first ZIM archive comes from

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,17 @@ Verify the install:
 openzim-mcp --help
 ```
 
-Download ZIM files from the [Kiwix Library](https://library.kiwix.org/) into a directory of your choice before running the server.
+### Get your first ZIM archive
+
+The server does nothing without an archive to read. Grab a real one — a 13.6 MB extract of English Wikipedia on climate change, from the openZIM project's own testing suite. No account, nothing to install:
+
+```bash
+mkdir -p ~/zim-files
+curl -fsSL -o ~/zim-files/wikipedia_en_climate_change_mini_2024-06.zim \
+  https://raw.githubusercontent.com/openzim/zim-testing-suite/main/data/withns/wikipedia_en_climate_change_mini_2024-06.zim
+```
+
+That is the directory you point the server at below. For full archives — Wikipedia, Wiktionary, Stack Exchange and the rest, ranging from a few hundred MB to tens of GB — browse [browse.library.kiwix.org](https://browse.library.kiwix.org/) and save the `.zim` into the same directory. More detail, including checksums and a Windows PowerShell equivalent: [Quick start](https://cameronrye.github.io/openzim-mcp/docs/quick-start/).
 
 ### Smithery & one-click install
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 > ✨ **Highlights.** A lean **8-tool advanced surface** (`zim_query`, `zim_search`, `zim_get`, `zim_get_section`, `zim_browse`, `zim_metadata`, `zim_links`, `zim_health`) with a schema small enough for small-model dispatch — or one-tool **Simple mode** for natural-language queries. **Archive-type presets** auto-tune retrieval per source (Wikipedia, Stack Exchange, …), **inbound link discovery** answers "what links here," and **native libzim introspection** validates and inspects any archive. Available on [Smithery](https://smithery.ai/servers/rye/openzim-mcp) and the [official MCP Registry](https://registry.modelcontextprotocol.io). [Release notes →](CHANGELOG.md) [Docs →](https://cameronrye.github.io/openzim-mcp/docs/)
 
-**OpenZIM MCP** is a modern, secure, high-performance [Model Context Protocol](https://modelcontextprotocol.io/) server that gives AI models structured, offline access to [ZIM format](https://en.wikipedia.org/wiki/ZIM_(file_format)) knowledge archives — Wikipedia, Wiktionary, Stack Exchange, and the rest of the [Kiwix Library](https://library.kiwix.org/).
+**OpenZIM MCP** is a modern, secure, high-performance [Model Context Protocol](https://modelcontextprotocol.io/) server that gives AI models structured, offline access to [ZIM format](https://en.wikipedia.org/wiki/ZIM_(file_format)) knowledge archives — Wikipedia, Wiktionary, Stack Exchange, and the rest of the [Kiwix Library](https://browse.library.kiwix.org/).
 
 Built for research assistants, knowledge chatbots, and content-analysis systems that need *intelligent* access to vast knowledge repositories — not just a raw text dump. Smart navigation by namespace (articles, metadata, media), structure-aware retrieval (sections, tables of contents, related articles), full-text search with suggestions and multi-archive search, and link-graph extraction to map content relationships. Cached, paginated operations keep things responsive across massive archives; comprehensive input validation and path-traversal protection keep things safe.
 
@@ -49,7 +49,7 @@ pip install openzim-mcp
 
 # Docker (multi-arch image, ghcr.io) — runs as a local stdio MCP server
 docker pull ghcr.io/cameronrye/openzim-mcp
-docker run -i --rm -v /path/to/zim/files:/data ghcr.io/cameronrye/openzim-mcp
+docker run -i --rm -v ~/zim-files:/data ghcr.io/cameronrye/openzim-mcp
 ```
 
 The container defaults to **stdio** transport, so `docker run -i` speaks MCP over stdin/stdout — wire it into an MCP client the same way as the binary (see [Quick start](#quick-start)). For the long-running **HTTP** service (bearer auth, CORS, health endpoints), opt in at runtime with `-e OPENZIM_MCP_TRANSPORT=http -e OPENZIM_MCP_HOST=0.0.0.0 -e OPENZIM_MCP_AUTH_TOKEN=… -p 8000:8000`; see [HTTP & Docker deployment](https://cameronrye.github.io/openzim-mcp/docs/http-and-docker-deployment/).
@@ -70,7 +70,7 @@ curl -fsSL -o ~/zim-files/wikipedia_en_climate_change_mini_2024-06.zim \
   https://raw.githubusercontent.com/openzim/zim-testing-suite/main/data/withns/wikipedia_en_climate_change_mini_2024-06.zim
 ```
 
-That is the directory you point the server at below. For full archives — Wikipedia, Wiktionary, Stack Exchange and the rest, ranging from a few hundred MB to tens of GB — browse [browse.library.kiwix.org](https://browse.library.kiwix.org/) and save the `.zim` into the same directory. More detail, including checksums and a Windows PowerShell equivalent: [Quick start](https://cameronrye.github.io/openzim-mcp/docs/quick-start/).
+`~/zim-files` is the directory every example below points the server at — the server expands `~` itself, so it works from a shell and from a client config file alike. For full archives — Wikipedia, Wiktionary, Stack Exchange and the rest, ranging from a few hundred MB to tens of GB — browse [browse.library.kiwix.org](https://browse.library.kiwix.org/) and save the `.zim` into the same directory. More detail, including checksums and a Windows PowerShell equivalent: [Quick start](https://cameronrye.github.io/openzim-mcp/docs/quick-start/).
 
 ### Smithery & one-click install
 
@@ -89,7 +89,7 @@ For a one-click **Claude Desktop extension**, download the `openzim-mcp-<version
 Run the server in Simple mode (default — exposes one natural-language tool, `zim_query`):
 
 ```bash
-openzim-mcp /path/to/zim/files
+openzim-mcp ~/zim-files
 ```
 
 Wire it into your MCP client. Example for Claude Desktop's `claude_desktop_config.json` (any MCP client that speaks stdio works the same way):
@@ -99,7 +99,7 @@ Wire it into your MCP client. Example for Claude Desktop's `claude_desktop_confi
   "mcpServers": {
     "openzim-mcp": {
       "command": "uvx",
-      "args": ["openzim-mcp", "/path/to/zim/files"]
+      "args": ["openzim-mcp", "~/zim-files"]
     }
   }
 }
@@ -114,7 +114,7 @@ For full control, run in Advanced mode to expose all 8 specialized tools:
   "mcpServers": {
     "openzim-mcp-advanced": {
       "command": "uvx",
-      "args": ["openzim-mcp", "--mode", "advanced", "/path/to/zim/files"]
+      "args": ["openzim-mcp", "--mode", "advanced", "~/zim-files"]
     }
   }
 }

--- a/openzim_mcp/main.py
+++ b/openzim_mcp/main.py
@@ -221,7 +221,7 @@ def main() -> None:
         # Through the logger, never ``print``: stdout is the JSON-RPC stream
         # under the default stdio transport, and prose written there corrupts
         # the frame for every stdio client.
-        if not onboarding.count_zim_files(config.allowed_directories):
+        if not onboarding.has_zim_files(config.allowed_directories):
             logger.warning(
                 "%s", onboarding.no_archives_log_message(config.allowed_directories)
             )

--- a/openzim_mcp/main.py
+++ b/openzim_mcp/main.py
@@ -11,7 +11,7 @@ from typing import Optional
 
 from pydantic import ValidationError as PydanticValidationError
 
-from . import __version__
+from . import __version__, onboarding
 from .config import OpenZimMcpConfig
 from .constants import TOOL_MODE_SIMPLE, VALID_TOOL_MODES
 from .exceptions import OpenZimMcpConfigurationError
@@ -212,6 +212,19 @@ def main() -> None:
         # emitted regardless of operator-configured verbosity.
         logger.info("OpenZIM MCP server started in %s", mode_desc)
         logger.info("Allowed directories: %s", ", ".join(args.directories))
+
+        # Config validation only proves the directories exist — a directory
+        # with no ``.zim`` in it starts a server that answers every query
+        # with nothing, under a log line that says "started successfully".
+        # Say so, and say where an archive comes from.
+        #
+        # Through the logger, never ``print``: stdout is the JSON-RPC stream
+        # under the default stdio transport, and prose written there corrupts
+        # the frame for every stdio client.
+        if not onboarding.count_zim_files(config.allowed_directories):
+            logger.warning(
+                "%s", onboarding.no_archives_log_message(config.allowed_directories)
+            )
 
         # ``OpenZimMcpServer.run()`` derives the wire transport from
         # ``config.transport`` directly (translating our short name 'http'

--- a/openzim_mcp/onboarding.py
+++ b/openzim_mcp/onboarding.py
@@ -1,0 +1,104 @@
+"""Where a first ZIM archive comes from, stated once.
+
+The server is inert without an archive, and the three places that have to
+say so — the startup log, the empty-listing tool result, and the
+no-archive-selected gate — used to say nothing useful, or would each have
+grown their own copy of the same URL. They share this module instead, and
+``tests/test_onboarding_zim_acquisition.py`` holds the README and the docs
+site to the same values, so the command a user is given is the command
+that was last verified.
+
+The starter archive is a real 13.6 MB extract of English Wikipedia on
+climate change from the openZIM project's own testing suite: a stable
+raw.githubusercontent URL, no account, nothing to install. Verified
+2026-09-03: HTTP 200, 14,239,035 bytes.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+#: Full library — everything past a first run lives here.
+KIWIX_LIBRARY_URL = "https://browse.library.kiwix.org/"
+
+#: Host alone, for prose and log lines that should stay one line.
+KIWIX_LIBRARY_HOST = "browse.library.kiwix.org"
+
+STARTER_ARCHIVE_FILENAME = "wikipedia_en_climate_change_mini_2024-06.zim"
+
+STARTER_ARCHIVE_URL = (
+    "https://raw.githubusercontent.com/openzim/zim-testing-suite/main/data/withns/"
+    + STARTER_ARCHIVE_FILENAME
+)
+
+#: Human-readable size, stated identically in the README and on the docs
+#: site (14,239,035 bytes).
+STARTER_ARCHIVE_SIZE = "13.6 MB"
+
+#: The download, as a single copy-pasteable line.
+STARTER_ARCHIVE_COMMAND = (
+    f"curl -fsSL -o ~/zim-files/{STARTER_ARCHIVE_FILENAME} {STARTER_ARCHIVE_URL}"
+)
+
+
+def count_zim_files(directories: Iterable[str]) -> int:
+    """Count discoverable ``.zim`` files across ``directories``.
+
+    Mirrors the ``glob("**/*.zim")`` traversal that
+    ``ZimOperations._glob_zim_paths`` uses for the real listing — a
+    top-level-only count would nag an operator whose archives sit one
+    directory down while the server itself found them fine.
+
+    Never raises: a directory that cannot be walked contributes nothing,
+    exactly as it does in the listing. This runs on the startup path, and
+    a diagnostic that can abort a boot is worse than no diagnostic.
+    """
+    total = 0
+    for directory in directories:
+        try:
+            total += sum(1 for _ in Path(directory).glob("**/*.zim"))
+        except Exception as exc:  # noqa: BLE001 — a hint must never abort boot
+            logger.debug("ZIM count failed for %s: %s", directory, exc)
+    return total
+
+
+def no_archives_log_message(directories: Iterable[str]) -> str:
+    """The startup warning for a directory tree holding no archives.
+
+    Emitted through the logger — and therefore stderr — never ``print``:
+    under the default stdio transport stdout carries the JSON-RPC stream,
+    and prose written there corrupts it for every stdio client.
+    """
+    listed = ", ".join(directories) or "(none)"
+    return (
+        "0 ZIM files found in the allowed directories (%s) — the server will "
+        "start but every query will come back empty. Browse %s for full "
+        "archives, or get a %s starter archive with: %s"
+        % (
+            listed,
+            KIWIX_LIBRARY_URL,
+            STARTER_ARCHIVE_SIZE,
+            STARTER_ARCHIVE_COMMAND,
+        )
+    )
+
+
+def acquisition_hint_markdown() -> str:
+    """The same guidance for a tool result, where a GUI client shows it.
+
+    Claude Desktop and its peers keep stderr in a log file the user never
+    opens, so the log line above is invisible to exactly the audience most
+    likely to have no archive yet. This is the copy they do see.
+    """
+    return (
+        "**Get an archive:**\n"
+        f"- Browse [{KIWIX_LIBRARY_HOST}]({KIWIX_LIBRARY_URL}) for full "
+        "archives (Wikipedia, Wiktionary, Stack Exchange, …)\n"
+        f"- Or start with a {STARTER_ARCHIVE_SIZE} sample:\n"
+        f"  `{STARTER_ARCHIVE_COMMAND}`\n"
+        "- Then point the server's allowed directory at where you saved it"
+    )

--- a/openzim_mcp/onboarding.py
+++ b/openzim_mcp/onboarding.py
@@ -1,12 +1,13 @@
 """Where a first ZIM archive comes from, stated once.
 
-The server is inert without an archive, and the three places that have to
-say so — the startup log, the empty-listing tool result, and the
-no-archive-selected gate — used to say nothing useful, or would each have
-grown their own copy of the same URL. They share this module instead, and
-``tests/test_onboarding_zim_acquisition.py`` holds the README and the docs
-site to the same values, so the command a user is given is the command
-that was last verified.
+The server is inert without an archive, and every place that has to say so
+— the startup log, the empty-listing tool result, the no-archive-selected
+gate, the zero-archive ``search all files`` fan-out and the ``zim_health``
+report — used to say nothing useful, or would each have grown its own copy
+of the same URL. They share this module instead, and
+``tests/test_onboarding_zim_acquisition.py`` holds the README, the docs
+site, the ``.mcpb`` bundle and ``server.json`` to the same values, so the
+command a user is given is the command that was last verified.
 
 The starter archive is a real 13.6 MB extract of English Wikipedia on
 climate change from the openZIM project's own testing suite: a stable
@@ -35,35 +36,71 @@ STARTER_ARCHIVE_URL = (
     + STARTER_ARCHIVE_FILENAME
 )
 
+#: Where the documented command puts the archive — and therefore the
+#: directory every documented invocation has to point the server at. The
+#: README used to download into this directory and then configure the
+#: server against a ``/path/to/zim/files`` placeholder, so following it
+#: top-to-bottom produced "Directory does not exist".
+STARTER_ARCHIVE_DIR = "~/zim-files"
+
+#: The two facts a reader can verify for themselves, and the ones the docs
+#: quote. ``STARTER_ARCHIVE_SIZE`` is derived from the byte count rather
+#: than restated independently of it (see the test).
+STARTER_ARCHIVE_BYTES = 14_239_035
+STARTER_ARCHIVE_SHA256 = (
+    "72db7ae7708d3a4cff918495078901ec027b14b427433a2328286ec130d1c43b"
+)
+
 #: Human-readable size, stated identically in the README and on the docs
 #: site (14,239,035 bytes).
 STARTER_ARCHIVE_SIZE = "13.6 MB"
 
 #: The download, as a single copy-pasteable line.
 STARTER_ARCHIVE_COMMAND = (
-    f"curl -fsSL -o ~/zim-files/{STARTER_ARCHIVE_FILENAME} {STARTER_ARCHIVE_URL}"
+    f"curl -fsSL -o {STARTER_ARCHIVE_DIR}/{STARTER_ARCHIVE_FILENAME} "
+    f"{STARTER_ARCHIVE_URL}"
 )
 
 
-def count_zim_files(directories: Iterable[str]) -> int:
-    """Count discoverable ``.zim`` files across ``directories``.
+def has_zim_files(directories: Iterable[str]) -> bool:
+    """True as soon as one discoverable ``.zim`` file is found.
 
     Mirrors the ``glob("**/*.zim")`` traversal that
     ``ZimOperations._glob_zim_paths`` uses for the real listing — a
-    top-level-only count would nag an operator whose archives sit one
+    top-level-only probe would nag an operator whose archives sit one
     directory down while the server itself found them fine.
 
+    Short-circuits on the first hit rather than counting every match: the
+    only caller wants a yes/no, this runs on the boot path *before*
+    ``server.run()`` starts reading stdin, and an allowed directory can
+    legitimately be a home directory or a network share. Enumerating one
+    of those to produce a number nobody reads can stall the client's
+    ``initialize`` long enough to drop the connection.
+
     Never raises: a directory that cannot be walked contributes nothing,
-    exactly as it does in the listing. This runs on the startup path, and
-    a diagnostic that can abort a boot is worse than no diagnostic.
+    exactly as it does in the listing. A diagnostic that can abort a boot
+    is worse than no diagnostic.
     """
-    total = 0
     for directory in directories:
         try:
-            total += sum(1 for _ in Path(directory).glob("**/*.zim"))
+            if any(Path(directory).glob("**/*.zim")):
+                return True
         except Exception as exc:  # noqa: BLE001 — a hint must never abort boot
-            logger.debug("ZIM count failed for %s: %s", directory, exc)
-    return total
+            logger.debug("ZIM probe failed for %s: %s", directory, exc)
+    return False
+
+
+def acquisition_hint_line() -> str:
+    """The guidance as one plain-text line, for logs and JSON string fields.
+
+    ``zim_health`` returns JSON, so it cannot carry the markdown block
+    below; it gets this instead, so the tool the troubleshooting page
+    sends people to says the same thing as the listing beside it.
+    """
+    return (
+        f"Browse {KIWIX_LIBRARY_URL} for full archives, or get a "
+        f"{STARTER_ARCHIVE_SIZE} starter archive with: {STARTER_ARCHIVE_COMMAND}"
+    )
 
 
 def no_archives_log_message(directories: Iterable[str]) -> str:
@@ -76,14 +113,8 @@ def no_archives_log_message(directories: Iterable[str]) -> str:
     listed = ", ".join(directories) or "(none)"
     return (
         "0 ZIM files found in the allowed directories (%s) — the server will "
-        "start but every query will come back empty. Browse %s for full "
-        "archives, or get a %s starter archive with: %s"
-        % (
-            listed,
-            KIWIX_LIBRARY_URL,
-            STARTER_ARCHIVE_SIZE,
-            STARTER_ARCHIVE_COMMAND,
-        )
+        "start but every query will come back empty. %s"
+        % (listed, acquisition_hint_line())
     )
 
 
@@ -100,5 +131,6 @@ def acquisition_hint_markdown() -> str:
         "archives (Wikipedia, Wiktionary, Stack Exchange, …)\n"
         f"- Or start with a {STARTER_ARCHIVE_SIZE} sample:\n"
         f"  `{STARTER_ARCHIVE_COMMAND}`\n"
-        "- Then point the server's allowed directory at where you saved it"
+        f"- Then point the server at `{STARTER_ARCHIVE_DIR}` "
+        "(the directory that command fills)"
     )

--- a/openzim_mcp/server_state.py
+++ b/openzim_mcp/server_state.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union, cast
 
 from . import __version__
 from .constants import CACHE_HIGH_HIT_RATE_THRESHOLD, CACHE_LOW_HIT_RATE_THRESHOLD
+from .onboarding import acquisition_hint_line
 from .responses import ToolErrorPayload, tool_error
 from .security import redact_paths_in_message, sanitize_path_for_error
 from .tool_schemas import HealthStatus, ServerConfigurationResponse
@@ -180,7 +181,15 @@ def _finalize_health_status(
     """Roll up accumulated checks into the final ``status`` field."""
     if total_zim_files == 0:
         warnings.append("No ZIM files found in any directory")
+        # "Add ZIM files" answers "what" and leaves "from where" hanging.
+        # ``troubleshooting.mdx`` sends readers here for exactly this
+        # symptom, and the file listing beside it already hands over a
+        # download command; a health report that stops short of one is the
+        # un-helped half of the same sentence. The warning string above is
+        # quoted verbatim by the docs, so it is left byte-identical and the
+        # guidance is added as a recommendation instead.
         recommendations.append("Add ZIM files to configured directories")
+        recommendations.append(acquisition_hint_line())
         _downgrade_to_warning(health_info)
 
     if accessible_dirs == 0:

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -34,6 +34,7 @@ from .exceptions import (
 )
 from .intent_parser import IntentParser, _strip_quote_pair, safe_regex_sub
 from .meta import build_meta, format_footer
+from .onboarding import acquisition_hint_markdown
 from .pagination import archive_identity
 from .rerank import (
     _INFO_LEVEL_TELEMETRY_EVENTS,
@@ -814,32 +815,7 @@ class SimpleToolsHandler(
                 if not zim_file_path:
                     zim_file_path = self._auto_select_zim_file()
                 if not zim_file_path:
-                    # Post-v2.0.5 D-M: callers hitting the
-                    # ambiguous-archive gate (2+ archives loaded, no
-                    # ``zim_file_path`` arg, intent doesn't
-                    # auto-select) saw only "specify a ZIM file
-                    # path" with a raw file listing — no hint that
-                    # ``search all files for X`` or
-                    # ``synthesize=True`` would route across all
-                    # archives without an explicit path. Add a
-                    # "Try one of these to recover:" block
-                    # mirroring the shape used elsewhere.
-                    return (
-                        "**No ZIM File Specified**\n\n"
-                        "Please specify a ZIM file path, or ensure there is "
-                        "exactly one ZIM file available.\n\n"
-                        "**Try one of these to recover:**\n"
-                        "- Pass the `zim_file_path` argument to target a "
-                        "specific archive\n"
-                        "- `search all files for <terms>` — fan out across "
-                        "every loaded archive\n"
-                        "- `tell me about <topic>` with `synthesize=True` — "
-                        "auto-open every loaded archive and pick the best "
-                        "hit\n\n"
-                        "**Available files:**\n"
-                        f"{self.zim_operations.list_zim_files()}"
-                        "\n<!-- intent=no_zim_file_specified cert=1.00 -->"
-                    )
+                    return self._no_zim_file_response()
             # Hallucinated paths were already normalized at the top of
             # ``handle_zim_query`` (see comment above the synthesize branch).
             # By this point, ``zim_file_path`` is either a known real path,
@@ -4679,6 +4655,68 @@ class SimpleToolsHandler(
             if real_path and Path(real_path).name.lower().startswith(stem):
                 hits.append(real_path)
         return hits[0] if len(hits) == 1 else None
+
+    def _no_archives_loaded(self) -> bool:
+        """True when the allowed directories hold no archive at all.
+
+        Separates the two situations ``_auto_select_zim_file`` collapses
+        into one ``None``: *ambiguous* (2+ archives, pick one) and *empty*
+        (nothing to pick). A probe that raises is reported as "not empty",
+        so an unexpected failure degrades to the pre-existing message
+        rather than telling a user with a full library to download one.
+        """
+        try:
+            return not self.zim_operations.list_zim_files_data()
+        except Exception as exc:  # noqa: BLE001 — advice must never raise
+            logger.debug("Archive-count probe failed: %s", exc)
+            return False
+
+    def _no_zim_file_response(self) -> str:
+        """The gate reached when no archive could be selected.
+
+        Post-v2.0.5 D-M: callers hitting the ambiguous-archive gate (2+
+        archives loaded, no ``zim_file_path`` arg, intent doesn't
+        auto-select) saw only "specify a ZIM file path" with a raw file
+        listing — no hint that ``search all files for X`` or
+        ``synthesize=True`` would route across all archives without an
+        explicit path. Hence the "Try one of these to recover:" block.
+
+        Those recovery steps are nonsense in the *other* case that lands
+        here — zero archives loaded — where fanning out across "every
+        loaded archive" fans out across nothing. A user whose directory is
+        empty (a mistyped path, or the far more common "installed the
+        server, never downloaded an archive") was told to specify a path
+        that does not exist. Give them the one thing that helps: where an
+        archive comes from.
+
+        Both arms keep the ``**No ZIM File Specified**`` title and the
+        ``intent=no_zim_file_specified`` footer — the envelope other
+        surfaces key on — and differ only in the advice between them.
+        """
+        if self._no_archives_loaded():
+            return (
+                "**No ZIM File Specified**\n\n"
+                "No ZIM archives are loaded — the allowed directories "
+                "contain no `.zim` files, so there is nothing to search.\n\n"
+                f"{acquisition_hint_markdown()}\n"
+                "\n<!-- intent=no_zim_file_specified cert=1.00 -->"
+            )
+        return (
+            "**No ZIM File Specified**\n\n"
+            "Please specify a ZIM file path, or ensure there is "
+            "exactly one ZIM file available.\n\n"
+            "**Try one of these to recover:**\n"
+            "- Pass the `zim_file_path` argument to target a "
+            "specific archive\n"
+            "- `search all files for <terms>` — fan out across "
+            "every loaded archive\n"
+            "- `tell me about <topic>` with `synthesize=True` — "
+            "auto-open every loaded archive and pick the best "
+            "hit\n\n"
+            "**Available files:**\n"
+            f"{self.zim_operations.list_zim_files()}"
+            "\n<!-- intent=no_zim_file_specified cert=1.00 -->"
+        )
 
     def _auto_select_zim_file(self) -> Optional[str]:
         """Phase F: thin wrapper delegating to ``topic_preprocessing``.

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -66,6 +66,11 @@ from .zim_operations import ZimOperations
 
 logger = logging.getLogger(__name__)
 
+#: ``search_all``'s aggregate count of archives the server could see, as it
+#: appears in the legacy JSON-string variant. Matched rather than parsed so a
+#: large fan-out response is not decoded just to read one integer.
+_NO_ARCHIVES_AVAILABLE_RE = re.compile(r'"files_available":\s*0\s*[,}]')
+
 
 # Phase D sub-D-2 query-rewrite telemetry events.
 _QUERY_REWRITE_MISSPELLING = "query_rewrite.misspelling"
@@ -3742,6 +3747,22 @@ class SimpleToolsHandler(
                 actual_query,
                 limit_per_file=options.get("limit", 5),
             )
+            # ``search all files for X`` is the one phrase the *ambiguous*
+            # arm of the no-archive gate actively advertises, so a user who
+            # read that recovery advice on a machine with archives and typed
+            # the same phrase on an empty one landed here — and got
+            # ``"files_available": 0`` with an empty result list, which
+            # states the problem and answers nothing. Fanning out across
+            # zero archives is the empty case, not a search.
+            #
+            # Read off the fan-out's own count rather than probing the
+            # directories again: the walk has already happened by this
+            # point, and a second one would be pure cost on every call,
+            # empty or not. ``== 0`` and not falsiness, because a payload
+            # that omits the key entirely has not told us the directories
+            # are empty and must not be answered as though it had.
+            if data.get("files_available") == 0:
+                return self._nothing_to_search_response()
             # Phase D sub-D-1: cross-encoder rerank across all archives.
             # Hits are flattened into a single candidate list (tagged with
             # their source archive index so they can be redistributed after
@@ -3777,9 +3798,26 @@ class SimpleToolsHandler(
             ):
                 reason = "archive_unavailable"
             return _HandlerResult(body=body, reason=reason, suggestions=suggestions)
-        return self.zim_operations.search_all(
+        legacy = self.zim_operations.search_all(
             params.get("query", query),
             limit_per_file=options.get("limit", 5),
+        )
+        # Same signal, read out of the legacy JSON string variant. This is
+        # this server's own envelope (``search_all`` is a ``json.dumps`` of
+        # ``search_all_data``), and ``files_available`` appears once, at the
+        # top level, so the scan is unambiguous — and, unlike re-listing the
+        # directories, it touches no filesystem.
+        if _NO_ARCHIVES_AVAILABLE_RE.search(legacy):
+            return self._nothing_to_search_response()
+        return legacy
+
+    def _nothing_to_search_response(self) -> str:
+        """What ``search all files`` says when there is nothing to fan out over."""
+        return (
+            "**No ZIM Archives Loaded**\n\n"
+            "There is nothing to search across — the allowed directories "
+            "contain no `.zim` files.\n\n"
+            f"{acquisition_hint_markdown()}"
         )
 
     def _handle_walk_namespace(

--- a/openzim_mcp/zim/archive.py
+++ b/openzim_mcp/zim/archive.py
@@ -55,6 +55,7 @@ from openzim_mcp.exceptions import (
     OpenZimMcpEntryNotFoundError,
 )
 from openzim_mcp.meta import attach_meta
+from openzim_mcp.onboarding import acquisition_hint_markdown
 from openzim_mcp.preset_data import ArchivePreset, resolve_preset_from_entries
 from openzim_mcp.security import PathValidator
 from openzim_mcp.timeout_utils import run_with_timeout
@@ -796,11 +797,26 @@ class ZimOperations(
 
         if not all_zim_files:
             if (name_filter or "").strip():
+                # A filter that matched nothing is not an empty library, so
+                # this arm deliberately stays free of download advice — the
+                # caller has archives, just none whose name contains this
+                # substring.
                 return (
                     "No ZIM files found in allowed directories matching filter "
                     f"{name_filter!r}"
                 )
-            return "No ZIM files found in allowed directories"
+            # Nothing at all. This string is the whole user interface for a
+            # GUI client, which keeps the server's stderr in a log file
+            # nobody opens, so the startup warning never reaches the person
+            # who most needs it. Say where an archive comes from here too.
+            #
+            # The first line stays byte-identical to what it always was —
+            # the docs site quotes it verbatim in two places, and callers
+            # match on it — so this only ever appends.
+            return (
+                "No ZIM files found in allowed directories\n\n"
+                f"{acquisition_hint_markdown()}"
+            )
 
         result_text = (
             f"Found {len(all_zim_files)} ZIM files in "

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -47,7 +47,7 @@
     "allowed_directories": {
       "type": "directory",
       "title": "ZIM directory",
-      "description": "Directory (or directories) containing your .zim archive files. Download archives from the Kiwix library (https://library.kiwix.org/).",
+      "description": "Directory (or directories) holding your .zim archive files. No archive yet? Download the 13.6 MB starter archive from https://raw.githubusercontent.com/openzim/zim-testing-suite/main/data/withns/wikipedia_en_climate_change_mini_2024-06.zim into a new folder (for example ~/zim-files) and choose that folder. Full archives: https://browse.library.kiwix.org/",
       "required": true,
       "multiple": true
     }

--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -126,6 +126,25 @@ SITE_BASE = f"{SITE_ORIGIN}{BASE}"
 # branch adding it, is not on main yet. Resolve against the working tree.
 EDIT_LINK_PREFIX = "https://github.com/cameronrye/openzim-mcp/blob/main/"
 
+# URLs this repo hands to users that none of the four link forms above can
+# collect. The starter ZIM archive is given as a bare ``curl`` line inside a
+# fenced block — a fence is blanked, and a bare URL is deliberately not
+# scraped — so the single external dependency the whole onboarding path rests
+# on was the one URL CI never probed. ``curl -fsSL`` writes nothing and prints
+# nothing on a 404, so upstream restructuring ``zim-testing-suite`` would reach
+# users as "the command did nothing" with every check still green.
+#
+# Kept as a literal because this script is stdlib-only and runs as bare
+# ``python3`` in CI (no ``uv``), so it cannot import ``openzim_mcp``.
+# ``tests/test_onboarding_zim_acquisition.py`` pins this list against
+# ``openzim_mcp.onboarding.STARTER_ARCHIVE_URL`` so the two cannot drift.
+EXTRA_EXTERNAL_URLS = {
+    "https://raw.githubusercontent.com/openzim/zim-testing-suite/main"
+    "/data/withns/wikipedia_en_climate_change_mini_2024-06.zim": (
+        "openzim_mcp/onboarding.py (STARTER_ARCHIVE_URL)"
+    ),
+}
+
 # Hosts that rate-limit or block unauthenticated HEAD/GET from CI runners.
 # Skipped rather than silently passed, and reported in the summary.
 EXTERNAL_SKIP_HOSTS = ("badge.fury.io", "img.shields.io", "codecov.io")
@@ -334,6 +353,8 @@ def _collect_external(index: SiteIndex) -> dict[str, set[str]]:
         for pattern in MARKDOWN_URL_RES:
             for url in pattern.findall(prose):
                 urls.setdefault(html.unescape(url), set()).add(name)
+    for url, source in EXTRA_EXTERNAL_URLS.items():
+        urls.setdefault(url, set()).add(source)
     return urls
 
 
@@ -395,7 +416,9 @@ def check_external(
     block; and, in the built HTML, an absolute ``src`` — HREF_RE reads
     ``href`` alone, so an ``<img src>`` pointing at another host is collected
     by neither half of this checker. A URL written any of those ways is
-    checked by nothing at all.
+    checked by nothing at all — unless it is listed in EXTRA_EXTERNAL_URLS,
+    which is how a URL that can only sensibly live inside a fence (the
+    starter archive's ``curl`` line) still gets probed.
 
     Only the URLs that reach the ``_probe`` call at the bottom are counted as
     probed: links to our own site are resolved against the build, "edit this

--- a/server.json
+++ b/server.json
@@ -21,7 +21,7 @@
         {
           "type": "positional",
           "valueHint": "zim_directory",
-          "description": "Path to a directory containing your .zim archive files. Repeat for multiple directories. Download archives from the Kiwix library (https://library.kiwix.org/).",
+          "description": "Path to a directory containing your .zim archive files. Repeat for multiple directories. No archive yet? Download the 13.6 MB starter archive from https://raw.githubusercontent.com/openzim/zim-testing-suite/main/data/withns/wikipedia_en_climate_change_mini_2024-06.zim into a new folder (for example ~/zim-files) and choose that folder. Full archives: https://browse.library.kiwix.org/",
           "format": "filepath",
           "isRequired": true,
           "isRepeated": true

--- a/tests/test_onboarding_zim_acquisition.py
+++ b/tests/test_onboarding_zim_acquisition.py
@@ -45,10 +45,26 @@ from openzim_mcp.zim_operations import ZimOperations
 REPO = Path(__file__).resolve().parent.parent
 README = REPO / "README.md"
 QUICK_START = REPO / "website/src/content/docs/quick-start.mdx"
+INSTALLATION = REPO / "website/src/content/docs/installation.mdx"
+LLMS_TXT = REPO / "website/src/pages/llms.txt.ts"
 
 
 def _readme() -> str:
     return README.read_text(encoding="utf-8")
+
+
+def _mentions(text: str, needle: str) -> bool:
+    """Substring test, written as a search rather than ``in``.
+
+    ``assert <hostname> in text`` reads perfectly well and trips CodeQL's
+    ``py/incomplete-url-substring-sanitization`` once per assertion: the
+    query cannot tell an assertion about documentation prose from a URL
+    allowlist check, and a hostname substring test is a real defect when
+    it *is* one. Nothing here decides anything about a URL — these are
+    assertions that a piece of guidance was printed — so the check is
+    spelled as a literal search instead of a containment test.
+    """
+    return re.search(re.escape(needle), text) is not None
 
 
 # --------------------------------------------------------------------------
@@ -73,8 +89,8 @@ def test_readme_offers_the_one_command_starter_archive() -> None:
     assert (
         onboarding.STARTER_ARCHIVE_SIZE in text
     ), f"README does not state the starter archive size ({onboarding.STARTER_ARCHIVE_SIZE})"
-    assert (
-        "browse.library.kiwix.org" in text
+    assert _mentions(
+        text, onboarding.KIWIX_LIBRARY_HOST
     ), "README does not point at the Kiwix library for full archives"
 
     # The command has to be copy-pasteable, which means it has to be in a
@@ -105,35 +121,38 @@ def test_readme_starter_archive_precedes_the_client_configuration() -> None:
     )
 
 
-def test_readme_and_quick_start_state_the_same_starter_archive() -> None:
-    """Two surfaces, one set of facts.
+def test_every_surface_states_the_same_starter_archive() -> None:
+    """Four surfaces, one set of facts.
 
     ``tests/test_docs_freshness.py`` exists because measurements stated in
-    two places drift. The size and URL are now stated in the README and in
-    ``quick-start.mdx``; assert they agree with each other and with the
-    constant the server logs, so a future edit to one is caught here rather
-    than by a user following a stale number.
+    more than one place drift. The size and URL are stated in the README,
+    on two docs pages and in the generated ``llms.txt``; assert they agree
+    with each other and with the constant the server logs, so a future edit
+    to one is caught here rather than by a user following a stale number.
     """
-    readme = _readme()
-    quick_start = QUICK_START.read_text(encoding="utf-8")
+    surfaces = {
+        "README.md": _readme(),
+        "quick-start.mdx": QUICK_START.read_text(encoding="utf-8"),
+        "installation.mdx": INSTALLATION.read_text(encoding="utf-8"),
+        "llms.txt.ts": LLMS_TXT.read_text(encoding="utf-8"),
+    }
+    # Guard the guard: a renamed page would otherwise silently drop out of
+    # the sweep and leave this test asserting less than it appears to.
+    assert len(surfaces) == 4
 
-    for surface, text in (("README.md", readme), ("quick-start.mdx", quick_start)):
+    for surface, text in surfaces.items():
         assert (
             onboarding.STARTER_ARCHIVE_URL in text
         ), f"{surface} does not use the canonical starter archive URL"
         assert (
             onboarding.STARTER_ARCHIVE_SIZE in text
         ), f"{surface} does not state the canonical starter archive size"
-
-    # And no surface may state a *different* size for the same file.
-    sizes = {
-        surface: set(re.findall(r"\d+\.\d+ MB", text))
-        for surface, text in (("README.md", readme), ("quick-start.mdx", quick_start))
-    }
-    for surface, found in sizes.items():
-        assert found <= {
-            onboarding.STARTER_ARCHIVE_SIZE
-        }, f"{surface} states a size other than {onboarding.STARTER_ARCHIVE_SIZE}: {found}"
+        # And no surface may state a *different* size for the same file.
+        found = set(re.findall(r"\d+\.\d+ MB", text))
+        assert found <= {onboarding.STARTER_ARCHIVE_SIZE}, (
+            f"{surface} states a size other than "
+            f"{onboarding.STARTER_ARCHIVE_SIZE}: {found}"
+        )
 
 
 # --------------------------------------------------------------------------
@@ -171,8 +190,8 @@ def test_startup_warns_when_no_archives_are_discoverable(
     joined = "\n".join(warnings)
     assert warnings, "no warning was emitted for a directory with zero ZIM files"
     assert "0" in joined, f"the warning does not name the count: {warnings!r}"
-    assert (
-        "browse.library.kiwix.org" in joined
+    assert _mentions(
+        joined, onboarding.KIWIX_LIBRARY_HOST
     ), f"the warning does not name the Kiwix library: {warnings!r}"
     assert (
         onboarding.STARTER_ARCHIVE_URL in joined
@@ -209,7 +228,7 @@ def test_startup_is_quiet_when_an_archive_is_present(
         record.getMessage()
         for record in caplog.records
         if record.levelno >= logging.WARNING
-        and "browse.library.kiwix.org" in record.getMessage()
+        and _mentions(record.getMessage(), onboarding.KIWIX_LIBRARY_HOST)
     ]
     assert (
         not warnings
@@ -271,7 +290,7 @@ def test_empty_listing_says_where_to_get_an_archive(
     result = empty_zim_operations.list_zim_files()
 
     assert "No ZIM files found" in result
-    assert "browse.library.kiwix.org" in result, result
+    assert _mentions(result, onboarding.KIWIX_LIBRARY_HOST), result
     assert onboarding.STARTER_ARCHIVE_URL in result, result
 
 
@@ -296,7 +315,7 @@ def test_filtered_empty_listing_does_not_offer_to_download_a_first_archive(
     result = operations.list_zim_files(name_filter="stackexchange")
 
     assert "No ZIM files found" in result
-    assert "browse.library.kiwix.org" not in result, result
+    assert not _mentions(result, onboarding.KIWIX_LIBRARY_HOST), result
 
 
 def test_query_gate_says_where_to_get_an_archive_when_none_are_loaded(
@@ -314,7 +333,7 @@ def test_query_gate_says_where_to_get_an_archive_when_none_are_loaded(
 
     result = handler.handle_zim_query("search for biology")
 
-    assert "browse.library.kiwix.org" in result, result
+    assert _mentions(result, onboarding.KIWIX_LIBRARY_HOST), result
     assert onboarding.STARTER_ARCHIVE_URL in result, result
     assert "search all files for" not in result, (
         "cross-archive recovery steps were offered with zero archives loaded: "
@@ -340,7 +359,7 @@ def test_query_gate_keeps_the_ambiguous_advice_when_archives_exist() -> None:
     result = SimpleToolsHandler(operations).handle_zim_query("search for biology")
 
     assert "search all files for" in result, result
-    assert "browse.library.kiwix.org" not in result, result
+    assert not _mentions(result, onboarding.KIWIX_LIBRARY_HOST), result
     assert "intent=no_zim_file_specified" in result, result
 
 
@@ -356,5 +375,5 @@ def test_query_gate_falls_back_to_the_ambiguous_advice_when_the_probe_fails() ->
 
     result = SimpleToolsHandler(operations)._no_zim_file_response()
 
-    assert "browse.library.kiwix.org" not in result, result
+    assert not _mentions(result, onboarding.KIWIX_LIBRARY_HOST), result
     assert "search all files for" in result, result

--- a/tests/test_onboarding_zim_acquisition.py
+++ b/tests/test_onboarding_zim_acquisition.py
@@ -189,7 +189,11 @@ def test_startup_warns_when_no_archives_are_discoverable(
     ]
     joined = "\n".join(warnings)
     assert warnings, "no warning was emitted for a directory with zero ZIM files"
-    assert "0" in joined, f"the warning does not name the count: {warnings!r}"
+    # The count, not merely the digit: ``tmp_path`` is full of digits, so a
+    # bare ``"0" in joined`` would pass on a message that never mentions it.
+    assert (
+        "0 ZIM files found" in joined
+    ), f"the warning does not name the count: {warnings!r}"
     assert _mentions(
         joined, onboarding.KIWIX_LIBRARY_HOST
     ), f"the warning does not name the Kiwix library: {warnings!r}"

--- a/tests/test_onboarding_zim_acquisition.py
+++ b/tests/test_onboarding_zim_acquisition.py
@@ -1,0 +1,360 @@
+"""The first-archive acquisition funnel.
+
+A server with no ZIM files is inert, and every surface a new user reaches
+before that point used to leave them to work out where an archive comes
+from:
+
+* ``README.md`` — the dominant landing surface — pointed only at
+  ``library.kiwix.org``, whose headline archives are tens of gigabytes.
+  The one-command 13.6 MB starter archive existed, but only on the docs
+  site (``website/src/content/docs/quick-start.mdx``).
+* Startup logged "server started" and the allowed directories whether or
+  not those directories contained a single ``.zim``.
+* The tool-result text a GUI client actually shows said "No ZIM files
+  found in allowed directories" and stopped there — and a GUI client is
+  precisely where the stderr log the operator would otherwise read is
+  buried in a file.
+
+These tests pin the three surfaces, and pin them to *the same* facts: the
+size and URL the README states must be the ones the docs site states, so
+the two cannot drift into contradicting each other.
+
+The startup signal is asserted to go through the logger *and* to leave
+stdout byte-for-byte empty: under the default stdio transport, stdout is
+the JSON-RPC channel, so a stray ``print`` there does not merely look
+untidy, it corrupts the protocol stream and breaks every stdio client.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openzim_mcp import onboarding
+from openzim_mcp.cache import OpenZimMcpCache
+from openzim_mcp.config import OpenZimMcpConfig
+from openzim_mcp.content_processor import ContentProcessor
+from openzim_mcp.security import PathValidator
+from openzim_mcp.simple_tools import SimpleToolsHandler
+from openzim_mcp.zim_operations import ZimOperations
+
+REPO = Path(__file__).resolve().parent.parent
+README = REPO / "README.md"
+QUICK_START = REPO / "website/src/content/docs/quick-start.mdx"
+
+
+def _readme() -> str:
+    return README.read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# README — the landing surface
+# --------------------------------------------------------------------------
+
+
+def test_readme_offers_the_one_command_starter_archive() -> None:
+    """The README must carry the starter archive, not just a library link.
+
+    ``library.kiwix.org`` is where the full archives live; its headline
+    downloads are tens of gigabytes. A reader who has just run
+    ``uv tool install openzim-mcp`` needs something they can finish in a
+    minute, and the fact that one exists was previously discoverable only
+    from the docs site.
+    """
+    text = _readme()
+
+    assert (
+        onboarding.STARTER_ARCHIVE_URL in text
+    ), "README does not name the starter archive URL"
+    assert (
+        onboarding.STARTER_ARCHIVE_SIZE in text
+    ), f"README does not state the starter archive size ({onboarding.STARTER_ARCHIVE_SIZE})"
+    assert (
+        "browse.library.kiwix.org" in text
+    ), "README does not point at the Kiwix library for full archives"
+
+    # The command has to be copy-pasteable, which means it has to be in a
+    # fence — a URL mentioned in prose is a fact, not an action.
+    fences = re.findall(r"```bash\n(.*?)```", text, flags=re.DOTALL)
+    assert any(
+        onboarding.STARTER_ARCHIVE_URL in fence and "curl" in fence for fence in fences
+    ), "the starter archive URL is not inside a copy-pasteable bash fence"
+
+
+def test_readme_starter_archive_precedes_the_client_configuration() -> None:
+    """Placement, not just presence.
+
+    The block only converts if it is read *before* the reader wires the
+    server into a client and points it at a directory. Anchor it to the
+    install section (it must land after "Verify the install" and before
+    the "## Quick start" heading) rather than merely somewhere in the file.
+    """
+    text = _readme()
+    verify = text.index("Verify the install")
+    quick_start = text.index("\n## Quick start")
+    url_at = text.index(onboarding.STARTER_ARCHIVE_URL)
+
+    assert verify < url_at < quick_start, (
+        "the starter archive block must sit in the install section, between "
+        f"'Verify the install' ({verify}) and '## Quick start' ({quick_start}); "
+        f"found at {url_at}"
+    )
+
+
+def test_readme_and_quick_start_state_the_same_starter_archive() -> None:
+    """Two surfaces, one set of facts.
+
+    ``tests/test_docs_freshness.py`` exists because measurements stated in
+    two places drift. The size and URL are now stated in the README and in
+    ``quick-start.mdx``; assert they agree with each other and with the
+    constant the server logs, so a future edit to one is caught here rather
+    than by a user following a stale number.
+    """
+    readme = _readme()
+    quick_start = QUICK_START.read_text(encoding="utf-8")
+
+    for surface, text in (("README.md", readme), ("quick-start.mdx", quick_start)):
+        assert (
+            onboarding.STARTER_ARCHIVE_URL in text
+        ), f"{surface} does not use the canonical starter archive URL"
+        assert (
+            onboarding.STARTER_ARCHIVE_SIZE in text
+        ), f"{surface} does not state the canonical starter archive size"
+
+    # And no surface may state a *different* size for the same file.
+    sizes = {
+        surface: set(re.findall(r"\d+\.\d+ MB", text))
+        for surface, text in (("README.md", readme), ("quick-start.mdx", quick_start))
+    }
+    for surface, found in sizes.items():
+        assert found <= {
+            onboarding.STARTER_ARCHIVE_SIZE
+        }, f"{surface} states a size other than {onboarding.STARTER_ARCHIVE_SIZE}: {found}"
+
+
+# --------------------------------------------------------------------------
+# Startup signal
+# --------------------------------------------------------------------------
+
+
+def _run_main(directory: Path) -> None:
+    from openzim_mcp.main import main
+
+    with (
+        patch("openzim_mcp.main.OpenZimMcpServer") as server_cls,
+        patch("sys.argv", ["openzim-mcp", str(directory)]),
+    ):
+        server_cls.return_value = MagicMock()
+        main()
+
+
+def test_startup_warns_when_no_archives_are_discoverable(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An empty directory used to log "started" and nothing else.
+
+    The server was working exactly as configured and completely useless,
+    and the log said only that it had started successfully.
+    """
+    with caplog.at_level(logging.DEBUG, logger="openzim_mcp.main"):
+        _run_main(tmp_path)
+
+    warnings = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+    ]
+    joined = "\n".join(warnings)
+    assert warnings, "no warning was emitted for a directory with zero ZIM files"
+    assert "0" in joined, f"the warning does not name the count: {warnings!r}"
+    assert (
+        "browse.library.kiwix.org" in joined
+    ), f"the warning does not name the Kiwix library: {warnings!r}"
+    assert (
+        onboarding.STARTER_ARCHIVE_URL in joined
+    ), f"the warning does not carry the starter command: {warnings!r}"
+
+
+def test_startup_warning_never_writes_to_stdout(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """stdout is the JSON-RPC channel under the default stdio transport.
+
+    A ``print`` here would interleave prose with framed JSON-RPC and break
+    every stdio client — a far worse failure than the silence it replaces.
+    """
+    _run_main(tmp_path)
+
+    captured = capsys.readouterr()
+    assert captured.out == "", (
+        "startup wrote to stdout, which is the stdio JSON-RPC stream: "
+        f"{captured.out!r}"
+    )
+
+
+def test_startup_is_quiet_when_an_archive_is_present(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The warning must be about the empty case, not a permanent banner."""
+    (tmp_path / "wikipedia.zim").write_bytes(b"not a real archive")
+
+    with caplog.at_level(logging.DEBUG, logger="openzim_mcp.main"):
+        _run_main(tmp_path)
+
+    warnings = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+        and "browse.library.kiwix.org" in record.getMessage()
+    ]
+    assert (
+        not warnings
+    ), f"acquisition warning fired with an archive present: {warnings!r}"
+
+
+def test_startup_counts_archives_in_nested_directories(tmp_path: Path) -> None:
+    """The listing globs ``**/*.zim``; the startup count must agree with it.
+
+    A count that only looked at the top level would nag an operator whose
+    archives live one directory down, while the server itself found them.
+    """
+    nested = tmp_path / "wikipedia" / "2024"
+    nested.mkdir(parents=True)
+    (nested / "wikipedia_en_all.zim").write_bytes(b"not a real archive")
+
+    assert onboarding.count_zim_files([str(tmp_path)]) == 1
+
+
+def test_counting_survives_a_directory_it_cannot_walk(tmp_path: Path) -> None:
+    """A diagnostic that can abort the boot is worse than no diagnostic.
+
+    ``count_zim_files`` runs before ``server.run()``, so an unreadable or
+    vanished directory must contribute zero rather than propagate — the
+    same degradation ``ZimOperations._glob_zim_paths`` applies.
+    """
+    good = tmp_path / "good"
+    good.mkdir()
+    (good / "wikipedia.zim").write_bytes(b"not a real archive")
+
+    with patch.object(Path, "glob", side_effect=OSError("permission denied")):
+        assert onboarding.count_zim_files([str(good)]) == 0
+
+    # The real walk still works either side of the failure.
+    assert onboarding.count_zim_files([str(good)]) == 1
+
+
+# --------------------------------------------------------------------------
+# Tool-result text — what a GUI client actually shows
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def empty_zim_operations(tmp_path: Path) -> ZimOperations:
+    """Real operations over a real, genuinely empty directory."""
+    config = OpenZimMcpConfig(allowed_directories=[str(tmp_path)])
+    return ZimOperations(
+        config,
+        PathValidator(config.allowed_directories),
+        OpenZimMcpCache(config.cache),
+        ContentProcessor(),
+    )
+
+
+def test_empty_listing_says_where_to_get_an_archive(
+    empty_zim_operations: ZimOperations,
+) -> None:
+    """Claude Desktop buries stderr in a log file; this string is the UI."""
+    result = empty_zim_operations.list_zim_files()
+
+    assert "No ZIM files found" in result
+    assert "browse.library.kiwix.org" in result, result
+    assert onboarding.STARTER_ARCHIVE_URL in result, result
+
+
+def test_filtered_empty_listing_does_not_offer_to_download_a_first_archive(
+    tmp_path: Path,
+) -> None:
+    """A filter that matched nothing is not an empty library.
+
+    The acquisition advice belongs to "you have no archives", not to "your
+    substring matched none of the archives you have" — offering a download
+    there would be answering a question the caller did not ask.
+    """
+    (tmp_path / "wikipedia.zim").write_bytes(b"not a real archive")
+    config = OpenZimMcpConfig(allowed_directories=[str(tmp_path)])
+    operations = ZimOperations(
+        config,
+        PathValidator(config.allowed_directories),
+        OpenZimMcpCache(config.cache),
+        ContentProcessor(),
+    )
+
+    result = operations.list_zim_files(name_filter="stackexchange")
+
+    assert "No ZIM files found" in result
+    assert "browse.library.kiwix.org" not in result, result
+
+
+def test_query_gate_says_where_to_get_an_archive_when_none_are_loaded(
+    empty_zim_operations: ZimOperations,
+) -> None:
+    """The zero-archive case reached the *ambiguous*-archive gate.
+
+    ``_auto_select_zim_file`` returns ``None`` both when two archives are
+    loaded and when none are, so a user with an empty directory was told to
+    "specify a ZIM file path" and offered cross-archive recovery steps
+    (``search all files for X``, ``synthesize=True``) that cannot possibly
+    work — there is nothing to search.
+    """
+    handler = SimpleToolsHandler(empty_zim_operations)
+
+    result = handler.handle_zim_query("search for biology")
+
+    assert "browse.library.kiwix.org" in result, result
+    assert onboarding.STARTER_ARCHIVE_URL in result, result
+    assert "search all files for" not in result, (
+        "cross-archive recovery steps were offered with zero archives loaded: "
+        f"{result}"
+    )
+
+
+def test_query_gate_keeps_the_ambiguous_advice_when_archives_exist() -> None:
+    """Two archives loaded is the case the recovery block was written for.
+
+    Splitting the gate must not cost the D-M cross-archive guidance: with
+    archives present the caller still needs ``zim_file_path`` /
+    ``search all files for`` / ``synthesize=True``, and telling them to go
+    download something would be actively wrong.
+    """
+    operations = MagicMock()
+    operations.list_zim_files_data.return_value = [
+        {"path": "/zim/wikipedia.zim"},
+        {"path": "/zim/wiktionary.zim"},
+    ]
+    operations.list_zim_files.return_value = "Found 2 ZIM files"
+
+    result = SimpleToolsHandler(operations).handle_zim_query("search for biology")
+
+    assert "search all files for" in result, result
+    assert "browse.library.kiwix.org" not in result, result
+    assert "intent=no_zim_file_specified" in result, result
+
+
+def test_query_gate_falls_back_to_the_ambiguous_advice_when_the_probe_fails() -> None:
+    """A failed count must not invent an empty library.
+
+    "You have no archives, download one" is a confident claim; make it only
+    on a probe that actually answered.
+    """
+    operations = MagicMock()
+    operations.list_zim_files_data.side_effect = RuntimeError("probe exploded")
+    operations.list_zim_files.return_value = "Found 2 ZIM files"
+
+    result = SimpleToolsHandler(operations)._no_zim_file_response()
+
+    assert "browse.library.kiwix.org" not in result, result
+    assert "search all files for" in result, result

--- a/tests/test_onboarding_zim_acquisition.py
+++ b/tests/test_onboarding_zim_acquisition.py
@@ -7,7 +7,10 @@ from:
 * ``README.md`` — the dominant landing surface — pointed only at
   ``library.kiwix.org``, whose headline archives are tens of gigabytes.
   The one-command 13.6 MB starter archive existed, but only on the docs
-  site (``website/src/content/docs/quick-start.mdx``).
+  site (``website/src/content/docs/quick-start.mdx``). The README then
+  downloaded into ``~/zim-files`` and configured the server against a
+  ``/path/to/zim/files`` placeholder, so following it top-to-bottom
+  ended in a configuration error.
 * Startup logged "server started" and the allowed directories whether or
   not those directories contained a single ``.zim``.
 * The tool-result text a GUI client actually shows said "No ZIM files
@@ -15,9 +18,13 @@ from:
   precisely where the stderr log the operator would otherwise read is
   buried in a file.
 
-These tests pin the three surfaces, and pin them to *the same* facts: the
-size and URL the README states must be the ones the docs site states, so
-the two cannot drift into contradicting each other.
+These tests pin those surfaces, and pin them to *the same* facts: the size
+and URL the README states must be the ones the docs site states, the
+``.mcpb`` bundle's directory prompt states and the server logs, so none of
+them can drift into contradicting the others. The size itself is pinned to
+the archive's measured byte count, so "stated consistently" cannot mean
+"consistently wrong", and the URL is registered with the repo's link
+checker, so an upstream move is caught by CI rather than by a user.
 
 The startup signal is asserted to go through the logger *and* to leave
 stdout byte-for-byte empty: under the default stdio transport, stdout is
@@ -27,6 +34,7 @@ untidy, it corrupts the protocol stream and breaks every stdio client.
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from pathlib import Path
@@ -65,6 +73,43 @@ def _mentions(text: str, needle: str) -> bool:
     spelled as a literal search instead of a containment test.
     """
     return re.search(re.escape(needle), text) is not None
+
+
+#: A size figure, with or without the space these pages use inconsistently
+#: ("13.6 MB" in the prose, "13.6MB" in installation.mdx's summary list).
+_SIZE_RE = re.compile(r"\d+(?:\.\d+)? ?MB")
+
+#: Words that mean the sentence is talking about *this* archive.
+_STARTER_ANCHORS = (
+    "climate change",
+    "climate-change",
+    onboarding.STARTER_ARCHIVE_FILENAME,
+)
+
+
+def _sizes_claimed_for_the_starter_archive(text: str) -> set[str]:
+    """Every size figure stated on a line that names the starter archive.
+
+    Deliberately not "every MB figure in the file". The earlier version of
+    this check swept the whole text, which made an unrelated future figure
+    — a cache ceiling, a reranker model download, a second archive's size —
+    fail a test named after the starter archive, in a file whose name gives
+    no hint that it polices unrelated numbers. It was also inconsistent
+    about what it caught: it forbade "2.5 MB" while ``~300 MB`` and
+    ``13.6MB`` both slipped past it.
+
+    Anchoring on the archive's own vocabulary keeps the drift this exists
+    to catch (a page restating the size wrongly) and drops the collateral.
+    Sizes are normalised so "13.6MB" and "13.6 MB" compare equal.
+    """
+    claimed: set[str] = set()
+    for line in text.splitlines():
+        lowered = line.lower()
+        if not any(anchor.lower() in lowered for anchor in _STARTER_ANCHORS):
+            continue
+        for match in _SIZE_RE.finditer(line):
+            claimed.add(match.group(0).replace("MB", " MB").replace("  ", " "))
+    return claimed
 
 
 # --------------------------------------------------------------------------
@@ -148,10 +193,132 @@ def test_every_surface_states_the_same_starter_archive() -> None:
             onboarding.STARTER_ARCHIVE_SIZE in text
         ), f"{surface} does not state the canonical starter archive size"
         # And no surface may state a *different* size for the same file.
-        found = set(re.findall(r"\d+\.\d+ MB", text))
+        found = _sizes_claimed_for_the_starter_archive(text)
         assert found <= {onboarding.STARTER_ARCHIVE_SIZE}, (
             f"{surface} states a size other than "
-            f"{onboarding.STARTER_ARCHIVE_SIZE}: {found}"
+            f"{onboarding.STARTER_ARCHIVE_SIZE} for the starter archive: {found}"
+        )
+
+
+def test_the_stated_size_is_the_measured_byte_count_rounded() -> None:
+    """The size is a derived fact, not an independent claim.
+
+    Everything above checks the four surfaces against
+    ``STARTER_ARCHIVE_SIZE``; this checks ``STARTER_ARCHIVE_SIZE`` against
+    the file. Without it a wrong number stated consistently everywhere is
+    a fully green suite.
+    """
+    mib = onboarding.STARTER_ARCHIVE_BYTES / 1024 / 1024
+    assert onboarding.STARTER_ARCHIVE_SIZE == f"{mib:.1f} MB", (
+        f"{onboarding.STARTER_ARCHIVE_BYTES:,} bytes rounds to "
+        f"{mib:.1f} MB, not {onboarding.STARTER_ARCHIVE_SIZE}"
+    )
+    # The two pages that quote the raw measurements must quote these ones.
+    for surface, path in (
+        ("quick-start.mdx", QUICK_START),
+        ("installation.mdx", INSTALLATION),
+    ):
+        text = path.read_text(encoding="utf-8")
+        assert (
+            f"{onboarding.STARTER_ARCHIVE_BYTES:,}" in text
+        ), f"{surface} does not state the canonical byte count"
+        assert (
+            onboarding.STARTER_ARCHIVE_SHA256 in text
+        ), f"{surface} does not state the canonical SHA-256"
+
+
+def test_readme_points_the_server_at_the_directory_the_download_fills() -> None:
+    """The README has to work end to end when it is followed literally.
+
+    It told the reader to ``mkdir -p ~/zim-files`` and download into it,
+    said "that is the directory you point the server at below", and then
+    every example below said ``/path/to/zim/files``. Copy-pasting the
+    Claude Desktop block verbatim produced ``Directory does not exist`` on
+    the exact onboarding path this section exists to unblock.
+    """
+    text = _readme()
+    quick_start = text[text.index("\n## Quick start") : text.index("\n## Highlights")]
+
+    assert (
+        onboarding.STARTER_ARCHIVE_DIR in quick_start
+    ), "the Quick start examples do not use the directory the download fills"
+    stale = re.findall(r"/path/to/[\w/]*zim[\w/]*", text)
+    assert not stale, (
+        "the README still configures the server against a placeholder "
+        f"directory the reader was never told to create: {sorted(set(stale))}"
+    )
+
+
+def test_a_literal_tilde_path_is_a_directory_the_server_accepts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``~`` in a client config file is never expanded by a shell.
+
+    The README now writes ``"args": ["openzim-mcp", "~/zim-files"]``, which
+    reaches the process as a literal tilde: no shell is involved when
+    Claude Desktop spawns it. That advice is only sound because the config
+    layer expands it itself, so pin that rather than trusting it.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))  # Windows
+    (tmp_path / "zim-files").mkdir()
+
+    config = OpenZimMcpConfig(allowed_directories=[onboarding.STARTER_ARCHIVE_DIR])
+
+    assert config.allowed_directories == [str((tmp_path / "zim-files").resolve())]
+
+
+def test_the_starter_url_is_a_url_the_link_checker_probes() -> None:
+    """The one external dependency onboarding rests on must be checked.
+
+    ``scripts/check_docs_links.py`` blanks fenced code blocks and does not
+    collect bare URLs, and the starter archive is only ever written as a
+    bare URL inside a ``curl`` fence — so it was the single URL in the repo
+    that CI never probed. ``curl -fsSL`` prints nothing on a 404, so an
+    upstream move would have reached users as "the command did nothing"
+    with every check still green.
+
+    The script is stdlib-only and runs as bare ``python3`` in CI, so it
+    cannot import the constant; this is the join that keeps the copy honest.
+    """
+    script = (REPO / "scripts/check_docs_links.py").read_text(encoding="utf-8")
+    collapsed = re.sub(r'"\s*\n\s*"', "", script)  # rejoin implicit concatenation
+
+    assert onboarding.STARTER_ARCHIVE_URL in collapsed, (
+        "scripts/check_docs_links.py does not list the starter archive URL, "
+        "so nothing detects it going stale"
+    )
+
+
+def test_the_one_click_install_prompt_says_where_to_get_an_archive() -> None:
+    """The directory picker is the highest-intent acquisition moment there is.
+
+    ``packaging/mcpb/manifest.json`` is the text Claude Desktop shows *while
+    asking the user for their ZIM directory*, and ``server.json`` is its MCP
+    Registry equivalent. Both used to point at the Kiwix library and nothing
+    else — the tens-of-gigabytes front door, which is the defect the rest of
+    this change exists to fix, shown to the one audience guaranteed to read it.
+    """
+    surfaces = {
+        "packaging/mcpb/manifest.json": json.loads(
+            (REPO / "packaging/mcpb/manifest.json").read_text(encoding="utf-8")
+        )["user_config"]["allowed_directories"]["description"],
+        "server.json": json.loads((REPO / "server.json").read_text(encoding="utf-8"))[
+            "packages"
+        ][0]["packageArguments"][0]["description"],
+    }
+    assert len(surfaces) == 2
+
+    for surface, description in surfaces.items():
+        assert (
+            onboarding.STARTER_ARCHIVE_URL in description
+        ), f"{surface} does not offer the starter archive"
+        assert (
+            onboarding.STARTER_ARCHIVE_SIZE in description
+        ), f"{surface} does not say how small the starter archive is"
+        assert _mentions(description, onboarding.KIWIX_LIBRARY_HOST), (
+            f"{surface} does not point at {onboarding.KIWIX_LIBRARY_HOST} "
+            "for full archives"
         )
 
 
@@ -239,24 +406,54 @@ def test_startup_is_quiet_when_an_archive_is_present(
     ), f"acquisition warning fired with an archive present: {warnings!r}"
 
 
-def test_startup_counts_archives_in_nested_directories(tmp_path: Path) -> None:
-    """The listing globs ``**/*.zim``; the startup count must agree with it.
+def test_startup_probe_finds_archives_in_nested_directories(tmp_path: Path) -> None:
+    """The listing globs ``**/*.zim``; the startup probe must agree with it.
 
-    A count that only looked at the top level would nag an operator whose
+    A probe that only looked at the top level would nag an operator whose
     archives live one directory down, while the server itself found them.
     """
     nested = tmp_path / "wikipedia" / "2024"
     nested.mkdir(parents=True)
     (nested / "wikipedia_en_all.zim").write_bytes(b"not a real archive")
 
-    assert onboarding.count_zim_files([str(tmp_path)]) == 1
+    assert onboarding.has_zim_files([str(tmp_path)]) is True
+    assert onboarding.has_zim_files([str(tmp_path / "wikipedia" / "empty")]) is False
 
 
-def test_counting_survives_a_directory_it_cannot_walk(tmp_path: Path) -> None:
+def test_startup_probe_stops_at_the_first_archive(tmp_path: Path) -> None:
+    """It answers a yes/no question, so it must not enumerate the tree.
+
+    This runs in ``main()`` *before* ``server.run()`` starts reading stdin,
+    and an allowed directory is allowed to be a home directory or a network
+    share. Counting every match there can stall the client's ``initialize``
+    past its timeout to produce a number nobody reads.
+    """
+    for index in range(5):
+        (tmp_path / f"archive-{index}.zim").write_bytes(b"not a real archive")
+
+    real_glob = Path.glob
+    consumed = 0
+
+    def counting_glob(self: Path, pattern: str):  # type: ignore[no-untyped-def]
+        nonlocal consumed
+        for item in real_glob(self, pattern):
+            consumed += 1
+            yield item
+
+    with patch.object(Path, "glob", counting_glob):
+        assert onboarding.has_zim_files([str(tmp_path)]) is True
+
+    assert consumed == 1, (
+        "the startup probe pulled "
+        f"{consumed} entries from the walk; it only needs the first"
+    )
+
+
+def test_probe_survives_a_directory_it_cannot_walk(tmp_path: Path) -> None:
     """A diagnostic that can abort the boot is worse than no diagnostic.
 
-    ``count_zim_files`` runs before ``server.run()``, so an unreadable or
-    vanished directory must contribute zero rather than propagate — the
+    ``has_zim_files`` runs before ``server.run()``, so an unreadable or
+    vanished directory must contribute nothing rather than propagate — the
     same degradation ``ZimOperations._glob_zim_paths`` applies.
     """
     good = tmp_path / "good"
@@ -264,10 +461,10 @@ def test_counting_survives_a_directory_it_cannot_walk(tmp_path: Path) -> None:
     (good / "wikipedia.zim").write_bytes(b"not a real archive")
 
     with patch.object(Path, "glob", side_effect=OSError("permission denied")):
-        assert onboarding.count_zim_files([str(good)]) == 0
+        assert onboarding.has_zim_files([str(good)]) is False
 
     # The real walk still works either side of the failure.
-    assert onboarding.count_zim_files([str(good)]) == 1
+    assert onboarding.has_zim_files([str(good)]) is True
 
 
 # --------------------------------------------------------------------------
@@ -296,6 +493,159 @@ def test_empty_listing_says_where_to_get_an_archive(
     assert "No ZIM files found" in result
     assert _mentions(result, onboarding.KIWIX_LIBRARY_HOST), result
     assert onboarding.STARTER_ARCHIVE_URL in result, result
+
+
+def test_the_documented_empty_listing_sample_is_the_real_output(
+    empty_zim_operations: ZimOperations,
+) -> None:
+    """``installation.mdx`` quotes this output; quote all of it.
+
+    The page showed the first line alone, which was the whole message
+    before this change and is a truncation of it now — a reader comparing
+    what their terminal says to the documented sample sees more than the
+    doc shows and cannot tell whether that is a version difference or a
+    fault. Pinning the sample to the live string means the doc cannot fall
+    behind the message again.
+    """
+    sample = empty_zim_operations.list_zim_files()
+    installation = INSTALLATION.read_text(encoding="utf-8")
+
+    assert f"```\n{sample}\n```" in installation, (
+        "installation.mdx does not quote the empty-listing output verbatim; "
+        f"the real output is:\n{sample}"
+    )
+
+
+def test_zim_health_says_where_to_get_an_archive(tmp_path: Path) -> None:
+    """The tool the troubleshooting page sends people to, for this symptom.
+
+    ``troubleshooting.mdx`` names the listing message and this warning in
+    one sentence, so a reader who follows it to ``zim_health`` used to get
+    the un-helped half: "No ZIM files found in any directory" and "Add ZIM
+    files to configured directories", with no URL and no command, while the
+    listing beside it handed over a download.
+    """
+    from openzim_mcp.server import OpenZimMcpServer
+    from openzim_mcp.server_state import _build_health_report
+
+    config = OpenZimMcpConfig(allowed_directories=[str(tmp_path)])
+    report = _build_health_report(OpenZimMcpServer(config))
+
+    # The existing warning is quoted verbatim by the docs; keep it intact.
+    assert "No ZIM files found in any directory" in report["warnings"]
+
+    advice = "\n".join(report["recommendations"])
+    assert _mentions(advice, onboarding.KIWIX_LIBRARY_HOST), advice
+    assert onboarding.STARTER_ARCHIVE_URL in advice, advice
+
+
+def test_zim_health_is_quiet_about_downloads_when_archives_exist(
+    tmp_path: Path,
+) -> None:
+    """Acquisition advice belongs to the empty case, not to every report."""
+    from openzim_mcp.server import OpenZimMcpServer
+    from openzim_mcp.server_state import _build_health_report
+    from openzim_mcp.zim.archive import ZIM_MAGIC
+
+    # The health report counts only files carrying the ZIM signature, so a
+    # placeholder of arbitrary bytes would read as "no archives here" and
+    # make this test pass for the wrong reason.
+    (tmp_path / "wikipedia.zim").write_bytes(ZIM_MAGIC + b"\x00" * 64)
+    config = OpenZimMcpConfig(allowed_directories=[str(tmp_path)])
+    report = _build_health_report(OpenZimMcpServer(config))
+
+    advice = "\n".join(report["recommendations"])
+    assert not _mentions(advice, onboarding.KIWIX_LIBRARY_HOST), advice
+
+
+@pytest.mark.parametrize("compact", [False, True])
+def test_search_all_says_where_to_get_an_archive_when_none_are_loaded(
+    empty_zim_operations: ZimOperations, compact: bool
+) -> None:
+    """``search all files for X`` is the phrase the ambiguous arm advertises.
+
+    A user who read that recovery advice on a machine with archives and
+    typed the same phrase on an empty one got ``"files_available": 0`` and
+    an empty result list: a JSON blob that states the problem and answers
+    nothing. Fanning out across zero archives is the empty case.
+
+    Both response shapes are checked because the handler reads the count
+    from two different places: the structured dict on the compact path and
+    the legacy JSON string on the other.
+    """
+    handler = SimpleToolsHandler(empty_zim_operations)
+
+    result = handler.handle_zim_query(
+        "search all files for biology", options={"compact": compact}
+    )
+
+    assert _mentions(result, onboarding.KIWIX_LIBRARY_HOST), result
+    assert onboarding.STARTER_ARCHIVE_URL in result, result
+
+
+def test_search_all_does_not_walk_the_directories_a_second_time(
+    tmp_path: Path,
+) -> None:
+    """The emptiness signal is read off the fan-out, not probed for.
+
+    An earlier draft called ``list_zim_files_data()`` before dispatching,
+    which put an extra recursive walk on every ``search all files`` call to
+    answer a question the fan-out's own ``files_available`` already
+    answers. Measured on a *non-empty* directory on purpose: that is the
+    overwhelmingly common case and the only one where the extra walk is
+    pure cost, since on an empty one the probe short-circuits the fan-out
+    it duplicates.
+    """
+    from openzim_mcp.zim.archive import ZIM_MAGIC
+
+    (tmp_path / "wikipedia.zim").write_bytes(ZIM_MAGIC + b"\x00" * 64)
+    config = OpenZimMcpConfig(allowed_directories=[str(tmp_path)])
+    operations = ZimOperations(
+        config,
+        PathValidator(config.allowed_directories),
+        OpenZimMcpCache(config.cache),
+        ContentProcessor(),
+    )
+    handler = SimpleToolsHandler(operations)
+
+    def _listings_during(run) -> int:  # type: ignore[no-untyped-def]
+        with patch.object(
+            operations,
+            "list_zim_files_data",
+            wraps=operations.list_zim_files_data,
+        ) as probe:
+            run()
+        return int(probe.call_count)
+
+    # The fan-out lists the directories once, by necessity. Measured rather
+    # than hard-coded, so this stays about what the *handler* adds.
+    baseline = _listings_during(lambda: operations.search_all("biology"))
+    through_handler = _listings_during(
+        lambda: handler._handle_search_all("biology", "", {"query": "biology"}, {})
+    )
+
+    assert through_handler == baseline, (
+        "the handler re-listed the directories to decide whether they were "
+        f"empty: {through_handler} listing(s) versus the fan-out's own "
+        f"{baseline}"
+    )
+
+
+def test_search_all_still_searches_when_archives_are_loaded() -> None:
+    """The empty arm must not swallow the real fan-out."""
+    operations = MagicMock()
+    operations.list_zim_files_data.return_value = [
+        {"path": "/zim/wikipedia.zim"},
+        {"path": "/zim/wiktionary.zim"},
+    ]
+    operations.search_all.return_value = '{"files_searched": 2, "results": []}'
+
+    result = SimpleToolsHandler(operations).handle_zim_query(
+        "search all files for biology"
+    )
+
+    operations.search_all.assert_called_once()
+    assert not _mentions(result, onboarding.KIWIX_LIBRARY_HOST), result
 
 
 def test_filtered_empty_listing_does_not_offer_to_download_a_first_archive(

--- a/tests/test_v3_field_fixes_protocol.py
+++ b/tests/test_v3_field_fixes_protocol.py
@@ -467,6 +467,14 @@ def _one_shot_stdio(
     of hanging it; the exit is then awaited separately, so a server that
     answers but lingers is told apart from one that never answers.
     """
+    # An allowed directory holding no ``.zim`` now draws a startup warning
+    # telling the operator where to get an archive — a real signal, and one
+    # this test's blanket ``"WARNING" not in stderr`` would otherwise read as
+    # the protocol-layer regression it is actually watching for. Give the
+    # server a nominal archive so the assertion keeps its full strength. None
+    # of the one-shot methods here (initialize / ping / tools|prompts list)
+    # opens an archive, so the bytes never have to be a valid ZIM.
+    (tmp_path / "sample.zim").write_bytes(b"placeholder")
     stderr_path = tmp_path / "server.stderr"
     with stderr_path.open("wb") as stderr:
         proc = subprocess.Popen(

--- a/website/src/content/docs/http-and-docker-deployment.mdx
+++ b/website/src/content/docs/http-and-docker-deployment.mdx
@@ -374,7 +374,7 @@ This recipe puts OpenZIM MCP on a single host, reachable from the rest of your L
 #### Prerequisites
 
 - Docker and Docker Compose v2 installed on the host
-- A directory of `.zim` files (download from the [Kiwix Library](https://library.kiwix.org/))
+- A directory of `.zim` files (download from the [Kiwix Library](https://browse.library.kiwix.org/))
 - A generated bearer token: `openssl rand -hex 32`
 
 #### `docker-compose.yml`

--- a/website/src/content/docs/installation.mdx
+++ b/website/src/content/docs/installation.mdx
@@ -510,9 +510,15 @@ Permission denied: '/path/to/zim/files'
 
 ```
 No ZIM files found in allowed directories
+
+**Get an archive:**
+- Browse [browse.library.kiwix.org](https://browse.library.kiwix.org/) for full archives (Wikipedia, Wiktionary, Stack Exchange, …)
+- Or start with a 13.6 MB sample:
+  `curl -fsSL -o ~/zim-files/wikipedia_en_climate_change_mini_2024-06.zim https://raw.githubusercontent.com/openzim/zim-testing-suite/main/data/withns/wikipedia_en_climate_change_mini_2024-06.zim`
+- Then point the server at `~/zim-files` (the directory that command fills)
 ```
 
-**Solution**: Download ZIM files from [Kiwix Library](https://browse.library.kiwix.org/) and place them in the specified directory
+**Solution**: run the command the tool gives you, or pick an archive from the [Kiwix Library](https://browse.library.kiwix.org/), and point the server at the directory you saved it in.
 
 ### Getting Help
 

--- a/website/src/pages/llms.txt.ts
+++ b/website/src/pages/llms.txt.ts
@@ -205,7 +205,7 @@ The server takes **directories**, not individual files. The published Docker ima
   "mcpServers": {
     "openzim": {
       "command": "uvx",
-      "args": ["openzim-mcp@${VERSION}", "/path/to/zim/files"]
+      "args": ["openzim-mcp@${VERSION}", "~/zim-files"]
     }
   }
 }
@@ -310,7 +310,7 @@ Full reference: ${SITE}/docs/configuration/
 - Changelog: https://github.com/cameronrye/openzim-mcp/blob/main/CHANGELOG.md
 - PyPI: https://pypi.org/project/openzim-mcp/
 - ZIM format specification: https://openzim.org/wiki/ZIM_file_format
-- ZIM archive library: https://library.kiwix.org/
+- ZIM archive library: https://browse.library.kiwix.org/
 - openZIM project: https://openzim.org/
 `;
 


### PR DESCRIPTION
A server with no ZIM archive is inert, and nothing told you where to get one.

The README — the page almost everyone lands on — offered a single sentence pointing at `library.kiwix.org`, whose headline downloads run to tens of gigabytes. A 13.6 MB starter archive reachable in one `curl` already existed, but only on the docs site, which is not where people arrive. After that the silence continued: a server pointed at a directory containing no `.zim` logged "started successfully" and then answered every query with nothing, and the tool result a GUI client actually displays said `No ZIM files found in allowed directories` and stopped there — while the log that would have explained it sat in a file Claude Desktop never surfaces.

**What changed**

- **README** now carries a "Get your first ZIM archive" section in the install flow, before you wire the server into a client: the `curl` one-liner for the 13.6 MB extract of English Wikipedia on climate change (from the openZIM project's own testing suite — verified HTTP 200, 14,239,035 bytes), plus a pointer to [browse.library.kiwix.org](https://browse.library.kiwix.org/) for full archives and a link to Quick start for checksums and the PowerShell equivalent. The examples below it now point the server at `~/zim-files`, the directory that command fills — previously they said `/path/to/zim/files`, so following the page top-to-bottom ended in `Directory does not exist`. `~` is expanded by the config layer, so it works in a client config file as well as a shell.
- **Startup** counts discoverable `.zim` files after directory validation and warns when there are none, naming the count, the library and the download command. It goes through the logger, so it lands on stderr and honours `OPENZIM_MCP_LOGGING__LEVEL`; stdout carries the JSON-RPC stream under the default stdio transport, and a test pins it byte-for-byte empty. The probe stops at the first archive it finds rather than enumerating the tree, because it runs before the server starts reading stdin and an allowed directory is allowed to be a home directory or a network share.
- **Tool results** say the same thing, on all four surfaces that can report an empty library. The empty file listing appends where to get an archive. The "No ZIM File Specified" gate now tells apart its two callers: with two or more archives loaded it keeps the existing cross-archive recovery advice, and with none loaded it stops recommending `search all files for …` (which would fan out across nothing) and offers the download instead. `search all files for …` with zero archives no longer returns a bare `"files_available": 0` blob. `zim_health` — the tool the troubleshooting page names for exactly this symptom — adds the same guidance to its recommendations; its existing warning string is unchanged, because the docs quote it verbatim. A name filter that matched nothing is deliberately left alone: that is not an empty library.
- **The one-click install prompts** — the `.mcpb` bundle's ZIM-directory field and its `server.json` equivalent — are the text you read *while* being asked for a directory, and pointed only at the full library. Both now name the starter archive.

The URL, size and command live in one module (`openzim_mcp/onboarding.py`). Tests hold the README, `quick-start.mdx`, `installation.mdx`, the generated `llms.txt`, the `.mcpb` manifest and `server.json` to those values, so they cannot drift into contradicting each other; the size itself is checked against the archive's measured byte count, so "stated consistently" cannot quietly mean "consistently wrong". The URL is also registered with the repo's link checker — it only ever appears as a bare URL inside a `curl` fence, which nothing collected, and `curl -fsSL` fails silently, so an upstream move would have reached every new user as "the command did nothing" with CI fully green.

**Anything you must do:** nothing. No configuration, API or output-schema change; the empty-listing message and the `zim_health` warning both keep their existing text verbatim, so anything matching on them still matches.
