### PR TITLE
fix: sink crawl artefacts and site navigation below the answers callers asked for

### DIFF
--- a/docs/field-report-disposition.md
+++ b/docs/field-report-disposition.md
@@ -58,19 +58,22 @@ and after the change:
 | Suggest | 6 → 1 | 29 of 40 → 0 |
 | Chooser | 7 → 1 | 7 of 39 → 0 |
 
-The remaining #1 is `migraine headache`, whose only row is an image stub.
+The remaining #1 on each surface is a page with nothing else on it:
+`migraine headache` in title and suggest, whose only row is an image stub,
+and `swollen glands` in the chooser, whose only strong match is an image
+stub — which `zim_query` still fetches as the answer.
 The artefact share of the rows (26.1% title, 26.6% suggest) does not move,
 and must not: the demote reorders the page it is handed and never evicts
 from it. On IEP, the `/category/` topic pages stay #1 for the four queries
 they answer.
 
-Getting there took three placements. Demoting inside the title lookup
+Getting there took three attempts at two placements. Demoting inside the title lookup
 reordered the page the canonical-title promotion reads as
 score-descending, so the probe blanked and a weaker hit was hoisted to #1
 at a fabricated score of 1.0. Moving the demote to the response edge fixed
 that call and broke the next one: the edge rewrote the *cached* page in
-place, so a second identical `title 'swollen glands'` brought the
-fabricated 1.0 back. The edge now demotes a copy. A "24.5% → 12.8%"
+place, so a second identical `title 'swollen glands'` at `limit=3` — the
+page size the promotion probe reads — brought the fabricated 1.0 back. The edge now demotes a copy. A "24.5% → 12.8%"
 artefact figure recorded along the way was measured on the first
 placement, and does not describe the shipped code.
 
@@ -80,17 +83,18 @@ count — on sidecars of 50 or more nodes — is site furniture and sinks to
 the end. Reader-only: no rebuild and no schema bump. On the IEP sidecar
 (1,187 nodes, threshold 594) the 33 nodes over the line are the home page,
 the 26 alphabet pages, five site pages and the RSS feed; the best-linked
-article, `plato/`, sits at 106. Of the 919 targets with at least one
-non-furniture linker, furniture led 654 before and leads none after; the
-235 targets linked only by furniture still lead with it, since a reorder
-cannot change them.
+article, `plato/`, sits at 106. Of the 919 article targets — targets not
+themselves furniture — with at least one non-furniture linker, furniture led
+654 before and leads none after; the 235 linked only by furniture still lead
+with it, since a reorder cannot change them.
 
 **The reranker docs stop claiming an improvement.** The only blind
 evaluation — 50 queries, 44 rerank-eligible, 132 judgments on two warc2zim
 archives — found no metric reaching significance (55 preference votes
 against 52, p = 0.85; a relevant article at #1 in 64.4% against 62.9%),
 while median latency roughly doubled and the model costs about 1.1 GB. The
-reranking page and the install page now say that, with the numbers.
+reranking page now says that, with the numbers; the install page carries the
+hedge and the latency cost, and links to them.
 
 ## Deliberately not fixed
 
@@ -108,7 +112,7 @@ omissions — reopen one only with evidence that changes its premise.
 | Re-adding `title`/`content_type` to batch items | Declined. Removed deliberately in PR #374; the bodies are self-identifying and the caller supplied the paths. |
 | Worker processes / single-flight coalescing for the HTTP transport | Declined. Horizontal scaling is the documented answer and the replica is the worker unit. Coalescing means per-key in-flight futures across a lock also touched from `atexit` and a cleanup thread — real deadlock risk, for a thundering-herd shape rare on a personal offline server, with no load-test harness in CI to defend it. |
 | Stripping the site-name suffix from browse titles | Declined. `strip_site_suffix` splits only on `" \| "`, so it would clean the IEP rows and ~553 MedlinePlus rows but none of the ~10,678 `": MedlinePlus …"` ones — and the same suffix rides `zim_search` and `zim_links` rows, so stripping it in browse alone desynchronises the surfaces. |
-| The builder-scoping half of fid 86 | Declined. Feeding the sidecar builder `select_main_content` would make outbound and inbound describe the same graph, but it inherits the furniture strips, which on MedlinePlus delete "Related Health Topics": 165 of 174 strip-only removals in a 250-page sample were genuine topic pages. That trades a contradiction no caller can observe for the loss of MedlinePlus's best inbound signal, and invalidates every sidecar in the field. |
+| The builder-scoping half of fid 86 | Declined. Feeding the sidecar builder `select_main_content` would make outbound and inbound describe the same graph, but it inherits the furniture strips, which on MedlinePlus delete "Related Health Topics": 165 of 174 strip-only removals in a 250-page sample were genuine topic pages. That trades an inconsistency between the two directions — `c/`'s inbound list includes `hume-causation/`, whose outbound list omits `c/` — for the loss of MedlinePlus's best inbound signal, and would invalidate every sidecar in the field. |
 | Dropping the reranker extra, or publishing an improvement figure | Declined. "No measured effect at n=44 on two warc2zim archives" is not "no effect" — the sample rules out a large effect, not a small one, and says nothing about Wikipedia-shaped corpora — and a published figure would be invented. The docs give the measured numbers and let a reader price the trade. |
 | Demoting index pagination (`/page/N/`) as a crawl artefact | Declined on measurement. It matched nothing on MedlinePlus and two IEP entries, both false positives: `category/…/metaphysics/page/2/` continues the topic index `/category/` is kept for, 19 more articles with no overlap. |
 | Over-fetching so a small title or suggest `limit` evicts artefacts | Declined. The demote reorders the page the data layer returns, so at `limit` 1 or 2 a page holding no real article still leads with an artefact, and a larger `limit` can change which row leads. Over-fetching means recomputing `total`, `done` and the paging arithmetic, in the same spot where the first placement broke promotion. Documented in the API reference. |
@@ -121,15 +125,18 @@ omissions — reopen one only with evidence that changes its premise.
 Recorded rather than closed, in rough order of value:
 
 - **Ranking headroom beyond artefacts.** Both reranker configurations put a
-  relevant article at #1 only about 64% of the time. The follow-up sank
-  scraper output; what remains is real articles in the wrong order — a
-  supplement monograph outranking "High blood pressure medications".
+  relevant article at #1 of `zim_query` search results only 63–64% of the
+  time. The follow-up sank scraper output on title, suggest and the chooser
+  only: fulltext and `zim_query` search still carry it (12% of top-5 rows
+  on the 40 MedlinePlus queries, 4 of them at #1), alongside real articles
+  in the wrong order — a supplement monograph outranking "High blood
+  pressure medications".
 - `zim_browse(mode='page')` renders a `preview` that is empty on 99.8% of
   IEP rows, making the default mode far slower than `mode='walk'` for
   identical rows.
 - Cross-archive fan-out has no cross-archive ranking. Cross-archive title
-  mode now sinks artefacts, but rows from different archives are still not
-  ranked against each other.
+  mode now sinks artefacts, but rows from different archives are still
+  interleaved by per-archive rank scores that mean nothing across archives.
 - Rate-limit pricing charges a wide search less than a batch fetch that does
   less work.
 - `zim_query "find article titled X"` is a title surface the artefact demote

--- a/docs/field-report-disposition.md
+++ b/docs/field-report-disposition.md
@@ -40,6 +40,58 @@ heading followed (invisible on the shipped corpus, where furniture always
 sits last), and a snippet-emphasis fix whose own repro cases were unchanged
 by it.
 
+### The follow-up
+
+A second branch took three of the six items the first left open.
+
+**Crawl artefacts sink below articles (fid 71).** Paths matching
+`/imagepages/` (image-caption stubs), `/languages/` (translation hubs) or
+ending `.srt` (subtitle sidecars) now sink below real articles on four
+surfaces: single-archive and cross-archive title mode, suggest mode, and the
+`zim_query` chooser. Measured on the shipped MedlinePlus archive with 40
+topic queries at `limit=5`, with the rate limiter and the cache off, before
+and after the change:
+
+| Surface | Artefact at #1 | Pages with an artefact above an article |
+| --- | --- | --- |
+| Title | 4 → 1 | 30 of 40 → 0 |
+| Suggest | 6 → 1 | 29 of 40 → 0 |
+| Chooser | 7 → 1 | 7 of 39 → 0 |
+
+The remaining #1 is `migraine headache`, whose only row is an image stub.
+The artefact share of the rows (26.1% title, 26.6% suggest) does not move,
+and must not: the demote reorders the page it is handed and never evicts
+from it. On IEP, the `/category/` topic pages stay #1 for the four queries
+they answer.
+
+Getting there took three placements. Demoting inside the title lookup
+reordered the page the canonical-title promotion reads as
+score-descending, so the probe blanked and a weaker hit was hoisted to #1
+at a fabricated score of 1.0. Moving the demote to the response edge fixed
+that call and broke the next one: the edge rewrote the *cached* page in
+place, so a second identical `title 'swollen glands'` brought the
+fabricated 1.0 back. The edge now demotes a copy. A "24.5% → 12.8%"
+artefact figure recorded along the way was measured on the first
+placement, and does not describe the shipped code.
+
+**"What links here?" stops answering with the navigation (fid 86, ranking
+half).** A linker whose inbound degree is at least half the sidecar's node
+count — on sidecars of 50 or more nodes — is site furniture and sinks to
+the end. Reader-only: no rebuild and no schema bump. On the IEP sidecar
+(1,187 nodes, threshold 594) the 33 nodes over the line are the home page,
+the 26 alphabet pages, five site pages and the RSS feed; the best-linked
+article, `plato/`, sits at 106. Of the 919 targets with at least one
+non-furniture linker, furniture led 654 before and leads none after; the
+235 targets linked only by furniture still lead with it, since a reorder
+cannot change them.
+
+**The reranker docs stop claiming an improvement.** The only blind
+evaluation — 50 queries, 44 rerank-eligible, 132 judgments on two warc2zim
+archives — found no metric reaching significance (55 preference votes
+against 52, p = 0.85; a relevant article at #1 in 64.4% against 62.9%),
+while median latency roughly doubled and the model costs about 1.1 GB. The
+reranking page and the install page now say that, with the numbers.
+
 ## Deliberately not fixed
 
 Each of these was reproduced and understood. They are decisions, not
@@ -56,39 +108,35 @@ omissions — reopen one only with evidence that changes its premise.
 | Re-adding `title`/`content_type` to batch items | Declined. Removed deliberately in PR #374; the bodies are self-identifying and the caller supplied the paths. |
 | Worker processes / single-flight coalescing for the HTTP transport | Declined. Horizontal scaling is the documented answer and the replica is the worker unit. Coalescing means per-key in-flight futures across a lock also touched from `atexit` and a cleanup thread — real deadlock risk, for a thundering-herd shape rare on a personal offline server, with no load-test harness in CI to defend it. |
 | Stripping the site-name suffix from browse titles | Declined. `strip_site_suffix` splits only on `" \| "`, so it would clean the IEP rows and ~553 MedlinePlus rows but none of the ~10,678 `": MedlinePlus …"` ones — and the same suffix rides `zim_search` and `zim_links` rows, so stripping it in browse alone desynchronises the surfaces. |
+| The builder-scoping half of fid 86 | Declined. Feeding the sidecar builder `select_main_content` would make outbound and inbound describe the same graph, but it inherits the furniture strips, which on MedlinePlus delete "Related Health Topics": 165 of 174 strip-only removals in a 250-page sample were genuine topic pages. That trades a contradiction no caller can observe for the loss of MedlinePlus's best inbound signal, and invalidates every sidecar in the field. |
+| Dropping the reranker extra, or publishing an improvement figure | Declined. "No measured effect at n=44 on two warc2zim archives" is not "no effect" — the sample rules out a large effect, not a small one, and says nothing about Wikipedia-shaped corpora — and a published figure would be invented. The docs give the measured numbers and let a reader price the trade. |
+| Demoting index pagination (`/page/N/`) as a crawl artefact | Declined on measurement. It matched nothing on MedlinePlus and two IEP entries, both false positives: `category/…/metaphysics/page/2/` continues the topic index `/category/` is kept for, 19 more articles with no overlap. |
+| Over-fetching so a small title or suggest `limit` evicts artefacts | Declined. The demote reorders the page the data layer returns, so at `limit` 1 or 2 a page holding no real article still leads with an artefact, and a larger `limit` can change which row leads. Over-fetching means recomputing `total`, `done` and the paging arithmetic, in the same spot where the first placement broke promotion. Documented in the API reference. |
+| Exempting MedlinePlus's per-language portals from `/languages/` | Accepted cost. The shape also matches about 53 "Health Information in *Language*" portals, which now sink below other rows on their page — `title 'Italian'` leads with a recipe. They are still returned. Telling a portal from a translation hub needs a language list or MedlinePlus-specific title matching. |
+| Versioning the inbound cursor across the ranking change | Recorded. A cursor minted before the upgrade resumes at the same offset in the new order, so a paging walk that spans the upgrade can repeat or skip a row. Within one server version paging is exact. Rejecting every pre-upgrade cursor is a contract change for a one-time effect. |
 | Malformed-frame classification on the `sse` transport | Not wired, recorded. `MCPServer.run(transport="sse")` builds its own ASGI app inside the SDK, so no middleware this server adds reaches it. Covering it means reimplementing `run_sse_async`'s uvicorn and transport-security setup for a transport already deprecated for removal in 4.0.0. The gap is named where the gate is wired, in the transport table, and in the deprecation warning an operator sees when they choose SSE — and asserted by tests, so it cannot be re-discovered as a surprise. |
 
 ## Still open
 
 Recorded rather than closed, in rough order of value:
 
-- **Ranking headroom.** Both reranker configurations put a relevant article
-  at #1 only about 64% of the time and carry ~2 off-topic entries in every
-  top-5 — a supplement monograph outranking "High blood pressure
-  medications", a raw `.srt` caption file in a top-5. Demoting crawl
-  artefacts (`/category/`, `/page/N/`, `/imagepages/`) has to land on the
-  title-suggest pool *and* the `zim_query` disambiguation chooser together,
-  or the two surfaces disagree about what an artefact is; and it moves
-  `results[0]`, which the canonical-splice promotion reads under a hard
-  score gate. Needs corpus validation paired across both halves.
-- **The optional reranker is unmeasured.** 50 queries, 44 eligible, 132
-  blind judgments: not one metric approaches significance, while the extra
-  costs ~1.1 GB of model and doubles query latency. Publish a measured
-  number, say in the docs that the improvement is unmeasured, or drop the
-  extra. (44 queries on two archives rules out a large effect, not a small
-  one, and says nothing about Wikipedia-shaped corpora.)
+- **Ranking headroom beyond artefacts.** Both reranker configurations put a
+  relevant article at #1 only about 64% of the time. The follow-up sank
+  scraper output; what remains is real articles in the wrong order — a
+  supplement monograph outranking "High blood pressure medications".
 - `zim_browse(mode='page')` renders a `preview` that is empty on 99.8% of
   IEP rows, making the default mode far slower than `mode='walk'` for
   identical rows.
-- The sidecar builder parses raw entry bytes while the bundle scopes to the
-  main-content landmark, so outbound and inbound describe slightly different
-  graphs; inbound ranks on raw `inbound_degree`, a signal boilerplate
-  maximises.
-- Cross-archive fan-out has no cross-archive ranking.
+- Cross-archive fan-out has no cross-archive ranking. Cross-archive title
+  mode now sinks artefacts, but rows from different archives are still not
+  ranked against each other.
 - Rate-limit pricing charges a wide search less than a batch fetch that does
   less work.
+- `zim_query "find article titled X"` is a title surface the artefact demote
+  does not reach, so the same title-index lookup comes back in a different
+  order there than from `zim_search` title mode.
 
-## Two things the process itself surfaced
+## Three things the process itself surfaced
 
 **Tests keep shipping vacuous.** Every fix here was mutation-proven, and the
 mutation pass repeatedly caught what the tests did not: a guard made
@@ -104,3 +152,11 @@ because the corpus is regular: MedlinePlus always puts furniture last, so a
 strip that ate everything after it never had anything to eat. Both live
 archives are `generic` zimit/warc2zim archives, so nothing here speaks to
 Wikipedia- or Stack Exchange-shaped content.
+
+**The cache is part of the surface.** The follow-up's artefact demote
+rewrote a cached page in place, and every test of it passed, because every
+test ran with the cache off and called once. It was found by re-measuring on
+the real archive with the default in-memory cache on and asking the same
+question twice. A fix that touches what a cached value holds needs a
+two-call test with the cache enabled, and needs the render epoch bumped for
+any cache that stores its output.

--- a/openzim_mcp/bundle.py
+++ b/openzim_mcp/bundle.py
@@ -84,10 +84,10 @@ _BUNDLE_KEY_PREFIX = "bundle:v2h"
 #
 # Bump this in any release that changes what the server renders OR RANKS into
 # a cache from an unchanged archive. tests/test_v3_cache_render_epoch.py pins
-# the epoch to a fingerprint of the rendering and of the crawl-artefact
-# ranking the suggestions cache holds, so it fails when either changes without
-# a bump, or when a bump is reverted. It cannot see any other ranking a cache
-# holds: check a new cached ordering by hand.
+# the epoch to fingerprints of the rendering, of the crawl-artefact demote's
+# code, and of how that demote orders a fixture, so it fails when any of them
+# changes without a bump, or when a bump is reverted. It cannot see a cached
+# ranking that comes from anywhere else: check that by hand.
 _RENDER_EPOCH = "r3"
 
 

--- a/openzim_mcp/bundle.py
+++ b/openzim_mcp/bundle.py
@@ -84,7 +84,7 @@ _BUNDLE_KEY_PREFIX = "bundle:v2h"
 #
 # Bump this in any release that changes what the server renders from an
 # unchanged archive; tests/test_v3_cache_render_epoch.py fails until you do.
-_RENDER_EPOCH = "r2"
+_RENDER_EPOCH = "r3"
 
 
 def archive_stat_token(validated_path: Any) -> str:

--- a/openzim_mcp/bundle.py
+++ b/openzim_mcp/bundle.py
@@ -82,8 +82,12 @@ _BUNDLE_KEY_PREFIX = "bundle:v2h"
 # content-derived cache at once, because embedding the token is already the
 # contract for all of them.
 #
-# Bump this in any release that changes what the server renders from an
-# unchanged archive; tests/test_v3_cache_render_epoch.py fails until you do.
+# Bump this in any release that changes what the server renders OR RANKS into
+# a cache from an unchanged archive. tests/test_v3_cache_render_epoch.py pins
+# the epoch to a fingerprint of the rendering and of the crawl-artefact
+# ranking the suggestions cache holds, so it fails when either changes without
+# a bump, or when a bump is reverted. It cannot see any other ranking a cache
+# holds: check a new cached ordering by hand.
 _RENDER_EPOCH = "r3"
 
 

--- a/openzim_mcp/linkgraph/reader.py
+++ b/openzim_mcp/linkgraph/reader.py
@@ -112,10 +112,10 @@ class LinkGraphReader:
         ).fetchone()[0]
         # v3.3.1 field report (fid 86): ranking purely on inbound_degree
         # answered "what links here?" with the site's navigation. A page in
-        # the nav bar links to everything and is therefore linked FROM
-        # everything, so it won this ordering for most targets — on the
-        # shipped IEP sidecar, furniture led 366 of the 371 targets with five
-        # or more linkers. Nodes at or above the threshold sink as a group;
+        # the nav bar is linked FROM every page that carries the bar, so it
+        # won this ordering for most targets — on the shipped IEP sidecar,
+        # furniture led 366 of the 371 non-furniture targets with five or
+        # more linkers. Nodes at or above the threshold sink as a group;
         # below it, inbound degree is still the signal.
         #
         # A demote by RANK only: no row is dropped, so ``total`` and the

--- a/openzim_mcp/linkgraph/reader.py
+++ b/openzim_mcp/linkgraph/reader.py
@@ -39,8 +39,9 @@ class InboundPage:
 # boilerplate to separate an article from — on a twenty-page archive a
 # genuinely central article can legitimately be linked from half of it — so the
 # demotion is switched off rather than applied to a population too small to
-# have the pattern. Returns 0 when it should not apply, including for an older
-# sidecar of this schema that never stored ``node_count``.
+# have the pattern. Returns 0 when it should not apply: below that floor, or
+# when ``node_count`` is missing or unparseable (defensive — every builder
+# writes it, so only a hand-made or damaged sidecar lacks it).
 _FURNITURE_DEGREE_FRACTION = 0.5
 _MIN_ARCHIVE_FOR_FURNITURE = 50
 
@@ -54,7 +55,7 @@ def _furniture_threshold(node_count: Optional[str]) -> int:
     if total < _MIN_ARCHIVE_FOR_FURNITURE:
         return 0
     # A true ceiling. ``-(-int(x) // 1)`` was written here and is a no-op:
-    # ``int()`` truncates first, so it computed the FLOOR and the docstring's
+    # ``int()`` truncates first, so it computed the FLOOR and the rule's
     # "at least half" was off by one on every odd node count.
     return math.ceil(total * _FURNITURE_DEGREE_FRACTION)
 
@@ -112,13 +113,16 @@ class LinkGraphReader:
         # v3.3.1 field report (fid 86): ranking purely on inbound_degree
         # answered "what links here?" with the site's navigation. A page in
         # the nav bar links to everything and is therefore linked FROM
-        # everything, so it won this ordering on every single query — on the
-        # shipped IEP sidecar the alphabet index led 366 of 371 article
-        # targets. Nodes at or above the threshold sink as a group; below it,
-        # inbound degree is still the signal.
+        # everything, so it won this ordering for most targets — on the
+        # shipped IEP sidecar, furniture led 366 of the 371 targets with five
+        # or more linkers. Nodes at or above the threshold sink as a group;
+        # below it, inbound degree is still the signal.
         #
-        # A demote by RANK only: no row is dropped, so ``total``, the
-        # pagination arithmetic and the cursor contract are untouched.
+        # A demote by RANK only: no row is dropped, so ``total`` and the
+        # pagination arithmetic are untouched and paging within one server
+        # version reaches every row exactly once. A cursor minted by a build
+        # that ranked purely on degree resumes at the same offset in this
+        # order, so a walk spanning the upgrade can repeat or skip a row.
         # ``threshold`` of 0 disables the clause (small or unlabelled
         # archives), leaving exactly the previous ordering.
         threshold = self._furniture_threshold or 0

--- a/openzim_mcp/linkgraph/reader.py
+++ b/openzim_mcp/linkgraph/reader.py
@@ -7,6 +7,7 @@ strict staleness decision). ``query_inbound`` is a ranked, paginated lookup.
 
 from __future__ import annotations
 
+import math
 import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
@@ -52,7 +53,10 @@ def _furniture_threshold(node_count: Optional[str]) -> int:
         return 0
     if total < _MIN_ARCHIVE_FOR_FURNITURE:
         return 0
-    return -(-int(total * _FURNITURE_DEGREE_FRACTION) // 1)
+    # A true ceiling. ``-(-int(x) // 1)`` was written here and is a no-op:
+    # ``int()`` truncates first, so it computed the FLOOR and the docstring's
+    # "at least half" was off by one on every odd node count.
+    return math.ceil(total * _FURNITURE_DEGREE_FRACTION)
 
 
 class LinkGraphReader:

--- a/openzim_mcp/linkgraph/reader.py
+++ b/openzim_mcp/linkgraph/reader.py
@@ -33,12 +33,35 @@ class InboundPage:
     total: int
 
 
+# A node linked from at least half the archive is site furniture, not a topic:
+# it is in the nav bar. Below ``_MIN_ARCHIVE_FOR_FURNITURE`` nodes there is no
+# boilerplate to separate an article from — on a twenty-page archive a
+# genuinely central article can legitimately be linked from half of it — so the
+# demotion is switched off rather than applied to a population too small to
+# have the pattern. Returns 0 when it should not apply, including for an older
+# sidecar of this schema that never stored ``node_count``.
+_FURNITURE_DEGREE_FRACTION = 0.5
+_MIN_ARCHIVE_FOR_FURNITURE = 50
+
+
+def _furniture_threshold(node_count: Optional[str]) -> int:
+    """Inbound degree at or above which a node counts as site furniture."""
+    try:
+        total = int(node_count or 0)
+    except (TypeError, ValueError):
+        return 0
+    if total < _MIN_ARCHIVE_FOR_FURNITURE:
+        return 0
+    return -(-int(total * _FURNITURE_DEGREE_FRACTION) // 1)
+
+
 class LinkGraphReader:
     """Open and query a link-graph sidecar. Construct via ``open_for``."""
 
     def __init__(self, conn: sqlite3.Connection) -> None:
         """Store the open read-only SQLite connection."""
         self._conn = conn
+        self._furniture_threshold: Optional[int] = None
 
     @classmethod
     def open_for(
@@ -65,7 +88,9 @@ class LinkGraphReader:
         if meta.get("archive_uuid") != live_archive_uuid:
             conn.close()
             return None
-        return cls(conn)
+        reader = cls(conn)
+        reader._furniture_threshold = _furniture_threshold(meta.get("node_count"))
+        return reader
 
     def query_inbound(
         self, target_path: str, *, limit: int, offset: int
@@ -80,15 +105,35 @@ class LinkGraphReader:
         total = self._conn.execute(
             "SELECT COUNT(*) FROM edges WHERE target_id = ?", (target_id,)
         ).fetchone()[0]
+        # v3.3.1 field report (fid 86): ranking purely on inbound_degree
+        # answered "what links here?" with the site's navigation. A page in
+        # the nav bar links to everything and is therefore linked FROM
+        # everything, so it won this ordering on every single query — on the
+        # shipped IEP sidecar the alphabet index led 366 of 371 article
+        # targets. Nodes at or above the threshold sink as a group; below it,
+        # inbound degree is still the signal.
+        #
+        # A demote by RANK only: no row is dropped, so ``total``, the
+        # pagination arithmetic and the cursor contract are untouched.
+        # ``threshold`` of 0 disables the clause (small or unlabelled
+        # archives), leaving exactly the previous ordering.
+        threshold = self._furniture_threshold or 0
         cur = self._conn.execute(
             """
             SELECT n.path, n.inbound_degree, e.anchor_text
               FROM edges e JOIN nodes n ON n.id = e.source_id
-             WHERE e.target_id = ?
-             ORDER BY n.inbound_degree DESC, n.path ASC
-             LIMIT ? OFFSET ?
+             WHERE e.target_id = :target_id
+             ORDER BY (:threshold > 0 AND n.inbound_degree >= :threshold) ASC,
+                      n.inbound_degree DESC,
+                      n.path ASC
+             LIMIT :limit OFFSET :offset
             """,
-            (target_id, limit, offset),
+            {
+                "target_id": target_id,
+                "threshold": threshold,
+                "limit": limit,
+                "offset": offset,
+            },
         )
         rows = [
             {"path": p, "inbound_degree": d, "anchor_text": a}

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -3891,9 +3891,10 @@ class SimpleToolsHandler(
                     strong_matches = cast(Any, [canonical_row, *strong_matches])
         # v3.3.1 field report (fid 71): this list is what the caller is
         # offered, so a scraper artefact leading it is a wrong ANSWER rather
-        # than a bad row on a page. The auto-pick rules downstream match on
-        # titles, not position, so this reorders a rendered chooser and never
-        # decides whether one is rendered. Demoted last, after the canonical
+        # than a bad row on a page. Whether a chooser is rendered does not
+        # depend on order, but when several rows title-match the topic the
+        # auto-pick takes the first, so a real article now wins over an
+        # artefact twin. Demoted last, after the canonical
         # prepend: a real canonical keeps its lead because the partition is
         # stable, and a canonical that is itself an artefact — an image stub
         # offered as "(canonical title match)" — sinks with the rest.

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -64,6 +64,7 @@ from .tool_schemas import (
     SearchResponse,
     SynthesizeResponse,
 )
+from .zim.search import demote_crawl_artefacts
 from .zim_operations import ZimOperations
 
 logger = logging.getLogger(__name__)
@@ -3888,7 +3889,11 @@ class SimpleToolsHandler(
                     # the type-checker since the synthetic row carries
                     # only the keys downstream consumers actually read.
                     strong_matches = cast(Any, [canonical_row, *strong_matches])
-        return strong_matches
+        # v3.3.1 field report (fid 71): this list decides what the caller
+        # is auto-fetched or offered, so a scraper artefact here is a wrong
+        # ANSWER rather than a bad row on a page. Demoted last, after the
+        # canonical prepend above, so the canonical row keeps its lead.
+        return demote_crawl_artefacts(strong_matches)
 
     def _auto_pick_or_render_disambiguation(
         self,

--- a/openzim_mcp/simple_tools.py
+++ b/openzim_mcp/simple_tools.py
@@ -3889,10 +3889,14 @@ class SimpleToolsHandler(
                     # the type-checker since the synthetic row carries
                     # only the keys downstream consumers actually read.
                     strong_matches = cast(Any, [canonical_row, *strong_matches])
-        # v3.3.1 field report (fid 71): this list decides what the caller
-        # is auto-fetched or offered, so a scraper artefact here is a wrong
-        # ANSWER rather than a bad row on a page. Demoted last, after the
-        # canonical prepend above, so the canonical row keeps its lead.
+        # v3.3.1 field report (fid 71): this list is what the caller is
+        # offered, so a scraper artefact leading it is a wrong ANSWER rather
+        # than a bad row on a page. The auto-pick rules downstream match on
+        # titles, not position, so this reorders a rendered chooser and never
+        # decides whether one is rendered. Demoted last, after the canonical
+        # prepend: a real canonical keeps its lead because the partition is
+        # stable, and a canonical that is itself an artefact — an image stub
+        # offered as "(canonical title match)" — sinks with the rest.
         return demote_crawl_artefacts(strong_matches)
 
     def _auto_pick_or_render_disambiguation(

--- a/openzim_mcp/tools/zim_search.py
+++ b/openzim_mcp/tools/zim_search.py
@@ -469,7 +469,13 @@ def _name_the_archive(payload: Any, resolved_path: str) -> Any:
     if isinstance(payload, dict) and not payload.get("error"):
         from ..meta import remeasure
 
-        payload["zim_file_path"] = resolved_path
+        # COPY-ON-WRITE, ``_meta`` included. The caller's copy is shallow, so
+        # ``_meta`` here was still the dict inside the cached search page, and
+        # re-measuring it in place rewrote the cache's size fields to describe
+        # a body the cache does not hold.
+        payload = {**payload, "zim_file_path": resolved_path}
+        if isinstance(payload.get("_meta"), dict):
+            payload["_meta"] = dict(payload["_meta"])
         # The data layer measured the payload before this field existed, so
         # ``_meta.chars`` would under-report the body by exactly the path it
         # now carries. Same defect as the splice's stale envelope, and the
@@ -766,7 +772,7 @@ async def _handle_title_mode(
     merged = _merge_promotion_into_title_results(raw, promoted, effective_limit)
     # v3.3.1 field report (fid 71), at the RESPONSE EDGE and nowhere earlier.
     # Scraper output — translation hubs, image-caption stubs, subtitle
-    # sidecars — outranks real articles on 39 of ~55 measured title pages
+    # sidecars — outranks a real article on 30 of 40 measured title pages
     # (``title 'hepatitis b'`` puts ``languages/hepatitisb.html`` above a real
     # ency article). Demoting it inside ``find_entry_by_title_data`` instead
     # would reorder the list the promotion probes above read as
@@ -902,8 +908,8 @@ def _merge_promotion_into_title_results(
         m for m in matches if (m.get("entry_path") or m.get("path")) != promoted_path
     ]
     promoted_row = dict(promoted)
-    # Score 1.0 marks a canonical title-index hit, the only kind promotion
-    # accepts. It is a label, not what keeps the row first: title rows go out
+    # Score 1.0 labels the row promotion chose as the topic's canonical match.
+    # It is a label, not what keeps the row first: title rows go out
     # in presentation order (crawl artefacts are sunk at the response edge),
     # and the API reference tells callers not to re-sort them on ``score``.
     promoted_row.setdefault("score", 1.0)

--- a/openzim_mcp/tools/zim_search.py
+++ b/openzim_mcp/tools/zim_search.py
@@ -725,7 +725,9 @@ async def _handle_title_mode(
             "Z3/Z4/OPP-1 promotion is per-archive. Pin a specific "
             "`zim_file_path` to enable promotion."
         )
-        return raw
+        # The fan-out is a title surface too: without this, the same lookup
+        # sank ``imagepages/`` stubs when pinned and led with them here.
+        return _demote_artefacts_in_response(raw)
 
     resolved_path = _resolve_path(server, zim_file_path)
     if resolved_path is None:
@@ -770,7 +772,7 @@ async def _handle_title_mode(
     # would reorder the list the promotion probes above read as
     # score-descending, which blanks the canonical probe and hoists a weaker
     # fallback to rank 1 at a fabricated 1.0. Promotion has run by here, so
-    # reordering is safe.
+    # reordering this response is safe — but only as a copy, see below.
     return _demote_artefacts_in_response(merged)
 
 
@@ -780,13 +782,23 @@ def _demote_artefacts_in_response(payload: Any) -> Any:
     Reorders ``results`` only: no row is added or dropped, so ``total``,
     ``done`` and the page arithmetic are untouched and ``_meta`` stays
     accurate without a re-measure.
+
+    COPY-ON-WRITE, like ``_merge_promotion_into_title_results``. When
+    promotion passes ``raw`` through unchanged, ``payload`` IS the cached
+    ``find_title:v2`` page, and the next call's promotion probes read that
+    page as score-descending. Reordering it in place brought back the very
+    defect the edge placement avoids, one call late: a second identical
+    ``title 'swollen glands'`` led with ``hormones.html`` at a fabricated 1.0.
     """
     if not isinstance(payload, dict) or payload.get("error"):
         return payload
     rows = payload.get("results")
-    if isinstance(rows, list):
-        payload["results"] = demote_crawl_artefacts(rows)
-    return payload
+    if not isinstance(rows, list):
+        return payload
+    demoted = demote_crawl_artefacts(rows)
+    if demoted is rows:
+        return payload
+    return {**payload, "results": demoted}
 
 
 # ``_meta`` keys that describe the SOURCE rather than the rendered page, so
@@ -890,13 +902,13 @@ def _merge_promotion_into_title_results(
         m for m in matches if (m.get("entry_path") or m.get("path")) != promoted_path
     ]
     promoted_row = dict(promoted)
-    # Score 1.0 keeps the emitted rank consistent with the ranking signal:
-    # promotion only accepts canonical title-index hits, and a hoisted row
-    # scored below the rows it displaced would be re-sorted back down by any
-    # caller ordering on ``score``.
+    # Score 1.0 marks a canonical title-index hit, the only kind promotion
+    # accepts. It is a label, not what keeps the row first: title rows go out
+    # in presentation order (crawl artefacts are sunk at the response edge),
+    # and the API reference tells callers not to re-sort them on ``score``.
     promoted_row.setdefault("score", 1.0)
     results = [promoted_row, *hoisted][:limit]
-    # COPY-ON-WRITE: ``raw`` is the cached ``find_title:v1`` object (H15 caches
+    # COPY-ON-WRITE: ``raw`` is the cached ``find_title:v2`` object (H15 caches
     # single-archive title lookups, returned by reference) and is shared with
     # the internal promotion probes that read the same key. Mutating it in place
     # would poison that cache (the H12 defect class), so build a new dict.

--- a/openzim_mcp/tools/zim_search.py
+++ b/openzim_mcp/tools/zim_search.py
@@ -42,6 +42,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from ..constants import MAX_QUERY_LENGTH, MAX_SEARCH_RESULT_LIMIT
 from ..responses import tool_error
+from ..zim.search import demote_crawl_artefacts
 from ._common import (
     READ_ONLY_ANNOTATIONS,
     enforce_rate_limit,
@@ -760,7 +761,32 @@ async def _handle_title_mode(
         zim_file_path=resolved_path,
         topic=preprocessed,
     )
-    return _merge_promotion_into_title_results(raw, promoted, effective_limit)
+    merged = _merge_promotion_into_title_results(raw, promoted, effective_limit)
+    # v3.3.1 field report (fid 71), at the RESPONSE EDGE and nowhere earlier.
+    # Scraper output — translation hubs, image-caption stubs, subtitle
+    # sidecars — outranks real articles on 39 of ~55 measured title pages
+    # (``title 'hepatitis b'`` puts ``languages/hepatitisb.html`` above a real
+    # ency article). Demoting it inside ``find_entry_by_title_data`` instead
+    # would reorder the list the promotion probes above read as
+    # score-descending, which blanks the canonical probe and hoists a weaker
+    # fallback to rank 1 at a fabricated 1.0. Promotion has run by here, so
+    # reordering is safe.
+    return _demote_artefacts_in_response(merged)
+
+
+def _demote_artefacts_in_response(payload: Any) -> Any:
+    """Sink crawl artefacts in a title-mode response, leaving ``_meta`` sized.
+
+    Reorders ``results`` only: no row is added or dropped, so ``total``,
+    ``done`` and the page arithmetic are untouched and ``_meta`` stays
+    accurate without a re-measure.
+    """
+    if not isinstance(payload, dict) or payload.get("error"):
+        return payload
+    rows = payload.get("results")
+    if isinstance(rows, list):
+        payload["results"] = demote_crawl_artefacts(rows)
+    return payload
 
 
 # ``_meta`` keys that describe the SOURCE rather than the rendered page, so

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -13,6 +13,7 @@ reference at import time.
 """
 
 import logging
+import re
 import unicodedata
 import urllib.parse
 from dataclasses import dataclass
@@ -343,6 +344,61 @@ def _paging_span(*, offset: int, shown: int, next_offset: int, total_text: str) 
         f"(scanned through {next_offset}; {collapsed} duplicate path{plural} "
         f"collapsed)"
     )
+
+
+# Scraper output that a crawl files as an entry but a reader would never ask
+# for: image-caption stubs, translation hubs, subtitle sidecars, and index
+# pagination. v3.3.1 field report (fid 71). Measured at v3.3.2 on the shipped
+# MedlinePlus archive, rate limiter disabled so the sweep does not read its own
+# throttling as clean pages: 24.5% of title-mode top-5 rows and 23.4% of
+# suggest-mode rows are one of these, against 11.9% in fulltext.
+#
+# ``/category/`` is deliberately ABSENT. On the IEP archive those pages are the
+# encyclopedia's own topic index and the correct #1, at score 1.0, for
+# "metaphysics", "philosophy of science", "feminist philosophy" and
+# "continental philosophy" — the demote the finding proposed would have turned
+# four right answers into wrong ones. The patterns below are matched
+# INDEPENDENTLY rather than as a precedence chain, so
+# ``category/m-and-e/metaphysics/page/2/`` is still demoted: index pagination
+# is scraper output wherever it lives.
+_CRAWL_ARTEFACT_RE = re.compile(
+    r"(?:/imagepages/)"  # ency image-caption stubs
+    r"|(?:/languages/)"  # per-language translation hubs
+    r"|(?:\.srt$)"  # subtitle sidecars filed as entries
+    r"|(?:/page/\d+/?$)",  # index pagination
+    re.IGNORECASE,
+)
+
+
+def is_crawl_artefact(path: str) -> bool:
+    """Whether ``path`` is scraper output rather than an article.
+
+    Shape only: no archive access, so this is safe to call inside a ranking
+    loop. See ``_CRAWL_ARTEFACT_RE`` for what is deliberately excluded.
+    """
+    return bool(path) and bool(_CRAWL_ARTEFACT_RE.search(path))
+
+
+def demote_crawl_artefacts(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Sink crawl artefacts below real articles, stably, dropping nothing.
+
+    A DEMOTE, not a filter: every row the caller would have had is still
+    there, and relative order inside each group is the archive's own ranking,
+    which this has no opinion about.
+
+    A page whose rows are ALL artefacts therefore comes back in its original
+    order — not by a special case, but because partitioning a list and
+    concatenating the halves in order reproduces it. An explicit
+    "all artefacts" guard here would be unreachable: it was written, and the
+    mutation that deleted it changed no behaviour at all.
+    """
+    if not rows:
+        return rows
+    artefacts = [r for r in rows if is_crawl_artefact(str(r.get("path", "")))]
+    if not artefacts:
+        return rows
+    keep = [r for r in rows if not is_crawl_artefact(str(r.get("path", "")))]
+    return keep + artefacts
 
 
 def _snippet_query(query: str) -> Optional[str]:
@@ -2677,7 +2733,12 @@ class _SearchMixin:
             # contract here: rename ``suggestions`` → ``results`` at the
             # top level (the Phase A ``_meta.suggestions[]`` recovery
             # candidates are unrelated and live inside ``_meta``).
-            suggestions = raw.get("suggestions", [])
+            # v3.3.1 field report (fid 71): suggest mode measured WORST of
+            # the three surfaces (23.4% of top-5 rows are scraper output on
+            # the shipped MedlinePlus archive), and it is served from here —
+            # a different function from ``_assemble_find_response``, which
+            # is why the finding, naming only two surfaces, missed it.
+            suggestions = demote_crawl_artefacts(raw.get("suggestions", []))
             actual_count = len(suggestions)
 
             # The suggestion pool is capped at ``limit``; we don't enumerate
@@ -3751,7 +3812,14 @@ class _SearchMixin:
                 continue
             seen.add(key)
             deduped.append(row)
-        aggregate_results = deduped
+        # v3.3.1 field report (fid 71): sink scraper output below real
+        # articles. Measured 24.5% of title-mode top-5 rows on the shipped
+        # MedlinePlus archive — ``title 'migraine headache'`` returned an
+        # image-caption stub as its only hit. After the dedup so a demoted
+        # twin cannot displace the row that survived it, and before the
+        # ``limit`` slice so the demote decides what makes the page rather
+        # than reordering what already did.
+        aggregate_results = demote_crawl_artefacts(deduped)
 
         # Build _meta.suggestions[] from archive-verified typo variants.
         # Two cases surface them (spec §14.4):

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -348,10 +348,10 @@ def _paging_span(*, offset: int, shown: int, next_offset: int, total_text: str) 
 
 # Scraper output that a crawl files as an entry but a reader would never ask
 # for: image-caption stubs, translation hubs and subtitle sidecars. v3.3.1
-# field report (fid 71). Measured at v3.3.2 on the shipped
-# MedlinePlus archive, rate limiter disabled so the sweep does not read its own
-# throttling as clean pages: 24.5% of title-mode top-5 rows and 23.4% of
-# suggest-mode rows are one of these, against 11.9% in fulltext.
+# field report (fid 71). Measured on the shipped MedlinePlus archive, 40 topic
+# queries at limit=5, rate limiter and cache off so the sweep does not read its
+# own throttling as clean pages: 26.1% of title-mode and 26.6% of suggest-mode
+# rows are one of these. Fulltext carries them too (12.0%) and is not demoted.
 #
 # ``/category/`` is deliberately ABSENT. On the IEP archive those pages are the
 # encyclopedia's own topic index and the correct #1, at score 1.0, for
@@ -2745,8 +2745,8 @@ class _SearchMixin:
             # v3.3.1 field report (fid 71): suggest mode is served from here,
             # a different function from ``_assemble_find_response``, which is
             # why the finding — naming only two surfaces — missed it. Measured
-            # 23.4% of top-5 rows scraper output on the shipped MedlinePlus
-            # archive, against title's 24.5%: comparable, not worse. Note the
+            # 26.6% of top-5 rows scraper output on the shipped MedlinePlus
+            # archive, against title's 26.1%: comparable. Note the
             # pool is already capped at ``limit`` by the generator above, so
             # this reorders the page it is given and cannot evict from it.
             suggestions = demote_crawl_artefacts(raw.get("suggestions", []))

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -357,17 +357,20 @@ def _paging_span(*, offset: int, shown: int, next_offset: int, total_text: str) 
 # encyclopedia's own topic index and the correct #1, at score 1.0, for
 # "metaphysics", "philosophy of science", "feminist philosophy" and
 # "continental philosophy" — the demote the finding proposed would have turned
-# four right answers into wrong ones. The patterns below are matched
-# INDEPENDENTLY rather than as a precedence chain, so
-# ``category/m-and-e/metaphysics/page/2/`` is still demoted: index pagination
-# is scraper output wherever it lives.
+# four right answers into wrong ones.
 _CRAWL_ARTEFACT_RE = re.compile(
     r"(?:/imagepages/)"  # ency image-caption stubs
     r"|(?:/languages/)"  # per-language translation hubs
-    r"|(?:\.srt$)"  # subtitle sidecars filed as entries
-    r"|(?:/page/\d+/?$)",  # index pagination
+    r"|(?:\.srt$)",  # subtitle sidecars filed as entries
     re.IGNORECASE,
 )
+# ``/page/N/`` was in this set and has been REMOVED. It matched nothing on
+# MedlinePlus and exactly two entries on the IEP archive, and both were false
+# positives: ``category/m-and-e/metaphysics/page/2/`` is the continuation of
+# the very topic index ``/category/`` is kept for — page 1 lists 50 articles,
+# page 2 lists 19 more with zero overlap, and both score 1.0. "Index
+# pagination is scraper output wherever it lives" was a reasonable-sounding
+# rule that, measured, only ever threw away real content.
 
 
 def is_crawl_artefact(path: str) -> bool:
@@ -385,6 +388,12 @@ def demote_crawl_artefacts(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     A DEMOTE, not a filter: every row the caller would have had is still
     there, and relative order inside each group is the archive's own ranking,
     which this has no opinion about.
+
+    Call it at a RESPONSE EDGE only. Applying it to a list that something
+    downstream reads as score-descending breaks that consumer: the title
+    surface's promotion probes read ``results[0]`` under a score gate, and
+    demoting before them blanks the probe and lets a weaker fallback pass be
+    hoisted to rank 1 at a fabricated score of 1.0.
 
     A page whose rows are ALL artefacts therefore comes back in its original
     order — not by a special case, but because partitioning a list and
@@ -2733,11 +2742,13 @@ class _SearchMixin:
             # contract here: rename ``suggestions`` → ``results`` at the
             # top level (the Phase A ``_meta.suggestions[]`` recovery
             # candidates are unrelated and live inside ``_meta``).
-            # v3.3.1 field report (fid 71): suggest mode measured WORST of
-            # the three surfaces (23.4% of top-5 rows are scraper output on
-            # the shipped MedlinePlus archive), and it is served from here —
-            # a different function from ``_assemble_find_response``, which
-            # is why the finding, naming only two surfaces, missed it.
+            # v3.3.1 field report (fid 71): suggest mode is served from here,
+            # a different function from ``_assemble_find_response``, which is
+            # why the finding — naming only two surfaces — missed it. Measured
+            # 23.4% of top-5 rows scraper output on the shipped MedlinePlus
+            # archive, against title's 24.5%: comparable, not worse. Note the
+            # pool is already capped at ``limit`` by the generator above, so
+            # this reorders the page it is given and cannot evict from it.
             suggestions = demote_crawl_artefacts(raw.get("suggestions", []))
             actual_count = len(suggestions)
 
@@ -3812,14 +3823,17 @@ class _SearchMixin:
                 continue
             seen.add(key)
             deduped.append(row)
-        # v3.3.1 field report (fid 71): sink scraper output below real
-        # articles. Measured 24.5% of title-mode top-5 rows on the shipped
-        # MedlinePlus archive — ``title 'migraine headache'`` returned an
-        # image-caption stub as its only hit. After the dedup so a demoted
-        # twin cannot displace the row that survived it, and before the
-        # ``limit`` slice so the demote decides what makes the page rather
-        # than reordering what already did.
-        aggregate_results = demote_crawl_artefacts(deduped)
+        # v3.3.1 field report (fid 71) is NOT applied here, deliberately.
+        # This list is score-descending, and ``title_promotion.find_title_match``
+        # reads ``results[0]`` and gates on ``score >= min_score`` — so
+        # demoting here silently blanks the canonical promotion probe, a later
+        # fallback pass wins instead, and its hit is hoisted to rank 1 stamped
+        # ``score: 1.0``. Measured: ``title 'Swollen glands'`` led with
+        # ``medlineplus.gov/hormones.html`` at 1.0, an article this query does
+        # not otherwise return at all, on a medical archive. The demote runs at
+        # the response edge instead (``tools/zim_search._handle_title_mode``),
+        # after promotion has read the ordering it depends on.
+        aggregate_results = deduped
 
         # Build _meta.suggestions[] from archive-verified typo variants.
         # Two cases surface them (spec §14.4):

--- a/openzim_mcp/zim/search.py
+++ b/openzim_mcp/zim/search.py
@@ -347,8 +347,8 @@ def _paging_span(*, offset: int, shown: int, next_offset: int, total_text: str) 
 
 
 # Scraper output that a crawl files as an entry but a reader would never ask
-# for: image-caption stubs, translation hubs, subtitle sidecars, and index
-# pagination. v3.3.1 field report (fid 71). Measured at v3.3.2 on the shipped
+# for: image-caption stubs, translation hubs and subtitle sidecars. v3.3.1
+# field report (fid 71). Measured at v3.3.2 on the shipped
 # MedlinePlus archive, rate limiter disabled so the sweep does not read its own
 # throttling as clean pages: 24.5% of title-mode top-5 rows and 23.4% of
 # suggest-mode rows are one of these, against 11.9% in fulltext.

--- a/openzim_mcp/zim/structure.py
+++ b/openzim_mcp/zim/structure.py
@@ -1706,7 +1706,9 @@ class _StructureMixin:
     ) -> "RelatedArticlesResponse":
         """Return the inbound linkers for ``entry_path`` from the sidecar.
 
-        Ranked by each linker's own inbound-degree. Raises
+        Ranked by each linker's own inbound-degree, except that site
+        furniture — a linker whose degree is at least half the sidecar's
+        ``node_count``, on sidecars of 50+ nodes — sinks to the end. Raises
         ``LinkGraphUnavailable`` when the sidecar is absent or stale (the
         tool layer renders that as a structured error). Phase-B five-key
         contract; paginated.

--- a/tests/live/test_live_inbound_linkgraph.py
+++ b/tests/live/test_live_inbound_linkgraph.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 from typing import Optional
 
@@ -39,7 +40,8 @@ def _build_first_linked_archive(zims) -> Optional[tuple]:
 
 
 def test_build_then_inbound_roundtrip(zim_dir, tmp_path) -> None:
-    """Building a sidecar then querying inbound returns importance-ranked linkers."""
+    """Building a sidecar then querying inbound returns importance-ranked
+    linkers, with site furniture sunk below every other linker."""
     zims = usable_zims(zim_dir)
     if not zims:
         pytest.skip("no ZIM test data available")
@@ -61,6 +63,9 @@ def test_build_then_inbound_roundtrip(zim_dir, tmp_path) -> None:
             "SELECT t.path FROM edges e JOIN nodes t ON t.id=e.target_id "
             "GROUP BY e.target_id ORDER BY COUNT(*) DESC LIMIT 1"
         ).fetchone()[0]
+        node_count = int(
+            conn.execute("SELECT value FROM meta WHERE key='node_count'").fetchone()[0]
+        )
         conn.close()
 
         # Read it back through the public reader, fingerprint-checked.
@@ -70,11 +75,27 @@ def test_build_then_inbound_roundtrip(zim_dir, tmp_path) -> None:
             uuid = str(a.uuid)
         reader = LinkGraphReader.open_for(str(archive), live_archive_uuid=uuid)
         assert reader is not None
-        page = reader.query_inbound(target, limit=5, offset=0)
-        assert len(page.rows) >= 1
-        degrees = [r["inbound_degree"] for r in page.rows]
-        assert degrees == sorted(degrees, reverse=True)  # ranked by importance
+        page = reader.query_inbound(target, limit=100_000, offset=0)
         reader.close()
+        assert len(page.rows) == page.total >= 1
+
+        # Ranked by importance, except that a linker whose degree reaches half
+        # the archive is in the nav bar and sinks to the end. Checked over the
+        # WHOLE list: the first version read five rows, which never reach the
+        # sunk group, so it went on asserting pure degree order. The threshold
+        # is recomputed here rather than imported, to cross-check the reader.
+        threshold = math.ceil(node_count / 2) if node_count >= 50 else 0
+        furniture = [
+            threshold > 0 and r["inbound_degree"] >= threshold for r in page.rows
+        ]
+        assert furniture == sorted(furniture), "a furniture linker outranks an article"
+        for group in (False, True):
+            degrees = [
+                r["inbound_degree"]
+                for r, is_furniture in zip(page.rows, furniture)
+                if is_furniture is group
+            ]
+            assert degrees == sorted(degrees, reverse=True)
     finally:
         if created_here:
             Path(sidecar).unlink(missing_ok=True)

--- a/tests/test_docs_freshness.py
+++ b/tests/test_docs_freshness.py
@@ -2916,11 +2916,16 @@ def test_the_reranker_page_does_not_claim_an_unmeasured_improvement() -> None:
 
 
 # Wording that asserts the reranker makes results better, and wording that
-# makes such a sentence honest by saying the effect was not shown.
+# makes such a sentence honest by saying the effect was not shown. A word list
+# cannot be exhaustive: it holds every phrasing a mutation pass has walked past
+# it so far ("more accurate", "the best match", "increases relevance",
+# "sharper rankings" were the second round). A false positive is the cheap
+# failure — hedge the sentence or reword it.
 _IMPROVEMENT_CLAIM_RE = re.compile(
     r"\b(?:improv\w*|better\w*|more relevant|most relevant|higher[- ]quality"
     r"|(?:retrieval|search|result|ranking) quality|boost\w*|enhanc\w*"
-    r"|upgrade\w*|outperform\w*|superior)\b"
+    r"|upgrade\w*|outperform\w*|superior|accura\w*|best"
+    r"|increas\w* (?:the )?relevance|sharper)\b"
 )
 _IMPROVEMENT_HEDGE_RE = re.compile(
     r"\b(?:unmeasured|no metric reaching significance)\b"
@@ -2928,8 +2933,12 @@ _IMPROVEMENT_HEDGE_RE = re.compile(
 
 
 def _unhedged_improvement_claims(collapsed_prose: str) -> list[str]:
-    """Sentences of ``collapsed_prose`` claiming an improvement unhedged."""
-    sentences = re.split(r"(?<=[.!?:])\s+", collapsed_prose)
+    """Sentences of ``collapsed_prose`` claiming an improvement unhedged.
+
+    ``;`` ends a clause too: "it improves results; only the size of that gain
+    is unmeasured" hedged the size and asserted the gain, and passed.
+    """
+    sentences = re.split(r"(?<=[.!?:;])\s+", collapsed_prose)
     return [
         s
         for s in sentences
@@ -2948,7 +2957,15 @@ def test_the_install_page_warns_before_the_download() -> None:
     assert lines, "the install page no longer mentions the reranker extra"
     window = " ".join(prose.split("[reranker]", 1)[-1].split()[:60]).lower()
     assert "unmeasured" in window, window
-    assert not _unhedged_improvement_claims(window), window
+    # Every paragraph that mentions the reranker, not a fixed window: an
+    # unhedged claim placed just past the first sixty words passed that.
+    paragraphs = [p for p in re.split(r"\n\s*\n", prose) if "rerank" in p.lower()]
+    unhedged = [
+        s
+        for p in paragraphs
+        for s in _unhedged_improvement_claims(" ".join(p.lower().split()))
+    ]
+    assert not unhedged, unhedged
 
 
 def test_the_api_reference_says_row_order_is_authoritative() -> None:
@@ -2956,7 +2973,9 @@ def test_the_api_reference_says_row_order_is_authoritative() -> None:
     ``inbound_degree`` order, and a client that re-sorts on the exposed
     number silently undoes the demote. Nothing pinned either note, so the
     title one could be rewritten to promise score order with every suite
-    green."""
+    green — and pinning only its bold label then let the note revert to its
+    title-only text, or tell clients to sort by ``score``, just as quietly.
+    So each note's contract sentences are pinned, not its label."""
     prose = " ".join(
         _visible_prose(
             (REPO / "website/src/content/docs/api-reference.mdx").read_text(
@@ -2965,5 +2984,15 @@ def test_the_api_reference_says_row_order_is_authoritative() -> None:
         ).split()
     )
 
-    assert "presentation order, not score order" in prose
-    assert "re-sorting rows on `inbound_degree` puts the navigation pages" in prose
+    for phrase in (
+        "presentation order, not score order",
+        '`mode="title"` (pinned or `cross_file=True`) and `mode="suggest"` sink '
+        "scraper output",
+        "a small `limit` whose page holds no real article still leads with "
+        "scraper output",
+        "Read `results` order as authoritative and treat `score` as a "
+        "match-quality signal",
+        "re-sorting rows by `score` undoes the demote",
+        "re-sorting rows on `inbound_degree` puts the navigation pages back on top",
+    ):
+        assert phrase in prose, phrase

--- a/tests/test_docs_freshness.py
+++ b/tests/test_docs_freshness.py
@@ -2874,3 +2874,45 @@ def test_changelog_stays_out_of_the_mcp_range_sweep() -> None:
         "is the thing the exclusion exists to permit *not* doing — or "
         "_MCP_RANGE_RE stopped matching the shape release notes use."
     )
+
+
+def test_the_reranker_page_does_not_claim_an_unmeasured_improvement() -> None:
+    """The extra's benefit is a null result, and the page must say so.
+
+    The only blind evaluation ever run against this server — 50 queries, 44
+    rerank-eligible, 132 judgments on two warc2zim archives — found no metric
+    reaching significance, while the extra costs a ~1.1 GB model and roughly
+    doubles query latency. The page previously asserted the opposite twice:
+    "the only one that changes retrieval quality" and "silently produce more
+    relevant top-K results".
+
+    Read out of ``_visible_prose`` so a hedge parked in a code fence or an MDX
+    comment counts as absent, which is the failure mode this repo has shipped
+    before.
+    """
+    page = REPO / "website/src/content/docs/search-reranking.mdx"
+    prose = _visible_prose(page.read_text(encoding="utf-8"))
+
+    assert "unmeasured" in prose.lower(), (
+        "search-reranking.mdx no longer discloses that the improvement is " "unmeasured"
+    )
+
+    banned = ("changes retrieval quality", "more relevant top-K")
+    present = [c for c in banned if c.lower() in prose.lower()]
+    assert not present, (
+        f"search-reranking.mdx asserts an improvement the evidence does not "
+        f"support: {present}"
+    )
+
+
+def test_the_install_page_warns_before_the_download() -> None:
+    """A reader decides whether to pull the model down on the install page,
+    not on the concept page, so the hedge has to appear there too."""
+    prose = _visible_prose(
+        (REPO / "website/src/content/docs/installation.mdx").read_text(encoding="utf-8")
+    )
+    lines = [ln for ln in prose.splitlines() if "reranker" in ln.lower()]
+
+    assert lines, "the install page no longer mentions the reranker extra"
+    window = " ".join(prose.split("[reranker]", 1)[-1].split()[:60]).lower()
+    assert "unmeasured" in window, window

--- a/tests/test_docs_freshness.py
+++ b/tests/test_docs_freshness.py
@@ -2897,8 +2897,18 @@ def test_the_reranker_page_does_not_claim_an_unmeasured_improvement() -> None:
         "search-reranking.mdx no longer discloses that the improvement is " "unmeasured"
     )
 
-    banned = ("changes retrieval quality", "more relevant top-K")
-    present = [c for c in banned if c.lower() in prose.lower()]
+    # Ban the CLAIM, not two exact spellings of it. The first version listed
+    # the two strings this commit happened to remove, so any reword — or the
+    # original sentence split across a line break — walked straight past it.
+    # Whitespace is collapsed for the same reason.
+    collapsed = " ".join(prose.lower().split())
+    banned = [
+        r"\bchanges? retrieval quality\b",
+        r"\bmore relevant\b",
+        r"\bimproves? (?:the )?(?:results|ranking|relevance)\b",
+        r"\bbetter (?:results|ranking|relevance)\b",
+    ]
+    present = [pat for pat in banned if re.search(pat, collapsed)]
     assert not present, (
         f"search-reranking.mdx asserts an improvement the evidence does not "
         f"support: {present}"

--- a/tests/test_docs_freshness.py
+++ b/tests/test_docs_freshness.py
@@ -2897,22 +2897,44 @@ def test_the_reranker_page_does_not_claim_an_unmeasured_improvement() -> None:
         "search-reranking.mdx no longer discloses that the improvement is " "unmeasured"
     )
 
-    # Ban the CLAIM, not two exact spellings of it. The first version listed
-    # the two strings this commit happened to remove, so any reword — or the
-    # original sentence split across a line break — walked straight past it.
-    # Whitespace is collapsed for the same reason.
+    # Gate SENTENCES, not phrases. The phrase list this replaced banned four
+    # spellings of the claim, and six realistic rewordings walked past it —
+    # "the only one that improves retrieval quality", "silently surface the
+    # most relevant articles first" — as did swapping the hedge for "is no
+    # longer unmeasured: it is an upgrade", because the keyword survived. Any
+    # sentence that speaks of improvement must carry the hedge itself, and the
+    # hedge sentence is pinned so it cannot be inverted in place.
     collapsed = " ".join(prose.lower().split())
-    banned = [
-        r"\bchanges? retrieval quality\b",
-        r"\bmore relevant\b",
-        r"\bimproves? (?:the )?(?:results|ranking|relevance)\b",
-        r"\bbetter (?:results|ranking|relevance)\b",
-    ]
-    present = [pat for pat in banned if re.search(pat, collapsed)]
-    assert not present, (
+    unhedged = _unhedged_improvement_claims(collapsed)
+    assert not unhedged, (
         f"search-reranking.mdx asserts an improvement the evidence does not "
-        f"support: {present}"
+        f"support: {unhedged}"
     )
+    assert (
+        "whether that reordering is an improvement is unmeasured." in collapsed
+    ), "search-reranking.mdx no longer carries the hedge sentence verbatim"
+
+
+# Wording that asserts the reranker makes results better, and wording that
+# makes such a sentence honest by saying the effect was not shown.
+_IMPROVEMENT_CLAIM_RE = re.compile(
+    r"\b(?:improv\w*|better\w*|more relevant|most relevant|higher[- ]quality"
+    r"|(?:retrieval|search|result|ranking) quality|boost\w*|enhanc\w*"
+    r"|upgrade\w*|outperform\w*|superior)\b"
+)
+_IMPROVEMENT_HEDGE_RE = re.compile(
+    r"\b(?:unmeasured|no metric reaching significance)\b"
+)
+
+
+def _unhedged_improvement_claims(collapsed_prose: str) -> list[str]:
+    """Sentences of ``collapsed_prose`` claiming an improvement unhedged."""
+    sentences = re.split(r"(?<=[.!?:])\s+", collapsed_prose)
+    return [
+        s
+        for s in sentences
+        if _IMPROVEMENT_CLAIM_RE.search(s) and not _IMPROVEMENT_HEDGE_RE.search(s)
+    ]
 
 
 def test_the_install_page_warns_before_the_download() -> None:
@@ -2926,3 +2948,22 @@ def test_the_install_page_warns_before_the_download() -> None:
     assert lines, "the install page no longer mentions the reranker extra"
     window = " ".join(prose.split("[reranker]", 1)[-1].split()[:60]).lower()
     assert "unmeasured" in window, window
+    assert not _unhedged_improvement_claims(window), window
+
+
+def test_the_api_reference_says_row_order_is_authoritative() -> None:
+    """Title and inbound rows are deliberately out of ``score`` and
+    ``inbound_degree`` order, and a client that re-sorts on the exposed
+    number silently undoes the demote. Nothing pinned either note, so the
+    title one could be rewritten to promise score order with every suite
+    green."""
+    prose = " ".join(
+        _visible_prose(
+            (REPO / "website/src/content/docs/api-reference.mdx").read_text(
+                encoding="utf-8"
+            )
+        ).split()
+    )
+
+    assert "presentation order, not score order" in prose
+    assert "re-sorting rows on `inbound_degree` puts the navigation pages" in prose

--- a/tests/test_fr_crawl_artifacts.py
+++ b/tests/test_fr_crawl_artifacts.py
@@ -4,30 +4,32 @@ v3.3.1 field report, fid 71 — the report's own "bigger opportunity
 underneath": both reranker configurations put a relevant article at #1 only
 about 64% of the time and carry off-topic entries in every top-5.
 
-Measured on the shipped archives at v3.3.2, with the rate limiter disabled
-so the sweep is not reading its own throttling as clean pages:
-
-    MedlinePlus, 20 topic queries, top-5
-      fulltext  101 rows  12 artefacts  11.9%
-      title      94 rows  23 artefacts  24.5%
-      suggest    94 rows  22 artefacts  23.4%
-
 The artefacts are scraper output, not articles: ``/imagepages/`` caption
-stubs, ``/languages/`` translation hubs, ``.srt`` caption files, and
-``/page/N/`` index pagination. ``title 'migraine headache'`` returns an
-image-caption stub as its single hit.
+stubs, ``/languages/`` translation hubs and ``.srt`` caption files.
+``title 'migraine headache'`` returns an image-caption stub as its single
+hit. Measured on the shipped MedlinePlus archive, 40 topic queries at
+``limit=5``, rate limiter and cache off, v3.3.2 against this change:
+
+                   rows  artefacts  artefact at #1  artefact above an article
+    title           184    26.1%       4  ->  1           30  ->  0 pages
+    suggest         184    26.6%       6  ->  1           29  ->  0 pages
+    chooser          82    12.2%       7  ->  1            7  ->  0 lists
+
+The artefact share does not move, and must not: the demote reorders the page
+it is given and never evicts from it. The one remaining #1 is a page whose
+every row is an artefact.
 
 **``/category/`` is deliberately NOT an artefact.** On the IEP archive
 those pages are the encyclopedia's own topic index and the correct #1, at
 score 1.0, for "metaphysics", "philosophy of science", "feminist
 philosophy" and "continental philosophy" — demoting them would turn four
-right answers into wrong ones. The shapes are matched independently, so
-``category/m-and-e/metaphysics/page/2/`` is still demoted: it is index
-pagination that happens to live under a category.
+right answers into wrong ones. Neither is ``/page/N/``: it was in the set and
+was removed on measurement (see ``test_index_pagination_is_not_an_artefact``).
 
-Three surfaces need it, not the two the finding names — suggest mode is
-served by ``get_search_suggestions_data``, a different function from
-``_assemble_find_response``, and measured worst of the three.
+Three surfaces need it, not the two the finding names: single- and
+cross-archive title mode at the response edge, suggest mode (served by
+``get_search_suggestions_data``, a different function from
+``_assemble_find_response``), and the ``zim_query`` chooser.
 
 The demote is STABLE and drops nothing: relative order within each group is
 the archive's own ranking, and every row the caller would have had is still
@@ -39,13 +41,18 @@ mutation pass proved by deleting the guard and changing no behaviour.
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from libzim.writer import Creator
 
+from openzim_mcp.async_operations import AsyncZimOperations
 from openzim_mcp.config import CacheConfig, OpenZimMcpConfig, RateLimitConfig
 from openzim_mcp.server import OpenZimMcpServer
+from openzim_mcp.title_promotion import find_title_match
 from openzim_mcp.zim.search import demote_crawl_artefacts, is_crawl_artefact
+from tests.conftest_v2_fixtures import _HtmlItem
 
 # ---------------------------------------------------------------------------
 # What counts as an artefact
@@ -58,6 +65,10 @@ from openzim_mcp.zim.search import demote_crawl_artefacts, is_crawl_artefact
         "medlineplus.gov/ency/imagepages/18146.htm",
         "medlineplus.gov/languages/hepatitisb.html",
         "medlineplus.gov/media/captions/tutorial.srt",
+        # Matched regardless of case; nothing pinned the flag before.
+        "medlineplus.gov/ency/ImagePages/1.htm",
+        "a.org/LANGUAGES/x.html",
+        "a.org/captions/x.SRT",
     ],
 )
 def test_scraper_output_is_an_artefact(path: str) -> None:
@@ -81,6 +92,8 @@ def test_scraper_output_is_an_artefact(path: str) -> None:
         "medlineplus.gov/languages-of-health.html",
         "A/Page_three",
         "medlineplus.gov/srt-therapy.html",
+        # ``.srt`` counts only at the END of the path.
+        "a.org/guide.srt.html",
         "",
     ],
 )
@@ -289,6 +302,49 @@ def test_the_title_response_edge_is_wired(tmp_path, monkeypatch):
     assert out["total"] == 2 and out["done"] is True
 
 
+def test_the_cross_archive_title_branch_is_wired(tmp_path):
+    """``cross_file=True`` returns from its own branch, ahead of the pinned
+    path's demote, so the same lookup used to sink ``imagepages/`` stubs when
+    pinned and lead with them here — while the API reference promised title
+    mode sinks them."""
+    from openzim_mcp.tools import zim_search as tool
+
+    server = _server(tmp_path)
+
+    class _Ops:
+        async def find_entry_by_title_data(self, path, q, *, cross_file, limit):
+            assert cross_file is True
+            return {
+                "results": [
+                    {"path": "med.gov/languages/asthma.html", "score": 1.0},
+                    {"path": "med.gov/asthma.html", "score": 0.9},
+                ],
+                "total": 2,
+                "done": True,
+                "files_searched": 1,
+                "_meta": {"chars": 1},
+            }
+
+    out = asyncio.run(
+        tool._handle_title_mode(
+            ops=_Ops(),
+            server=server,
+            query="asthma",
+            zim_file_path=None,
+            cross_file=True,
+            limit=5,
+            offset=0,
+            cursor=None,
+        )
+    )
+
+    assert [r["path"] for r in out["results"]] == [
+        "med.gov/asthma.html",
+        "med.gov/languages/asthma.html",
+    ]
+    assert out["_meta"]["promotion_applied"] is False
+
+
 def test_the_title_data_layer_is_deliberately_NOT_wired(tmp_path, monkeypatch):
     """The other half of the contract, and the regression this replaced.
 
@@ -325,6 +381,116 @@ class _StubOps:
     config = SimpleNamespace(search=SimpleNamespace(structured_suggestions_limit=3))
 
 
+# ---------------------------------------------------------------------------
+# Against a real archive, with the cache ON
+# ---------------------------------------------------------------------------
+#
+# Every wiring test above runs with the cache off and calls once, so none of
+# them could see the title demote reorder a CACHED page in place — which it
+# did. ``_merge_promotion_into_title_results`` passes the cached
+# ``find_title:v2`` page straight through when promotion changes nothing, and
+# the edge then rewrote it; the next call's promotion probe read the demoted
+# order, and on MedlinePlus a second ``title 'swollen glands'`` led with
+# ``hormones.html`` at a fabricated 1.0.
+
+_HOST = "medlineplus.gov"
+# The artefact is the exact-title hit, so the title index ranks it first and
+# the promotion probe resolves to it.
+_ASTHMA_PAGES = [
+    (f"{_HOST}/languages/asthma.html", "Asthma"),
+    (f"{_HOST}/asthmainchildren.html", "Asthma in Children"),
+]
+
+
+def _medlineplus_like_zim(tmp_path: Path) -> Path:
+    out = tmp_path / "medlineplus_like.zim"
+    with Creator(out).config_indexing(True, "eng") as creator:
+        for path, title in _ASTHMA_PAGES:
+            creator.add_item(
+                _HtmlItem(
+                    path, title, f"<html><body><h1>{title}</h1><p>x</p></body></html>"
+                )
+            )
+        creator.set_mainpath(_ASTHMA_PAGES[1][0])
+    return out
+
+
+def _cached_server(tmp_path: Path) -> OpenZimMcpServer:
+    return OpenZimMcpServer(
+        OpenZimMcpConfig(
+            allowed_directories=[str(tmp_path)],
+            tool_mode="advanced",
+            cache=CacheConfig(
+                enabled=True,
+                persistence_enabled=False,
+                persistence_path=str(tmp_path / "cache"),
+            ),
+            rate_limit=RateLimitConfig(enabled=False),
+        )
+    )
+
+
+def _title_page(ops, zim: Path, *, limit: int) -> list:
+    page = ops.find_entry_by_title_data(str(zim), "asthma", limit=limit)
+    return [(r["path"], r["score"]) for r in page["results"]]
+
+
+def test_the_title_data_layer_stays_score_descending(tmp_path):
+    """The public function the promotion probes actually call.
+
+    ``test_the_title_data_layer_is_deliberately_NOT_wired`` drives the
+    private ``_assemble_find_response``, so a demote added one function up —
+    inside ``find_entry_by_title_data`` itself — passed every test while
+    bringing the fabricated-promotion defect back on the first call.
+    """
+    zim = _medlineplus_like_zim(tmp_path)
+    ops = _cached_server(tmp_path).zim_operations
+
+    rows = _title_page(ops, zim, limit=5)
+    scores = [score for _path, score in rows]
+
+    assert len(scores) == 2, rows
+    assert scores == sorted(scores, reverse=True), rows
+    match = find_title_match(ops, str(zim), "asthma")
+    assert match is not None and match["path"] == _ASTHMA_PAGES[0][0]
+
+
+def test_the_title_edge_leaves_the_cached_page_alone(tmp_path):
+    """A title call must not reorder the page the NEXT call's probe reads.
+
+    ``limit=3`` is the size the promotion probe asks for, so this call and
+    the probe share one cache key — the configuration in which the defect
+    changed answers. The response is demoted; the cached page is not.
+    """
+    from openzim_mcp.tools import zim_search as tool
+
+    zim = _medlineplus_like_zim(tmp_path)
+    server = _cached_server(tmp_path)
+    ops = server.zim_operations
+    before = _title_page(ops, zim, limit=3)
+
+    out = asyncio.run(
+        tool._handle_title_mode(
+            ops=AsyncZimOperations(ops),
+            server=server,
+            query="asthma",
+            zim_file_path=str(zim),
+            cross_file=False,
+            limit=3,
+            offset=0,
+            cursor=None,
+        )
+    )
+
+    assert [r["path"] for r in out["results"]] == [
+        _ASTHMA_PAGES[1][0],
+        _ASTHMA_PAGES[0][0],
+    ]
+    assert _title_page(ops, zim, limit=3) == before
+    match = find_title_match(ops, str(zim), "asthma")
+    assert match is not None and match["path"] == _ASTHMA_PAGES[0][0]
+
+
 def test_the_suggest_wiring_is_live(tmp_path, monkeypatch):
     """``get_search_suggestions_data`` — a different function from the title
     assembly, which is why the finding that named two surfaces missed it."""
@@ -353,6 +519,34 @@ def test_the_suggest_wiring_is_live(tmp_path, monkeypatch):
         "med.gov/real.html",
         "med.gov/ency/imagepages/1.htm",
     ]
+
+
+def test_the_suggest_demote_survives_a_cache_hit(tmp_path, monkeypatch):
+    """The test above runs cache-off and calls once, so a demote applied only
+    on the cold path — after the cache write — passed it, and every repeat
+    of a query then served the raw order."""
+    from openzim_mcp.zim import search as search_mod
+
+    (tmp_path / "a.zim").write_bytes(b"ZIM\x04" + b"\0" * 100)
+    ops = _cached_server(tmp_path).zim_operations
+    monkeypatch.setattr(
+        search_mod._SearchMixin,
+        "_generate_search_suggestions",
+        lambda self, archive, q, limit: {
+            "partial_query": q,
+            "suggestions": [
+                {"path": "med.gov/ency/imagepages/1.htm", "text": "X"},
+                {"path": "med.gov/real.html", "text": "X"},
+            ],
+            "has_more": False,
+        },
+    )
+    monkeypatch.setattr(search_mod, "_zim_ops_mod", _FakeArchiveModule(), raising=False)
+
+    want = ["med.gov/real.html", "med.gov/ency/imagepages/1.htm"]
+    for _call in range(2):
+        out = ops.get_search_suggestions_data(str(tmp_path / "a.zim"), "x", limit=5)
+        assert [r["path"] for r in out["results"]] == want
 
 
 class _FakeArchiveModule:
@@ -395,3 +589,37 @@ def test_the_chooser_wiring_is_live(tmp_path, monkeypatch):
     paths = [r["path"] for r in out]
     assert paths and paths[-1] == "med.gov/languages/asthma.html", paths
     assert "med.gov/asthma.html" in paths
+
+
+def test_an_artefact_canonical_does_not_lead_the_chooser(tmp_path, monkeypatch):
+    """The title-index canonical is prepended, then the list is demoted — so
+    a canonical that is itself scraper output sinks with the rest.
+
+    Deliberate: that canonical is the field report's own example of a wrong
+    answer, an image-caption stub offered first as "(canonical title
+    match)". Demoting before the prepend instead passed every test.
+    """
+    from openzim_mcp import simple_tools as st
+
+    handler = st.SimpleToolsHandler(_server(tmp_path).zim_operations)
+    monkeypatch.setattr(st, "is_strong_title_match", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        handler,
+        "_promote_topic_via_title_index",
+        lambda *_a, **_k: {
+            "path": "med.gov/ency/imagepages/1.htm",
+            "title": "Migraine headache",
+        },
+    )
+    rows = [
+        {"path": "med.gov/migraine.html", "title": "Migraine"},
+        {"path": "med.gov/headache.html", "title": "Headache"},
+    ]
+
+    out = handler._collect_tell_me_about_strong_matches(
+        "migraine headache", str(tmp_path / "a.zim"), rows, "Migraine"
+    )
+
+    paths = [r["path"] for r in out]
+    assert paths[0] == "med.gov/migraine.html", paths
+    assert paths[-1] == "med.gov/ency/imagepages/1.htm", paths

--- a/tests/test_fr_crawl_artifacts.py
+++ b/tests/test_fr_crawl_artifacts.py
@@ -1,0 +1,186 @@
+"""Crawl artefacts must not outrank the article the caller asked for.
+
+v3.3.1 field report, fid 71 — the report's own "bigger opportunity
+underneath": both reranker configurations put a relevant article at #1 only
+about 64% of the time and carry off-topic entries in every top-5.
+
+Measured on the shipped archives at v3.3.2, with the rate limiter disabled
+so the sweep is not reading its own throttling as clean pages:
+
+    MedlinePlus, 20 topic queries, top-5
+      fulltext  101 rows  12 artefacts  11.9%
+      title      94 rows  23 artefacts  24.5%
+      suggest    94 rows  22 artefacts  23.4%
+
+The artefacts are scraper output, not articles: ``/imagepages/`` caption
+stubs, ``/languages/`` translation hubs, ``.srt`` caption files, and
+``/page/N/`` index pagination. ``title 'migraine headache'`` returns an
+image-caption stub as its single hit.
+
+**``/category/`` is deliberately NOT an artefact.** On the IEP archive
+those pages are the encyclopedia's own topic index and the correct #1, at
+score 1.0, for "metaphysics", "philosophy of science", "feminist
+philosophy" and "continental philosophy" — demoting them would turn four
+right answers into wrong ones. The shapes are matched independently, so
+``category/m-and-e/metaphysics/page/2/`` is still demoted: it is index
+pagination that happens to live under a category.
+
+Three surfaces need it, not the two the finding names — suggest mode is
+served by ``get_search_suggestions_data``, a different function from
+``_assemble_find_response``, and measured worst of the three.
+
+The demote is STABLE and drops nothing: relative order within each group is
+the archive's own ranking, and every row the caller would have had is still
+there. A page whose rows are *all* artefacts therefore comes back untouched
+— which falls out of the partition rather than needing a guard, as the
+mutation pass proved by deleting the guard and changing no behaviour.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openzim_mcp.zim.search import demote_crawl_artefacts, is_crawl_artefact
+
+# ---------------------------------------------------------------------------
+# What counts as an artefact
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "medlineplus.gov/ency/imagepages/18146.htm",
+        "medlineplus.gov/languages/hepatitisb.html",
+        "medlineplus.gov/media/captions/tutorial.srt",
+        "iep.utm.edu/category/m-and-e/metaphysics/page/2/",
+        "iep.utm.edu/page/3/",
+    ],
+)
+def test_scraper_output_is_an_artefact(path: str) -> None:
+    assert is_crawl_artefact(path) is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        # The load-bearing exclusion: IEP's own topic index, and the correct
+        # #1 at score 1.0 for four real queries.
+        "iep.utm.edu/category/m-and-e/metaphysics/",
+        "iep.utm.edu/category/traditions/feminist/",
+        # Ordinary articles.
+        "medlineplus.gov/hepatitisb.html",
+        "medlineplus.gov/druginfo/natural/211.html",
+        "iep.utm.edu/aristotle/",
+        "A/Climate_change",
+        # Near-misses that must not trip the patterns.
+        "medlineplus.gov/imagepagesreview.html",
+        "medlineplus.gov/languages-of-health.html",
+        "A/Page_three",
+        "medlineplus.gov/srt-therapy.html",
+        "",
+    ],
+)
+def test_real_content_is_not_an_artefact(path: str) -> None:
+    assert is_crawl_artefact(path) is False
+
+
+def test_a_category_page_is_kept_but_its_pagination_is_not():
+    """The shapes are independent, not a precedence chain. Stated because
+    "skip anything under /category/" is the obvious wrong simplification —
+    it would keep index pagination that is pure scraper output."""
+    assert is_crawl_artefact("iep.utm.edu/category/s-l-m/science/") is False
+    assert is_crawl_artefact("iep.utm.edu/category/s-l-m/science/page/2/") is True
+
+
+# ---------------------------------------------------------------------------
+# How the demote behaves
+# ---------------------------------------------------------------------------
+
+
+def _paths(rows):
+    return [r["path"] for r in rows]
+
+
+def test_artefacts_sink_below_articles():
+    rows = [
+        {"path": "medlineplus.gov/ency/imagepages/18146.htm"},
+        {"path": "medlineplus.gov/migraine.html"},
+        {"path": "medlineplus.gov/languages/migraine.html"},
+        {"path": "medlineplus.gov/headache.html"},
+    ]
+
+    assert _paths(demote_crawl_artefacts(rows)) == [
+        "medlineplus.gov/migraine.html",
+        "medlineplus.gov/headache.html",
+        "medlineplus.gov/ency/imagepages/18146.htm",
+        "medlineplus.gov/languages/migraine.html",
+    ]
+
+
+def test_the_demote_is_stable_within_each_group():
+    """Relative order is the archive's ranking, and the demote is not
+    entitled to an opinion about it — only about which group a row is in.
+
+    The rows below MUST include an artefact: with none, the function early
+    -returns and this never reaches the partition at all. The first version
+    of this test used five clean rows and so passed against a build that
+    reversed the kept group.
+    """
+    rows = [
+        {"path": "a.org/0.html"},
+        {"path": "a.org/1.html"},
+        {"path": "a.org/languages/x.html"},
+        {"path": "a.org/2.html"},
+        {"path": "a.org/ency/imagepages/9.htm"},
+        {"path": "a.org/3.html"},
+    ]
+
+    assert _paths(demote_crawl_artefacts(rows)) == [
+        "a.org/0.html",
+        "a.org/1.html",
+        "a.org/2.html",
+        "a.org/3.html",
+        "a.org/languages/x.html",
+        "a.org/ency/imagepages/9.htm",
+    ]
+
+
+def test_a_page_of_nothing_but_artefacts_is_left_alone():
+    """On a query whose honest answer IS an image page, the archive's own
+    ranking is the best available. This falls out of the partition rather
+    than from a special case — pinned as behaviour, since an explicit guard
+    for it turned out to be unreachable."""
+    rows = [
+        {"path": "medlineplus.gov/ency/imagepages/1.htm"},
+        {"path": "medlineplus.gov/languages/x.html"},
+    ]
+
+    assert demote_crawl_artefacts(rows) == rows
+
+
+def test_nothing_is_dropped_ever():
+    """A demote, not a filter: the caller keeps every row it would have had.
+    Paired with the ordering tests so "artefacts are gone" cannot be
+    satisfied by deleting them."""
+    rows = [
+        {"path": "medlineplus.gov/ency/imagepages/1.htm"},
+        {"path": "medlineplus.gov/migraine.html"},
+        {"path": "medlineplus.gov/media/x.srt"},
+    ]
+
+    out = demote_crawl_artefacts(rows)
+    assert sorted(_paths(out)) == sorted(_paths(rows))
+    assert len(out) == len(rows)
+
+
+def test_an_empty_page_is_handled():
+    assert demote_crawl_artefacts([]) == []
+
+
+def test_rows_without_a_path_are_not_promoted_or_dropped():
+    """Defensive: a malformed row must not crash the sort or vanish."""
+    rows = [{"title": "no path"}, {"path": "a.org/real.html"}]
+
+    out = demote_crawl_artefacts(rows)
+    assert len(out) == 2

--- a/tests/test_fr_crawl_artifacts.py
+++ b/tests/test_fr_crawl_artifacts.py
@@ -38,8 +38,13 @@ mutation pass proved by deleting the guard and changing no behaviour.
 
 from __future__ import annotations
 
+import asyncio
+from types import SimpleNamespace
+
 import pytest
 
+from openzim_mcp.config import CacheConfig, OpenZimMcpConfig, RateLimitConfig
+from openzim_mcp.server import OpenZimMcpServer
 from openzim_mcp.zim.search import demote_crawl_artefacts, is_crawl_artefact
 
 # ---------------------------------------------------------------------------
@@ -53,8 +58,6 @@ from openzim_mcp.zim.search import demote_crawl_artefacts, is_crawl_artefact
         "medlineplus.gov/ency/imagepages/18146.htm",
         "medlineplus.gov/languages/hepatitisb.html",
         "medlineplus.gov/media/captions/tutorial.srt",
-        "iep.utm.edu/category/m-and-e/metaphysics/page/2/",
-        "iep.utm.edu/page/3/",
     ],
 )
 def test_scraper_output_is_an_artefact(path: str) -> None:
@@ -85,12 +88,19 @@ def test_real_content_is_not_an_artefact(path: str) -> None:
     assert is_crawl_artefact(path) is False
 
 
-def test_a_category_page_is_kept_but_its_pagination_is_not():
-    """The shapes are independent, not a precedence chain. Stated because
-    "skip anything under /category/" is the obvious wrong simplification —
-    it would keep index pagination that is pure scraper output."""
+def test_index_pagination_is_not_an_artefact():
+    """``/page/N/`` was in the set and was removed on measurement.
+
+    It matched nothing on MedlinePlus and exactly two entries on IEP, both
+    false positives: ``category/…/metaphysics/page/2/`` is the continuation
+    of the topic index ``/category/`` is kept for — page 1 lists 50 articles,
+    page 2 lists 19 more with zero overlap, both at score 1.0. "Index
+    pagination is scraper output wherever it lives" sounded right and, on
+    every shipped archive, only ever discarded real content.
+    """
     assert is_crawl_artefact("iep.utm.edu/category/s-l-m/science/") is False
-    assert is_crawl_artefact("iep.utm.edu/category/s-l-m/science/page/2/") is True
+    assert is_crawl_artefact("iep.utm.edu/category/s-l-m/science/page/2/") is False
+    assert is_crawl_artefact("iep.utm.edu/page/3/") is False
 
 
 # ---------------------------------------------------------------------------
@@ -179,8 +189,209 @@ def test_an_empty_page_is_handled():
 
 
 def test_rows_without_a_path_are_not_promoted_or_dropped():
-    """Defensive: a malformed row must not crash the sort or vanish."""
-    rows = [{"title": "no path"}, {"path": "a.org/real.html"}]
+    """Defensive: a malformed row must not crash the sort or vanish.
+
+    Asserts both halves its name claims — that the pathless row is still
+    there (not dropped) and that it did not jump the real row (not
+    promoted). The first version checked only ``len(out) == 2``, which is
+    satisfied by any ordering at all.
+    """
+    rows = [
+        {"path": "a.org/languages/x.html"},
+        {"title": "no path"},
+        {"path": "a.org/real.html"},
+    ]
 
     out = demote_crawl_artefacts(rows)
-    assert len(out) == 2
+
+    assert {r.get("path") or r.get("title") for r in out} == {
+        "a.org/languages/x.html",
+        "no path",
+        "a.org/real.html",
+    }
+    # A pathless row is not an artefact, so it keeps its place relative to
+    # the other non-artefact row and both lead the demoted one.
+    assert [r.get("path", "") for r in out][-1] == "a.org/languages/x.html"
+
+
+# ---------------------------------------------------------------------------
+# The wirings — each drives a real surface whose ranking actually inverts
+# ---------------------------------------------------------------------------
+#
+# The first version of this file tested only the two pure helpers. All three
+# call sites could be reverted and every test here, the full unit suite and
+# the live suite still passed — the exact "tested the renderer, called the
+# wiring covered" shape this project has shipped before. Each test below
+# feeds a surface an ordering where an artefact outranks an article, which is
+# the only condition under which the demote is observable.
+
+
+def _server(tmp_path):
+    (tmp_path / "a.zim").write_bytes(b"ZIM\x04" + b"\0" * 100)
+    return OpenZimMcpServer(
+        OpenZimMcpConfig(
+            allowed_directories=[str(tmp_path)],
+            tool_mode="advanced",
+            cache=CacheConfig(enabled=False),
+            rate_limit=RateLimitConfig(enabled=False),
+        )
+    )
+
+
+def test_the_title_response_edge_is_wired(tmp_path, monkeypatch):
+    """``_handle_title_mode`` — driven end to end, not via its own helper.
+
+    The first attempt at this test called ``_demote_artefacts_in_response``
+    directly, so deleting the call from ``_handle_title_mode`` left it
+    passing. Calling the helper you just wired proves the helper works and
+    says nothing about the wiring; this drives the dispatch.
+    """
+    from openzim_mcp.tools import zim_search as tool
+
+    server = _server(tmp_path)
+    archive = str(tmp_path / "a.zim")
+
+    class _Ops:
+        async def find_entry_by_title_data(self, path, q, *, cross_file, limit):
+            return {
+                "results": [
+                    {"path": "med.gov/languages/asthma.html", "score": 1.0},
+                    {"path": "med.gov/asthma.html", "score": 0.9},
+                ],
+                "total": 2,
+                "done": True,
+                "_meta": {"chars": 1},
+            }
+
+    monkeypatch.setattr(tool, "_resolve_path", lambda *_a, **_k: archive)
+    monkeypatch.setattr(
+        "openzim_mcp.topic_preprocessing.promote_topic_via_title_index",
+        lambda **_kw: None,
+    )
+
+    out = asyncio.run(
+        tool._handle_title_mode(
+            ops=_Ops(),
+            server=server,
+            query="asthma",
+            zim_file_path=archive,
+            cross_file=False,
+            limit=5,
+            offset=0,
+            cursor=None,
+        )
+    )
+
+    assert [r["path"] for r in out["results"]] == [
+        "med.gov/asthma.html",
+        "med.gov/languages/asthma.html",
+    ]
+    assert out["total"] == 2 and out["done"] is True
+
+
+def test_the_title_data_layer_is_deliberately_NOT_wired(tmp_path, monkeypatch):
+    """The other half of the contract, and the regression this replaced.
+
+    ``find_entry_by_title_data`` must keep emitting score-descending rows, or
+    ``title_promotion.find_title_match`` — which reads ``results[0]`` under a
+    score gate — silently stops resolving.
+    """
+    from openzim_mcp.zim import search as search_mod
+
+    rows = [
+        {"path": "med.gov/languages/asthma.html", "score": 1.0, "zim_file": "a"},
+        {"path": "med.gov/asthma.html", "score": 0.9, "zim_file": "a"},
+    ]
+    assembled = search_mod._SearchMixin._assemble_find_response(
+        _StubOps(),
+        list(rows),
+        title="asthma",
+        limit=5,
+        files=["a"],
+        fast_path_hit=False,
+        fuzzy_path_hit=False,
+        verified_variants=[],
+    )
+
+    scores = [r["score"] for r in assembled["results"]]
+    assert scores == sorted(scores, reverse=True), assembled["results"]
+    assert assembled["results"][0]["path"] == "med.gov/languages/asthma.html"
+
+
+class _StubOps:
+    """Minimal ``self`` for ``_assemble_find_response`` — it is a pure
+    transformation and touches only ``config.search``."""
+
+    config = SimpleNamespace(search=SimpleNamespace(structured_suggestions_limit=3))
+
+
+def test_the_suggest_wiring_is_live(tmp_path, monkeypatch):
+    """``get_search_suggestions_data`` — a different function from the title
+    assembly, which is why the finding that named two surfaces missed it."""
+    from openzim_mcp.zim import search as search_mod
+
+    server = _server(tmp_path)
+    ops = server.zim_operations
+
+    monkeypatch.setattr(
+        search_mod._SearchMixin,
+        "_generate_search_suggestions",
+        lambda self, archive, q, limit: {
+            "partial_query": q,
+            "suggestions": [
+                {"path": "med.gov/ency/imagepages/1.htm", "text": "X"},
+                {"path": "med.gov/real.html", "text": "X"},
+            ],
+            "has_more": False,
+        },
+    )
+    monkeypatch.setattr(search_mod, "_zim_ops_mod", _FakeArchiveModule(), raising=False)
+
+    out = ops.get_search_suggestions_data(str(tmp_path / "a.zim"), "x", limit=5)
+
+    assert [r["path"] for r in out["results"]] == [
+        "med.gov/real.html",
+        "med.gov/ency/imagepages/1.htm",
+    ]
+
+
+class _FakeArchiveModule:
+    """``zim_archive`` context manager yielding a do-nothing archive."""
+
+    class _Ctx:
+        def __enter__(self):
+            return object()
+
+        def __exit__(self, *a):
+            return False
+
+    def zim_archive(self, _path):
+        return self._Ctx()
+
+
+def test_the_chooser_wiring_is_live(tmp_path, monkeypatch):
+    """``_collect_tell_me_about_strong_matches`` — the real method.
+
+    Same correction as the title test: importing ``demote_crawl_artefacts``
+    from ``simple_tools`` and calling it proves nothing about whether the
+    method calls it.
+    """
+    from openzim_mcp import simple_tools as st
+
+    server = _server(tmp_path)
+    handler = st.SimpleToolsHandler(server.zim_operations)
+
+    monkeypatch.setattr(st, "is_strong_title_match", lambda *_a, **_k: True)
+
+    rows = [
+        {"path": "med.gov/languages/asthma.html", "title": "Asthma"},
+        {"path": "med.gov/asthma.html", "title": "Asthma"},
+    ]
+
+    out = handler._collect_tell_me_about_strong_matches(
+        "asthma", str(tmp_path / "a.zim"), rows, "Asthma"
+    )
+
+    paths = [r["path"] for r in out]
+    assert paths and paths[-1] == "med.gov/languages/asthma.html", paths
+    assert "med.gov/asthma.html" in paths

--- a/tests/test_fr_inbound_ranking.py
+++ b/tests/test_fr_inbound_ranking.py
@@ -2,19 +2,21 @@
 
 v3.3.1 field report, fid 86 (ranking half). Inbound linkers were ranked
 ``ORDER BY n.inbound_degree DESC`` — a signal site boilerplate maximises.
-A page in the nav bar links to everything and is therefore linked FROM
-everything, so it wins that ordering for most targets, and the caller asking
-what links to an article gets the alphabet index instead of the articles.
+A page in the nav bar is linked FROM every page that carries the bar, so it
+wins that ordering for most targets, and the caller asking what links to an
+article gets the alphabet index instead of the articles.
 
 Measured on the shipped IEP sidecar (1,187 nodes, threshold 594): the 33
 nodes at or above the threshold are the home page, the 26 alphabet pages,
 five site pages and the RSS feed; the best-linked article, ``plato/``, sits
-at 106. Of the 919 targets that have at least one non-furniture linker,
-furniture led 654 before the fix and leads none after it. Among the 371
-targets with five or more linkers, it led 366.
+at 106. Of the 919 article targets (those not themselves furniture) that
+have at least one non-furniture linker, furniture led 654 before the fix and
+leads none after it. Among the 371 article targets with five or more
+linkers, it led 366.
 
 The demote is by RANK, not by removal: rows are only reordered, so
-``total``, the pagination arithmetic and the cursor contract are untouched.
+``total`` and the pagination arithmetic are untouched, and paging within one
+server version reaches every row exactly once.
 A node whose inbound degree reaches half the archive's node count is
 treated as site-wide furniture. Small archives are exempt — on a
 twenty-page archive a genuinely central article can legitimately be linked
@@ -30,21 +32,40 @@ inbound signal.
 
 from __future__ import annotations
 
+import asyncio
 import sqlite3
 from pathlib import Path
+from typing import Optional
 
 import pytest
+from libzim.writer import Creator
 
+from openzim_mcp.config import CacheConfig, OpenZimMcpConfig, RateLimitConfig
 from openzim_mcp.linkgraph.reader import LinkGraphReader, sidecar_path_for
 from openzim_mcp.linkgraph.schema import SCHEMA_VERSION
+from openzim_mcp.server import OpenZimMcpServer
+from tests.conftest_v2_fixtures import _HtmlItem
 
 _UUID = "11111111-2222-3333-4444-555555555555"
 
 
-def _sidecar(tmp_path: Path, *, nodes, edges, node_count=None) -> Path:
-    """Build a minimal sidecar. ``nodes`` is [(id, path, inbound_degree)]."""
-    archive = tmp_path / "a.zim"
-    archive.write_bytes(b"ZIM\x04" + b"\0" * 100)
+def _sidecar(
+    tmp_path: Path,
+    *,
+    nodes,
+    edges,
+    node_count=None,
+    archive: Optional[Path] = None,
+    uuid: str = _UUID,
+) -> Path:
+    """Build a minimal sidecar. ``nodes`` is [(id, path, inbound_degree)].
+
+    Beside a placeholder archive unless ``archive`` names a real one, in which
+    case ``uuid`` must be that archive's so the reader accepts the sidecar.
+    """
+    if archive is None:
+        archive = tmp_path / "a.zim"
+        archive.write_bytes(b"ZIM\x04" + b"\0" * 100)
     db = Path(sidecar_path_for(str(archive)))
     conn = sqlite3.connect(db)
     conn.executescript("""
@@ -56,7 +77,7 @@ def _sidecar(tmp_path: Path, *, nodes, edges, node_count=None) -> Path:
         "INSERT INTO meta VALUES (?, ?)",
         [
             ("schema_version", str(SCHEMA_VERSION)),
-            ("archive_uuid", _UUID),
+            ("archive_uuid", uuid),
             ("node_count", str(node_count if node_count is not None else len(nodes))),
         ],
     )
@@ -190,6 +211,60 @@ def test_pagination_still_spans_every_linker(tmp_path):
         ["a.org/aristotle/", "a.org/plato/", "a.org/index-of-everything/"]
     )
     assert first.total == second.total == 3
+
+
+def test_the_inbound_surface_sinks_furniture(tmp_path):
+    """Every test above drives ``LinkGraphReader`` directly, so a re-sort on
+    ``inbound_degree`` added in the data layer or in the ``zim_links``
+    handler — the layers a caller actually reaches — put the navigation back
+    on top with every suite green. This one goes through the registered tool,
+    on a real archive with the same graph as ``_nav_bar_archive``."""
+    from openzim_mcp.zim_operations import zim_archive
+
+    archive = tmp_path / "site.zim"
+    with Creator(archive).config_indexing(True, "eng") as creator:
+        creator.add_item(
+            _HtmlItem(
+                "a.org/target/", "Target", "<html><body><h1>Target</h1></body></html>"
+            )
+        )
+        creator.set_mainpath("a.org/target/")
+    with zim_archive(archive) as opened:
+        uuid = str(opened.uuid)
+    _sidecar(
+        tmp_path,
+        nodes=[
+            (1, "a.org/index-of-everything/", 90),
+            (2, "a.org/aristotle/", 12),
+            (3, "a.org/plato/", 8),
+            (5, "a.org/target/", 3),
+        ],
+        edges=[(1, 5, "Index"), (2, 5, "Aristotle"), (3, 5, "Plato")],
+        node_count=100,
+        archive=archive,
+        uuid=uuid,
+    )
+    server = OpenZimMcpServer(
+        OpenZimMcpConfig(
+            allowed_directories=[str(tmp_path)],
+            tool_mode="advanced",
+            cache=CacheConfig(enabled=False),
+            rate_limit=RateLimitConfig(enabled=False),
+        )
+    )
+    zim_links = server.mcp._tool_manager._tools["zim_links"].fn
+
+    out = asyncio.run(
+        zim_links(
+            zim_file_path=str(archive), entry_path="a.org/target/", direction="inbound"
+        )
+    )
+
+    assert [r["path"] for r in out["results"]] == [
+        "a.org/aristotle/",
+        "a.org/plato/",
+        "a.org/index-of-everything/",
+    ]
 
 
 def test_a_sidecar_without_node_count_still_answers(tmp_path):

--- a/tests/test_fr_inbound_ranking.py
+++ b/tests/test_fr_inbound_ranking.py
@@ -3,11 +3,15 @@
 v3.3.1 field report, fid 86 (ranking half). Inbound linkers were ranked
 ``ORDER BY n.inbound_degree DESC`` — a signal site boilerplate maximises.
 A page in the nav bar links to everything and is therefore linked FROM
-everything, so it wins that ordering on every query, and the caller asking
+everything, so it wins that ordering for most targets, and the caller asking
 what links to an article gets the alphabet index instead of the articles.
 
-Measured on the shipped IEP sidecar: 366 of 371 article targets get a real
-article at rank 1 under the fix, where before they got the index page.
+Measured on the shipped IEP sidecar (1,187 nodes, threshold 594): the 33
+nodes at or above the threshold are the home page, the 26 alphabet pages,
+five site pages and the RSS feed; the best-linked article, ``plato/``, sits
+at 106. Of the 919 targets that have at least one non-furniture linker,
+furniture led 654 before the fix and leads none after it. Among the 371
+targets with five or more linkers, it led 366.
 
 The demote is by RANK, not by removal: rows are only reordered, so
 ``total``, the pagination arithmetic and the cursor contract are untouched.
@@ -141,6 +145,36 @@ def test_a_small_archive_is_exempt(tmp_path):
     assert rows[0]["path"] == "a.org/hub/"
 
 
+def test_the_threshold_is_inclusive_at_the_boundary(tmp_path):
+    """``at least half`` only matters AT the boundary, and only the pure
+    arithmetic below was pinned: ``>=`` could become ``>`` in the SQL and the
+    ceiling could become a floor with every ordering test still green.
+
+    101 nodes puts the threshold at 51, so degree 51 is furniture and sinks,
+    while degree 50 — a floor's threshold — is an ordinary linker and must not.
+    """
+    nodes = [
+        (1, "a.org/at-threshold/", 51),
+        (2, "a.org/just-below/", 50),
+        (3, "a.org/article/", 12),
+        (5, "a.org/target/", 1),
+    ]
+    edges = [(1, 5, "Nav"), (2, 5, "Hub"), (3, 5, "Article")]
+    archive = _sidecar(tmp_path, nodes=nodes, edges=edges, node_count=101)
+
+    reader = _open(archive)
+    try:
+        rows = reader.query_inbound("a.org/target/", limit=10, offset=0).rows
+    finally:
+        reader.close()
+
+    assert [r["path"] for r in rows] == [
+        "a.org/just-below/",
+        "a.org/article/",
+        "a.org/at-threshold/",
+    ]
+
+
 def test_pagination_still_spans_every_linker(tmp_path):
     """The demote reorders within the full set, so paging must still reach
     every row exactly once — the cursor contract depends on it."""
@@ -159,8 +193,9 @@ def test_pagination_still_spans_every_linker(tmp_path):
 
 
 def test_a_sidecar_without_node_count_still_answers(tmp_path):
-    """Older sidecars of the same schema may lack the key. Degrading to the
-    previous ordering is right; refusing to answer is not."""
+    """Defensive: every builder writes ``node_count``, so only a hand-made or
+    damaged sidecar lacks it. Degrading to the previous ordering is right;
+    refusing to answer is not."""
     nodes = [(1, "a.org/hub/", 90), (2, "a.org/x/", 2), (5, "a.org/target/", 1)]
     edges = [(1, 5, "Hub"), (2, 5, "X")]
     archive = tmp_path / "b.zim"
@@ -195,7 +230,8 @@ def test_the_shipped_iep_sidecar_leads_with_an_article():
     """The measured case, on the real sidecar rather than a fixture."""
     import os
 
-    iep = "/Users/cameron/Developer/zim/internet-encyclopedia-philosophy_en_all_2025-06.zim"
+    zim_dir = os.environ.get("ZIM_TEST_DATA_DIR", str(Path.home() / "Developer/zim"))
+    iep = str(Path(zim_dir) / "internet-encyclopedia-philosophy_en_all_2025-06.zim")
     if not os.path.exists(sidecar_path_for(iep)):
         pytest.skip("IEP sidecar not present")
 
@@ -233,8 +269,8 @@ def test_the_shipped_iep_sidecar_leads_with_an_article():
     ],
 )
 def test_the_furniture_threshold_is_a_true_ceiling(node_count, expected):
-    """The docstring says "at least half", and the first implementation did
-    not do that: ``-(-int(x) // 1)`` truncates inside ``int()`` before the
+    """The rule is "at least half", and the first implementation did not do
+    that: ``-(-int(x) // 1)`` truncates inside ``int()`` before the
     ceiling idiom runs, so it computed the FLOOR and was off by one on every
     odd node count. Nothing in the file pinned the arithmetic, so it passed.
     """

--- a/tests/test_fr_inbound_ranking.py
+++ b/tests/test_fr_inbound_ranking.py
@@ -1,0 +1,218 @@
+""" "What links here?" must not answer with the site's navigation.
+
+v3.3.1 field report, fid 86 (ranking half). Inbound linkers were ranked
+``ORDER BY n.inbound_degree DESC`` — a signal site boilerplate maximises.
+A page in the nav bar links to everything and is therefore linked FROM
+everything, so it wins that ordering on every query, and the caller asking
+what links to an article gets the alphabet index instead of the articles.
+
+Measured on the shipped IEP sidecar: 366 of 371 article targets get a real
+article at rank 1 under the fix, where before they got the index page.
+
+The demote is by RANK, not by removal: rows are only reordered, so
+``total``, the pagination arithmetic and the cursor contract are untouched.
+A node whose inbound degree reaches half the archive's node count is
+treated as site-wide furniture. Small archives are exempt — on a
+twenty-page archive a genuinely central article can legitimately be linked
+from half of it, and there is no boilerplate to separate it from.
+
+The builder-scoping half of fid 86 was deliberately NOT taken: feeding the
+builder ``select_main_content`` inherits the furniture strips, which on
+MedlinePlus delete "Related Health Topics" — 165 of 174 strip-only removals
+in a 250-page sample were genuine topic pages. That would trade a cosmetic
+contradiction between the two directions for the loss of MedlinePlus's best
+inbound signal.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from openzim_mcp.linkgraph.reader import LinkGraphReader, sidecar_path_for
+from openzim_mcp.linkgraph.schema import SCHEMA_VERSION
+
+_UUID = "11111111-2222-3333-4444-555555555555"
+
+
+def _sidecar(tmp_path: Path, *, nodes, edges, node_count=None) -> Path:
+    """Build a minimal sidecar. ``nodes`` is [(id, path, inbound_degree)]."""
+    archive = tmp_path / "a.zim"
+    archive.write_bytes(b"ZIM\x04" + b"\0" * 100)
+    db = Path(sidecar_path_for(str(archive)))
+    conn = sqlite3.connect(db)
+    conn.executescript("""
+        CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+        CREATE TABLE nodes (id INTEGER PRIMARY KEY, path TEXT, inbound_degree INTEGER);
+        CREATE TABLE edges (source_id INTEGER, target_id INTEGER, anchor_text TEXT);
+        """)
+    conn.executemany(
+        "INSERT INTO meta VALUES (?, ?)",
+        [
+            ("schema_version", str(SCHEMA_VERSION)),
+            ("archive_uuid", _UUID),
+            ("node_count", str(node_count if node_count is not None else len(nodes))),
+        ],
+    )
+    conn.executemany("INSERT INTO nodes VALUES (?, ?, ?)", nodes)
+    conn.executemany("INSERT INTO edges VALUES (?, ?, ?)", edges)
+    conn.commit()
+    conn.close()
+    return archive
+
+
+def _open(archive: Path) -> LinkGraphReader:
+    reader = LinkGraphReader.open_for(str(archive), live_archive_uuid=_UUID)
+    assert reader is not None
+    return reader
+
+
+# A 100-node archive: node 1 is in the nav bar (linked from 90 of them), the
+# rest are ordinary articles. All four link to the target, node 5.
+def _nav_bar_archive(tmp_path: Path) -> Path:
+    nodes = [
+        (1, "a.org/index-of-everything/", 90),
+        (2, "a.org/aristotle/", 12),
+        (3, "a.org/plato/", 8),
+        (5, "a.org/target/", 3),
+    ]
+    edges = [(1, 5, "Index"), (2, 5, "Aristotle"), (3, 5, "Plato")]
+    return _sidecar(tmp_path, nodes=nodes, edges=edges, node_count=100)
+
+
+def test_site_furniture_does_not_lead_the_answer(tmp_path):
+    reader = _open(_nav_bar_archive(tmp_path))
+    try:
+        page = reader.query_inbound("a.org/target/", limit=10, offset=0)
+    finally:
+        reader.close()
+
+    assert [r["path"] for r in page.rows] == [
+        "a.org/aristotle/",
+        "a.org/plato/",
+        "a.org/index-of-everything/",
+    ]
+
+
+def test_the_furniture_row_is_still_returned(tmp_path):
+    """A demote, not a filter. Paired with the test above so "the index is
+    not first" cannot be satisfied by dropping it — it IS a real linker, and
+    a caller enumerating linkers must still see it."""
+    reader = _open(_nav_bar_archive(tmp_path))
+    try:
+        page = reader.query_inbound("a.org/target/", limit=10, offset=0)
+    finally:
+        reader.close()
+
+    assert len(page.rows) == 3
+    assert page.total == 3
+
+
+def test_ordinary_linkers_keep_degree_ordering_among_themselves(tmp_path):
+    """Below the furniture threshold, inbound degree is still the signal —
+    the fix is about separating boilerplate from articles, not about
+    abandoning the ranking."""
+    reader = _open(_nav_bar_archive(tmp_path))
+    try:
+        rows = reader.query_inbound("a.org/target/", limit=10, offset=0).rows
+    finally:
+        reader.close()
+
+    ordinary = [r for r in rows if "index-of-everything" not in r["path"]]
+    assert [r["inbound_degree"] for r in ordinary] == [12, 8]
+
+
+def test_a_small_archive_is_exempt(tmp_path):
+    """On a tiny archive a genuinely central article can be linked from half
+    of it, and there is no boilerplate to separate it from. Without this the
+    fix would demote the single most useful linker on small archives."""
+    nodes = [(1, "a.org/hub/", 9), (2, "a.org/x/", 2), (5, "a.org/target/", 1)]
+    edges = [(1, 5, "Hub"), (2, 5, "X")]
+    archive = _sidecar(tmp_path, nodes=nodes, edges=edges, node_count=12)
+
+    reader = _open(archive)
+    try:
+        rows = reader.query_inbound("a.org/target/", limit=10, offset=0).rows
+    finally:
+        reader.close()
+
+    assert rows[0]["path"] == "a.org/hub/"
+
+
+def test_pagination_still_spans_every_linker(tmp_path):
+    """The demote reorders within the full set, so paging must still reach
+    every row exactly once — the cursor contract depends on it."""
+    reader = _open(_nav_bar_archive(tmp_path))
+    try:
+        first = reader.query_inbound("a.org/target/", limit=2, offset=0)
+        second = reader.query_inbound("a.org/target/", limit=2, offset=2)
+    finally:
+        reader.close()
+
+    seen = [r["path"] for r in first.rows] + [r["path"] for r in second.rows]
+    assert sorted(seen) == sorted(
+        ["a.org/aristotle/", "a.org/plato/", "a.org/index-of-everything/"]
+    )
+    assert first.total == second.total == 3
+
+
+def test_a_sidecar_without_node_count_still_answers(tmp_path):
+    """Older sidecars of the same schema may lack the key. Degrading to the
+    previous ordering is right; refusing to answer is not."""
+    nodes = [(1, "a.org/hub/", 90), (2, "a.org/x/", 2), (5, "a.org/target/", 1)]
+    edges = [(1, 5, "Hub"), (2, 5, "X")]
+    archive = tmp_path / "b.zim"
+    archive.write_bytes(b"ZIM\x04" + b"\0" * 100)
+    db = Path(sidecar_path_for(str(archive)))
+    conn = sqlite3.connect(db)
+    conn.executescript("""
+        CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
+        CREATE TABLE nodes (id INTEGER PRIMARY KEY, path TEXT, inbound_degree INTEGER);
+        CREATE TABLE edges (source_id INTEGER, target_id INTEGER, anchor_text TEXT);
+        """)
+    conn.executemany(
+        "INSERT INTO meta VALUES (?, ?)",
+        [("schema_version", str(SCHEMA_VERSION)), ("archive_uuid", _UUID)],
+    )
+    conn.executemany("INSERT INTO nodes VALUES (?, ?, ?)", nodes)
+    conn.executemany("INSERT INTO edges VALUES (?, ?, ?)", edges)
+    conn.commit()
+    conn.close()
+
+    reader = _open(archive)
+    try:
+        rows = reader.query_inbound("a.org/target/", limit=10, offset=0).rows
+    finally:
+        reader.close()
+
+    assert [r["path"] for r in rows] == ["a.org/hub/", "a.org/x/"]
+
+
+@pytest.mark.live
+def test_the_shipped_iep_sidecar_leads_with_an_article():
+    """The measured case, on the real sidecar rather than a fixture."""
+    import os
+
+    iep = "/Users/cameron/Developer/zim/internet-encyclopedia-philosophy_en_all_2025-06.zim"
+    if not os.path.exists(sidecar_path_for(iep)):
+        pytest.skip("IEP sidecar not present")
+
+    from openzim_mcp.zim.archive import zim_archive
+
+    with zim_archive(Path(iep)) as archive:
+        uuid = str(archive.uuid)
+    reader = LinkGraphReader.open_for(iep, live_archive_uuid=uuid)
+    if reader is None:
+        pytest.skip("IEP sidecar is stale for this archive")
+    try:
+        rows = reader.query_inbound(
+            "iep.utm.edu/hume-causation/", limit=5, offset=0
+        ).rows
+    finally:
+        reader.close()
+
+    assert rows, "no inbound linkers for a well-linked article"
+    # The alphabet index (iep.utm.edu/a/ and friends) must not lead.
+    assert len(rows[0]["path"].rstrip("/").rsplit("/", 1)[-1]) > 2, rows[0]

--- a/tests/test_fr_inbound_ranking.py
+++ b/tests/test_fr_inbound_ranking.py
@@ -216,3 +216,28 @@ def test_the_shipped_iep_sidecar_leads_with_an_article():
     assert rows, "no inbound linkers for a well-linked article"
     # The alphabet index (iep.utm.edu/a/ and friends) must not lead.
     assert len(rows[0]["path"].rstrip("/").rsplit("/", 1)[-1]) > 2, rows[0]
+
+
+@pytest.mark.parametrize(
+    "node_count,expected",
+    [
+        (0, 0),
+        (49, 0),  # below the exemption floor
+        (50, 25),
+        (100, 50),
+        (101, 51),  # ODD: "at least half" must round UP, not truncate
+        (999, 500),
+        (None, 0),
+        ("not-a-number", 0),
+        ("-5", 0),
+    ],
+)
+def test_the_furniture_threshold_is_a_true_ceiling(node_count, expected):
+    """The docstring says "at least half", and the first implementation did
+    not do that: ``-(-int(x) // 1)`` truncates inside ``int()`` before the
+    ceiling idiom runs, so it computed the FLOOR and was off by one on every
+    odd node count. Nothing in the file pinned the arithmetic, so it passed.
+    """
+    from openzim_mcp.linkgraph.reader import _furniture_threshold
+
+    assert _furniture_threshold(node_count) == expected

--- a/tests/test_fr_search_get_handoff.py
+++ b/tests/test_fr_search_get_handoff.py
@@ -29,6 +29,7 @@ envelope path) against a real libzim archive on disk.
 
 from __future__ import annotations
 
+import copy
 import shutil
 from pathlib import Path
 from typing import Any, Optional
@@ -41,7 +42,9 @@ from openzim_mcp.server import OpenZimMcpServer
 _MINI = "wikipedia_en_climate_change_mini_2024-06.zim"
 
 
-def _one_archive_server(tmp_path: Path, corpus: Optional[Path]) -> OpenZimMcpServer:
+def _one_archive_server(
+    tmp_path: Path, corpus: Optional[Path], *, cache: bool = False
+) -> OpenZimMcpServer:
     if corpus is None:
         pytest.skip("ZIM_TEST_DATA_DIR not set")
     source = corpus / "withns" / _MINI
@@ -54,7 +57,15 @@ def _one_archive_server(tmp_path: Path, corpus: Optional[Path]) -> OpenZimMcpSer
         OpenZimMcpConfig(
             allowed_directories=[str(solo)],
             tool_mode="advanced",
-            cache=CacheConfig(enabled=False),
+            cache=(
+                CacheConfig(
+                    enabled=True,
+                    persistence_enabled=False,
+                    persistence_path=str(tmp_path / "cache"),
+                )
+                if cache
+                else CacheConfig(enabled=False)
+            ),
         )
     )
 
@@ -71,6 +82,27 @@ def _handler(server: OpenZimMcpServer, name: str) -> Any:
 # ---------------------------------------------------------------------------
 # The fulltext response names the archive it searched
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_naming_the_archive_leaves_the_cached_page_alone(
+    tmp_path, zim_test_data_dir
+):
+    """The stamp re-measures ``_meta`` on the page it returns, and
+    ``_strip_next_cursor`` copies only the top level — so that ``_meta`` was
+    the dict inside the cached search page. Every fulltext call rewrote the
+    cache's size fields to describe a body the cache does not hold, and a
+    cross-archive call for the same query then reported a different size
+    than a fresh server did. The same defect class as the title demote that
+    reordered its cached page, one call site over."""
+    server = _one_archive_server(tmp_path, zim_test_data_dir, cache=True)
+    archive = str(tmp_path / "solo" / _MINI)
+    ops = server.zim_operations
+    cached = copy.deepcopy(ops.search_zim_file_data(archive, "carbon", 5, 0))
+
+    await _handler(server, "zim_search")(query="carbon", limit=5)
+
+    assert ops.search_zim_file_data(archive, "carbon", 5, 0) == cached
 
 
 @pytest.mark.asyncio

--- a/tests/test_fr_transport_state.py
+++ b/tests/test_fr_transport_state.py
@@ -248,7 +248,7 @@ def mcp_session(tmp_path: Path) -> Iterator["tuple[TestClient, str]"]:
 
 def _open_get_stream(
     client: TestClient, headers: "dict[str, str]"
-) -> "tuple[int | None, str, list[BaseException]]":
+) -> "tuple[int | None, str, list[Exception]]":
     """Open the SSE GET stream on the real app; report how it answered.
 
     ``TestClient`` runs an ASGI app to completion before handing back a
@@ -260,9 +260,9 @@ def _open_get_stream(
     """
     import anyio
 
-    async def drive() -> "tuple[int | None, str, list[BaseException]]":
+    async def drive() -> "tuple[int | None, str, list[Exception]]":
         started: "dict[str, Any]" = {}
-        failures: "list[BaseException]" = []
+        failures: "list[Exception]" = []
         first_receive = True
 
         async def receive() -> "dict[str, Any]":
@@ -305,11 +305,10 @@ def _open_get_stream(
         with anyio.move_on_after(20):
             try:
                 await client.app(scope, receive, send)  # type: ignore[operator]
-            except BaseException as exc:  # noqa: BLE001 - the 500 arrives here
-                if not isinstance(exc, anyio.get_cancelled_exc_class()):
-                    failures.append(exc)
-                else:
-                    raise
+            except Exception as exc:  # noqa: BLE001 - the 500 arrives here
+                # Cancellation is a BaseException, so the hang-up still
+                # reaches ``move_on_after`` without being recorded here.
+                failures.append(exc)
         content_type = ""
         for name, value in started.get("headers", []):
             if name.lower() == b"content-type":

--- a/tests/test_v3_cache_render_epoch.py
+++ b/tests/test_v3_cache_render_epoch.py
@@ -204,12 +204,15 @@ _RENDER_FIXTURE_HTML = """
 </main></body></html>
 """
 
-# sha256 over the rendering these caches hold. If this assertion fails, the
-# server renders something different from what a cache written by the current
-# epoch contains: bump ``_RENDER_EPOCH`` in openzim_mcp/bundle.py, then
-# replace this digest with the one the failure prints.
+# (epoch, sha256) over the rendering these caches hold. If this assertion
+# fails, the server renders something different from what a cache written by
+# the current epoch contains: bump ``_RENDER_EPOCH`` in openzim_mcp/bundle.py,
+# then re-pin BOTH pairs in this file with the new epoch and the printed
+# digest. The epoch is part of the pin so that reverting a bump fails too —
+# pinning the digest alone let ``r3`` go back to ``r2`` with every suite green.
 _PINNED_RENDER_FINGERPRINT = (
-    "d62d668001dd2a7ca972108f82ff6e49d7f2b2d5bebeb40af0890a607ba89c18"
+    "r3",
+    "d62d668001dd2a7ca972108f82ff6e49d7f2b2d5bebeb40af0890a607ba89c18",
 )
 
 
@@ -245,10 +248,52 @@ def test_render_fingerprint_is_pinned_to_the_current_epoch(
     content_processor: ContentProcessor,
 ) -> None:
     """A rendering change must not land without an epoch bump."""
-    observed = _render_fingerprint(content_processor)
+    observed = (_RENDER_EPOCH, _render_fingerprint(content_processor))
 
     assert observed == _PINNED_RENDER_FINGERPRINT, (
-        f"what the bundle/entry/snippet caches hold changed (fingerprint "
+        f"what the bundle/entry/snippet caches hold, or the epoch, changed "
+        f"(observed {observed}). Bump _RENDER_EPOCH in openzim_mcp/bundle.py "
+        f"so an upgrade invalidates persisted values, then re-pin both pairs."
+    )
+
+
+# The epoch also guards what a RANKING cache holds. ``suggestions_data``
+# stores its page after the fid 71 crawl-artefact demote, under a key whose
+# only build-sensitive part is the epoch, so a snapshot persisted by a build
+# that ranked differently re-serves that build's order until its TTL — which
+# is what reverting this release's ``r2`` -> ``r3`` bump did, with every
+# suite green. Every shape the demote treats specially is in the fixture,
+# including the two it deliberately leaves alone.
+_RANKING_FIXTURE_PATHS = (
+    "a/languages/x.html",
+    "a/real.html",
+    "a/ency/imagepages/1.htm",
+    "a/captions/x.srt",
+    "a/b.html",
+    "a/category/c/",
+    "a/category/c/page/2/",
+)
+_PINNED_RANKING_FINGERPRINT = (
+    "r3",
+    "5d5745359f1eaa811b415ce912d61851e74d0fcc475704852100369c371896f4",
+)
+
+
+def _ranking_fingerprint() -> str:
+    """Digest the order ``demote_crawl_artefacts`` gives the fixture."""
+    from openzim_mcp.zim.search import demote_crawl_artefacts
+
+    rows = [{"path": p} for p in _RANKING_FIXTURE_PATHS]
+    ordered = [r["path"] for r in demote_crawl_artefacts(rows)]
+    return hashlib.sha256(json.dumps(ordered).encode("utf-8")).hexdigest()
+
+
+def test_ranking_fingerprint_is_pinned_to_the_current_epoch() -> None:
+    """A change to the cached suggest ranking must not land without a bump."""
+    observed = (_RENDER_EPOCH, _ranking_fingerprint())
+
+    assert observed == _PINNED_RANKING_FINGERPRINT, (
+        f"what the suggestions cache holds, or the epoch, changed (observed "
         f"{observed}). Bump _RENDER_EPOCH in openzim_mcp/bundle.py so an "
-        f"upgrade invalidates persisted values, then pin the new digest here."
+        f"upgrade invalidates persisted values, then re-pin both pairs."
     )

--- a/tests/test_v3_cache_render_epoch.py
+++ b/tests/test_v3_cache_render_epoch.py
@@ -22,6 +22,7 @@ without bumping the epoch.
 
 from __future__ import annotations
 
+import ast
 import hashlib
 import json
 from contextlib import suppress
@@ -296,4 +297,59 @@ def test_ranking_fingerprint_is_pinned_to_the_current_epoch() -> None:
         f"what the suggestions cache holds, or the epoch, changed (observed "
         f"{observed}). Bump _RENDER_EPOCH in openzim_mcp/bundle.py so an "
         f"upgrade invalidates persisted values, then re-pin both pairs."
+    )
+
+
+# The fixture above only sees a change that moves one of its seven paths: a
+# new artefact shape, a dropped regex flag or a new rule inside the demote all
+# passed it, and a persisted snapshot then served the old order. So the CODE
+# the suggestions cache's order comes from is pinned as well — read through
+# ``ast``, so comments and docstrings can change freely. If this fails and the
+# cached ordering provably does not change, re-pin it with the same epoch;
+# otherwise bump the epoch.
+_RANKING_CODE_NAMES = (
+    "_CRAWL_ARTEFACT_RE",
+    "is_crawl_artefact",
+    "demote_crawl_artefacts",
+)
+_PINNED_RANKING_CODE = (
+    "r3",
+    "d8cdb6b474b72f0f6fe73971a01d483540d48b9da34d4014ee13f5b2e8e0544b",
+)
+
+
+def _ranking_code_fingerprint() -> str:
+    """Digest the demote's source with docstrings stripped and comments gone."""
+    source = (
+        Path(__file__).resolve().parents[1] / "openzim_mcp" / "zim" / "search.py"
+    ).read_text(encoding="utf-8")
+    parts: dict[str, str] = {}
+    for node in ast.parse(source).body:
+        if isinstance(node, ast.FunctionDef) and node.name in _RANKING_CODE_NAMES:
+            first = node.body[0] if node.body else None
+            if (
+                isinstance(first, ast.Expr)
+                and isinstance(first.value, ast.Constant)
+                and isinstance(first.value.value, str)
+            ):
+                node.body = node.body[1:]
+            parts[node.name] = ast.unparse(node)
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id in _RANKING_CODE_NAMES:
+                    parts[target.id] = ast.unparse(node)
+    assert set(parts) == set(_RANKING_CODE_NAMES), sorted(parts)
+    blob = "\x00".join(parts[name] for name in _RANKING_CODE_NAMES)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def test_ranking_code_is_pinned_to_the_current_epoch() -> None:
+    """A change to the demote's code must not land without a decision."""
+    observed = (_RENDER_EPOCH, _ranking_code_fingerprint())
+
+    assert observed == _PINNED_RANKING_CODE, (
+        f"the crawl-artefact demote's code, or the epoch, changed (observed "
+        f"{observed}). If what the suggestions cache holds changes, bump "
+        f"_RENDER_EPOCH in openzim_mcp/bundle.py and re-pin every pair here; "
+        f"if it provably does not, re-pin this one with the same epoch."
     )

--- a/website/src/content/docs/api-reference.mdx
+++ b/website/src/content/docs/api-reference.mdx
@@ -375,6 +375,8 @@ zim_search(
 
 **Returns:** mode-shaped response — `SearchResponse` / `SearchAllResponse` / `SearchWithFiltersResponse` / `FindEntryResponse` / `SearchSuggestionsResponse` — or `ToolErrorPayload` on validation failure. Every `next_cursor` in these responses is nulled; page with `offset`.
 
+`mode="title"` returns rows in **presentation order, not score order**: scraper output the archive files as its own entry — per-language translation hubs (`/languages/…`), image-caption stubs (`/ency/imagepages/…`) and subtitle sidecars (`.srt`) — is sunk below real articles even when the archive scores it higher. Nothing is dropped, so `total` and the paging arithmetic are unaffected. Read `results` order as authoritative and treat `score` as a match-quality signal rather than a rank; re-sorting rows by `score` undoes the demote and puts the scraper output back on top.
+
 Single-archive `fulltext` responses carry a top-level **`zim_file_path`** naming the archive that answered — including when the server auto-selected it because only one is loaded. Hand it straight to `zim_get`, `zim_get_section`, `zim_links`, `zim_browse` or `zim_metadata`, all of which require the field. (`mode="title"` states the same fact per hit, as `zim_file`; the cross-archive fan-out states it per file.) If you get a `zim_file_path: Field required` rejection anyway, it names the archive for you whenever exactly one is loaded.
 
 ---

--- a/website/src/content/docs/api-reference.mdx
+++ b/website/src/content/docs/api-reference.mdx
@@ -375,7 +375,7 @@ zim_search(
 
 **Returns:** mode-shaped response — `SearchResponse` / `SearchAllResponse` / `SearchWithFiltersResponse` / `FindEntryResponse` / `SearchSuggestionsResponse` — or `ToolErrorPayload` on validation failure. Every `next_cursor` in these responses is nulled; page with `offset`.
 
-`mode="title"` returns rows in **presentation order, not score order**: scraper output the archive files as its own entry — per-language translation hubs (`/languages/…`), image-caption stubs (`/ency/imagepages/…`) and subtitle sidecars (`.srt`) — is sunk below real articles even when the archive scores it higher. Nothing is dropped, so `total` and the paging arithmetic are unaffected. Read `results` order as authoritative and treat `score` as a match-quality signal rather than a rank; re-sorting rows by `score` undoes the demote and puts the scraper output back on top.
+`mode="title"` (pinned or `cross_file=True`) and `mode="suggest"` sink scraper output the archive files as its own entry — per-language translation hubs (`/languages/…`), image-caption stubs (`/ency/imagepages/…`) and subtitle sidecars (`.srt`) — below real articles, even when the archive ranks it higher. The demote reorders the page it is handed: nothing is dropped, so `total` and the paging arithmetic are unaffected, and a small `limit` whose page holds no real article still leads with scraper output. Title rows therefore come back in **presentation order, not score order**. Read `results` order as authoritative and treat `score` as a match-quality signal rather than a rank; re-sorting rows by `score` undoes the demote and puts the scraper output back on top.
 
 Single-archive `fulltext` responses carry a top-level **`zim_file_path`** naming the archive that answered — including when the server auto-selected it because only one is loaded. Hand it straight to `zim_get`, `zim_get_section`, `zim_links`, `zim_browse` or `zim_metadata`, all of which require the field. (`mode="title"` states the same fact per hit, as `zim_file`; the cross-archive fan-out states it per file.) If you get a `zim_file_path: Field required` rejection anyway, it names the archive for you whenever exactly one is loaded.
 
@@ -538,6 +538,8 @@ On a scraped archive (warc2zim/ZIMIT), whose entry paths are host-prefixed, the 
 **Returns:** a paginated `{results, next_cursor, total, done, page_info, …}` envelope for every direction. `direction="outbound"` adds `kind` and `category_totals` alongside; `"inbound"` and `"related"` carry neither, and key the article as `entry_path` rather than `path`/`title`.
 
 Outbound entries carry `url`/`text`/`title` (plus `domain` for external, `alt` for media). **`url` is the raw href as written in the article** — it does not necessarily round-trip into `zim_get`. Internal rows additionally carry `path`, the resolved entry path, and that is the one to pass to `zim_get`. Inbound entries are `{path, title, inbound_degree, anchor_text}`; related entries are `{path, title, …}` rows.
+
+Inbound rows are ranked by the linker's `inbound_degree`, except that **site furniture sinks to the end**: a linker whose `inbound_degree` is at least half the sidecar's node count — on a sidecar of 50 or more nodes — is in the site's navigation, links to everything, and would otherwise lead every answer. Nothing is dropped, so `total` and paging are unaffected. Read `results` order as authoritative; re-sorting rows on `inbound_degree` puts the navigation pages back on top.
 
 ---
 

--- a/website/src/content/docs/api-reference.mdx
+++ b/website/src/content/docs/api-reference.mdx
@@ -539,7 +539,7 @@ On a scraped archive (warc2zim/ZIMIT), whose entry paths are host-prefixed, the 
 
 Outbound entries carry `url`/`text`/`title` (plus `domain` for external, `alt` for media). **`url` is the raw href as written in the article** — it does not necessarily round-trip into `zim_get`. Internal rows additionally carry `path`, the resolved entry path, and that is the one to pass to `zim_get`. Inbound entries are `{path, title, inbound_degree, anchor_text}`; related entries are `{path, title, …}` rows.
 
-Inbound rows are ranked by the linker's `inbound_degree`, except that **site furniture sinks to the end**: a linker whose `inbound_degree` is at least half the sidecar's node count — on a sidecar of 50 or more nodes — is in the site's navigation, links to everything, and would otherwise lead every answer. Nothing is dropped, so `total` and paging are unaffected. Read `results` order as authoritative; re-sorting rows on `inbound_degree` puts the navigation pages back on top.
+Inbound rows are ranked by the linker's `inbound_degree`, except that **site furniture sinks to the end**: a linker whose `inbound_degree` is at least half the sidecar's node count — on a sidecar of 50 or more nodes — is linked from nearly every page — it is the site's navigation — and would otherwise lead most answers. Nothing is dropped, so `total` and paging are unaffected. Read `results` order as authoritative; re-sorting rows on `inbound_degree` puts the navigation pages back on top.
 
 ---
 

--- a/website/src/content/docs/installation.mdx
+++ b/website/src/content/docs/installation.mdx
@@ -72,8 +72,10 @@ uv sync --no-dev
 
 ### Optional extras
 
-One extra ships: `[reranker]`, which adds cross-encoder relevance reranking
-over Xapian's results.
+One extra ships: `[reranker]`, which re-scores Xapian's results with a
+cross-encoder. Whether that improves them is unmeasured, and it roughly
+doubles query latency — see [Search reranking](/openzim-mcp/docs/search-reranking/)
+before pulling the model down.
 
 ```bash
 uv tool install "openzim-mcp[reranker]"    # or: pip install "openzim-mcp[reranker]"

--- a/website/src/content/docs/search-reranking.mdx
+++ b/website/src/content/docs/search-reranking.mdx
@@ -5,15 +5,27 @@ group: Concepts
 sidebar_order: 2
 ---
 
-The only optional install OpenZIM MCP ships, and the only one that changes
-retrieval quality. Everything here is opt-in: the base install neither
-includes it nor reaches the network.
+The only optional install OpenZIM MCP ships. Everything here is opt-in: the
+base install neither includes it nor reaches the network.
 
-The `[reranker]` extra adds cross-encoder relevance reranking on top of
-Xapian's BM25 results. When installed, `zim_query` search intents and
-`synthesize` mode silently produce more relevant top-K results on
-content-fragment queries. The advanced `zim_search` tool returns raw
-Xapian ranking and is not reranked. Caller surface is unchanged.
+The `[reranker]` extra re-scores Xapian's BM25 candidates with a
+cross-encoder and reorders the top-K that `zim_query` search intents and
+`synthesize` mode return. The advanced `zim_search` tool returns raw Xapian
+ranking and is not reranked. The caller's arguments and response shape are
+unchanged.
+
+**Whether that reordering is an improvement is unmeasured.** The one blind
+evaluation run against this server — 50 queries, 44 of them rerank-eligible,
+132 blind judgments, on two warc2zim archives (MedlinePlus and the Internet
+Encyclopedia of Philosophy) — found no metric reaching significance: 55
+preference votes for reranked output against 52 for Xapian alone (p = 0.85),
+and a relevant article at rank 1 in 64.4% of reranked results against 62.9%
+without. Median query latency roughly doubled, 0.44 s to 0.885 s. That
+sample rules out a large effect, not a small one, and says nothing about
+Wikipedia- or Stack Exchange-shaped archives, which were not tested.
+
+Install it to evaluate it on your own corpus. The ranking this project
+stands behind is Xapian's.
 
 ## Install
 

--- a/website/src/content/docs/search-reranking.mdx
+++ b/website/src/content/docs/search-reranking.mdx
@@ -10,9 +10,8 @@ base install neither includes it nor reaches the network.
 
 The `[reranker]` extra re-scores Xapian's BM25 candidates with a
 cross-encoder and reorders the top-K that `zim_query` search intents and
-`synthesize` mode return. The advanced `zim_search` tool returns raw Xapian
-ranking and is not reranked. The caller's arguments and response shape are
-unchanged.
+`synthesize` mode return. The advanced `zim_search` tool is not reranked.
+The caller's arguments and response shape are unchanged.
 
 **Whether that reordering is an improvement is unmeasured.** The one blind
 evaluation run against this server — 50 queries, 44 of them rerank-eligible,


### PR DESCRIPTION
## Description

Takes three of the six items the real-world field report left open after #429, and fixes what re-measuring them on the real archives found wrong with this branch's own first attempt.

- **Crawl artefacts sink below articles (fid 71).** Image-caption stubs, translation hubs and subtitle sidecars no longer lead title, suggest and `zim_query` chooser answers that contain a real article.
- **"What links here?" stops answering with the site's navigation (fid 86, ranking half).** On IEP an alphabet page led 881 of 1,187 inbound lists; it now leads only the 231 whose linkers are all navigation.
- **The reranker docs stop claiming an improvement** the only evaluation ever run did not find.

The defect worth knowing about is one this branch introduced and then fixed. The title demote was placed at the response edge so it could not break the canonical-title promotion, but it rewrote the *cached* page in place, so the promotion regression it was placed there to avoid came back on the second identical call at `limit=3`, the page size the promotion probe reads: `title 'swollen glands'` led with `hormones.html` at a fabricated score of 1.0, and `zim_query` followed it. Every test of the demote passed, because each ran with the cache off and called once. Re-measuring on MedlinePlus with the cache on found it. The edge now demotes a copy, and a test that builds a two-entry ZIM and keeps the cache on pins it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📚 Documentation update (changes to documentation only)
- [x] 🧪 Test improvements

## Related Issues

- Relates to #429 — the field report's first pass. `docs/field-report-disposition.md` is the running record of what closed, what was declined and why, and what stays open.

## Changes Made

**Crawl artefacts (fid 71)**

- Paths matching `/imagepages/`, `/languages/` or ending `.srt` sink below real articles on single- and cross-archive title mode, suggest mode and the `zim_query` chooser. A reorder, never a filter: nothing is dropped, and `total` and paging are unchanged.
- `/category/` and `/page/N/` are deliberately excluded. On IEP the category pages are the encyclopedia's own topic index and the correct #1 for four real queries; `/page/N/` matched only continuations of that index.
- Title mode demotes at the response edge, after promotion has read the score-descending page, and demotes a copy of it.
- Measured on MedlinePlus with 40 topic queries at `limit=5`, rate limiter and cache off, 3.3.2 against this branch:

  | Surface | Artefact at #1 | Pages with an artefact above an article |
  | --- | --- | --- |
  | Title | 4 → 1 | 30 of 40 → 0 |
  | Suggest | 6 → 1 | 29 of 40 → 0 |
  | Chooser | 7 → 1 | 7 of 39 → 0 |

  The artefact share of the rows (26.1% title, 26.6% suggest) does not move, by construction: the demote reorders the page it is handed and never evicts from it. The remaining #1 on each surface is a page with nothing else on it — `migraine headache` in title and suggest, `swollen glands` in the chooser, whose only strong match is an image stub that `zim_query` still fetches as the answer.
- Not reached, and recorded as open: fulltext and `zim_query` search results (12% of top-5 rows are artefacts on the same 40 queries), and `zim_query "find article titled X"`.

**Inbound ranking (fid 86, ranking half)**

- A linker whose inbound degree is at least half the sidecar's node count, on sidecars of 50 or more nodes, is site furniture and sinks to the end. Reader-only: no rebuild and no schema bump.
- On the IEP sidecar (1,187 nodes, threshold 594) the 33 nodes over the line are all navigation; the best-linked article sits at 106. Of the 919 article targets (those not themselves furniture) with at least one non-furniture linker, furniture led 654 before and none after. `hume-causation/` now answers `hume/`, `con-meta/`, `hume-rel/` instead of `c/`, `h/`.
- The builder half is declined: scoping the builder to the main-content landmark deletes MedlinePlus's "Related Health Topics", its best inbound signal, and would invalidate every sidecar in the field.

**Reranker docs** — the reranking page states the null result with its numbers (55 preference votes against 52, p = 0.85; 64.4% against 62.9% relevant at #1; median latency roughly doubled; a ~1.1 GB model), and the install page carries the hedge and the latency cost and links to them. The extra stays: no measured effect at n=44 is not no effect.

**Cache epoch** — `_RENDER_EPOCH` r2 → r3. The suggestions cache stores its page after the demote, and the epoch is what stops a snapshot persisted by 3.3.2 (persistence is opt-in) re-serving pre-demote order for the rest of its entries' TTL, one hour by default. The epoch is now pinned together with fingerprints of the rendering, of the demote's code, and of how the demote orders a fixture: a revert of the bump fails, and so does a change to the demote without one. A cached ranking changed anywhere else still needs a bump by hand.

**One more in-place cache write** — fulltext's archive stamp (fid 27, from #429) re-measured `_meta` on the cached search page itself, so each call rewrote the cache's size fields to describe a body the cache does not hold. It copies `_meta` first now, with a two-call test.

**API reference** — title and suggest rows come back in presentation order, and inbound rows sink furniture; re-sorting title rows on `score` or inbound rows on `inbound_degree` undoes the reorder. A docs test pins each note's contract sentences.

## Testing

### Test Coverage

- [x] Tests pass locally — **5,289 passed, 222 skipped, 0 failed** (from 5,274 at the start of this round of work)
- [x] All quality checks pass — pre-commit (stricter than CI) green on every commit
- [x] Integration tests pass — live suite **35 passed / 17 skipped / 0 failed**; `main` on the same machine gives 34 / 17 / 0 with an identical skip set (Docker not running; no Wikipedia archive, which also skips the canonical-query checks; the IEP sidecar already present)
- [x] New tests added for new functionality
- [x] Existing tests updated for changed functionality

**Every new test is mutation-proven** — the defect reintroduced, the test confirmed to fail — in two independent passes. Before the fixes, fifteen mutants in nine groups survived the default suite: the demote moved into `find_entry_by_title_data` (the promotion bug again, on the first call); the chooser demote moved ahead of the canonical prepend; a suggest demote applied only on the cold path; the epoch bump reverted; six rewordings of the withdrawn reranker claim and an inversion of its hedge; `>=` → `>` at the furniture threshold; case-insensitivity dropped; the `.srt` anchor dropped; the API reference's title-order note rewritten. After them, a second pass found twelve more in five groups: a re-sort on `inbound_degree` in the data layer or the `zim_links` handler; an unbumped change to the demote's code; the title note reverted, or inverted with its label kept; five further rewordings of the reranker claim; an unhedged claim just past the install page's check window. Each now fails a named test.

### Manual Testing

- [x] Tested with real ZIM files — every fid 71 and fid 86 number above was measured on the shipped MedlinePlus and IEP archives against a `main` checkout, and the fid 71 table reproduced independently; the reranker figures are quoted from the earlier blind evaluation. With the cache warm, 36 of 36 repeat-call scenarios match the cold output (the pre-fix branch: 22 of 36, with 11 fabricated hoists); a 41-query sweep served twice from the cache matches cold on all 82 pages; a persisted snapshot reloaded into a new server matches cold on all 129 title pages.
- [x] Tested edge cases — archives under 50 nodes, a sidecar without `node_count`, a linker exactly at the threshold, pages of nothing but artefacts
- [x] Verified backward compatibility — no sidecar rebuild, no schema change

## Security Considerations

- [x] No new security vulnerabilities introduced
- [x] Path traversal protection maintained — no path handling changed

## Performance Impact

- [x] No meaningful regression — the demote is one pass over a page already in memory; the inbound sort key gains one term (a full sweep of all 1,187 IEP targets with every paging walk took 94 s against 87 s on `main`; not a benchmark)
- [x] Caching behavior verified — two-call tests with the cache on; epoch pinned

## Backward Compatibility

- [x] No breaking changes. Title and inbound rows are no longer in `score` / `inbound_degree` order, and the API reference says so. A paging cursor minted before the upgrade resumes at the same offset in the new order, so a walk that spans the upgrade can repeat or skip a row.

## Additional Notes

- Still open, and recorded in the disposition doc: ranking headroom beyond artefacts, including artefacts in fulltext and `zim_query` search; `zim_browse(mode='page')` previews; cross-archive ranking; rate-limit pricing; `zim_query "find article titled X"`.
- Found during review, pre-existing, not changed here: cross-archive title mode overwrites a "more matches exist" `_meta.hint` with its promotion note (and a pinned promotion hoist drops it), and a blank cross-archive title query reports that no archives are loaded.
- Pre-existing and left for a separate change: pointed at a real corpus, the live suite rewrites the IEP archive in place with its own bytes (`test_live_subscriptions.py`) and force-rebuilds its sidecar (`test_live_inbound_linkgraph.py`).
- Also closes CodeQL alert 355 (`py/catch-base-exception` in a test helper).
