### PR TITLE
test: stop the live suite writing to the library it was pointed at

### DIFF
--- a/tests/live/README.md
+++ b/tests/live/README.md
@@ -26,6 +26,13 @@ auto-skip otherwise, so you don't need to remember to filter.
 
 - A directory containing at least one `.zim` file.
   Default: `~/Developer/zim`. Override with `ZIM_TEST_DATA_DIR`.
+  **That directory is read-only to this suite.** A test that rewrites an
+  archive, or builds a sidecar beside one, takes the `disposable_corpus`
+  fixture instead and gets a writable copy (an APFS clone where available).
+  A session-wide guard fails the run if anything in the configured
+  directory moves: the suite used to rewrite an archive in place and
+  force-rebuild its sidecar, which left the bytes identical but moved the
+  mtime that every cache key derived from that archive depends on.
 - Free loopback ports: each test asks the kernel for a fresh port via
   `127.0.0.1:0`, so they don't collide with each other or with anything
   else on the machine.

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -12,6 +12,12 @@ Run them explicitly with ``make test-live`` or ``uv run pytest -m live``.
 A ZIM directory must be reachable; set ``ZIM_TEST_DATA_DIR`` to override
 the default of ``~/Developer/zim``. The fixtures skip the test if no
 ``.zim`` files are found there.
+
+That directory is READ-ONLY to this suite: it is whatever library the
+operator happens to keep there. A test that rewrites an archive, or builds a
+sidecar beside one, takes ``disposable_corpus`` and gets a writable copy, and
+``_zim_dir_stays_read_only`` fails the session if anything in the configured
+directory moves.
 """
 
 from __future__ import annotations
@@ -19,6 +25,7 @@ from __future__ import annotations
 import contextlib
 import os
 import secrets
+import shutil
 import socket
 import subprocess
 import sys
@@ -89,12 +96,101 @@ def resolve_zim_dir(d: Path) -> Optional[Path]:
 
 @pytest.fixture(scope="session")
 def zim_dir() -> Path:
-    """Resolve the directory of ZIM files; skip if none present."""
+    """Resolve the directory of ZIM files; skip if none present.
+
+    READ-ONLY. This is whatever library the operator pointed
+    ``ZIM_TEST_DATA_DIR`` at, defaulting to ``~/Developer/zim``. A test that
+    writes to an archive, or beside one, takes ``disposable_corpus`` instead.
+    """
     d = _zim_dir()
     resolved = resolve_zim_dir(d)
     if resolved is None:
         pytest.skip(f"No .zim files found in {d}. Set ZIM_TEST_DATA_DIR to override.")
     return resolved
+
+
+def smallest_usable_zim(d: Path) -> Optional[Path]:
+    """The smallest archive in ``d`` a test may assert on, or None."""
+    candidates = usable_zims(d)
+    return min(candidates, key=lambda f: f.stat().st_size) if candidates else None
+
+
+def writable_copy(archive: Path, dest_dir: Path) -> Path:
+    """Copy ``archive`` into ``dest_dir`` so a test may write to or beside it.
+
+    On APFS this is a clone: instant, and it occupies no extra space until
+    something writes. Elsewhere it is a plain copy, which is cheap on the
+    archives CI actually ships.
+    """
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / archive.name
+    if sys.platform == "darwin":
+        cloned = subprocess.run(
+            ["/bin/cp", "-c", str(archive), str(dest)],
+            capture_output=True,
+            check=False,
+        )
+        if cloned.returncode == 0:
+            return dest
+    shutil.copyfile(archive, dest)
+    return dest
+
+
+@pytest.fixture
+def disposable_corpus(zim_dir: Path, tmp_path: Path) -> Path:
+    """A directory holding a writable copy of the smallest usable archive.
+
+    For the tests that rewrite what they watch, or build a sidecar beside it.
+    Pointed at a real library, those tests used to do that in place: same
+    bytes, new mtime — which invalidates every cache key derived from the
+    file — and a sidecar rebuilt by whichever builder the branch under test
+    happened to carry.
+    """
+    archive = smallest_usable_zim(zim_dir)
+    if archive is None:  # pragma: no cover - zim_dir skips first
+        pytest.skip(f"no usable .zim files in {zim_dir}")
+    corpus = tmp_path / "corpus"
+    writable_copy(archive, corpus)
+    return corpus
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _zim_dir_stays_read_only() -> Iterator[None]:
+    """Fail the session if anything under the configured ZIM directory moved.
+
+    Three runs rewrote an archive or its sidecar in place before this existed
+    and nothing noticed, because the bytes were identical and only the mtime
+    moved. Compares name, mtime and size of every file in the directory,
+    which is what a rewrite-in-place changes and what every cache key derived
+    from an archive depends on.
+    """
+    resolved = resolve_zim_dir(_zim_dir())
+    if resolved is None:
+        yield
+        return
+
+    def snapshot() -> dict:
+        return {
+            entry.name: (entry.stat().st_mtime_ns, entry.stat().st_size)
+            for entry in sorted(resolved.iterdir())
+            if entry.is_file()
+        }
+
+    before = snapshot()
+    try:
+        yield
+    finally:
+        after = snapshot()
+        changed = sorted(
+            name
+            for name in set(before) | set(after)
+            if before.get(name) != after.get(name)
+        )
+        assert not changed, (
+            f"the live suite modified {resolved}: {changed}. That directory is "
+            "the operator's library, not a fixture — take a copy with the "
+            "disposable_corpus fixture instead."
+        )
 
 
 @dataclass
@@ -311,11 +407,15 @@ def spawn_live_server(zim_dir: Path, tmp_path: Path) -> Iterator:
         def test_x(spawn_live_server):
             srv = spawn_live_server(transport="http", token="secret")
             assert srv.healthz().status_code == 200
+
+    Pass ``zim_dir=`` to serve a different directory — ``disposable_corpus``
+    for a test that writes to what the server is watching.
     """
     spawned: List[LiveServer] = []
 
     def _factory(**kwargs) -> LiveServer:
-        srv = _spawn(zim_dir=zim_dir, tmp_path=tmp_path, **kwargs)
+        served = kwargs.pop("zim_dir", zim_dir)
+        srv = _spawn(zim_dir=served, tmp_path=tmp_path, **kwargs)
         spawned.append(srv)
         return srv
 

--- a/tests/live/test_live_inbound_linkgraph.py
+++ b/tests/live/test_live_inbound_linkgraph.py
@@ -1,20 +1,28 @@
-"""End-to-end: build a link-graph sidecar then query inbound through the reader."""
+"""End-to-end: build a link-graph sidecar then query inbound through the reader.
+
+Both tests work on a COPY of an archive. Building a sidecar writes a file
+beside the archive it describes, and this test built with ``force=True``, so
+pointed at a real library it overwrote the operator's own sidecar with
+whatever the builder on the branch under test produced. The archives
+themselves are only ever read.
+"""
 
 from __future__ import annotations
 
 import math
+import shutil
 from pathlib import Path
 from typing import Optional
 
 import pytest
 
-from tests.live.conftest import usable_zims
+from tests.live.conftest import usable_zims, writable_copy
 
 pytestmark = pytest.mark.live
 
 
-def _build_first_linked_archive(zims) -> Optional[tuple]:
-    """Build a sidecar for the first archive that yields edges.
+def _build_first_linked_archive(zims, workdir: Path) -> Optional[tuple]:
+    """Build a sidecar beside a copy of the first archive that yields edges.
 
     ``zims[0]`` alone was not enough: the fixture corpus leads with
     ``small.zim``, a two-entry archive whose articles link to nothing, so the
@@ -22,95 +30,93 @@ def _build_first_linked_archive(zims) -> Optional[tuple]:
     candidates and keep the first that actually has a link graph — the
     behavior under test only exists once there are edges to rank.
 
-    Returns ``(archive, sidecar, stats, created_here)``, or None.
+    Each candidate is copied into ``workdir`` first, so the sibling sidecar
+    the reader expects lands next to the copy. A candidate without edges has
+    its copy discarded before the next one is tried.
+
+    Returns ``(archive, sidecar, stats)``, or None.
     """
     from openzim_mcp.linkgraph.builder import build_link_graph
     from openzim_mcp.linkgraph.reader import sidecar_path_for
 
-    for archive in zims:
-        # Build directly to the sibling path the reader expects.
+    for candidate in zims:
+        staged = workdir / candidate.stem
+        archive = writable_copy(candidate, staged)
         sidecar = sidecar_path_for(str(archive))
-        created_here = not Path(sidecar).exists()
         stats = build_link_graph(str(archive), sidecar, force=True)
         if stats.node_count > 0 and stats.edge_count > 0:
-            return archive, sidecar, stats, created_here
-        if created_here:
-            Path(sidecar).unlink(missing_ok=True)
+            return archive, sidecar, stats
+        shutil.rmtree(staged, ignore_errors=True)
     return None
 
 
 def test_build_then_inbound_roundtrip(zim_dir, tmp_path) -> None:
     """Building a sidecar then querying inbound returns importance-ranked
     linkers, with site furniture sunk below every other linker."""
-    zims = usable_zims(zim_dir)
+    # Smallest first: every candidate is copied before it is built, and the
+    # smallest archive that has edges is the cheapest way to get one.
+    zims = sorted(usable_zims(zim_dir), key=lambda f: f.stat().st_size)
     if not zims:
         pytest.skip("no ZIM test data available")
 
     from openzim_mcp.linkgraph.reader import LinkGraphReader
 
-    built = _build_first_linked_archive(zims)
+    built = _build_first_linked_archive(zims, tmp_path / "staged")
     if built is None:
         pytest.skip("no archive in the corpus produces a non-empty link graph")
-    archive, sidecar, stats, created_here = built
+    archive, sidecar, stats = built
 
-    try:
-        assert stats.node_count > 0 and stats.edge_count > 0
+    assert stats.node_count > 0 and stats.edge_count > 0
 
-        import sqlite3
+    import sqlite3
 
-        conn = sqlite3.connect(sidecar)
-        target = conn.execute(
-            "SELECT t.path FROM edges e JOIN nodes t ON t.id=e.target_id "
-            "GROUP BY e.target_id ORDER BY COUNT(*) DESC LIMIT 1"
-        ).fetchone()[0]
-        node_count = int(
-            conn.execute("SELECT value FROM meta WHERE key='node_count'").fetchone()[0]
-        )
-        conn.close()
+    conn = sqlite3.connect(sidecar)
+    target = conn.execute(
+        "SELECT t.path FROM edges e JOIN nodes t ON t.id=e.target_id "
+        "GROUP BY e.target_id ORDER BY COUNT(*) DESC LIMIT 1"
+    ).fetchone()[0]
+    node_count = int(
+        conn.execute("SELECT value FROM meta WHERE key='node_count'").fetchone()[0]
+    )
+    conn.close()
 
-        # Read it back through the public reader, fingerprint-checked.
-        from openzim_mcp.zim_operations import zim_archive
+    # Read it back through the public reader, fingerprint-checked.
+    from openzim_mcp.zim_operations import zim_archive
 
-        with zim_archive(Path(str(archive))) as a:
-            uuid = str(a.uuid)
-        reader = LinkGraphReader.open_for(str(archive), live_archive_uuid=uuid)
-        assert reader is not None
-        page = reader.query_inbound(target, limit=100_000, offset=0)
-        reader.close()
-        assert len(page.rows) == page.total >= 1
+    with zim_archive(Path(str(archive))) as a:
+        uuid = str(a.uuid)
+    reader = LinkGraphReader.open_for(str(archive), live_archive_uuid=uuid)
+    assert reader is not None
+    page = reader.query_inbound(target, limit=100_000, offset=0)
+    reader.close()
+    assert len(page.rows) == page.total >= 1
 
-        # Ranked by importance, except that a linker whose degree reaches half
-        # the archive is in the nav bar and sinks to the end. Checked over the
-        # WHOLE list: the first version read five rows, which never reach the
-        # sunk group, so it went on asserting pure degree order. The threshold
-        # is recomputed here rather than imported, to cross-check the reader.
-        threshold = math.ceil(node_count / 2) if node_count >= 50 else 0
-        furniture = [
-            threshold > 0 and r["inbound_degree"] >= threshold for r in page.rows
+    # Ranked by importance, except that a linker whose degree reaches half
+    # the archive is in the nav bar and sinks to the end. Checked over the
+    # WHOLE list: the first version read five rows, which never reach the
+    # sunk group, so it went on asserting pure degree order. The threshold
+    # is recomputed here rather than imported, to cross-check the reader.
+    threshold = math.ceil(node_count / 2) if node_count >= 50 else 0
+    furniture = [threshold > 0 and r["inbound_degree"] >= threshold for r in page.rows]
+    assert furniture == sorted(furniture), "a furniture linker outranks an article"
+    for group in (False, True):
+        degrees = [
+            r["inbound_degree"]
+            for r, is_furniture in zip(page.rows, furniture)
+            if is_furniture is group
         ]
-        assert furniture == sorted(furniture), "a furniture linker outranks an article"
-        for group in (False, True):
-            degrees = [
-                r["inbound_degree"]
-                for r, is_furniture in zip(page.rows, furniture)
-                if is_furniture is group
-            ]
-            assert degrees == sorted(degrees, reverse=True)
-    finally:
-        if created_here:
-            Path(sidecar).unlink(missing_ok=True)
+        assert degrees == sorted(degrees, reverse=True)
 
 
-def test_inbound_absent_sidecar_is_graceful(zim_dir) -> None:
-    """With no sidecar present, open_for reports absence (None), not an error."""
-    zims = usable_zims(zim_dir)
-    if not zims:
-        pytest.skip("no ZIM test data available")
-    from openzim_mcp.linkgraph.reader import LinkGraphReader, sidecar_path_for
+def test_inbound_absent_sidecar_is_graceful(disposable_corpus: Path) -> None:
+    """With no sidecar present, open_for reports absence (None), not an error.
 
-    archive = zims[0]
-    if Path(sidecar_path_for(str(archive))).exists():
-        pytest.skip("a sidecar already exists next to the fixture archive")
+    On a fresh copy there never is one, so this no longer skips itself on a
+    library whose archives have been indexed.
+    """
+    from openzim_mcp.linkgraph.reader import LinkGraphReader
+
+    archive = sorted(disposable_corpus.glob("*.zim"))[0]
     from openzim_mcp.zim_operations import zim_archive
 
     with zim_archive(Path(str(archive))) as a:

--- a/tests/live/test_live_subscriptions.py
+++ b/tests/live/test_live_subscriptions.py
@@ -57,16 +57,22 @@ async def _collect(subscription: Any, events: List[Any], seen: asyncio.Event) ->
 
 @pytest.mark.asyncio
 async def test_listen_stream_receives_both_notification_kinds(
-    spawn_live_server, zim_dir: Path
+    spawn_live_server, disposable_corpus: Path
 ) -> None:
-    """A replace fires ``updated``; an add fires ``list_changed``."""
+    """A replace fires ``updated``; an add fires ``list_changed``.
+
+    Served from a copy: this test rewrites the archive it watches and drops a
+    second file beside it, and doing that to the operator's own library moved
+    the mtime of a 128 MB archive every time the suite ran.
+    """
     srv = spawn_live_server(
         transport="http",
         token=TOKEN,
+        zim_dir=disposable_corpus,
         extra_env={"OPENZIM_MCP_WATCH_INTERVAL_SECONDS": WATCH_INTERVAL},
     )
 
-    zims = sorted(zim_dir.glob("*.zim"))
+    zims = sorted(disposable_corpus.glob("*.zim"))
     assert zims, "no .zim files to exercise"
     target = zims[0]
     archive_uri = f"zim://{target.stem}"
@@ -119,7 +125,7 @@ async def test_listen_stream_receives_both_notification_kinds(
 
                         # (2) Add a new file -> list_changed.
                         seen.clear()
-                        added = zim_dir / "live_subscription_probe.zim"
+                        added = disposable_corpus / "live_subscription_probe.zim"
                         shutil.copyfile(target, added)
                         try:
                             await asyncio.wait_for(


### PR DESCRIPTION
## Description

The live suite wrote to whatever library it was pointed at. `ZIM_TEST_DATA_DIR` defaults to `~/Developer/zim`, so a plain `make test-live` on a developer machine:

- rewrote an archive in place (`test_live_subscriptions.py`: `target.write_bytes(target.read_bytes())`) and dropped a probe archive beside it, and
- force-rebuilt that archive's link-graph sidecar (`test_live_inbound_linkgraph.py`: `build_link_graph(..., force=True)`).

Both are reasonable things for those tests to do — one needs a file change to fire `notifications/resources/updated`, the other needs a sidecar to read back. Neither should do it to the operator's own files. The bytes were identical, so nothing looked broken, but the mtime moved, and the mtime is half of `archive_stat_token`: every cache key derived from that archive was invalidated, including persisted ones. The sidecar was replaced outright by whichever builder the branch under test happened to carry.

It happened three times in one day on a real library while verifying an unrelated branch, which is what prompted this.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test improvements

## Changes Made

- **`disposable_corpus`** — a new fixture holding a writable copy of the smallest usable archive. `writable_copy` clones on APFS (instant, no extra space until written) and falls back to a plain copy elsewhere, which is cheap on the archives CI ships.
- **`spawn_live_server(zim_dir=...)`** — a spawned server can now be pointed at a directory other than the operator's library.
- **The subscriptions test** serves `disposable_corpus`, so the rewrite and the added probe file land on the copy.
- **The link-graph roundtrip** copies each candidate archive before building, so the sibling sidecar lands next to the copy, and discards the copy if that archive has no edges. Candidates are tried smallest-first, since every one is copied before it is built.
- **`test_inbound_absent_sidecar_is_graceful`** no longer skips itself on a library whose archives have been indexed: a fresh copy never has a sidecar, so the test actually runs.
- **A session-wide guard** (autouse, `tests/live/` only) snapshots the name, mtime and size of every file in the configured directory and fails the session if any of it moved. That is exactly what a rewrite-in-place changes, and what went unnoticed three times.
- `zim_dir`'s docstring now says it is read-only, and points writers at `disposable_corpus`.

## Testing

### Test Coverage

- [x] Tests pass locally — **5,289 passed, 222 skipped, 0 failed**, unchanged by this change
- [x] All quality checks pass — pre-commit green
- [x] Integration tests pass — **36 passed / 16 skipped / 0 failed** against the real library at the default path (was 35 / 17 / 0: the absent-sidecar test now runs instead of skipping)
- [x] Existing tests updated for changed functionality

**The fix is verified the only way that counts: by running the live suite against a real library at the default path and fingerprinting it.** Name, mtime, size and sha256 of both archives (1.9 GB and 128 MB) and the sidecar, before and after: **identical on all three**. The same run on the previous commit moved the archive's mtime and replaced the sidecar.

**The guard is mutation-proven.** Pointing the subscriptions test back at `zim_dir` (against a throwaway clone, so the proof touches nothing real) fails the session, with the guard naming both files that moved:

```text
AssertionError: the live suite modified <dir>:
['internet-encyclopedia-philosophy_en_all_2025-06.zim',
 'internet-encyclopedia-philosophy_en_all_2025-06.zim.linkgraph.sqlite'].
That directory is the operator's library, not a fixture — take a copy with
the disposable_corpus fixture instead.
```

### Manual Testing

- [x] Tested with real ZIM files — the 1.9 GB MedlinePlus and 128 MB IEP archives in the default location
- [x] Verified backward compatibility — no production code changed; `ZIM_TEST_DATA_DIR` still selects the library, and the suite still reads the real archives

## Security Considerations

- [x] No new security vulnerabilities introduced
- [x] No production code changed

## Performance Impact

- [x] Live-suite runtime is unchanged in practice — the copy is an APFS clone on macOS; on other filesystems it is one copy of the smallest usable archive
- [x] One skip becomes a pass, because the absent-sidecar test no longer opts out

## Backward Compatibility

- [x] No breaking changes. Test-only.

## Additional Notes

- CI runs no live job, so this is a local-safety fix: it protects whoever runs `make test-live`, and any agent that runs it on a machine with a real library.
